### PR TITLE
feat: define AgentService proto — ExecuteCapability streaming RPC

### DIFF
--- a/protos/buf.yaml
+++ b/protos/buf.yaml
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: Apache-2.0
+# buf workspace configuration for all Zynax proto contracts.
+# Run: make lint-protos  →  buf lint
+# Run: make generate-protos  →  buf generate (issue #12)
+version: v2
+modules:
+  - path: zynax
+lint:
+  use:
+    - DEFAULT
+  except:
+    # Versioning is handled at the directory level (zynax/v1/).
+    # buf's PACKAGE_VERSION_SUFFIX rule would require the package name to
+    # end in "v1" which conflicts with our zynax.v1 package naming choice.
+    - PACKAGE_VERSION_SUFFIX
+breaking:
+  use:
+    - FILE  # Detect breaking changes at the file boundary between versions

--- a/protos/buf.yaml
+++ b/protos/buf.yaml
@@ -4,15 +4,21 @@
 # Run: make generate-protos  →  buf generate (issue #12)
 version: v2
 modules:
-  - path: zynax
+  # Module root is protos/ so that zynax/v1/agent.proto resolves to
+  # package zynax.v1 — matching PACKAGE_DIRECTORY_MATCH expectations.
+  - path: .
 lint:
   use:
-    - DEFAULT
+    - STANDARD
   except:
     # Versioning is handled at the directory level (zynax/v1/).
     # buf's PACKAGE_VERSION_SUFFIX rule would require the package name to
     # end in "v1" which conflicts with our zynax.v1 package naming choice.
     - PACKAGE_VERSION_SUFFIX
+    # Streaming RPCs emit typed event messages, not response wrappers.
+    # TaskEvent is the correct domain name for events in the ExecuteCapability
+    # stream; renaming it ExecuteCapabilityResponse would obscure its purpose.
+    - RPC_RESPONSE_STANDARD_NAME
 breaking:
   use:
     - FILE  # Detect breaking changes at the file boundary between versions

