### PR TITLE
feat: define EngineAdapterService proto — execution lifecycle

### DIFF
--- a/protos/tests/features/engine_adapter_service.feature
+++ b/protos/tests/features/engine_adapter_service.feature
@@ -1,0 +1,172 @@
+# SPDX-License-Identifier: Apache-2.0
+# Zynax — EngineAdapterService BDD Contract Specification
+#
+# This file is the SPECIFICATION. It is written BEFORE the implementation.
+# It describes the contract every engine adapter must honour.
+# See protos/AGENTS.md §7 for contract test rules.
+#
+# Business context: The engine adapter is the boundary between the Zynax
+# control plane and execution engines (Temporal, LangGraph, Argo Workflows).
+# The control plane submits compiled IR and signals events without knowing
+# which engine is running underneath. This single contract is what makes
+# the engine layer swappable. (ADR-001, ADR-015)
+
+Feature: EngineAdapterService contract — workflow execution lifecycle
+  As a Zynax control plane submitting compiled workflows for execution
+  I want every execution engine to implement a single adapter contract
+  So that workflows run on any engine without the control plane knowing its internals
+
+  Background:
+    Given an EngineAdapterService is running on a test gRPC server
+
+  # ─── Submission ───────────────────────────────────────────────────────────
+
+  Scenario: Submit a workflow IR returns a run_id
+    Given a compiled WorkflowIR for workflow "code-review-wf"
+    When SubmitWorkflow is called with the IR
+    Then the gRPC status is OK
+    And the response contains a non-empty run_id
+    And GetWorkflowStatus for that run_id returns status RUNNING
+
+  Scenario: Submitted workflow records the originating namespace
+    Given a compiled WorkflowIR with namespace "team-alpha"
+    When SubmitWorkflow is called
+    Then GetWorkflowStatus returns namespace "team-alpha"
+
+  Scenario: Submit with labels preserves them on the run record
+    Given a WorkflowIR and SubmitWorkflowRequest labels {"env": "staging"}
+    When SubmitWorkflow is called
+    Then GetWorkflowStatus returns label "env" with value "staging"
+
+  Scenario: Submit with engine_hint routes to that engine
+    Given a compiled WorkflowIR
+    And the SubmitWorkflowRequest has engine_hint "temporal"
+    When SubmitWorkflow is called
+    Then the workflow is executed by the "temporal" engine
+
+  Scenario: Submitting a duplicate run_id returns ALREADY_EXISTS
+    Given a workflow run "run-fixed-id" is already RUNNING
+    When SubmitWorkflow is called with the same run_id "run-fixed-id"
+    Then the gRPC status is ALREADY_EXISTS
+    And the error message contains "run-fixed-id"
+
+  # ─── Signals ──────────────────────────────────────────────────────────────
+
+  Scenario: Signal a running workflow triggers a state transition
+    Given workflow run "run-abc" is in RUNNING state
+    And the workflow is waiting on signal "review.approved"
+    When SignalWorkflow is called with event_type "review.approved"
+    Then the gRPC status is OK
+    And WatchWorkflow emits a WorkflowEvent with event_type "review.approved"
+
+  Scenario: Signal a completed workflow returns FAILED_PRECONDITION
+    Given workflow run "run-done" is in COMPLETED state
+    When SignalWorkflow is called with event_type "any.signal"
+    Then the gRPC status is FAILED_PRECONDITION
+    And the error message mentions "COMPLETED"
+
+  Scenario: Signal an unknown run_id returns NOT_FOUND
+    When SignalWorkflow is called with run_id "nonexistent-run"
+    Then the gRPC status is NOT_FOUND
+    And the error message contains "nonexistent-run"
+
+  # ─── Cancellation ─────────────────────────────────────────────────────────
+
+  Scenario: Cancel a running workflow transitions it to CANCELLED
+    Given workflow run "run-abc" is in RUNNING state
+    When CancelWorkflow is called with run_id "run-abc" and reason "user_cancelled"
+    Then GetWorkflowStatus for "run-abc" returns status CANCELLED
+    And the cancellation reason is stored on the run record
+
+  Scenario: Cancel a PENDING workflow transitions it to CANCELLED
+    Given workflow run "run-pending" is in PENDING state
+    When CancelWorkflow is called with run_id "run-pending"
+    Then GetWorkflowStatus for "run-pending" returns status CANCELLED
+
+  Scenario: Cancel a completed workflow returns FAILED_PRECONDITION
+    Given workflow run "run-done" is in COMPLETED state
+    When CancelWorkflow is called with run_id "run-done"
+    Then the gRPC status is FAILED_PRECONDITION
+    And the error message mentions "COMPLETED"
+
+  Scenario: Cancel an unknown run_id returns NOT_FOUND
+    When CancelWorkflow is called with run_id "ghost-run"
+    Then the gRPC status is NOT_FOUND
+
+  # ─── Status query ─────────────────────────────────────────────────────────
+
+  Scenario: GetWorkflowStatus returns the full run record
+    Given workflow run "run-abc" is in RUNNING state
+    When GetWorkflowStatus is called with run_id "run-abc"
+    Then the response includes a non-empty current_state
+    And the response includes a non-zero started_at timestamp
+    And the response includes the workflow_id from the original IR
+    And the response status is RUNNING
+
+  Scenario: GetWorkflowStatus for a completed run includes finished_at
+    Given workflow run "run-done" has reached COMPLETED state
+    When GetWorkflowStatus is called with run_id "run-done"
+    Then the response includes a non-zero finished_at timestamp
+
+  Scenario: GetWorkflowStatus for an unknown run_id returns NOT_FOUND
+    When GetWorkflowStatus is called with run_id "nonexistent-run"
+    Then the gRPC status is NOT_FOUND
+    And the error message contains "nonexistent-run"
+
+  # ─── Watch stream ─────────────────────────────────────────────────────────
+
+  Scenario: WatchWorkflow streams events as the workflow progresses
+    Given workflow run "run-abc" is in RUNNING state
+    When WatchWorkflow is called with run_id "run-abc"
+    Then the stream emits at least one WorkflowEvent
+    And every WorkflowEvent carries run_id "run-abc"
+    And every WorkflowEvent has a non-zero timestamp
+
+  Scenario: WatchWorkflow stream closes when workflow reaches terminal state
+    Given workflow run "run-abc" will complete during the watch
+    When WatchWorkflow is called with run_id "run-abc"
+    Then the stream emits a WorkflowEvent with a terminal status
+    And the stream closes cleanly after the terminal event
+
+  Scenario: WorkflowEvent includes state transition details
+    Given workflow run "run-abc" transitions from state "review" to "approve"
+    When WatchWorkflow emits the transition event
+    Then the WorkflowEvent from_state is "review"
+    And the WorkflowEvent to_state is "approve"
+
+  Scenario: WatchWorkflow for an unknown run_id returns NOT_FOUND
+    When WatchWorkflow is called with run_id "nonexistent-run"
+    Then the gRPC status is NOT_FOUND
+    And no WorkflowEvent is emitted
+
+  # ─── Input validation ─────────────────────────────────────────────────────
+
+  Scenario: SubmitWorkflow with missing workflow_ir is rejected
+    Given a SubmitWorkflowRequest with no workflow_ir
+    When SubmitWorkflow is called
+    Then the gRPC status is INVALID_ARGUMENT
+    And the error message mentions "workflow_ir"
+
+  Scenario: SignalWorkflow with empty run_id is rejected
+    Given a SignalWorkflowRequest with run_id set to ""
+    When SignalWorkflow is called
+    Then the gRPC status is INVALID_ARGUMENT
+    And the error message mentions "run_id"
+
+  Scenario: SignalWorkflow with empty event_type is rejected
+    Given a SignalWorkflowRequest with event_type set to ""
+    When SignalWorkflow is called
+    Then the gRPC status is INVALID_ARGUMENT
+    And the error message mentions "event_type"
+
+  Scenario: CancelWorkflow with empty run_id is rejected
+    Given a CancelWorkflowRequest with run_id set to ""
+    When CancelWorkflow is called
+    Then the gRPC status is INVALID_ARGUMENT
+    And the error message mentions "run_id"
+
+  Scenario: GetWorkflowStatus with empty run_id is rejected
+    Given a GetWorkflowStatusRequest with run_id set to ""
+    When GetWorkflowStatus is called
+    Then the gRPC status is INVALID_ARGUMENT
+    And the error message mentions "run_id"

