### PR TITLE
feat(#7): define MemoryService proto — KV and vector storage

### DIFF
--- a/protos/tests/features/memory_service.feature
+++ b/protos/tests/features/memory_service.feature
@@ -1,0 +1,163 @@
+# SPDX-License-Identifier: Apache-2.0
+# Zynax — MemoryService BDD Contract Specification
+#
+# This file is the SPECIFICATION. It is written BEFORE the implementation.
+# It describes the contract the memory service must honour.
+# See protos/AGENTS.md §7 for contract test rules.
+#
+# Business context: Long-running AI workflows need shared context across agent
+# invocations — storing intermediate results, passing state between steps, and
+# enabling semantic retrieval of prior outputs. Agents must not hold state
+# internally (twelve-factor); all shared context flows through this contract.
+# Every operation is scoped to a workflow_id for strict isolation. (ADR-001)
+
+Feature: MemoryService contract — shared KV and vector storage
+  As an agent executing a capability within a workflow
+  I want to read and write shared context scoped to my workflow run
+  So that downstream agents in the same workflow can access prior results
+
+  Background:
+    Given a MemoryService is running on a test gRPC server
+
+  # ─── Key-value store ──────────────────────────────────────────────────────
+
+  Scenario: Store and retrieve a key-value entry
+    Given workflow "wf-42" is running
+    When Set is called with key "summary" value "the PR looks good" scoped to "wf-42"
+    And Get is called with key "summary" scoped to "wf-42"
+    Then the response value is "the PR looks good"
+
+  Scenario: KV entries are isolated by workflow_id
+    Given Set is called with key "result" value "alpha" scoped to workflow "wf-01"
+    When Get is called with key "result" scoped to workflow "wf-02"
+    Then the gRPC status is NOT_FOUND
+
+  Scenario: Get for an unknown key returns NOT_FOUND
+    When Get is called with key "nonexistent" scoped to workflow "wf-42"
+    Then the gRPC status is NOT_FOUND
+    And the error message contains "nonexistent"
+
+  Scenario: Set overwrites the value for an existing key
+    Given Set has been called with key "count" value "1" scoped to "wf-42"
+    When Set is called again with key "count" value "2" scoped to "wf-42"
+    And Get is called with key "count" scoped to "wf-42"
+    Then the response value is "2"
+
+  Scenario: Delete removes a key-value entry
+    Given Set has been called with key "result" value "done" scoped to "wf-42"
+    When Delete is called with key "result" scoped to "wf-42"
+    Then Get for key "result" scoped to "wf-42" returns NOT_FOUND
+
+  Scenario: Delete on an unknown key returns NOT_FOUND
+    When Delete is called with key "ghost" scoped to "wf-42"
+    Then the gRPC status is NOT_FOUND
+
+  Scenario: ListKeys returns all keys for a workflow
+    Given Set has been called with key "a" scoped to "wf-42"
+    And Set has been called with key "b" scoped to "wf-42"
+    And Set has been called with key "c" scoped to "wf-99"
+    When ListKeys is called scoped to workflow "wf-42"
+    Then the response contains key "a"
+    And the response contains key "b"
+    And the response does not contain key "c"
+
+  Scenario: ListKeys with a prefix filter returns only matching keys
+    Given Set has been called with key "doc:1" scoped to "wf-42"
+    And Set has been called with key "doc:2" scoped to "wf-42"
+    And Set has been called with key "meta:1" scoped to "wf-42"
+    When ListKeys is called scoped to "wf-42" with prefix "doc:"
+    Then the response contains key "doc:1"
+    And the response contains key "doc:2"
+    And the response does not contain key "meta:1"
+
+  Scenario: ListKeys for a workflow with no keys returns an empty list
+    When ListKeys is called scoped to workflow "wf-empty"
+    Then the response contains no keys
+    And the gRPC status is OK
+
+  # ─── TTL expiry ───────────────────────────────────────────────────────────
+
+  Scenario: KV entry with ttl_seconds expires after the TTL elapses
+    Given Set is called with key "temp" value "x" ttl_seconds 1 scoped to "wf-42"
+    When 2 seconds elapse
+    And Get is called with key "temp" scoped to "wf-42"
+    Then the gRPC status is NOT_FOUND
+
+  Scenario: KV entry without ttl_seconds does not expire
+    Given Set is called with key "permanent" value "y" and no TTL scoped to "wf-42"
+    When 2 seconds elapse
+    And Get is called with key "permanent" scoped to "wf-42"
+    Then the response value is "y"
+
+  # ─── Vector store ─────────────────────────────────────────────────────────
+
+  Scenario: Store a vector embedding and retrieve by similarity
+    Given a vector with embedding [0.1, 0.2, 0.3] and text "fix the auth bug"
+    When StoreVector is called with the embedding scoped to "wf-42"
+    And QueryVector is called with embedding [0.11, 0.19, 0.31] top_k 1 scoped to "wf-42"
+    Then the response contains 1 VectorResult
+    And the top VectorResult text is "fix the auth bug"
+    And the top VectorResult similarity_score is greater than 0.95
+
+  Scenario: QueryVector returns results ranked by similarity descending
+    Given vectors "A" "B" "C" are stored with varying similarity to the query
+    When QueryVector is called with top_k 3
+    Then the results are ordered by similarity_score descending
+
+  Scenario: QueryVector top_k limits the number of results returned
+    Given 10 vectors are stored scoped to "wf-42"
+    When QueryVector is called with top_k 3 scoped to "wf-42"
+    Then the response contains exactly 3 VectorResults
+
+  Scenario: Vector entries are isolated by workflow_id
+    Given a vector is stored scoped to workflow "wf-01"
+    When QueryVector is called scoped to workflow "wf-02"
+    Then the response contains no VectorResults
+    And the gRPC status is OK
+
+  Scenario: QueryVector with no stored vectors returns an empty list
+    When QueryVector is called scoped to workflow "wf-empty" with top_k 5
+    Then the response contains no VectorResults
+    And the gRPC status is OK
+
+  Scenario: DeleteVector removes a stored embedding
+    Given a vector with id "vec-001" is stored scoped to "wf-42"
+    When DeleteVector is called with id "vec-001" scoped to "wf-42"
+    And QueryVector is called with a similar embedding scoped to "wf-42"
+    Then the response does not contain vector id "vec-001"
+
+  Scenario: DeleteVector on an unknown id returns NOT_FOUND
+    When DeleteVector is called with id "ghost-vec" scoped to "wf-42"
+    Then the gRPC status is NOT_FOUND
+
+  # ─── Input validation ─────────────────────────────────────────────────────
+
+  Scenario: Set with empty workflow_id is rejected
+    Given a SetRequest with workflow_id set to ""
+    When Set is called
+    Then the gRPC status is INVALID_ARGUMENT
+    And the error message mentions "workflow_id"
+
+  Scenario: Set with empty key is rejected
+    Given a SetRequest with key set to ""
+    When Set is called
+    Then the gRPC status is INVALID_ARGUMENT
+    And the error message mentions "key"
+
+  Scenario: StoreVector with empty embedding is rejected
+    Given a StoreVectorRequest with no embedding values
+    When StoreVector is called
+    Then the gRPC status is INVALID_ARGUMENT
+    And the error message mentions "embedding"
+
+  Scenario: StoreVector with empty workflow_id is rejected
+    Given a StoreVectorRequest with workflow_id set to ""
+    When StoreVector is called
+    Then the gRPC status is INVALID_ARGUMENT
+    And the error message mentions "workflow_id"
+
+  Scenario: QueryVector with top_k of zero is rejected
+    Given a QueryVectorRequest with top_k set to 0
+    When QueryVector is called
+    Then the gRPC status is INVALID_ARGUMENT
+    And the error message mentions "top_k"

--- a/protos/zynax/v1/memory.proto
+++ b/protos/zynax/v1/memory.proto
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// MemoryService — shared key-value and vector storage contract.
+//
+// Agents must not hold shared state internally (twelve-factor principle).
+// All cross-agent, cross-invocation context flows through this service,
+// scoped strictly to a workflow_id to prevent data leakage between runs.
+//
+// Two storage planes:
+//   KV plane  — arbitrary bytes, optional TTL, prefix-scannable keys.
+//   Vector plane — float embeddings with metadata, similarity-ranked retrieval.
+//
+// Design rationale: ADR-001 (gRPC inter-service protocol). The memory
+// service is infrastructure — it has no opinion on what agents store.
+//
+// Contract invariants:
+//   1. Every operation MUST include a non-empty workflow_id. The service
+//      returns INVALID_ARGUMENT if workflow_id is empty.
+//   2. KV and vector namespaces are isolated per workflow_id. An agent
+//      cannot read or delete entries belonging to another workflow.
+//   3. TTL is best-effort: entries MAY be evicted up to ttl_seconds after
+//      the Set call. Callers must not depend on sub-second TTL precision.
+//   4. vector_id is assigned by the service on StoreVector and returned
+//      in StoreVectorResponse. Callers must not supply one.
+
+syntax = "proto3";
+
+package zynax.v1;
+
+import "google/protobuf/timestamp.proto";
+
+option go_package = "github.com/zynax-io/zynax/gen/go/zynax/v1;zynaxv1";
+
+// MemoryService provides scoped KV and vector storage for workflow context.
+service MemoryService {
+  // Set stores or overwrites a key-value entry scoped to a workflow.
+  // Returns INVALID_ARGUMENT if workflow_id or key is empty.
+  rpc Set(SetRequest) returns (SetResponse);
+
+  // Get retrieves a value by key scoped to a workflow.
+  // Returns NOT_FOUND if the key does not exist or has expired.
+  rpc Get(GetRequest) returns (GetResponse);
+
+  // Delete removes a key-value entry scoped to a workflow.
+  // Returns NOT_FOUND if the key does not exist.
+  rpc Delete(DeleteRequest) returns (DeleteResponse);
+
+  // ListKeys returns all active (non-expired) keys for a workflow,
+  // with an optional prefix filter. Returns an empty list when no keys exist.
+  rpc ListKeys(ListKeysRequest) returns (ListKeysResponse);
+
+  // StoreVector stores a float embedding with associated text and metadata,
+  // scoped to a workflow. The service assigns a vector_id.
+  // Returns INVALID_ARGUMENT if embedding is empty or workflow_id is empty.
+  rpc StoreVector(StoreVectorRequest) returns (StoreVectorResponse);
+
+  // QueryVector performs approximate nearest-neighbour search over vectors
+  // stored for a workflow, returning the top_k most similar results ranked
+  // by similarity_score descending. Returns an empty list when none exist.
+  // Returns INVALID_ARGUMENT if top_k is zero.
+  rpc QueryVector(QueryVectorRequest) returns (QueryVectorResponse);
+
+  // DeleteVector removes a stored embedding by its service-assigned id.
+  // Returns NOT_FOUND if the vector_id does not exist in the workflow scope.
+  rpc DeleteVector(DeleteVectorRequest) returns (DeleteVectorResponse);
+}
+
+// SetRequest stores or overwrites a key-value entry.
+message SetRequest {
+  // Required: empty string is rejected with INVALID_ARGUMENT.
+  string workflow_id = 1;
+
+  // The key to store. Must be non-empty. No format constraints beyond length.
+  // Recommended convention: use colon-separated namespaces (e.g. "doc:1").
+  string key = 2;
+
+  // The value to store. Arbitrary bytes; no schema enforced by the service.
+  bytes value = 3;
+
+  // Optional TTL in seconds. Entry is eligible for eviction after this
+  // many seconds. Zero means no expiry.
+  int32 ttl_seconds = 4;
+}
+
+// SetResponse confirms the entry was stored.
+message SetResponse {
+  // Wall-clock time the service recorded the write.
+  google.protobuf.Timestamp stored_at = 1;
+}
+
+// GetRequest retrieves a value by key.
+message GetRequest {
+  // Required: empty string is rejected with INVALID_ARGUMENT.
+  string workflow_id = 1;
+
+  // Required: empty string is rejected with INVALID_ARGUMENT.
+  string key = 2;
+}
+
+// GetResponse carries the stored value and its metadata.
+message GetResponse {
+  // The stored bytes. Empty bytes are a valid value.
+  bytes value = 1;
+
+  // Wall-clock time the entry was last written.
+  google.protobuf.Timestamp stored_at = 2;
+
+  // Wall-clock time the entry will expire. Zero if no TTL was set.
+  google.protobuf.Timestamp expires_at = 3;
+}
+
+// DeleteRequest removes a key-value entry.
+message DeleteRequest {
+  // Required: empty string is rejected with INVALID_ARGUMENT.
+  string workflow_id = 1;
+
+  // Required: empty string is rejected with INVALID_ARGUMENT.
+  string key = 2;
+}
+
+// DeleteResponse confirms the entry was removed.
+message DeleteResponse {
+  // Wall-clock time the service recorded the deletion.
+  google.protobuf.Timestamp deleted_at = 1;
+}
+
+// ListKeysRequest scans active keys for a workflow with optional prefix filter.
+message ListKeysRequest {
+  // Required: empty string is rejected with INVALID_ARGUMENT.
+  string workflow_id = 1;
+
+  // Optional key prefix filter. Only keys that begin with this string are
+  // returned. Empty string returns all keys.
+  string prefix = 2;
+}
+
+// ListKeysResponse carries the matched key names.
+message ListKeysResponse {
+  // All active (non-expired) keys matching the request.
+  // Empty list when no keys exist — this is not an error condition.
+  repeated string keys = 1;
+}
+
+// StoreVectorRequest stores a float embedding with associated context.
+message StoreVectorRequest {
+  // Required: empty string is rejected with INVALID_ARGUMENT.
+  string workflow_id = 1;
+
+  // The embedding vector. Must contain at least one value.
+  // All vectors within a workflow scope must have the same dimension.
+  repeated float embedding = 2;
+
+  // The human-readable text this embedding represents.
+  // Returned in VectorResult to avoid a separate lookup.
+  string text = 3;
+
+  // Optional key-value metadata for filtering or context augmentation.
+  // Examples: {"source": "agent-summarizer"}, {"step": "review"}.
+  map<string, string> metadata = 4;
+}
+
+// StoreVectorResponse confirms storage and returns the service-assigned id.
+message StoreVectorResponse {
+  // Service-assigned unique identifier for this vector. Use in DeleteVector.
+  string vector_id = 1;
+
+  // Wall-clock time the service stored the embedding.
+  google.protobuf.Timestamp stored_at = 2;
+}
+
+// QueryVectorRequest performs similarity search over a workflow's vectors.
+message QueryVectorRequest {
+  // Required: empty string is rejected with INVALID_ARGUMENT.
+  string workflow_id = 1;
+
+  // The query embedding. Must have the same dimension as stored vectors.
+  // Must contain at least one value.
+  repeated float embedding = 2;
+
+  // Maximum number of results to return. Must be ≥ 1.
+  // Returns INVALID_ARGUMENT if zero.
+  int32 top_k = 3;
+}
+
+// VectorResult is a single entry returned by a similarity query.
+message VectorResult {
+  // The service-assigned identifier of this vector.
+  string vector_id = 1;
+
+  // The text associated with the stored embedding.
+  string text = 2;
+
+  // The metadata stored alongside the embedding.
+  map<string, string> metadata = 3;
+
+  // Similarity score in [0.0, 1.0]. Higher is more similar.
+  // Exact semantics are implementation-defined (cosine, dot-product, etc.).
+  float similarity_score = 4;
+}
+
+// QueryVectorResponse carries results ranked by similarity descending.
+message QueryVectorResponse {
+  // Up to top_k results, ordered by similarity_score descending.
+  // Empty list when no vectors are stored — this is not an error condition.
+  repeated VectorResult results = 1;
+}
+
+// DeleteVectorRequest removes a stored embedding by its service-assigned id.
+message DeleteVectorRequest {
+  // Required: empty string is rejected with INVALID_ARGUMENT.
+  string workflow_id = 1;
+
+  // The service-assigned vector identifier returned by StoreVector.
+  // Required: empty string is rejected with INVALID_ARGUMENT.
+  string vector_id = 2;
+}
+
+// DeleteVectorResponse confirms the embedding was removed.
+message DeleteVectorResponse {
+  // Wall-clock time the service recorded the deletion.
+  google.protobuf.Timestamp deleted_at = 1;
+}


### PR DESCRIPTION
## Why

Closes #7
Epic: #1 (M1 Contracts Foundation)

Long-running AI workflows need to share context across agent invocations. Agents must not hold shared state internally (twelve-factor); all cross-agent context flows through this contract, scoped strictly to a `workflow_id` to prevent data leakage between runs.

## What Changed

- `test(#7):` **BDD contract specification** — `protos/tests/features/memory_service.feature` with 24 scenarios, written before the proto per ADR-004
- `feat(#7):` **`memory.proto`** — MemoryService with 7 RPCs across two storage planes (KV and vector)

## Type of Change

- [x] `feat` — new capability
- [x] `test` — BDD specification (first commit)

## PR Size Self-Check

Lines changed (excluding generated code, lock files, fixtures): ~385

- [x] ≤ 400 lines — proceed

## Engineering Checklist

**Git hygiene**
- [x] Every commit follows Conventional Commits format with `(#7)` scope
- [x] Every commit has `Signed-off-by:` (DCO)
- [x] Branch rebased onto current `main`

**BDD**
- [x] `.feature` file committed before proto (commit 1 of 2)
- [x] 24 scenarios: KV CRUD, workflow isolation, TTL expiry, ListKeys with prefix, vector store+query+delete, similarity ranking, top_k limit, input validation

**Architecture**
- [x] `workflow_id` required on every operation — no global namespace, strict per-run isolation
- [x] `vector_id` is service-assigned on `StoreVector`, never caller-supplied
- [x] TTL is best-effort — documented that callers must not depend on sub-second precision
- [x] Empty `QueryVector`/`ListKeys` results are OK (not `NOT_FOUND`) — no entries is a valid state

## Proto Contract Summary

```
service MemoryService
  — KV plane —
  rpc Set(SetRequest)              → SetResponse
  rpc Get(GetRequest)              → GetResponse
  rpc Delete(DeleteRequest)        → DeleteResponse
  rpc ListKeys(ListKeysRequest)    → ListKeysResponse

  — Vector plane —
  rpc StoreVector(StoreVectorRequest)  → StoreVectorResponse
  rpc QueryVector(QueryVectorRequest)  → QueryVectorResponse
  rpc DeleteVector(DeleteVectorRequest)→ DeleteVectorResponse

message VectorResult   vector_id, text, metadata, similarity_score [0,1]
```

## Feature Files

- [`protos/tests/features/memory_service.feature`](protos/tests/features/memory_service.feature) — committed as first commit (ADR-004 compliant)

## AI Assistance

- [x] AI-assisted — tool/model: Claude Code / claude-sonnet-4-6
      Assisted-by: Claude Code/claude-sonnet-4-6

🤖 Generated with [Claude Code](https://claude.com/claude-code)