--- a/protos/tests/features/agent_service.feature
+++ b/protos/tests/features/agent_service.feature
@@ -1,0 +1,98 @@
+# SPDX-License-Identifier: Apache-2.0
+# Zynax — AgentService BDD Contract Specification
+#
+# This file is the SPECIFICATION. It is written BEFORE the implementation.
+# It describes the contract every adapter and agent in Zynax must honour.
+# See protos/AGENTS.md §7 for contract test rules.
+#
+# Business context: Any system that can serve ExecuteCapability becomes a
+# first-class Zynax capability without adopting the SDK (ADR-013). This
+# contract is the only gRPC interface required to join the platform.
+
+Feature: AgentService contract — ExecuteCapability streaming RPC
+  As a task broker dispatching work to capability providers
+  I want every agent and adapter to implement a single ExecuteCapability contract
+  So that any system can become a platform capability without knowing Zynax internals
+
+  Background:
+    Given an agent implementing AgentService is running on a test gRPC server
+
+  # ─── Happy path ────────────────────────────────────────────────────────────
+
+  Scenario: Successful capability execution streams progress then completes
+    Given a valid ExecuteCapabilityRequest for capability "summarize"
+    And the input payload is valid JSON: {"documents": ["hello world"]}
+    When ExecuteCapability is called
+    Then the stream emits at least one TaskEvent with event_type PROGRESS
+    And the final TaskEvent has event_type COMPLETED
+    And the COMPLETED event payload is valid JSON
+    And the stream closes cleanly after the COMPLETED event
+
+  Scenario: Every event in the stream carries the originating task_id
+    Given a valid ExecuteCapabilityRequest with task_id "task-contract-99"
+    When ExecuteCapability is called and the stream is fully consumed
+    Then every TaskEvent in the stream has task_id "task-contract-99"
+
+  Scenario: Every PROGRESS and COMPLETED event has a populated timestamp
+    Given a valid ExecuteCapabilityRequest for capability "summarize"
+    When ExecuteCapability is called
+    Then every TaskEvent has a non-zero timestamp
+
+  # ─── Timeout handling ─────────────────────────────────────────────────────
+
+  Scenario: Agent honours timeout_seconds and emits FAILED with TIMEOUT code
+    Given an ExecuteCapabilityRequest with timeout_seconds set to 1
+    And the agent simulates a capability that runs for 5 seconds
+    When ExecuteCapability is called
+    Then the stream receives a TaskEvent of type FAILED within 2 seconds
+    And the CapabilityError code is "TIMEOUT"
+    And the gRPC status is DEADLINE_EXCEEDED
+
+  # ─── Failure paths ────────────────────────────────────────────────────────
+
+  Scenario: Capability failure produces a structured CapabilityError
+    Given an ExecuteCapabilityRequest for capability "always_fails"
+    When ExecuteCapability is called
+    Then the stream emits exactly one TaskEvent with event_type FAILED
+    And the TaskEvent.error.code is a non-empty string
+    And the TaskEvent.error.message is a non-empty string
+    And no further events are emitted after the FAILED event
+
+  Scenario: Unknown capability returns NOT_FOUND without entering the stream
+    Given an ExecuteCapabilityRequest for capability "nonexistent_cap"
+    When ExecuteCapability is called
+    Then the gRPC status is NOT_FOUND
+    And the error message contains "nonexistent_cap"
+    And no TaskEvent is emitted
+
+  # ─── Input validation ─────────────────────────────────────────────────────
+
+  Scenario: Empty capability_name is rejected before execution begins
+    Given an ExecuteCapabilityRequest with capability_name set to ""
+    When ExecuteCapability is called
+    Then the gRPC status is INVALID_ARGUMENT
+    And the error message mentions "capability_name"
+
+  Scenario: Empty task_id is rejected before execution begins
+    Given an ExecuteCapabilityRequest with task_id set to ""
+    When ExecuteCapability is called
+    Then the gRPC status is INVALID_ARGUMENT
+    And the error message mentions "task_id"
+
+  Scenario: Non-JSON input_payload is rejected before execution begins
+    Given an ExecuteCapabilityRequest with input_payload set to "not valid json"
+    When ExecuteCapability is called
+    Then the gRPC status is INVALID_ARGUMENT
+    And the error message mentions "input_payload"
+
+  # ─── Stream ordering invariants ───────────────────────────────────────────
+
+  Scenario: Stream always terminates with COMPLETED or FAILED — never with PROGRESS
+    Given a valid ExecuteCapabilityRequest
+    When ExecuteCapability is called and the stream is fully consumed
+    Then the final TaskEvent has event_type COMPLETED or FAILED
+
+  Scenario: No events are emitted after a terminal event
+    Given a valid ExecuteCapabilityRequest for capability "always_fails"
+    When ExecuteCapability is called and the stream is fully consumed
+    Then no TaskEvent is received after the first FAILED event

--- a/protos/zynax/v1/agent.proto
+++ b/protos/zynax/v1/agent.proto
@@ -32,8 +32,7 @@ service AgentService {
   // to the caller. The stream ends with TASK_EVENT_TYPE_COMPLETED on success
   // or TASK_EVENT_TYPE_FAILED on error. Zero or more PROGRESS events may
   // precede the terminal event.
-  rpc ExecuteCapability(ExecuteCapabilityRequest)
-      returns (stream TaskEvent);
+  rpc ExecuteCapability(ExecuteCapabilityRequest) returns (stream TaskEvent);
 }
 
 // ExecuteCapabilityRequest is the entry point for all capability invocations.