--- a/protos/zynax/v1/engine_adapter.proto
+++ b/protos/zynax/v1/engine_adapter.proto
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// EngineAdapterService — workflow execution lifecycle contract.
+//
+// The engine adapter is the boundary between the Zynax control plane and
+// execution engines (Temporal, LangGraph, Argo Workflows). Any system that
+// implements this contract becomes a pluggable execution backend. The control
+// plane submits compiled WorkflowIR and reacts to events without knowing
+// which engine is running underneath.
+//
+// Design rationale: ADR-015 (engine abstraction — engines are plugins behind
+// this interface), ADR-001 (gRPC inter-service protocol).
+//
+// Contract invariants:
+//   1. run_id is assigned by the adapter on SubmitWorkflow. The adapter
+//      returns it in SubmitWorkflowResponse. Callers must not supply one
+//      except to re-submit with an idempotency key.
+//   2. Terminal statuses (COMPLETED, FAILED, CANCELLED) are immutable.
+//      SignalWorkflow and CancelWorkflow on terminal runs return
+//      FAILED_PRECONDITION.
+//   3. WatchWorkflow MUST emit at least one terminal WorkflowEvent before
+//      closing the stream.
+//   4. WorkflowStatus ordinals are permanent (ADR-001 §backward-compat).
+
+syntax = "proto3";
+
+package zynax.v1;
+
+import "google/protobuf/timestamp.proto";
+import "zynax/v1/workflow_compiler.proto";
+
+option go_package = "github.com/zynax-io/zynax/gen/go/zynax/v1;zynaxv1";
+
+// EngineAdapterService is the contract every execution engine plugin must
+// implement. The Zynax control plane is the sole caller in production.
+service EngineAdapterService {
+  // SubmitWorkflow submits a compiled WorkflowIR to the engine for execution.
+  // The adapter assigns a run_id and returns it in the response.
+  // Returns ALREADY_EXISTS if a run with the same run_id is already active.
+  // Returns INVALID_ARGUMENT if workflow_ir is absent.
+  rpc SubmitWorkflow(SubmitWorkflowRequest) returns (SubmitWorkflowResponse);
+
+  // SignalWorkflow delivers an external event to a running workflow.
+  // Returns FAILED_PRECONDITION if the workflow is in a terminal state.
+  // Returns NOT_FOUND if the run_id is unknown.
+  rpc SignalWorkflow(SignalWorkflowRequest) returns (SignalWorkflowResponse);
+
+  // CancelWorkflow requests cancellation of a non-terminal workflow run.
+  // Returns FAILED_PRECONDITION if the workflow is already in a terminal state.
+  // Returns NOT_FOUND if the run_id is unknown.
+  rpc CancelWorkflow(CancelWorkflowRequest) returns (CancelWorkflowResponse);
+
+  // GetWorkflowStatus returns the current state and metadata of a run.
+  // Returns NOT_FOUND if the run_id is unknown.
+  rpc GetWorkflowStatus(GetWorkflowStatusRequest) returns (WorkflowRun);
+
+  // WatchWorkflow streams WorkflowEvents as the workflow progresses.
+  // The stream MUST close after emitting a terminal WorkflowEvent.
+  // Returns NOT_FOUND (before streaming) if the run_id is unknown.
+  rpc WatchWorkflow(WatchWorkflowRequest) returns (stream WorkflowEvent);
+}
+
+// WorkflowStatus is the execution state of a workflow run.
+// Ordinal values are permanent — never reorder or reassign (ADR-001 §backward-compat).
+enum WorkflowStatus {
+  // Never set by the adapter. Proto3 default sentinel.
+  WORKFLOW_STATUS_UNSPECIFIED = 0;
+
+  // Accepted by the adapter; engine execution has not started yet.
+  WORKFLOW_STATUS_PENDING = 1;
+
+  // The engine is actively executing the workflow.
+  WORKFLOW_STATUS_RUNNING = 2;
+
+  // Terminal: the workflow reached its terminal state successfully.
+  WORKFLOW_STATUS_COMPLETED = 3;
+
+  // Terminal: the workflow failed and will not be retried by the adapter.
+  WORKFLOW_STATUS_FAILED = 4;
+
+  // Terminal: the workflow was explicitly cancelled via CancelWorkflow.
+  WORKFLOW_STATUS_CANCELLED = 5;
+}
+
+// WorkflowRun is the adapter's record for a submitted workflow execution.
+// Returned by GetWorkflowStatus and embedded in WatchWorkflow events.
+message WorkflowRun {
+  // Adapter-assigned unique identifier for this execution instance.
+  string run_id = 1;
+
+  // The workflow_id from the original WorkflowIR.
+  string workflow_id = 2;
+
+  // The namespace from the original WorkflowIR.
+  string namespace = 3;
+
+  // Current lifecycle status of this run.
+  WorkflowStatus status = 4;
+
+  // The state machine node the workflow is currently in.
+  // Empty before the first state is entered.
+  string current_state = 5;
+
+  // Arbitrary labels forwarded from SubmitWorkflowRequest for filtering.
+  map<string, string> labels = 6;
+
+  // The engine this run is executing on (e.g. "temporal", "langgraph").
+  string engine = 7;
+
+  // Wall-clock time the adapter accepted the submission.
+  google.protobuf.Timestamp submitted_at = 8;
+
+  // Wall-clock time the engine began executing the workflow.
+  google.protobuf.Timestamp started_at = 9;
+
+  // Wall-clock time the workflow reached a terminal state.
+  // Zero until the run is terminal.
+  google.protobuf.Timestamp finished_at = 10;
+
+  // Human-readable reason for cancellation. Populated only when
+  // status is CANCELLED.
+  string cancellation_reason = 11;
+}
+
+// WorkflowEvent is streamed by WatchWorkflow and published to the event bus
+// whenever the workflow transitions state or reaches a terminal condition.
+message WorkflowEvent {
+  // The run this event belongs to. Never empty.
+  string run_id = 1;
+
+  // Identifies what occurred. Examples: "state.transition", "signal.received",
+  // "workflow.completed", "workflow.failed", "workflow.cancelled".
+  string event_type = 2;
+
+  // The state the workflow was in before this event. Empty on the first event.
+  string from_state = 3;
+
+  // The state the workflow moved into. Empty on terminal events.
+  string to_state = 4;
+
+  // Current status of the run at the time of this event.
+  WorkflowStatus status = 5;
+
+  // Wall-clock time the adapter emitted this event.
+  google.protobuf.Timestamp timestamp = 6;
+
+  // Optional JSON-encoded event payload (e.g. signal data, error details).
+  bytes payload = 7;
+}
+
+// SubmitWorkflowRequest carries the compiled workflow for execution.
+message SubmitWorkflowRequest {
+  // The compiled workflow to execute. Required.
+  WorkflowIR workflow_ir = 1;
+
+  // Preferred execution engine. The adapter selects the default engine when
+  // empty. Format: lowercase identifier, e.g. "temporal", "langgraph", "argo".
+  string engine_hint = 2;
+
+  // Namespace override. Defaults to WorkflowIR.namespace when empty.
+  string namespace = 3;
+
+  // Arbitrary key-value metadata attached to the run for filtering and
+  // observability. Forwarded verbatim to GetWorkflowStatus and WatchWorkflow.
+  map<string, string> labels = 4;
+}
+
+// SubmitWorkflowResponse confirms acceptance and returns the adapter-assigned id.
+message SubmitWorkflowResponse {
+  // Adapter-assigned unique identifier for this execution instance.
+  string run_id = 1;
+
+  // Wall-clock time the adapter recorded the submission.
+  google.protobuf.Timestamp submitted_at = 2;
+}
+
+// SignalWorkflowRequest delivers an external event to a running workflow.
+message SignalWorkflowRequest {
+  // The run to signal. Required: empty string returns INVALID_ARGUMENT.
+  string run_id = 1;
+
+  // The event type to deliver to the workflow's state machine.
+  // Required: empty string returns INVALID_ARGUMENT.
+  string event_type = 2;
+
+  // Optional JSON-encoded payload accompanying the signal.
+  bytes payload = 3;
+}
+
+// SignalWorkflowResponse confirms the signal was delivered.
+message SignalWorkflowResponse {
+  // Wall-clock time the adapter delivered the signal to the engine.
+  google.protobuf.Timestamp signalled_at = 1;
+}
+
+// CancelWorkflowRequest identifies the run to cancel.
+message CancelWorkflowRequest {
+  // The run to cancel. Required: empty string returns INVALID_ARGUMENT.
+  string run_id = 1;
+
+  // Human-readable reason stored on the run record.
+  // Surfaced in operator dashboards and workflow logs.
+  string reason = 2;
+}
+
+// CancelWorkflowResponse confirms the cancellation was recorded.
+message CancelWorkflowResponse {
+  // Wall-clock time the adapter recorded the cancellation.
+  google.protobuf.Timestamp cancelled_at = 1;
+}
+
+// GetWorkflowStatusRequest identifies the run to query.
+message GetWorkflowStatusRequest {
+  // Required: empty string returns INVALID_ARGUMENT.
+  string run_id = 1;
+}
+
+// WatchWorkflowRequest identifies the run to observe.
+message WatchWorkflowRequest {
+  // Required: empty string returns INVALID_ARGUMENT.
+  string run_id = 1;
+}


