### PR TITLE
docs: Introduce layered testing strategy, scope BDD to boundaries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,9 +144,23 @@ Backing services as attached resources.
 - Python (agents/adapters): functions ≤ 20 lines. No `print()`. Types 100%.
 - Both: no magic numbers. No dead code. Comments explain WHY.
 
-### 4.4 BDD-First
-`.feature` file written before any implementation. Gherkin for both Go (godog)
-and Python (pytest-bdd). A feature without a passing scenario is not done.
+### 4.4 Layered Testing Strategy
+
+Four testing tiers — use the right one for the right scope (ADR-016).
+
+| Tier | Volume | What goes here |
+|------|--------|---------------|
+| BDD | 10–15% | Agent capability contracts, inter-service gRPC, E2E workflows |
+| Unit / property-based | ≥ 40% | Domain logic, routing, state transitions, message handling |
+| Contract | CI gate | Proto breaking-change detection, YAML manifest schema |
+| Simulation | As needed | Fault injection, retry storms, topology changes |
+
+**BDD-first at system boundaries:** `.feature` file committed before any
+boundary implementation. Gherkin for Go (godog) and Python (pytest-bdd).
+
+**TDD for domain logic:** Red → green → refactor. No `.feature` file required.
+
+**Property-based tests for invariants:** `hypothesis` (Python), `rapid` (Go).
 
 ---
 
@@ -377,8 +391,9 @@ Two ways to add execution capability:
 
 A feature is DONE when **ALL** are true:
 
-- [ ] `.feature` file written before implementation
-- [ ] All unit tests pass (`make test-unit`)
+- [ ] System-boundary features: `.feature` file committed before implementation
+- [ ] Domain logic: unit tests or property tests (≥ 90% coverage)
+- [ ] All tests pass (`make test-unit`)
 - [ ] Go: `golangci-lint` clean. Python: `ruff` + `mypy --strict` clean.
 - [ ] `make security` clean
 - [ ] Health probes correct
@@ -398,7 +413,8 @@ Breaking any of them is a hard blocker at code review.
 **Both layers:**
 - Never install tools on host — everything in Docker
 - Never commit secrets, tokens, or credentials