--- a/protos/zynax/v1/agent.proto
+++ b/protos/zynax/v1/agent.proto
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// AgentService — the universal capability provider contract.
+//
+// Any system that serves this single RPC becomes a first-class Zynax
+// capability: no SDK required, no framework required, no language requirement.
+// The task broker calls ExecuteCapability; the agent streams events back.
+//
+// Design rationale: ADR-013 (adapter-first, no SDK required), ADR-001 (gRPC
+// as the inter-service protocol). See protos/AGENTS.md §8 for language-specific
+// consuming instructions.
+//
+// Contract invariants (also expressed in protos/tests/features/agent_service.feature):
+//   1. Every stream MUST end with exactly one terminal event: COMPLETED or FAILED.
+//   2. Every TaskEvent MUST echo the task_id from the originating request.
+//   3. Agents MUST honour timeout_seconds and emit FAILED with code "TIMEOUT".
+//   4. The stream MUST NOT emit events after the terminal event.
+
+syntax = "proto3";
+
+package zynax.v1;
+
+import "google/protobuf/timestamp.proto";
+
+option go_package = "github.com/zynax-io/zynax/gen/go/zynax/v1;zynaxv1";
+
+// AgentService is the contract every Zynax capability provider must implement.
+// The task broker is the sole caller in production; test harnesses call it
+// directly to validate contract compliance.
+service AgentService {
+  // ExecuteCapability invokes a named capability and streams TaskEvents back
+  // to the caller. The stream ends with TASK_EVENT_TYPE_COMPLETED on success
+  // or TASK_EVENT_TYPE_FAILED on error. Zero or more PROGRESS events may
+  // precede the terminal event.
+  rpc ExecuteCapability(ExecuteCapabilityRequest)
+      returns (stream TaskEvent);
+}
+
+// ExecuteCapabilityRequest is the entry point for all capability invocations.
+// Agents route internally based on capability_name — never on caller identity.
+message ExecuteCapabilityRequest {
+  // Idempotency key (UUID v4). Agents MAY use this to deduplicate retried
+  // requests. Required: empty string is rejected with INVALID_ARGUMENT.
+  string request_id = 1;
+
+  // The capability to invoke, as declared in the agent's AgentDef manifest.
+  // Format: lowercase letters, digits, and underscores; 1–64 characters.
+  // Examples: "summarize", "review_code", "run_tests".
+  // Required: empty string is rejected with INVALID_ARGUMENT.
+  string capability_name = 2;
+
+  // Opaque task identifier set by the task broker. Echoed back in every
+  // TaskEvent so the broker can correlate stream events to queued tasks.
+  // Required: empty string is rejected with INVALID_ARGUMENT.
+  string task_id = 3;
+
+  // The workflow run that owns this task. Used by agents to scope memory
+  // service reads/writes and by observability tooling for trace correlation.
+  string workflow_id = 4;
+
+  // JSON-encoded input conforming to the capability's declared input_schema.
+  // Agents MUST validate this against the schema and return INVALID_ARGUMENT
+  // if validation fails before any execution begins.
+  bytes input_payload = 5;
+
+  // Maximum wall-clock seconds the agent may spend executing this capability.
+  // Agents MUST emit TASK_EVENT_TYPE_FAILED with error code "TIMEOUT" if
+  // execution exceeds this value. Zero means no agent-side timeout (the
+  // caller's gRPC deadline still applies).
+  int32 timeout_seconds = 6;
+}
+
+// TaskEvent is streamed by the agent during capability execution.
+// The task broker consumes this stream to update task state, trigger
+// workflow transitions, and surface diagnostics to operators.
+message TaskEvent {
+  // Echoes ExecuteCapabilityRequest.task_id. Never empty.
+  string task_id = 1;
+
+  // The lifecycle stage this event represents.
+  // Streams MUST terminate with exactly one COMPLETED or FAILED event.
+  TaskEventType event_type = 2;
+
+  // JSON-encoded event data. Schema is capability-defined.
+  // Populated for PROGRESS and COMPLETED events.
+  // Empty for FAILED events — use the error field instead.
+  bytes payload = 3;
+
+  // Wall-clock time when the agent emitted this event.
+  // Agents MUST populate this on every event.
+  google.protobuf.Timestamp timestamp = 4;
+
+  // Structured error details. Populated only when event_type is
+  // TASK_EVENT_TYPE_FAILED. The task broker inspects error.code to
+  // determine retry eligibility and escalation policy.
+  CapabilityError error = 5;
+}
+
+// TaskEventType classifies each event in the ExecuteCapability stream.
+// Ordinal values are permanent — never reorder or reassign (ADR-001 §backward-compat).
+enum TaskEventType {
+  // Never used by agents. Proto3 default sentinel; presence indicates
+  // a missing or corrupt event_type field.
+  TASK_EVENT_TYPE_UNSPECIFIED = 0;
+
+  // An intermediate progress update. The capability is still running.
+  // Zero or more PROGRESS events MAY precede the terminal event.
+  TASK_EVENT_TYPE_PROGRESS = 1;
+
+  // Terminal: the capability completed successfully.
+  // The payload field MUST be populated with the capability output.
+  TASK_EVENT_TYPE_COMPLETED = 2;
+
+  // Terminal: the capability failed. The error field MUST be populated.
+  // The stream MUST close immediately after this event.
+  TASK_EVENT_TYPE_FAILED = 3;
+}
+
+// CapabilityError provides structured failure information.
+// The task broker uses error.code to drive retry and escalation decisions:
+//   "TIMEOUT"            → eligible for retry up to max_retries
+//   "INVALID_INPUT"      → not retried; surfaced to workflow author
+//   "UPSTREAM_ERROR"     → eligible for retry with backoff
+//   "RESOURCE_EXHAUSTED" → eligible for retry after delay
+//   "INTERNAL"           → eligible for limited retry; triggers alerting
+message CapabilityError {
+  // Machine-readable error code. Uppercase snake case.
+  // Well-known codes: "TIMEOUT", "INVALID_INPUT", "UPSTREAM_ERROR",
+  // "RESOURCE_EXHAUSTED", "INTERNAL".
+  // Agents SHOULD use well-known codes where applicable and document
+  // capability-specific codes in their AgentDef manifest.
+  string code = 1;
+
+  // Human-readable description of the failure. Non-empty when error is set.
+  // Surfaced in workflow logs and operator dashboards.
+  string message = 2;
+
+  // Optional key-value pairs for additional diagnostic context.
+  // Examples: {"upstream_status": "503"}, {"model": "claude-3-opus"},
+  //           {"line": "42", "field": "documents"}.
+  map<string, string> details = 3;
+}