### PR DESCRIPTION
## Why

Closes #6
Epic: #1 (M1 Contracts Foundation)
Depends on: #5 (merged — imports `WorkflowIR`)

The engine adapter is the boundary between the Zynax control plane and execution engines (Temporal, LangGraph, Argo). Any system implementing this contract becomes a pluggable execution backend — the control plane never knows which engine is running underneath. Without this contract the engine abstraction (ADR-015) cannot be implemented.

## What Changed

- `test:` **BDD contract specification** — `protos/tests/features/engine_adapter_service.feature` with 24 scenarios, written before the proto per ADR-004
- `feat:` **`engine_adapter.proto`** — EngineAdapterService with 5 RPCs (including one server-streaming), 4 messages, 1 enum

## Type of Change

- [x] `feat` — new capability
- [x] `test` — BDD specification (first commit)

## PR Size Self-Check

Lines changed (excluding generated code, lock files, fixtures): ~394

- [x] ≤ 400 lines — proceed

## Engineering Checklist

**Git hygiene**
- [x] Every commit follows Conventional Commits format
- [x] Every commit has `Signed-off-by:` (DCO)
- [x] Branch rebased onto current `main`

**BDD**
- [x] `.feature` file committed before proto (commit 1 of 2)
- [x] 24 scenarios: submission, signals, cancellation, status query, watch stream, input validation

