### PR TITLE
feat(#8): define EventBusService proto — pub/sub contract

### DIFF
--- a/protos/tests/features/cloudevents_envelope.feature
+++ b/protos/tests/features/cloudevents_envelope.feature
@@ -1,0 +1,136 @@
+# SPDX-License-Identifier: Apache-2.0
+# Zynax — CloudEvents Envelope BDD Contract Specification
+#
+# This file is the SPECIFICATION. It is written BEFORE the implementation.
+# It describes the contract the CloudEvent envelope must honour.
+# See protos/AGENTS.md §7 for contract test rules.
+#
+# Business context: All async events in Zynax must be interoperable with the
+# cloud-native ecosystem. CloudEvents is the CNCF standard for describing event
+# data in a common way. Every event published to the event bus uses a
+# CloudEvents-compatible envelope so external consumers (monitoring, audit,
+# third-party tooling) can process events without Zynax-specific clients.
+# (ADR-001, CloudEvents v1.0 spec)
+
+Feature: CloudEvents-compatible event envelope
+  As a platform operator
+  I want all Zynax events to conform to the CloudEvents specification
+  So that any CloudEvents-compatible consumer can process them without custom code
+
+  # ─── Schema validation ────────────────────────────────────────────────────
+
+  Scenario: A valid CloudEvent passes schema validation
+    Given a JSON object with required fields: specversion "1.0", id "evt-001", source "/zynax/wf-42", type "zynax.workflow.completed", datacontenttype "application/json"
+    When the envelope is validated against the Zynax CloudEvent JSON Schema
+    Then validation passes with zero errors
+
+  Scenario: A CloudEvent missing the id field is rejected
+    Given a valid CloudEvent JSON with the "id" field removed
+    When the envelope is validated against the Zynax CloudEvent JSON Schema
+    Then validation fails
+    And the error names the missing field "id"
+
+  Scenario: A CloudEvent missing the source field is rejected
+    Given a valid CloudEvent JSON with the "source" field removed
+    When the envelope is validated against the Zynax CloudEvent JSON Schema
+    Then validation fails
+    And the error names the missing field "source"
+
+  Scenario: A CloudEvent missing the specversion field is rejected
+    Given a valid CloudEvent JSON with the "specversion" field removed
+    When the envelope is validated against the Zynax CloudEvent JSON Schema
+    Then validation fails
+    And the error names the missing field "specversion"
+
+  Scenario: A CloudEvent missing the type field is rejected
+    Given a valid CloudEvent JSON with the "type" field removed
+    When the envelope is validated against the Zynax CloudEvent JSON Schema
+    Then validation fails
+    And the error names the missing field "type"
+
+  Scenario: specversion must be exactly "1.0"
+    Given a valid CloudEvent JSON with specversion set to "0.3"
+    When the envelope is validated against the Zynax CloudEvent JSON Schema
+    Then validation fails
+    And the error references the "specversion" field
+
+  Scenario: A CloudEvent with all optional fields passes validation
+    Given a valid CloudEvent JSON base
+    And the envelope includes optional field "datacontenttype" with value "application/json"
+    And the envelope includes optional field "subject" with value "wf-42/step-3"
+    When the envelope is validated against the Zynax CloudEvent JSON Schema
+    Then validation passes with zero errors
+
+  # ─── Zynax extension attributes ───────────────────────────────────────────
+
+  Scenario: Zynax extension attributes are accepted
+    Given a valid CloudEvent JSON base
+    And the envelope includes Zynax extension "workflow_id" with value "wf-42"
+    And the envelope includes Zynax extension "run_id" with value "run-abc"
+    And the envelope includes Zynax extension "namespace" with value "team-alpha"
+    When the envelope is validated against the Zynax CloudEvent JSON Schema
+    Then validation passes and extension attributes are preserved
+
+  Scenario: Zynax capability_name extension is accepted
+    Given a valid CloudEvent JSON base
+    And the envelope includes Zynax extension "capability_name" with value "code-review"
+    When the envelope is validated against the Zynax CloudEvent JSON Schema
+    Then validation passes with zero errors
+
+  Scenario: A CloudEvent without Zynax extension attributes is still valid
+    Given a valid CloudEvent JSON base with no Zynax extension fields
+    When the envelope is validated against the Zynax CloudEvent JSON Schema
+    Then validation passes with zero errors
+
+  # ─── Proto message structure ──────────────────────────────────────────────
+
+  Scenario: CloudEvent proto has all required fields
+    Given the CloudEvent proto message definition
+    Then it contains field "id" of type string
+    And it contains field "source" of type string
+    And it contains field "specversion" of type string
+    And it contains field "type" of type string
+    And it contains field "datacontenttype" of type string
+    And it contains field "time" of type google.protobuf.Timestamp
+    And it contains field "data" of type bytes
+
+  Scenario: CloudEvent proto has Zynax extension attribute fields
+    Given the CloudEvent proto message definition
+    Then it contains field "workflow_id" of type string
+    And it contains field "run_id" of type string
+    And it contains field "namespace" of type string
+    And it contains field "capability_name" of type string
+
+  # ─── Proto JSON round-trip ────────────────────────────────────────────────
+
+  Scenario: Proto representation round-trips through JSON
+    Given a CloudEvent proto message with id "evt-001" source "/zynax/wf-42" type "zynax.workflow.completed"
+    When it is serialised to JSON using proto-json encoding
+    And deserialised back to a CloudEvent proto message
+    Then the result is equal to the original message
+
+  Scenario: Proto round-trip preserves Zynax extension attributes
+    Given a CloudEvent proto message with workflow_id "wf-42" run_id "run-abc" namespace "team-alpha"
+    When it is serialised to JSON and deserialised back to proto
+    Then workflow_id is "wf-42"
+    And run_id is "run-abc"
+    And namespace is "team-alpha"
+
+  Scenario: Proto round-trip preserves binary data payload
+    Given a CloudEvent proto message with data bytes [0x01, 0x02, 0x03, 0xFF]
+    When it is serialised to JSON and deserialised back to proto
+    Then the data bytes equal [0x01, 0x02, 0x03, 0xFF]
+
+  # ─── Input validation ─────────────────────────────────────────────────────
+
+  Scenario: CloudEvent with empty id is structurally invalid
+    Given a CloudEvent JSON with id set to ""
+    When the envelope is validated against the Zynax CloudEvent JSON Schema
+    Then validation fails
+    And the error references the "id" field
+
+  Scenario: CloudEvent with empty source is structurally invalid
+    Given a CloudEvent JSON with source set to ""
+    When the envelope is validated against the Zynax CloudEvent JSON Schema
+    Then validation fails
+    And the error references the "source" field

--- a/protos/tests/features/event_bus_service.feature
+++ b/protos/tests/features/event_bus_service.feature
@@ -1,0 +1,168 @@
+# SPDX-License-Identifier: Apache-2.0
+# Zynax — EventBusService BDD Contract Specification
+#
+# This file is the SPECIFICATION. It is written BEFORE the implementation.
+# It describes the contract the event bus service must honour.
+# See protos/AGENTS.md §7 for contract test rules.
+#
+# Business context: Zynax workflows are event-driven state machines (ADR-014).
+# State transitions are triggered by events — "review.approved", "push",
+# "task.completed". These events flow through a central bus. All services
+# (workflow engine, task broker, adapters) must be able to publish and subscribe
+# to events via a stable contract. (ADR-001, ADR-014)
+
+Feature: EventBusService contract — async event publish/subscribe
+  As a workflow engine
+  I want to publish and subscribe to domain events
+  So that state transitions trigger automatically without polling
+
+  Background:
+    Given an EventBusService is running on a test gRPC server
+
+  # ─── Publish ──────────────────────────────────────────────────────────────
+
+  Scenario: Publish an event returns an event_id
+    Given a valid CloudEvent with type "zynax.workflow.review.approved" scoped to "wf-42"
+    When Publish is called with the event
+    Then the gRPC status is OK
+    And the response contains a non-empty event_id
+
+  Scenario: Published event is delivered to a matching subscriber
+    Given subscriber "sub-A" is listening to type pattern "zynax.workflow.*"
+    When Publish is called with a CloudEvent of type "zynax.workflow.review.approved"
+    Then subscriber "sub-A" receives the event
+    And the received event type is "zynax.workflow.review.approved"
+
+  Scenario: Published event is delivered to all matching subscribers
+    Given subscriber "sub-A" is listening to type pattern "zynax.workflow.*"
+    And subscriber "sub-B" is listening to type pattern "zynax.workflow.*"
+    When Publish is called with a CloudEvent of type "zynax.workflow.completed"
+    Then subscriber "sub-A" receives the event
+    And subscriber "sub-B" receives the event
+
+  Scenario: Published event is not delivered to a non-matching subscriber
+    Given subscriber "sub-A" is listening to type pattern "zynax.task.*"
+    When Publish is called with a CloudEvent of type "zynax.workflow.completed"
+    Then subscriber "sub-A" does not receive the event
+
+  Scenario: Publish with missing CloudEvent returns INVALID_ARGUMENT
+    Given a PublishRequest with no CloudEvent envelope
+    When Publish is called
+    Then the gRPC status is INVALID_ARGUMENT
+    And the error message mentions "event"
+
+  Scenario: Publish with empty workflow_id in event is accepted
+    Given a valid CloudEvent with an empty workflow_id field
+    When Publish is called with the event
+    Then the gRPC status is OK
+
+  # ─── Subscribe ────────────────────────────────────────────────────────────
+
+  Scenario: Subscribe streams CloudEvents matching the type pattern
+    Given subscriber "sub-A" subscribes with type pattern "zynax.workflow.*"
+    When a CloudEvent of type "zynax.workflow.review.approved" is published
+    Then the Subscribe stream delivers the CloudEvent to "sub-A"
+    And the delivered event has a non-empty id
+
+  Scenario: Subscribe filters events by workflow_id scope
+    Given subscriber "sub-A" subscribes with workflow_id scope "wf-1"
+    And subscriber "sub-B" subscribes with workflow_id scope "wf-2"
+    When a CloudEvent scoped to workflow_id "wf-1" is published
+    Then subscriber "sub-A" receives the event
+    And subscriber "sub-B" does not receive the event
+
+  Scenario: Subscribe with no workflow_id scope receives events for all workflows
+    Given subscriber "sub-A" subscribes with type pattern "zynax.*" and no workflow_id filter
+    When a CloudEvent scoped to "wf-1" is published
+    And a CloudEvent scoped to "wf-2" is published
+    Then subscriber "sub-A" receives both events
+
+  Scenario: Subscribe with empty subscriber_id returns INVALID_ARGUMENT
+    Given a SubscribeRequest with subscriber_id set to ""
+    When Subscribe is called
+    Then the gRPC status is INVALID_ARGUMENT
+    And the error message mentions "subscriber_id"
+
+  Scenario: Subscribe with empty type_pattern returns INVALID_ARGUMENT
+    Given a SubscribeRequest with type_pattern set to ""
+    When Subscribe is called
+    Then the gRPC status is INVALID_ARGUMENT
+    And the error message mentions "type_pattern"
+
+  Scenario: Subscribe stream stays open until Unsubscribe is called
+    Given subscriber "sub-keep" subscribes with type pattern "zynax.*"
+    When a CloudEvent is published
+    And Unsubscribe is not called
+    Then the Subscribe stream remains open
+    And "sub-keep" continues to receive subsequent events
+
+  # ─── Unsubscribe ──────────────────────────────────────────────────────────
+
+  Scenario: Unsubscribe stops event delivery
+    Given subscriber "sub-99" is actively subscribed to type pattern "zynax.*"
+    When Unsubscribe is called for subscriber_id "sub-99"
+    Then the gRPC status is OK
+    And a subsequent matching event is published
+    And "sub-99" receives no further events
+
+  Scenario: Unsubscribe closes the Subscribe stream cleanly
+    Given subscriber "sub-99" has an active Subscribe stream
+    When Unsubscribe is called for subscriber_id "sub-99"
+    Then the Subscribe stream closes with status OK
+
+  Scenario: Unsubscribe for unknown subscriber_id returns NOT_FOUND
+    When Unsubscribe is called for subscriber_id "ghost-sub"
+    Then the gRPC status is NOT_FOUND
+    And the error message contains "ghost-sub"
+
+  Scenario: Unsubscribe with empty subscriber_id returns INVALID_ARGUMENT
+    Given an UnsubscribeRequest with subscriber_id set to ""
+    When Unsubscribe is called
+    Then the gRPC status is INVALID_ARGUMENT
+    And the error message mentions "subscriber_id"
+
+  # ─── Glob pattern matching ────────────────────────────────────────────────
+
+  Scenario: Wildcard pattern matches multiple event type prefixes
+    Given subscriber "sub-A" subscribes with type pattern "zynax.*"
+    When a CloudEvent of type "zynax.workflow.completed" is published
+    And a CloudEvent of type "zynax.task.failed" is published
+    Then subscriber "sub-A" receives both events
+
+  Scenario: Exact pattern matches only the exact event type
+    Given subscriber "sub-A" subscribes with type pattern "zynax.workflow.completed"
+    When a CloudEvent of type "zynax.workflow.completed" is published
+    And a CloudEvent of type "zynax.workflow.started" is published
+    Then subscriber "sub-A" receives exactly 1 event
+
+  Scenario: Double-wildcard pattern matches nested event types
+    Given subscriber "sub-A" subscribes with type pattern "zynax.**"
+    When a CloudEvent of type "zynax.workflow.review.approved" is published
+    Then subscriber "sub-A" receives the event
+
+  # ─── SubscribeResponse metadata ───────────────────────────────────────────
+
+  Scenario: Subscribe response includes the subscriber_id
+    Given a SubscribeRequest with subscriber_id "sub-meta"
+    When Subscribe is called
+    Then the initial SubscribeResponse contains subscriber_id "sub-meta"
+
+  # ─── Input validation ─────────────────────────────────────────────────────
+
+  Scenario: Publish with CloudEvent missing required id field is rejected
+    Given a CloudEvent with id set to ""
+    When Publish is called
+    Then the gRPC status is INVALID_ARGUMENT
+    And the error message mentions "id"
+
+  Scenario: Publish with CloudEvent missing required source field is rejected
+    Given a CloudEvent with source set to ""
+    When Publish is called
+    Then the gRPC status is INVALID_ARGUMENT
+    And the error message mentions "source"
+
+  Scenario: Publish with CloudEvent missing required type field is rejected
+    Given a CloudEvent with type set to ""
+    When Publish is called
+    Then the gRPC status is INVALID_ARGUMENT
+    And the error message mentions "type"

--- a/protos/zynax/v1/cloudevents.proto
+++ b/protos/zynax/v1/cloudevents.proto
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// CloudEvent — CNCF CloudEvents v1.0 compatible event envelope.
+//
+// All async events in Zynax use this envelope so that external consumers
+// (monitoring, audit, third-party tooling) can process events without
+// Zynax-specific clients. Every event published to the EventBusService
+// is wrapped in a CloudEvent.
+//
+// Design rationale: ADR-001 (gRPC inter-service protocol). The CloudEvent
+// message follows the CloudEvents v1.0 specification attribute names and
+// semantics exactly, with Zynax-specific extension attributes added as
+// optional fields. Extension attribute names are lowercase with no
+// separators, matching the CloudEvents extension attribute naming rules.
+//
+// Contract invariants:
+//   1. specversion is always "1.0". Publishers MUST set this value.
+//   2. id, source, and type are required. Publishers MUST set these.
+//   3. Extension attributes (workflow_id, run_id, namespace,
+//      capability_name) are optional and may be empty.
+//   4. data is arbitrary bytes. datacontenttype indicates the media type.
+//   5. Field numbers are permanent (ADR-001 §backward-compat).
+
+syntax = "proto3";
+
+package zynax.v1;
+
+import "google/protobuf/timestamp.proto";
+
+option go_package = "github.com/zynax-io/zynax/gen/go/zynax/v1;zynaxv1";
+
+// CloudEvent is a CNCF CloudEvents v1.0 compatible event envelope.
+// All Zynax async events are wrapped in this message before publication
+// to the EventBusService.
+message CloudEvent {
+  // CloudEvents required attributes ─────────────────────────────────────────
+
+  // Unique identifier for this event. Required; MUST be non-empty.
+  // Producers SHOULD use a UUID or similar collision-resistant identifier.
+  string id = 1;
+
+  // URI reference identifying the event producer context.
+  // Required; MUST be non-empty. Example: "/zynax/wf-42/compiler".
+  string source = 2;
+
+  // The CloudEvents specification version. Always "1.0".
+  // Required; MUST equal "1.0".
+  string specversion = 3;
+
+  // The fully-qualified event type. Required; MUST be non-empty.
+  // Zynax convention: "zynax.<service>.<verb>" e.g. "zynax.workflow.completed".
+  string type = 4;
+
+  // CloudEvents optional attributes ─────────────────────────────────────────
+
+  // The content type of the data field (RFC 2046 media type).
+  // Recommended: "application/json", "application/octet-stream".
+  string datacontenttype = 5;
+
+  // A URI reference identifying the event subject within the source context.
+  // Example: "wf-42/step-review".
+  string subject = 6;
+
+  // Wall-clock time the event occurred, per the event producer.
+  google.protobuf.Timestamp time = 7;
+
+  // Arbitrary event payload bytes. Format described by datacontenttype.
+  bytes data = 8;
+
+  // Zynax extension attributes ──────────────────────────────────────────────
+  // Extension attribute names follow CloudEvents naming rules: lowercase,
+  // no separators, no collision with core attribute names.
+
+  // The workflow instance this event belongs to.
+  // Maps to CloudEvents extension "workflowid".
+  string workflow_id = 9;
+
+  // The execution run identifier assigned by the engine adapter.
+  // Maps to CloudEvents extension "runid".
+  string run_id = 10;
+
+  // The Zynax namespace the workflow runs in.
+  // Maps to CloudEvents extension "namespace".
+  string namespace = 11;
+
+  // The capability name that produced this event, when applicable.
+  // Maps to CloudEvents extension "capabilityname".
+  string capability_name = 12;
+}

--- a/protos/zynax/v1/event_bus.proto
+++ b/protos/zynax/v1/event_bus.proto
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// EventBusService — async event publish/subscribe contract.
+//
+// Zynax workflows are event-driven state machines (ADR-014). State transitions
+// are triggered by events — "review.approved", "push", "task.completed". All
+// events flow through this service as CloudEvent envelopes, enabling any
+// CloudEvents-compatible consumer to process them without Zynax-specific
+// clients.
+//
+// Design rationale: ADR-014 (event-driven workflow execution), ADR-001 (gRPC
+// inter-service protocol). Events are wrapped in CloudEvent envelopes
+// (cloudevents.proto) to ensure CNCF ecosystem interoperability.
+//
+// Contract invariants:
+//   1. Publish validates that id, source, and type are non-empty on the
+//      CloudEvent. Returns INVALID_ARGUMENT on validation failure.
+//   2. Subscribe streams CloudEvent messages to the caller until the
+//      caller calls Unsubscribe or the server closes the stream.
+//   3. type_pattern uses glob syntax: "*" matches a single segment,
+//      "**" matches zero or more segments. Empty pattern returns
+//      INVALID_ARGUMENT.
+//   4. workflow_id in SubscribeRequest is an optional scope filter.
+//      Empty string means "all workflows".
+//   5. event_id in PublishResponse is assigned by the service and
+//      uniquely identifies the published event within the bus.
+//   6. Field numbers are permanent (ADR-001 §backward-compat).
+
+syntax = "proto3";
+
+package zynax.v1;
+
+import "google/protobuf/timestamp.proto";
+import "zynax/v1/cloudevents.proto";
+
+option go_package = "github.com/zynax-io/zynax/gen/go/zynax/v1;zynaxv1";
+
+// EventBusService provides async event publish/subscribe for workflow-driven
+// state transitions and cross-service communication.
+service EventBusService {
+  // Publish submits a CloudEvent to the bus for delivery to all matching
+  // subscribers. Returns INVALID_ARGUMENT if the CloudEvent envelope is
+  // missing or has empty required fields (id, source, type).
+  rpc Publish(PublishRequest) returns (PublishResponse);
+
+  // Subscribe opens a server-streaming channel that delivers CloudEvents
+  // matching the subscriber's type_pattern and optional workflow_id scope.
+  // The stream remains open until Unsubscribe is called or the server closes
+  // it. Returns INVALID_ARGUMENT if subscriber_id or type_pattern is empty.
+  rpc Subscribe(SubscribeRequest) returns (stream SubscribeResponse);
+
+  // Unsubscribe closes the active Subscribe stream for a subscriber_id and
+  // stops event delivery. Returns NOT_FOUND if the subscriber_id is unknown.
+  // Returns INVALID_ARGUMENT if subscriber_id is empty.
+  rpc Unsubscribe(UnsubscribeRequest) returns (UnsubscribeResponse);
+}
+
+// PublishRequest carries the CloudEvent to publish to the bus.
+message PublishRequest {
+  // The CloudEvent envelope to publish. Required.
+  // id, source, and type must be non-empty or INVALID_ARGUMENT is returned.
+  CloudEvent event = 1;
+}
+
+// PublishResponse confirms the event was accepted by the bus.
+message PublishResponse {
+  // Service-assigned unique identifier for the published event.
+  string event_id = 1;
+
+  // Wall-clock time the service accepted the event for delivery.
+  google.protobuf.Timestamp accepted_at = 2;
+}
+
+// SubscribeRequest registers a subscriber and opens the event stream.
+message SubscribeRequest {
+  // Unique identifier for this subscriber. Required; must be non-empty.
+  // Used as the key for Unsubscribe.
+  string subscriber_id = 1;
+
+  // Glob pattern matched against the event type field of incoming CloudEvents.
+  // Required; must be non-empty.
+  // "*" matches a single dot-separated segment.
+  // "**" matches zero or more dot-separated segments.
+  // Example: "zynax.workflow.*" matches "zynax.workflow.completed" but not
+  // "zynax.task.failed".
+  string type_pattern = 2;
+
+  // Optional scope filter. When non-empty, only events whose CloudEvent
+  // workflow_id extension matches this value are delivered.
+  // Empty string means "all workflows".
+  string workflow_id = 3;
+}
+
+// SubscribeResponse is streamed to the subscriber for each matching event.
+message SubscribeResponse {
+  // The subscriber_id from the SubscribeRequest.
+  // Included in every message to allow multiplexing on the caller side.
+  string subscriber_id = 1;
+
+  // The delivered CloudEvent. Never empty on a data message.
+  CloudEvent event = 2;
+}
+
+// UnsubscribeRequest identifies the subscriber to remove.
+message UnsubscribeRequest {
+  // The subscriber_id to unsubscribe. Required; must be non-empty.
+  string subscriber_id = 1;
+}
+
+// UnsubscribeResponse confirms the subscriber was removed.
+message UnsubscribeResponse {
+  // Wall-clock time the service closed the subscription.
+  google.protobuf.Timestamp unsubscribed_at = 1;
+}

--- a/spec/schemas/cloudevent.schema.json
+++ b/spec/schemas/cloudevent.schema.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://zynax.io/schemas/cloudevent/v1.0",
+  "title": "Zynax CloudEvent Envelope",
+  "description": "JSON Schema for the Zynax CloudEvent envelope. Compatible with the CNCF CloudEvents v1.0 specification. All async events published to the EventBusService must conform to this schema.",
+  "type": "object",
+  "required": ["specversion", "id", "source", "type"],
+  "properties": {
+    "specversion": {
+      "type": "string",
+      "description": "The version of the CloudEvents specification. Must be '1.0'.",
+      "const": "1.0"
+    },
+    "id": {
+      "type": "string",
+      "description": "Unique identifier for this event. Must be non-empty.",
+      "minLength": 1
+    },
+    "source": {
+      "type": "string",
+      "description": "URI reference identifying the event producer context. Must be non-empty.",
+      "minLength": 1
+    },
+    "type": {
+      "type": "string",
+      "description": "The fully-qualified event type. Zynax convention: 'zynax.<service>.<verb>'. Must be non-empty.",
+      "minLength": 1
+    },
+    "datacontenttype": {
+      "type": "string",
+      "description": "The content type of the data field (RFC 2046 media type). Recommended: 'application/json'."
+    },
+    "subject": {
+      "type": "string",
+      "description": "A URI reference identifying the event subject within the source context."
+    },
+    "time": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Wall-clock time the event occurred (RFC 3339)."
+    },
+    "data": {
+      "description": "Arbitrary event payload. Format described by datacontenttype."
+    },
+    "workflow_id": {
+      "type": "string",
+      "description": "Zynax extension: the workflow instance this event belongs to. Maps to CloudEvents extension 'workflowid'."
+    },
+    "run_id": {
+      "type": "string",
+      "description": "Zynax extension: the execution run identifier assigned by the engine adapter. Maps to CloudEvents extension 'runid'."
+    },
+    "namespace": {
+      "type": "string",
+      "description": "Zynax extension: the Zynax namespace the workflow runs in. Maps to CloudEvents extension 'namespace'."
+    },
+    "capability_name": {
+      "type": "string",
+      "description": "Zynax extension: the capability name that produced this event. Maps to CloudEvents extension 'capabilityname'."
+    }
+  },
+  "additionalProperties": true
+}


