### PR TITLE
test(protos): Add BDD scenarios for proto stub generation pipeline

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -160,7 +160,7 @@ jobs:
             if [ "$has_impl" -gt 0 ] && [ -z "$feature_commit" ]; then
               subject=$(git log -1 --format="%s" "$sha")
               # Allow commits that only touch _test.go files (test helpers are OK)
-              non_test_impl=$(echo "$files" | grep -E "\.(go|py|ts)$" | grep -v "_test\." || true)
+              non_test_impl=$(echo "$files" | grep -E "\.(go|py|ts)$" | grep -v "_test\." | grep -v "^protos/generated/" || true)
               if [ -n "$non_test_impl" ]; then
                 violation="${sha:0:12}: ${subject}"
                 break

--- a/protos/tests/features/stub_generation.feature
+++ b/protos/tests/features/stub_generation.feature
@@ -133,3 +133,35 @@ Feature: Proto stub generation pipeline
     Given all .proto files in protos/zynax/v1/ are present
     When buf format --diff --exit-code is run from the protos/ directory
     Then it reports no formatting differences
+
+  # ─── Committed generated stubs (#30) ──────────────────────────────────────
+  # These scenarios verify the initial generated stubs are committed to the
+  # repo, activating the proto-stubs-fresh freshness gate in CI.
+
+  Scenario: Go stubs are committed for every proto service
+    Given the repository contains protos/generated/go/zynax/v1/
+    Then it contains "agent.pb.go" and "agent_grpc.pb.go"
+    And it contains "agent_registry.pb.go" and "agent_registry_grpc.pb.go"
+    And it contains "task_broker.pb.go" and "task_broker_grpc.pb.go"
+    And it contains "workflow_compiler.pb.go" and "workflow_compiler_grpc.pb.go"
+    And it contains "engine_adapter.pb.go" and "engine_adapter_grpc.pb.go"
+    And it contains "memory.pb.go" and "memory_grpc.pb.go"
+    And it contains "event_bus.pb.go" and "event_bus_grpc.pb.go"
+    And it contains "cloudevents.pb.go"
+
+  Scenario: Python stubs are committed for every proto service
+    Given the repository contains protos/generated/python/zynax/v1/
+    Then it contains "agent_pb2.py" and "agent_pb2_grpc.py"
+    And it contains "agent_registry_pb2.py" and "agent_registry_pb2_grpc.py"
+    And it contains "task_broker_pb2.py" and "task_broker_pb2_grpc.py"
+    And it contains "workflow_compiler_pb2.py" and "workflow_compiler_pb2_grpc.py"
+    And it contains "engine_adapter_pb2.py" and "engine_adapter_pb2_grpc.py"
+    And it contains "memory_pb2.py" and "memory_pb2_grpc.py"
+    And it contains "event_bus_pb2.py" and "event_bus_pb2_grpc.py"
+    And it contains "cloudevents_pb2.py" and "cloudevents_pb2_grpc.py"
+
+  Scenario: Generated stubs are not excluded by .gitignore
+    Given the file ".gitignore" at the repository root
+    When the gitignore rules are inspected
+    Then "protos/generated/" is not excluded
+    And a comment confirms the stubs are intentionally committed


### PR DESCRIPTION
Part of #30
Stacked on #37 (ci: Exclude generated artifacts from BDD-first gate) — merge #37 first, then rebase this onto main before merging.

## Why

ADR-003 identifies generated proto stubs as the compilation boundary between
all platform services and agent adapters. ADR-004 (BDD-first) requires a
`.feature` file to be committed before the implementation it describes.

This PR adds the BDD contract for the `make generate-protos` pipeline before
the generated stubs themselves land. The scenarios define:

- Which `buf` plugins must be configured in `buf.gen.yaml` and their output paths
- Which Go and Python stub files must exist after generation (all 8 services)
- Expected Go package name and gRPC import in the generated stubs
- How the `proto-stubs-fresh` CI gate must respond to proto changes
- `buf lint` and `buf format` must pass with zero errors

The last group of scenarios (committed stubs) will remain pending until the
generated files land in the next PR in the chain.

## Part of PR chain for #30

```
PR 1  #37    ci: Exclude generated artifacts from BDD-first gate          [1 line]
PR 2  (this) test(protos): Add BDD scenarios for proto stub generation     [32 lines]
PR 3         chore(protos): Commit initial generated Go and Python stubs   ← closes #30
```

## Test plan

- [ ] `protos/tests/features/stub_generation.feature` is present
- [ ] BDD-first gate accepts this commit (no implementation files added)
- [ ] Scenarios for committed stubs are pending (stubs not yet in repo) — expected

AI assistance: Claude Code / claude-sonnet-4-6 (scenario drafting, PR description)