### PR TITLE
feat(#11): capability schema and validate-spec target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,17 @@ clean-all: clean dev-down clean-tools ## ⚠ Remove everything
 # ── Spec validation ───────────────────────────────────────────────────────────
 .PHONY: validate-spec validate-asyncapi dry-run
 
-validate-spec: validate-asyncapi ## Validate all specs (AsyncAPI + workflow manifests)
+validate-spec: validate-asyncapi validate-capability-schemas ## Validate all specs (AsyncAPI + capability schemas)
+
+validate-capability-schemas: ## Validate capability declarations in spec/ against capability.schema.json
+	docker run --rm \
+		-v "$(PWD)":/workspace \
+		-w /workspace \
+		python:3.12-slim sh -c " \
+			pip install --quiet jsonschema pyyaml && \
+			python tools/validate_capabilities.py spec/schemas/capability.schema.json spec/workflows/examples/ \
+		"
+	@echo "✅ Capability schemas valid"
 
 validate-asyncapi: ## Validate spec/asyncapi/zynax-events.yaml via AsyncAPI CLI (Docker)
 	docker run --rm \

--- a/spec/schemas/capability.schema.json
+++ b/spec/schemas/capability.schema.json
@@ -1,0 +1,117 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://zynax.io/schemas/capability/v1.0",
+  "title": "Zynax Capability Declaration",
+  "description": "JSON Schema for a single capability declared inside an AgentDef manifest. Defines the input/output contract, timeout, and retry policy for one agent capability. Used by the task broker to validate task inputs at dispatch time and by tooling to generate type-safe clients.",
+  "type": "object",
+  "required": ["name"],
+  "additionalProperties": false,
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Unique identifier for this capability within the agent. Must be non-empty. Used as the routing key by the task broker.",
+      "minLength": 1
+    },
+    "description": {
+      "type": "string",
+      "description": "Human-readable explanation of what this capability does. Shown in the agent registry UI and generated documentation."
+    },
+    "input_schema": {
+      "$ref": "#/$defs/jsonSchemaObject",
+      "description": "JSON Schema object describing the expected task input payload. The task broker validates dispatch payloads against this schema. Omit if the capability accepts arbitrary input."
+    },
+    "output_schema": {
+      "$ref": "#/$defs/jsonSchemaObject",
+      "description": "JSON Schema object describing the task result payload. Downstream workflow steps and tooling use this to type-check outputs. Omit if the capability produces unstructured output."
+    },
+    "timeout_seconds": {
+      "type": "integer",
+      "description": "Maximum wall-clock seconds the capability may run before the task broker marks the task as FAILED. Must be a positive integer.",
+      "minimum": 1,
+      "default": 300
+    },
+    "max_retries": {
+      "type": "integer",
+      "description": "Maximum number of times the task broker will re-queue a failed task before marking it FAILED permanently. Zero means no retries.",
+      "minimum": 0,
+      "default": 0
+    }
+  },
+  "$defs": {
+    "jsonSchemaObject": {
+      "type": "object",
+      "description": "A JSON Schema object (draft 2020-12 subset). Must have type 'object' at the top level and declare properties.",
+      "required": ["type"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "object"
+        },
+        "description": {
+          "type": "string"
+        },
+        "properties": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/jsonSchemaField"
+          }
+        },
+        "required": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true
+        },
+        "additionalProperties": {
+          "type": "boolean"
+        }
+      }
+    },
+    "jsonSchemaField": {
+      "type": "object",
+      "description": "A single field definition within a JSON Schema properties map.",
+      "required": ["type"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["string", "integer", "number", "boolean", "array", "object", "null"],
+          "description": "The JSON Schema primitive type. Must be one of the seven standard types."
+        },
+        "description": {
+          "type": "string"
+        },
+        "default": {},
+        "enum": {
+          "type": "array"
+        },
+        "minimum": {
+          "type": "number"
+        },
+        "maximum": {
+          "type": "number"
+        },
+        "minLength": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "maxLength": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "items": {
+          "type": "object"
+        },
+        "properties": {
+          "type": "object"
+        },
+        "required": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/spec/tests/features/capability_schema.feature
+++ b/spec/tests/features/capability_schema.feature
@@ -1,0 +1,149 @@
+# SPDX-License-Identifier: Apache-2.0
+# Zynax — Capability Schema BDD Contract
+#
+# This file is the SPECIFICATION. It is written BEFORE the implementation.
+# It describes what the capability schema must enforce and how it integrates
+# with task dispatch validation.
+# See spec/AGENTS.md for spec governance rules.
+#
+# Business context: Every capability in Zynax has declared input and output
+# contracts. Without a machine-readable schema the platform cannot validate
+# task inputs at dispatch time, tooling cannot generate type-safe clients,
+# and workflow authors have no contract to write against. The capability
+# schema is the "OpenAPI spec" for individual agent capabilities. (ADR-013)
+
+Feature: Capability schema for input/output declarations
+  As a workflow author
+  I want to declare capability inputs and outputs with a schema
+  So that the platform can validate task data before dispatching
+
+  Background:
+    Given the JSON Schema at "spec/schemas/capability.schema.json" is loaded
+
+  # ─── Valid declarations ───────────────────────────────────────────────────
+
+  Scenario: A valid capability declaration passes schema validation
+    Given a capability declaration with name "summarize"
+    And the capability declares input_schema with fields: text (string), max_words (integer)
+    And the capability declares output_schema with fields: summary (string), word_count (integer)
+    When the declaration is validated against the capability schema
+    Then validation passes with zero errors
+
+  Scenario: A minimal capability with only required fields passes validation
+    Given a capability declaration with name "ping" and description "health check"
+    And no input_schema or output_schema is provided
+    When the declaration is validated against the capability schema
+    Then validation passes with zero errors
+
+  Scenario: A capability with timeout_seconds passes validation
+    Given a capability declaration with name "slow-job"
+    And timeout_seconds is set to 600
+    When the declaration is validated against the capability schema
+    Then validation passes with zero errors
+
+  Scenario: A capability with max_retries passes validation
+    Given a capability declaration with name "flaky-op"
+    And max_retries is set to 3
+    When the declaration is validated against the capability schema
+    Then validation passes with zero errors
+
+  Scenario: Optional fields with defaults are accepted when omitted
+    Given a capability declaration with name "code-review"
+    And neither timeout_seconds nor max_retries is specified
+    When the declaration is validated against the capability schema
+    Then validation passes with zero errors
+    And the default timeout_seconds is 300
+    And the default max_retries is 0
+
+  # ─── Required field validation ────────────────────────────────────────────
+
+  Scenario: A capability missing the name field is rejected
+    Given a capability declaration with no name field
+    When the declaration is validated against the capability schema
+    Then validation fails
+    And the error names the missing field "name"
+
+  Scenario: A capability with an empty name is rejected
+    Given a capability declaration with name set to ""
+    When the declaration is validated against the capability schema
+    Then validation fails
+    And the error references the "name" field
+
+  # ─── input_schema and output_schema structure ─────────────────────────────
+
+  Scenario: input_schema must be a valid JSON Schema object
+    Given a capability declaration with name "check"
+    And input_schema is set to a valid JSON Schema object with type "object"
+    When the declaration is validated against the capability schema
+    Then validation passes with zero errors
+
+  Scenario: output_schema must be a valid JSON Schema object
+    Given a capability declaration with name "check"
+    And output_schema is set to a valid JSON Schema object with type "object"
+    When the declaration is validated against the capability schema
+    Then validation passes with zero errors
+
+  Scenario: A capability with invalid input_schema type reference is rejected
+    Given a capability declaration with name "bad-cap"
+    And input_schema declares a field "count" with type "doesNotExist"
+    When the declaration is validated against the capability schema
+    Then validation fails
+    And the error names the invalid type on field "count"
+
+  Scenario: input_schema with nested object properties passes validation
+    Given a capability declaration with name "complex-cap"
+    And input_schema declares a nested object field "config" with sub-fields
+    When the declaration is validated against the capability schema
+    Then validation passes with zero errors
+
+  # ─── Field type constraints ───────────────────────────────────────────────
+
+  Scenario: timeout_seconds must be a positive integer
+    Given a capability declaration with name "timed"
+    And timeout_seconds is set to -1
+    When the declaration is validated against the capability schema
+    Then validation fails
+    And the error references the "timeout_seconds" field
+
+  Scenario: timeout_seconds must not be zero
+    Given a capability declaration with name "timed"
+    And timeout_seconds is set to 0
+    When the declaration is validated against the capability schema
+    Then validation fails
+    And the error references the "timeout_seconds" field
+
+  Scenario: max_retries must be a non-negative integer
+    Given a capability declaration with name "retryable"
+    And max_retries is set to -1
+    When the declaration is validated against the capability schema
+    Then validation fails
+    And the error references the "max_retries" field
+
+  Scenario: max_retries of zero is valid
+    Given a capability declaration with name "no-retry"
+    And max_retries is set to 0
+    When the declaration is validated against the capability schema
+    Then validation passes with zero errors
+
+  # ─── AgentDef YAML integration ────────────────────────────────────────────
+
+  Scenario: A valid AgentDef YAML with capability declarations passes validation
+    Given a YAML AgentDef at "spec/workflows/examples/agent-def-example.yaml"
+    When it is validated against the capability schema for each capability
+    Then all capability declarations pass with zero errors
+
+  Scenario: make validate-spec validates all AgentDef YAMLs in spec/
+    Given a Makefile exists at the repository root
+    When the "validate-spec" target is inspected
+    Then it validates YAML files in spec/ against capability.schema.json
+
+  # ─── Schema self-consistency ──────────────────────────────────────────────
+
+  Scenario: The capability schema itself is a valid JSON Schema document
+    When "spec/schemas/capability.schema.json" is validated as a JSON Schema
+    Then it is a valid draft 2020-12 JSON Schema document
+
+  Scenario: The capability schema has a title and description
+    When "spec/schemas/capability.schema.json" is parsed
+    Then the title field is present and non-empty
+    And the description field is present and non-empty

--- a/spec/workflows/examples/agent-def-example.yaml
+++ b/spec/workflows/examples/agent-def-example.yaml
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: Apache-2.0
+# Example AgentDef manifest — illustrates valid capability declarations.
+# Validated by: make validate-spec (against spec/schemas/capability.schema.json)
+
+apiVersion: zynax.io/v1alpha1
+kind: AgentDef
+metadata:
+  name: code-review-agent
+  namespace: default
+  labels:
+    team: platform
+
+capabilities:
+  - name: summarize
+    description: >
+      Produces a concise summary of a pull request diff.
+      Returns a plain-text summary and an estimated word count.
+    input_schema:
+      type: object
+      required: [text]
+      properties:
+        text:
+          type: string
+          description: The raw diff or PR body text to summarize.
+        max_words:
+          type: integer
+          description: Upper bound on summary length in words.
+          default: 200
+          minimum: 10
+    output_schema:
+      type: object
+      required: [summary, word_count]
+      properties:
+        summary:
+          type: string
+          description: The generated summary text.
+        word_count:
+          type: integer
+          description: Number of words in the returned summary.
+    timeout_seconds: 30
+    max_retries: 2
+
+  - name: score-complexity
+    description: >
+      Assigns a complexity score (1–10) to a code change based on
+      cyclomatic complexity heuristics.
+    input_schema:
+      type: object
+      required: [diff]
+      properties:
+        diff:
+          type: string
+          description: Unified diff of the code change.
+        language:
+          type: string
+          description: Programming language hint (e.g. "go", "python").
+    output_schema:
+      type: object
+      required: [score]
+      properties:
+        score:
+          type: integer
+          description: Complexity score from 1 (trivial) to 10 (very complex).
+          minimum: 1
+          maximum: 10
+        rationale:
+          type: string
+          description: Human-readable explanation of the score.
+    timeout_seconds: 15
+    max_retries: 1
+
+  - name: ping
+    description: Health-check capability. Returns immediately with no payload processing.
+    timeout_seconds: 5
+    max_retries: 0

--- a/tools/validate_capabilities.py
+++ b/tools/validate_capabilities.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Validates all capability declarations in AgentDef YAML files against
+# spec/schemas/capability.schema.json.
+# Usage: python tools/validate_capabilities.py <schema-path> <yaml-dir>
+import json
+import sys
+from pathlib import Path
+
+import jsonschema
+import yaml
+
+
+def main() -> None:
+    if len(sys.argv) != 3:
+        print("Usage: validate_capabilities.py <schema.json> <yaml-dir>")
+        sys.exit(1)
+
+    schema_path = Path(sys.argv[1])
+    yaml_dir = Path(sys.argv[2])
+
+    schema = json.loads(schema_path.read_text())
+    validator = jsonschema.Draft202012Validator(schema)
+
+    errors_found = False
+    for yaml_file in sorted(yaml_dir.glob("*.yaml")):
+        doc = yaml.safe_load(yaml_file.read_text())
+        capabilities = doc.get("capabilities", [])
+        if not capabilities:
+            continue
+        for cap in capabilities:
+            errs = sorted(validator.iter_errors(cap), key=lambda e: str(e.path))
+            if errs:
+                errors_found = True
+                print(f"FAIL {yaml_file.name} capability '{cap.get('name', '?')}':")
+                for e in errs:
+                    print(f"  {e.json_path}: {e.message}")
+            else:
+                print(f"  OK  {yaml_file.name} :: {cap.get('name', '?')}")
+
+    if errors_found:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #11

## What
Defines the machine-readable JSON Schema for capability input/output declarations, enabling the task broker to validate payloads at dispatch time and tooling to generate type-safe clients.

## Deliverables
- **`spec/schemas/capability.schema.json`** — JSON Schema (draft 2020-12) for a single capability declaration. Covers:
  - `name` (required, non-empty string) — routing key for task broker
  - `description` (optional string)
  - `input_schema` / `output_schema` — JSON Schema objects; field types validated against the 7 standard JSON Schema primitives (rejects unknown types like `doesNotExist`)
  - `timeout_seconds` (integer ≥ 1, default 300)
  - `max_retries` (integer ≥ 0, default 0)
- **`spec/workflows/examples/agent-def-example.yaml`** — AgentDef example with 3 capability declarations (`summarize`, `score-complexity`, `ping`) exercising all schema fields
- **`tools/validate_capabilities.py`** — Python validator script; iterates all `*.yaml` in a directory, extracts `capabilities[]`, validates each against the schema using `jsonschema` (Draft 2020-12)
- **`Makefile`** — `validate-capability-schemas` target runs the validator via `python:3.12-slim` Docker; `validate-spec` now depends on both `validate-asyncapi` and `validate-capability-schemas`
- **`spec/tests/features/capability_schema.feature`** — 19 BDD scenarios (BDD-first committed separately)

## PR Checklist
- [x] BDD `.feature` file committed before implementation
- [x] Schema rejects unknown types (enum constraint on field `type`)
- [x] `timeout_seconds` minimum is 1 (not 0 — zero would mean no timeout, which is a different thing)
- [x] `max_retries` minimum is 0 (zero retries is valid)
- [x] `additionalProperties: false` on top-level capability object — no undeclared fields
- [x] Schema self-validates as a valid JSON Schema document
- [x] Example YAML covers all optional fields and edge cases
- [x] `make validate-spec` depends on `validate-capability-schemas`
- [x] No proto changes — schema artifact only
- [x] Depends on: nothing new (standalone schema)

🤖 Generated with [Claude Code](https://claude.com/claude-code)