### PR TITLE
ci: Exclude generated artifacts from BDD-first gate

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -160,7 +160,7 @@ jobs:
             if [ "$has_impl" -gt 0 ] && [ -z "$feature_commit" ]; then
               subject=$(git log -1 --format="%s" "$sha")
               # Allow commits that only touch _test.go files (test helpers are OK)
-              non_test_impl=$(echo "$files" | grep -E "\.(go|py|ts)$" | grep -v "_test\." || true)
+              non_test_impl=$(echo "$files" | grep -E "\.(go|py|ts)$" | grep -v "_test\." | grep -v "^protos/generated/" || true)
               if [ -n "$non_test_impl" ]; then
                 violation="${sha:0:12}: ${subject}"
                 break


### PR DESCRIPTION
## Why

The `bdd-first` CI gate blocks commits that add `.go` or `.py` files without a
matching `.feature` file committed first. This is the right rule for hand-written
code, but `protos/generated/` contains the output of `buf generate` — machine-
produced files that have no BDD step definitions and must not be gated this way.

Without this exclusion, committing the initial proto stubs (issue #30) trips the
gate even though the BDD contract for the generation pipeline exists in the
`test/ISSUE-30-proto-stub-bdd-scenarios` PR that precedes it in the chain.

## What changed

Added `grep -v "^protos/generated/"` to the `non_test_impl` filter in
`.github/workflows/pr-checks.yml` so the gate ignores machine-generated proto
stubs while continuing to enforce BDD-first for all hand-written code.

## Part of PR chain for #30

```
PR 1 (this)  ci: Exclude generated artifacts from BDD-first gate
PR 2         test(protos): Add BDD scenarios for proto stub generation pipeline
PR 3         chore(protos): Commit initial generated Go and Python proto stubs  ← closes #30
```

## Test plan

- [ ] A commit containing only `protos/generated/` changes — BDD gate passes
- [ ] A commit containing new hand-written `.go` without a feature file — BDD gate still fails

AI assistance: Claude Code / claude-sonnet-4-6 (implementation, PR description)