-- Never skip the `.feature` file — no feature exists without a passing scenario
+- System-boundary features require a `.feature` file before implementation (BDD-first)
+- Domain logic requires unit or property tests — `.feature` files are optional here
 - Never share a database between services
 - Never couple Layer 1 (YAML) to Layer 3 (engines)
 - Never make changes outside the stated scope of an issue or task

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ a reason, and knowing the reason makes it easier to apply in edge cases.
 4. [Engineering Standards](#4-engineering-standards)
 5. [Git Workflow & Commit Hygiene](#5-git-workflow--commit-hygiene)
 6. [PR Size & Decomposition](#6-pr-size--decomposition)
-7. [BDD-First Workflow](#7-bdd-first-workflow)
+7. [Layered Testing Strategy](#7-layered-testing-strategy)
 8. [Pull Request Process](#8-pull-request-process)
 9. [Code Review Etiquette](#9-code-review-etiquette)
 10. [Issue Workflow](#10-issue-workflow)
@@ -429,17 +429,35 @@ the code that uses it). In that case:
 
 ---
 
-## 7. BDD-First Workflow
+## 7. Layered Testing Strategy
 
-This is the required development flow for all features. No exceptions.
+Zynax uses a four-tier testing pyramid (ADR-016). Apply the right tier for the
+scope of the code you are writing — not every change needs a BDD scenario.
+
+### Which tier to use
+
+| Tier | When to use | Tools |
+|------|-------------|-------|
+| **BDD** | Agent contracts, inter-service gRPC, E2E workflows | pytest-bdd, godog |
+| **Unit / property-based** | Domain logic, routing, state transitions, message handling | pytest + hypothesis, testing + rapid |
+| **Contract** | Any proto or schema change | `buf breaking`, `make validate-spec` |
+| **Simulation** | Fault injection, retry storms, topology changes | testcontainers harness (coming) |
+
+### Tier 1: BDD — system boundaries only
+
+Use BDD when the behaviour you are defining is observable at a service boundary:
+a gRPC contract, a capability execution path, or a full workflow end-to-end.
+
+**Do NOT use BDD for** internal domain logic, scheduling algorithms, networking
+internals, or performance characteristics. Use unit or property-based tests instead.
+
+**BDD-first flow (required when BDD applies):**
 
 ```
-1. Write .feature file  →  2. Commit it  →  3. Implement steps  →  4. Write domain code  →  5. Pass tests
+1. Write .feature file  →  2. Commit it  →  3. Write step definitions  →  4. Write domain code  →  5. Pass
 ```
 
-### Step 1: Feature File First
-
-Before writing any Go or Python, create the `.feature` file:
+Commit the `.feature` file alone, before any implementation:
 
 ```gherkin
 # services/agent-registry/tests/features/capability_discovery.feature
@@ -454,17 +472,9 @@ Feature: Capability-based agent discovery
     When I query for agents with capability "summarize"
     Then I receive exactly two agents
     And none of the agents have only "search" capability
-
-  Scenario: No agents for an unknown capability
-    Given no agent is registered with capability "fly"
-    When I query for agents with capability "fly"
-    Then I receive an empty result
-    And no error is returned
 ```
 
-Commit the `.feature` file alone, before any implementation:
 ```bash
-git add services/agent-registry/tests/features/capability_discovery.feature
 git commit -s -m "test(agent-registry): add BDD scenarios for capability discovery
 
 Defines expected behaviour for capability-based agent lookup.
@@ -473,12 +483,72 @@ No implementation yet — scenarios will fail until domain code is added.
 Closes #123"
 ```
 
-### Step 2–4: Implement
+Only after the feature file is committed: write step definitions, then domain code.
+All scenarios must pass before the PR is opened.
 
-Only after the feature file is committed:
-1. Write step definitions (test code).
-2. Write domain code driven by failing tests.
-3. All scenarios must pass before the PR is opened.
+### Tier 2: Unit and property-based tests — domain logic
+
+Domain logic (routing algorithms, state transitions, message handlers) is tested
+with standard unit tests and property-based tests. No `.feature` file is required.
+
+Property tests express invariants that hold across the entire input space:
+
+```python
+# Python — hypothesis
+from hypothesis import given, strategies as st
+
+@given(st.lists(st.builds(Agent), min_size=1))
+def test_task_always_assigned(agents):
+    result = route_task(agents, task_id="t1")
+    assert result is not None
+```
+
+```go
+// Go — rapid
+func TestRoutingAlwaysAssigns(t *testing.T) {
+    rapid.Check(t, func(tc *rapid.T) {
+        agents := rapid.SliceOfN(genAgent(), 1, 10).Draw(tc, "agents").([]*Agent)
+        result, err := RouteTask(agents, "task-1")
+        require.NoError(t, err)
+        require.NotNil(t, result)
+    })
+}
+```
+
+### Tier 3: Contract tests — enforced by CI
+
+Every PR that touches `.proto` files must pass `buf breaking --against main`.
+Every PR that modifies YAML schemas must pass `make validate-spec`.
+These run automatically — no action needed beyond keeping them green.
+
+### Tier 4: Simulation tests — distributed faults
+
+For scenarios that require multiple agents, injected failures, or message
+drops, use the simulation harness in `tests/simulation/` (introduced in a
+follow-up PR). Write simulation tests for: retry storms, agent timeouts,
+topology changes, eventual consistency violations.
+
+### BDD as an AI prompting tool
+
+When using Claude or another AI assistant, write the `.feature` file first and
+ask the model to generate code that satisfies the scenarios. This forces precise
+behaviour definition before generation and dramatically improves output quality:
+
+```
+Feature: Task distribution
+
+  Scenario: Assign to least-loaded agent
+    Given 3 available agents with loads 2, 5, 1
+    When a task is submitted
+    Then it is assigned to the agent with load 1
+
+  Scenario: Reassign on agent failure
+    Given an agent is assigned a task
+    When the agent becomes unresponsive for 5 seconds
+    Then the task is reassigned to another agent
+```
+
+Then: "Generate production Go code that satisfies these scenarios, including tests."
 
 ---
 

--- a/docs/adr/ADR-004-bdd-testing.md
+++ b/docs/adr/ADR-004-bdd-testing.md
@@ -1,10 +1,16 @@
 # ADR-004: BDD as Primary Testing Methodology
 
-**Status:** Accepted  **Date:** 2025-04-01
+**Status:** Superseded by ADR-016  **Date:** 2025-04-01
+
+**Superseded by ADR-016, which scopes BDD to system boundaries and introduces
+unit/property-based and simulation tiers. The BDD-first workflow steps here remain
+correct and apply at system boundaries as defined in ADR-016.**
+
+---
 
 ## Decision
 Use Behavior-Driven Development (BDD) with Gherkin feature files as the
-primary testing methodology. Tool: `pytest-bdd`.
+testing methodology at system boundaries. Tool: `pytest-bdd`.
 
 ## Rationale
 - Feature files serve as living documentation readable by non-engineers.

--- a/docs/adr/ADR-016-layered-testing-strategy.md
+++ b/docs/adr/ADR-016-layered-testing-strategy.md
@@ -1,0 +1,98 @@
+# ADR-016: Layered Testing Strategy
+
+**Status:** Accepted  **Date:** 2026-04-21
+**Supersedes:** ADR-004 (BDD as Primary Testing Methodology)
+
+---
+
+## Context
+
+Zynax is a distributed, event-driven control plane with async state machines,
+eventual consistency, pluggable engine adapters, and dynamic agent topology.
+ADR-004 established BDD as the *primary* testing methodology. In practice, this
+creates two problems:
+
+1. **Noise at the wrong layer.** Gherkin is a poor fit for internal domain logic
+   (routing algorithms, state transitions, message handlers). Forcing `.feature`
+   files there produces verbose specs that test implementation details, slow down
+   iteration, and add no documentation value.
+
+2. **A gap at the distributed layer.** Classic unit and BDD tests cannot express
+   partial failures, retry storms, message drops, or dynamic topology changes.
+   The most important correctness properties of a mesh system are untestable with
+   the current approach.
+
+---
+
+## Decision
+
+Adopt a **four-tier testing pyramid**. BDD remains mandatory at system
+boundaries; the other tiers cover what BDD cannot.
+
+| Tier | Volume | Scope |
+|------|--------|-------|
+| BDD | 10–15% | System boundaries: agent contracts, inter-service gRPC, E2E flows |
+| Unit / property-based | ≥ 40% | Domain layer: routing, state transitions, message handling |
+| Contract | CI gate | Proto breaking-change detection, YAML manifest schema |
+| Simulation / fault injection | As needed | Failure modes, retries, topology changes |
+
+### Where BDD applies
+
+- **Agent capability contracts** — task delegation, retry logic, failure handling
+- **Inter-service gRPC contracts** — expected responses, error codes, edge cases
+- **End-to-end workflows** — YAML submitted → distributed → result aggregated
+
+BDD scenarios at these boundaries double as human-readable contract documentation
+and as a prompting tool when generating code with AI assistants (write the scenario
+first, then ask for code that satisfies it).
+
+### Where BDD does NOT apply
+
+- Internal domain logic (routing algorithms, scheduler, state machine internals)
+- Networking and transport layer
+- Performance and throughput
+- Low-level concurrency primitives
+
+Use unit tests and property-based tests for all of the above.
+
+### Property-based testing
+
+State machines and message handlers have invariants that hold across the entire
+input space, not just for the handful of examples a human writes. Property tests
+express these invariants and let the framework find counterexamples.
+
+Tools: `hypothesis` (Python), `rapid` or `go-fuzz` (Go).
+
+### Simulation / fault-injection testing
+
+Distributed robustness requires injecting failures that cannot be reproduced in
+unit tests: agent timeouts, dropped NATS messages, retry storms, nodes
+joining/leaving mid-workflow. A simulation harness using `testcontainers` with
+controlled fault injection is introduced as a follow-up to this ADR.
+
+---
+
+## Rationale
+
+| Concern | BDD-only | Layered |
+|---------|----------|---------|
+| Internal domain correctness | Verbose, fragile | Unit + property: fast, precise |
+| Distributed fault tolerance | Cannot express | Simulation harness |
+| Contract safety | Scenarios only | `buf breaking` + schema CI gate |
+| AI-assisted development | Feature file as prompt | Feature file as boundary prompt |
+| Documentation value | High at boundaries | High where BDD is used, zero noise elsewhere |
+
+---
+
+## Consequences
+
+- **DoD updated (AGENTS.md §11):** `.feature` file required only for
+  system-boundary features. Domain logic requires unit or property tests.
+- **Hard constraint updated (AGENTS.md §12):** BDD-first applies at boundaries;
+  domain code is TDD.
+- **BDD-first CI gate:** The existing `bdd-first` gate checks all `.go`/`.py`
+  files. A follow-up PR will scope it to boundary code only
+  (paths: `api/`, `tests/features/`, adapter entry points).
+- **Simulation harness:** Introduced in a follow-up PR under `tests/simulation/`.
+- **ADR-004** status updated to Superseded. Its BDD-first workflow steps remain
+  correct and apply at system boundaries as described here.


### PR DESCRIPTION
## Why

ADR-004 made BDD the primary testing methodology for all code. For a distributed,
event-driven control plane this creates two problems:

1. **Noise at the wrong layer.** Forcing `.feature` files on internal domain logic
   (routing algorithms, state machine internals, message handlers) produces verbose
   specs that test implementation details, slow iteration, and add no documentation
   value.

2. **A gap at the distributed layer.** BDD and unit tests cannot express retry
   storms, dropped messages, agent timeouts, or topology changes — the scenarios
   where Zynax must be most robust.

## What this PR does

Introduces **ADR-016** (layered testing pyramid) and updates the engineering
contract and contributor guide to reflect it.

### New four-tier pyramid

| Tier | Volume | Scope |
|------|--------|-------|
| BDD | 10–15% | Agent contracts, inter-service gRPC, E2E workflows |
| Unit / property-based | ≥ 40% | Domain logic, routing, state transitions |
| Contract | CI gate | Proto breaking changes, YAML manifest schema |
| Simulation | As needed | Fault injection, retry storms, topology changes |

BDD remains mandatory **at system boundaries**. Domain logic is TDD +
property-based. This matches how the architecture is actually layered.

### Files changed

| File | Change |
|------|--------|
| `docs/adr/ADR-016-layered-testing-strategy.md` | New ADR — full decision record |
| `docs/adr/ADR-004-bdd-testing.md` | Status: Superseded by ADR-016 |
| `AGENTS.md §4.4` | BDD-First → Layered Testing table |
| `AGENTS.md §11` | DoD split: boundary feature requires `.feature`; domain requires unit/property |
| `AGENTS.md §12` | Hard constraint scoped to system boundaries |
| `CONTRIBUTING.md §7` | Full rewrite: four tiers, examples, BDD-as-AI-prompting-tool pattern |

### Not in this PR (follow-ups required)

- Scope the `bdd-first` CI gate to boundary paths (`api/`, `tests/features/`) — currently it flags all `.go`/`.py`
- Add `hypothesis` (Python) and `rapid` (Go) to tooling configs
- Introduce `tests/simulation/` fault-injection harness

## Review note

Per CONTRIBUTING.md §8, changes to `AGENTS.md` require a **5-day comment period**
before merge. Please treat this PR accordingly.

AI assistance: Claude Code / claude-sonnet-4-6 (ADR drafting, doc updates)