### PR DESCRIPTION
Closes #8
⚠️ **Stack order**: merge #22 (CloudEvent envelope) into `main` before merging this PR. This branch is stacked on `feat/ISSUE-9-cloudevents-envelope` and imports `cloudevents.proto`.

## What
Defines the `EventBusService` gRPC contract for async event publish/subscribe. All workflow state transitions flow through this bus as CloudEvent envelopes.

## Deliverables
- `protos/zynax/v1/event_bus.proto` — `EventBusService` with three RPCs:
  - `Publish(PublishRequest) → PublishResponse` — submits a `CloudEvent` to the bus; validates required fields (`id`, `source`, `type`)
  - `Subscribe(SubscribeRequest) → stream SubscribeResponse` — opens an event stream; filtered by `type_pattern` (glob) and optional `workflow_id` scope
  - `Unsubscribe(UnsubscribeRequest) → UnsubscribeResponse` — closes an active subscription
- `protos/tests/features/event_bus_service.feature` — 23 BDD scenarios covering publish delivery, subscriber pattern matching, workflow_id scoping, unsubscribe lifecycle, and input validation

## Pattern matching
`type_pattern` uses glob syntax: `*` = single segment, `**` = zero or more segments. Validated non-empty on subscribe.

## PR Checklist
- [x] BDD `.feature` file committed before proto (BDD-first gate)
- [x] `buf lint` passes (zero errors)
- [x] `buf format` diff is empty
- [x] Imports `cloudevents.proto` — delivered by #22
- [x] `SubscribeResponse` wrapper used (not raw `CloudEvent`) — no `RPC_RESPONSE_STANDARD_NAME` exception needed
- [x] No breaking changes — initial definition
- [x] Depends on: #22 must merge first

🤖 Generated with [Claude Code](https://claude.com/claude-code)