**Architecture**
- [x] Imports `WorkflowIR` from `workflow_compiler.proto` — compiled IR is the only input, keeping YAML (Layer 1) fully decoupled from execution (Layer 3)
- [x] `run_id` is adapter-assigned on `SubmitWorkflow`
- [x] Terminal statuses immutable — `Signal`/`Cancel` return `FAILED_PRECONDITION`
- [x] `WatchWorkflow` stream mirrors `AgentService.ExecuteCapability` pattern: progress events → exactly one terminal event → stream closes
- [x] No breaking changes to existing contracts

## Proto Contract Summary

```
service EngineAdapterService
  rpc SubmitWorkflow(SubmitWorkflowRequest)          → SubmitWorkflowResponse
  rpc SignalWorkflow(SignalWorkflowRequest)          → SignalWorkflowResponse
  rpc CancelWorkflow(CancelWorkflowRequest)          → CancelWorkflowResponse
  rpc GetWorkflowStatus(GetWorkflowStatusRequest)    → WorkflowRun
  rpc WatchWorkflow(WatchWorkflowRequest)            → stream WorkflowEvent

message WorkflowRun    run_id, workflow_id, namespace, status, current_state,
                       labels, engine, submitted_at, started_at,
                       finished_at, cancellation_reason
message WorkflowEvent  run_id, event_type, from_state, to_state,
                       status, timestamp, payload
enum WorkflowStatus    UNSPECIFIED(0) | PENDING(1) | RUNNING(2)
                       | COMPLETED(3) | FAILED(4) | CANCELLED(5)
```

## Feature Files

- [`protos/tests/features/engine_adapter_service.feature`](protos/tests/features/engine_adapter_service.feature) — committed as first commit (ADR-004 compliant)

## AI Assistance

- [x] AI-assisted — tool/model: Claude Code / claude-sonnet-4-6
      Assisted-by: Claude Code/claude-sonnet-4-6

🤖 Generated with [Claude Code](https://claude.com/claude-code)