### PR DESCRIPTION
## Why

Closes #2
Epic: #1 (M1 Contracts Foundation)

Defines \`AgentService\` — the single gRPC contract every Zynax capability provider must implement. Serving this one RPC is sufficient to join the platform as a capability: no SDK, no framework, no language requirement (ADR-013).

---

## What Changed

- \`test:\` **BDD contract specification** — \`protos/tests/features/agent_service.feature\` written before any proto line, per ADR-004
- \`feat:\` **buf workspace config** — \`protos/buf.yaml\` with \`STANDARD\` lint rules, shared by all M1 proto PRs
- \`feat:\` **\`agent.proto\`** — the AgentService contract, written against the BDD spec
- \`fix(protos):\` **buf.yaml corrections** — module root set to \`protos/\`, deprecated DEFAULT → STANDARD, RPC_RESPONSE_STANDARD_NAME excepted for streaming event types
- \`style(protos):\` **buf format** — collapse RPC declaration to one line per buf canonical style

---

## Type of Change

- [x] \`feat\` — new capability
- [x] \`test\` — BDD specification (first commit)

---

## PR Size Self-Check

Lines changed (excluding generated code, lock files, fixtures): ~140

- [x] ≤ 400 lines — proceed

---

## Engineering Checklist

**Git hygiene**
- [x] Every commit follows Conventional Commits format
- [x] Every commit has \`Signed-off-by:\` (DCO) — verified by \`dco\` CI job ✅
- [x] No WIP / fixup commits remain
- [x] Branch rebased onto current \`main\`

**BDD**
- [x] \`.feature\` file committed before any implementation code — \`bdd-first\` CI job ✅
- [x] All scenarios documented; godog step definitions tracked in #14 (CI toolchain epic)

**Code quality**
- [x] \`buf lint\` passes — \`lint\` CI job ✅
- [x] \`buf format --diff --exit-code\` passes — \`lint\` CI job ✅
- [x] No layer boundary violations — \`Layer boundary enforcement\` CI job ✅
- [x] Proto field numbers stable; no removals or reuse

**Testing**
- [x] \`test-unit\` CI job ✅ (no Go/Python services yet; godog step definitions tracked in #14)
- [x] \`test-integration\` CI job ✅

**Security**
- [x] No secrets, tokens, or PII in proto definitions or fixtures
- [x] \`security\` CI job ✅
- [x] Input validation requirements documented in field comments (\`capability_name\`, \`task_id\`, \`input_payload\`)

**Architecture**
- [x] \`UNSPECIFIED = 0\` sentinel on \`TaskEventType\` — backward-compat rule (protos/AGENTS.md §3)
- [x] Proto backward compatibility check — \`Proto backward compatibility\` CI job ✅
- [x] No breaking changes; new file, no existing contract modified
- [x] \`RPC_RESPONSE_STANDARD_NAME\` excepted: streaming RPCs emit typed event messages, not response wrappers

**Documentation**
- [x] All fields and invariants documented inline in the proto
- [x] Contract invariants cross-referenced to this PR in the file header comment

---

## Proto Contract Summary

\`\`\`
service AgentService
  rpc ExecuteCapability(ExecuteCapabilityRequest) returns (stream TaskEvent)

message ExecuteCapabilityRequest   request_id, capability_name, task_id,
                                   workflow_id, input_payload, timeout_seconds
message TaskEvent                  task_id, event_type, payload, timestamp, error
enum    TaskEventType              UNSPECIFIED(0) | PROGRESS(1) | COMPLETED(2) | FAILED(3)
message CapabilityError            code, message, details (map<string,string>)
\`\`\`

\`go_package\`: \`github.com/zynax-io/zynax/gen/go/zynax/v1;zynaxv1\`

### BDD scenarios covered

| Scenario | Status |
|---|---|
| Successful execution: PROGRESS* → COMPLETED stream | Specified ✅ |
| Every event echoes originating task_id | Specified ✅ |
| Every PROGRESS and COMPLETED event has a populated timestamp | Specified ✅ |
| Agent honours timeout_seconds → FAILED with TIMEOUT code | Specified ✅ |
| Capability failure → structured CapabilityError | Specified ✅ |
| Unknown capability → NOT_FOUND, no TaskEvent emitted | Specified ✅ |
| Empty capability_name → INVALID_ARGUMENT | Specified ✅ |
| Empty task_id → INVALID_ARGUMENT | Specified ✅ |
| Non-JSON input_payload → INVALID_ARGUMENT | Specified ✅ |
| Stream always terminates with COMPLETED or FAILED | Specified ✅ |
| No events emitted after terminal event | Specified ✅ |

Godog step definitions (execution against a live gRPC server) tracked in #14.

---

## Feature Files

- [\`protos/tests/features/agent_service.feature\`](protos/tests/features/agent_service.feature) — committed as first commit in this branch (ADR-004 compliant)

---

## AI Assistance

- [x] AI-assisted — tool/model: Claude Code / claude-sonnet-4-6
      Assisted-by: Claude Code/claude-sonnet-4-6

---

## References

- ADR-001: gRPC as inter-service protocol
- ADR-013: adapter-first, no SDK required
- ADR-004: BDD-first development
- \`protos/AGENTS.md\` — proto authoring rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)