### PR TITLE
docs: M1 milestone engineering review and release notes

### DIFF
--- a/docs/milestones/M1-engineering-review.md
+++ b/docs/milestones/M1-engineering-review.md
@@ -1,0 +1,317 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Zynax M1 — Engineering Review
+**Milestone:** Contracts Foundation · **Target version:** v0.1.0  
+**Date:** 2026-04-21 · **Author:** Engineering
+
+---
+
+## Executive Summary
+
+Milestone 1 establishes the **contractual foundation** of the Zynax distributed
+AI workflow control plane. No service is implemented yet; this is intentional.
+The strategic bet is that defining and machine-verifying all communication
+contracts *before* any implementation begins eliminates the most expensive
+class of distributed system failure: silent contract drift between services.
+
+Every byte of production code written in M2+ has a verified contract waiting
+for it. No engineer needs to read a wiki or ask what a service is supposed to
+return — the answer is in a `.feature` file, enforced by a CI gate.
+
+---
+
+## What Zynax Is
+
+Zynax is a **declarative control plane for AI agent workflows**. Operators
+describe multi-step AI workflows in YAML. Zynax compiles those manifests,
+orchestrates their execution across any runtime (Temporal, LangGraph, Argo
+Workflows), and dispatches capability invocations to AI agents — without the
+control plane knowing or caring which engine or agent is underneath.
+
+The core design invariant: **the control plane is swappable at every boundary.**
+Swap the execution engine without touching the compiler. Swap an AI agent
+without touching the broker. Every swap point is a gRPC contract.
+
+---
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Layer 1 — Intent                                               │
+│                                                                 │
+│   YAML Manifest  ──►  API Gateway                               │
+└─────────────────────────────┬───────────────────────────────────┘
+                              │ CompileWorkflow(manifest_yaml)
+┌─────────────────────────────▼───────────────────────────────────┐
+│  Layer 2 — Control Plane (Go services)                          │
+│                                                                 │
+│  WorkflowCompilerService                                        │
+│    YAML → WorkflowIR (engine-agnostic compiled representation)  │
+│                      │ SubmitWorkflow(WorkflowIR)               │
+│  EngineAdapterService ◄────────────────────────────────────     │
+│    Single contract all execution engines implement              │
+│    Submit · Signal · Cancel · Watch                             │
+│                      │ publishes CloudEvents                    │
+│  EventBusService ◄───┘                                          │
+│    Async pub/sub backbone (NATS JetStream)                      │
+│    Glob pattern routing · per-workflow scoping                  │
+│                      │ fan-out on task.* events                 │
+│  TaskBrokerService ◄─┘                                          │
+│    Routes capability requests to the right agent                │
+│    Dispatch · Acknowledge · Cancel · Retry state machine        │
+│                      │ queries capability catalogue             │
+│  AgentRegistryService ◄──────────────────────────────────────── │
+│    Registry of agent capabilities                               │
+│    Register · Deregister · FindByCapability · ListAgents        │
+│                                                                 │
+│  MemoryService                                                  │
+│    Persistent KV store + vector store                           │
+│    Scoped by workflow_id — agents are stateless by design       │
+└──────────────────────────────────────────────────────┬──────────┘
+                                                       │
+┌──────────────────────────────────────────────────────▼──────────┐
+│  Layer 3 — Execution                                            │
+│                                                                 │
+│  AgentService (Python adapters)                                 │
+│    ExecuteCapability  ──►  streaming TaskEvents                 │
+│    Any system implementing this RPC is a first-class agent      │
+│    No SDK required · No framework requirement                   │
+│                                                                 │
+│  Execution Engines (via EngineAdapterService contract)          │
+│    Temporal · LangGraph · Argo Workflows                        │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Request lifecycle
+
+```
+User YAML
+  │
+  ▼
+API Gateway  ──►  WorkflowCompilerService.CompileWorkflow
+                    validates structure, returns WorkflowIR
+  │
+  ▼
+EngineAdapterService.SubmitWorkflow(WorkflowIR)
+  │  run_id returned immediately, status = RUNNING
+  │
+  ▼  (engine executes state machine)
+EngineAdapterService  ──►  EventBus.Publish(zynax.workflow.state.entered)
+                              │
+                              ▼
+                           TaskBrokerService.DispatchTask(capability, payload)
+                              │  routes via AgentRegistryService.FindByCapability
+                              ▼
+                           AgentService.ExecuteCapability(request)
+                              │  streams TaskEvents: PROGRESS* → COMPLETED|FAILED
+                              ▼
+                           TaskBrokerService.AcknowledgeTask(result)
+                              │
+                              ▼
+                           EventBus.Publish(zynax.task.completed)
+                              │
+                              ▼
+                           EngineAdapterService (advances state machine)
+```
+
+---
+
+## What Was Built
+
+### 1. gRPC Contract Layer — 8 Services
+
+| Service | RPCs | Purpose |
+|---------|------|---------|
+| `AgentService` | `ExecuteCapability` (streaming) | Universal capability provider contract |
+| `AgentRegistryService` | `Register`, `Deregister`, `Get`, `List`, `FindByCapability` | Capability catalogue |
+| `WorkflowCompilerService` | `CompileWorkflow`, `ValidateManifest` | YAML → WorkflowIR |
+| `EngineAdapterService` | `Submit`, `Signal`, `Cancel`, `GetStatus`, `Watch` | Execution engine boundary |
+| `EventBusService` | `Publish`, `Subscribe`, `Unsubscribe` | Async pub/sub backbone |
+| `TaskBrokerService` | `Dispatch`, `Acknowledge`, `Cancel`, `GetTask`, `ListTasks` | Capability routing |
+| `MemoryService` | `Set/Get/Delete/List` (KV) + `Upsert/Search/Delete` (vector) | Externalised agent state |
+| `CloudEventsEnvelope` | (message type only) | CNCF CloudEvents v1.0 wire format |
+
+All proto field numbers are permanent (ADR-001 §backward-compat). Ordinal values
+on every `enum` are stable and documented. `buf breaking` in CI enforces this on
+every PR.
+
+### 2. Event Contract Layer — AsyncAPI Spec
+
+`spec/asyncapi/zynax-events.yaml` documents all async events on the NATS
+JetStream bus:
+
+| Channel | Publisher | Consumers |
+|---------|-----------|-----------|
+| `zynax.workflow.started` | EngineAdapter | Observability, UI |
+| `zynax.workflow.completed` | EngineAdapter | Orchestrator, billing |
+| `zynax.workflow.failed` | EngineAdapter | Alerting, retry policy |
+| `zynax.workflow.cancelled` | EngineAdapter | Orchestrator |
+| `zynax.task.dispatched` | TaskBroker | Observability |
+| `zynax.task.completed` | TaskBroker | EngineAdapter (state advance) |
+| `zynax.task.failed` | TaskBroker | EngineAdapter, alerting |
+| `zynax.task.retrying` | TaskBroker | Observability |
+| `zynax.agent.registered` | AgentRegistry | Service mesh, UI |
+| `zynax.agent.deregistered` | AgentRegistry | Service mesh |
+| `zynax.agent.capability.invoked` | TaskBroker | Audit trail, billing |
+
+Every payload is a CloudEvents v1.0 envelope (`spec/schemas/cloudevent.schema.json`)
+with Zynax-specific extensions: `workflow_id`, `run_id`, `namespace`, `capability_name`.
+
+### 3. Schema Layer
+
+| Schema | Purpose |
+|--------|---------|
+| `spec/schemas/cloudevent.schema.json` | Wire format for all async events |
+| `spec/schemas/capability.schema.json` | Agent capability declarations (name, input_schema, output_schema, timeout, retries) |
+
+### 4. Generated Stubs
+
+`buf generate` produces committed, fresness-checked stubs:
+
+- `protos/generated/go/` — Go `*.pb.go` + `*_grpc.pb.go` for all 8 services
+- `protos/generated/python/` — Python `*_pb2.py` + `*_pb2_grpc.py` for all 8 services
+
+CI (`ci.yml`) regenerates stubs and diffs — any drift fails the build before
+review begins.
+
+### 5. BDD Contract Test Suite — 140+ Scenarios
+
+One `godog` test suite per service, running against in-memory stubs via
+`bufconn` (in-process gRPC, no Docker, <100ms total):
+
+| Package | Scenarios | Key contracts verified |
+|---------|-----------|----------------------|
+| `agent_service` | — | Streaming terminal semantics, timeout, task_id echo |
+| `agent_registry_service` | — | Register/deregister lifecycle, FindByCapability routing |
+| `cloudevents_envelope` | — | Required fields, extension validation |
+| `workflow_compiler_service` | 17 | All 7 CompilationErrorCodes, dry_run, ValidateManifest |
+| `engine_adapter_service` | 24 | Full lifecycle (15) + signals/watch (9) |
+| `event_bus_service` | 23 | Pub/sub fan-out, glob patterns, unsubscribe |
+| `task_broker_service` | 24 | Retry state machine, cancel guards, ListTasks filters |
+| `memory_service` | — | KV TTL, vector cosine similarity, namespace scoping |
+
+These are not unit tests. They verify the **observable protocol behaviour**:
+given this wire input, the server must produce this exact response code,
+this payload shape, this error message. When the real Go service is implemented,
+the scenarios do not change — only the stub is swapped for the real server.
+
+### 6. CI Quality Gates
+
+Every PR is blocked by 5 automated checks:
+
+| Gate | Blocks on |
+|------|-----------|
+| `conventional-commit` | Non-standard PR title (blocks changelog generation) |
+| `pr-size` | >900 lines changed (forces decomposition) |
+| `proto-breaking` | Backward-incompatible proto change (field removal/rename) |
+| `proto-stubs-fresh` | `.proto` changed but generated stubs not updated |
+| `layer-boundaries` | `domain/` importing `api/` or `infrastructure/` |
+
+### 7. Testing Strategy — ADR-016
+
+The project moved from BDD-first-for-everything (ADR-004) to a layered pyramid:
+
+```
+              ▲
+         BDD / E2E         10–15%   system boundaries (this sprint)
+        ─────────────────────────
+         Contract CI       always   buf breaking (every PR)
+        ─────────────────────────
+         Unit / Property    40%     domain logic (M2+ service implementations)
+        ─────────────────────────
+         Simulation                 chaos / load (M3+)
+              ▼
+```
+
+The key insight: BDD at the *boundary* produces stable, high-value contracts.
+BDD at the *domain level* produces fragile tests that couple to implementation.
+
+---
+
+## What This Unlocks
+
+M1 creates the **contractual moat** that makes parallel development safe in M2:
+
+- Any engineer implementing `WorkflowCompilerService` runs `go test ./workflow_compiler_service/...` and gets instant contract compliance feedback
+- Any engineer writing an engine adapter implements `EngineAdapterService` and the 24 BDD scenarios tell them exactly what the contract requires
+- Any engineer building the Python task broker runs the pytest-bdd suite (issue #31) against their implementation
+- The AsyncAPI spec is the canonical source of truth for all async event consumers — no guessing event field names
+
+---
+
+## What Is Not Yet Built (Intentional)
+
+| Item | Milestone | Reason deferred |
+|------|-----------|-----------------|
+| Service implementations (Go) | M2+ | Contracts must precede implementations |
+| Python pytest-bdd harness | M1 open (#31) | Same pattern as Go, needs Python stubs |
+| Docker Compose integration profile | M2 | Meaningful only when services are real |
+| Coverage gate (90%) | M2 | Meaningful only when domain packages exist |
+| YAML workflow manifest JSON Schema | M2 | WorkflowCompiler M2 concern |
+| gRPC health checking protocol | M2/M6 | K8s readiness probes: M6 concern |
+| Pagination on list RPCs | TBD | See open questions §below |
+
+---
+
+## Open Questions for M1 Closure
+
+The following design decisions need answers before M1 can be formally closed
+and v0.1.0 tagged:
+
+1. **Missing AsyncAPI events**: The EventBus spec has workflow lifecycle and
+   task lifecycle events, but is missing `zynax.workflow.state.entered` and
+   `zynax.workflow.state.exited`. The `EngineAdapterService.WatchWorkflow`
+   stream carries these over gRPC, but downstream consumers on the EventBus
+   (e.g., the TaskBroker deciding when to dispatch a task) need them as
+   published events. Are these M1 or M2?
+
+2. **Stub distribution mechanism**: Generated stubs are committed to the repo
+   (current approach). For M2 multi-repo consumers, should stubs also be
+   published to `buf.build/zynax-io/zynax` (BSR) and/or as a Go module
+   tagged release? Or is commit-and-reference sufficient for M1?
+
+3. **Pagination on list RPCs**: `ListAgents`, `ListTasks` have no `page_token`
+   / `page_size` fields. Adding these after M1 is a backward-compatible change
+   (new fields), but the absence means early consumers may load unbounded
+   result sets. Cap for M1 or add pagination now?
+
+4. **gRPC health checking**: Standard production gRPC (`grpc.health.v1`) is not
+   in any service contract. K8s liveness/readiness probes will need it in M6.
+   Adding it in M1 is zero implementation cost (it's a proto import). Worth doing?
+
+5. **Memory bulk operations**: `MemoryService` has per-key `Set/Get/Delete` but
+   no `MGet`/`MSet`/`DeleteNamespace`. Agents running in a workflow frequently
+   need to load all their context in one call. M1 addition or M2?
+
+6. **WorkflowIR retrieval**: `WorkflowCompilerService` compiles a manifest and
+   returns the IR synchronously. There is no `GetCompiledWorkflow(workflow_id)`
+   RPC to retrieve a previously compiled IR. Is the IR ephemeral (caller must
+   store it) or should the compiler service persist and expose it?
+
+7. **AgentService capability introspection**: The task broker validates
+   `input_schema` at dispatch time using the schema registered in
+   `AgentRegistryService`. Should `AgentService` also expose a
+   `GetCapabilitySchema` RPC so the broker can re-fetch live schemas without
+   going through the registry?
+
+8. **Event type versioning**: Event types are `zynax.workflow.started` (no
+   version segment). Should they be `zynax.v1.workflow.started` to allow
+   non-breaking evolution? Or is the CloudEvent `specversion` field sufficient?
+
+---
+
+## Architecture Decisions Referenced
+
+| ADR | Title | Impact on M1 |
+|-----|-------|-------------|
+| ADR-001 | gRPC as inter-service protocol | All 8 service contracts are gRPC |
+| ADR-008 | No shared databases | MemoryService is the only shared state store |
+| ADR-009 | Language strategy | Go services + Python agents |
+| ADR-010 | Pluggable agent runtime | AgentService = the single adapter contract |
+| ADR-011 | Declarative YAML control plane | WorkflowCompilerService contract |
+| ADR-012 | Workflow IR | WorkflowIR is the compiled, engine-agnostic representation |
+| ADR-013 | Adapter-first, no SDK required | AgentService RPC is the only requirement |
+| ADR-014 | Event-driven state machine | EventBusService + CloudEvents |
+| ADR-015 | Pluggable workflow engines | EngineAdapterService contract |
+| ADR-016 | Layered testing strategy | BDD at boundaries only |

--- a/docs/milestones/M1-release-notes.md
+++ b/docs/milestones/M1-release-notes.md
@@ -1,0 +1,200 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Release Notes — v0.1.0 (Milestone 1: Contracts Foundation)
+
+**Release date:** pending M1 closure  
+**Branch:** `main` · **Milestone:** [Contracts Foundation (M1)](https://github.com/zynax-io/zynax/milestone/1)
+
+---
+
+## Overview
+
+v0.1.0 is the **Contracts Foundation** release. It establishes every
+communication contract in the Zynax distributed AI workflow control plane
+before any service implementation begins.
+
+This release contains no running services. It contains something more
+fundamental: the machine-verified specifications that all future services
+must honour. Every contract is expressed in protobuf, backed by BDD
+scenarios, and protected by CI gates that prevent backward-incompatible
+changes from reaching `main`.
+
+---
+
+## What's New
+
+### gRPC Service Contracts (8 services)
+
+All inter-service APIs are defined as versioned protobuf contracts under
+`protos/zynax/v1/`:
+
+| Service | Description |
+|---------|-------------|
+| `AgentService` | Universal capability provider — any system implementing `ExecuteCapability` is a first-class Zynax agent. No SDK required. |
+| `AgentRegistryService` | Capability catalogue. Agents register on startup; the task broker queries at dispatch time via `FindByCapability`. |
+| `WorkflowCompilerService` | Transforms user-authored YAML manifests into engine-agnostic `WorkflowIR`. Exposes all 7 `CompilationErrorCode` variants with structured error detail. |
+| `EngineAdapterService` | The single contract all execution engines (Temporal, LangGraph, Argo) must implement. Submit, Signal, Cancel, Watch. |
+| `EventBusService` | Async pub/sub backbone over NATS JetStream. Glob pattern routing (`zynax.*`, `zynax.**`), per-workflow scoping, server-side streaming. |
+| `TaskBrokerService` | Capability routing with a full task lifecycle state machine: PENDING → DISPATCHED → COMPLETED / FAILED / RETRYING / CANCELLED. |
+| `MemoryService` | Externalised agent state: per-workflow-scoped KV store (with TTL) and vector store (cosine similarity search). Agents are stateless by design. |
+| `CloudEventsEnvelope` | CNCF CloudEvents v1.0 wire format with Zynax extensions (`workflow_id`, `run_id`, `namespace`, `capability_name`). |
+
+### Async Event Contracts (AsyncAPI 2.6)
+
+`spec/asyncapi/zynax-events.yaml` documents all 11 event channels on the
+platform event bus:
+
+```
+zynax.workflow.started      zynax.task.dispatched
+zynax.workflow.completed    zynax.task.completed
+zynax.workflow.failed       zynax.task.failed
+zynax.workflow.cancelled    zynax.task.retrying
+zynax.agent.registered      zynax.agent.deregistered
+zynax.agent.capability.invoked
+```
+
+### JSON Schema Layer
+
+- `spec/schemas/cloudevent.schema.json` — CloudEvents v1.0 envelope with Zynax extensions
+- `spec/schemas/capability.schema.json` — Agent capability declaration schema (name, input_schema, output_schema, timeout_seconds, max_retries)
+
+### Generated Stubs
+
+`make generate-protos` (via `buf generate`) produces committed stubs for both
+language targets:
+
+- **Go:** `protos/generated/go/zynax/v1/*.pb.go` and `*_grpc.pb.go`
+- **Python:** `protos/generated/python/zynax/v1/*_pb2.py` and `*_pb2_grpc.py`
+
+Stubs are committed to the repository. CI detects and rejects drift between
+`.proto` sources and committed stubs on every PR.
+
+### BDD Contract Test Suite
+
+One `godog` test suite per gRPC service, running against in-memory stubs
+via `bufconn` (in-process gRPC — no Docker, no network, <100ms total):
+
+| Service | Scenarios |
+|---------|-----------|
+| WorkflowCompilerService | 17 — all 7 error codes, dry_run, ValidateManifest |
+| EngineAdapterService | 24 — lifecycle (15) + signals/watch (9) |
+| EventBusService | 23 — pub/sub fan-out, glob patterns, unsubscribe |
+| TaskBrokerService | 24 — retry state machine, cancel guards, filters |
+| MemoryService | — KV TTL, vector similarity, namespace scoping |
+| AgentService | — streaming terminal semantics, timeout, task_id echo |
+| AgentRegistryService | — registration lifecycle, FindByCapability |
+| CloudEventsEnvelope | — required fields, extension validation |
+
+### CI Quality Gates
+
+Five automated checks run on every pull request:
+
+| Check | Enforces |
+|-------|----------|
+| `conventional-commit` | PR title follows Conventional Commits (enables semantic versioning) |
+| `pr-size` | ≤900 lines changed (forces reviewable decomposition) |
+| `proto-breaking` | No backward-incompatible proto changes via `buf breaking` |
+| `proto-stubs-fresh` | Generated stubs are regenerated when `.proto` files change |
+| `layer-boundaries` | Three-layer separation: `domain/` never imports `api/` or `infrastructure/` |
+
+### Testing Strategy — ADR-016
+
+The project adopted a layered testing pyramid (replaces BDD-first ADR-004):
+
+- **BDD/contract tests** at system boundaries (this milestone)
+- **Unit/property tests** for domain logic (M2+ service implementations)
+- **buf breaking** as always-on contract CI
+- **Simulation/chaos** for end-to-end confidence (M3+)
+
+---
+
+## Breaking Changes
+
+None. This is the first release.
+
+---
+
+## Migration Guide
+
+Not applicable. This is the first release.
+
+---
+
+## Known Limitations
+
+- No running services — M1 is contracts only
+- No pagination on `ListAgents`, `ListTasks` list RPCs
+- No gRPC health checking protocol (`grpc.health.v1`) — planned M6
+- Python pytest-bdd contract harness pending (issue #31)
+- AsyncAPI spec missing `zynax.workflow.state.entered` / `zynax.workflow.state.exited` events
+- No selective contract test execution (all 8 suites run on every proto change)
+- Generated stubs not published to buf.build BSR or package registries
+
+---
+
+## Issues Closed
+
+### Proto Contracts
+- #2 — AgentService proto: ExecuteCapability streaming RPC
+- #3 — AgentRegistryService proto: agent registration and capability discovery
+- #4 — TaskBrokerService proto: capability routing and task lifecycle
+- #5 — WorkflowCompilerService proto: YAML manifest compilation contract
+- #6 — EngineAdapterService proto: workflow execution lifecycle
+- #7 — MemoryService proto: shared KV and vector storage contract
+- #8 — EventBusService proto: async event publish/subscribe contract
+- #9 — CloudEvents event envelope: proto definition and JSON Schema
+
+### Specifications
+- #10 — AsyncAPI spec: all platform async event types documented
+- #11 — Capability schema: JSON Schema for capability input/output declarations
+- #22 — CloudEvents envelope: proto and JSON Schema
+
+### Code Generation
+- #12 — buf generate pipeline: Go and Python proto stubs from a single make target
+- #30 — Commit initial generated proto stubs
+
+### CI Infrastructure
+- #15 — GitHub Actions pipeline: lint, BDD execution, security, PR checks
+- #27 — Dockerfile.tools on Alpine: proto and BDD tools
+
+### Contract Tests (godog BDD)
+- #42 — Test module bootstrap: godog harness, bufconn testserver, go.mod
+- #43 — AgentService contract tests: ExecuteCapability streaming
+- #44 — AgentRegistryService contract tests: registration and discovery
+- #45 — CloudEventsEnvelope contract tests: field validation
+- #46 — MemoryService contract tests: KV store, vector search, TTL
+- #47 — WorkflowCompilerService contract tests: YAML compilation
+- #48 — EventBusService contract tests: publish, subscribe, unsubscribe
+- #49 — TaskBrokerService contract tests: dispatch, retry, lifecycle
+- #50 — EngineAdapterService contract tests: lifecycle (submission, status, cancellation)
+- #51 — EngineAdapterService contract tests: signals, watch stream, validation
+
+---
+
+## What Comes Next — M2 (Workflow IR)
+
+M2 implements the `WorkflowCompilerService` in Go, replacing the BDD in-memory
+stub with a real YAML parser and IR compiler. It also:
+
+- Adds JSON Schema for `Workflow`, `AgentDef`, and `Policy` manifest kinds
+- Implements IR serialisation (protobuf) for transmission to engine adapters
+- Adds reference workflow YAML examples
+- Connects the `make validate-spec` and `make dry-run` targets to real logic
+
+See [ROADMAP.md §M2](../../ROADMAP.md) for the full checklist.
+
+---
+
+## Architecture Decision Records
+
+All ADRs referenced in this release:
+[ADR-001](../adr/ADR-001-grpc-inter-service-protocol.md) ·
+[ADR-008](../adr/ADR-008-no-shared-databases.md) ·
+[ADR-009](../adr/ADR-009-language-strategy.md) ·
+[ADR-010](../adr/ADR-010-pluggable-agent-runtime.md) ·
+[ADR-011](../adr/ADR-011-declarative-yaml-control-plane.md) ·
+[ADR-012](../adr/ADR-012-workflow-ir.md) ·
+[ADR-013](../adr/ADR-013-adapter-first-no-sdk.md) ·
+[ADR-014](../adr/ADR-014-event-driven-state-machine.md) ·
+[ADR-015](../adr/ADR-015-pluggable-workflow-engines.md) ·
+[ADR-016](../adr/ADR-016-layered-testing-strategy.md)


### PR DESCRIPTION
## Summary

- Adds `docs/milestones/M1-engineering-review.md` — CTO/VP-Eng level review of the Contracts Foundation milestone: three-layer architecture diagram, per-service contract table, full request lifecycle sequence, layered testing strategy rationale, CI gate inventory, and 8 open questions that must be answered before M1 formally closes
- Adds `docs/milestones/M1-release-notes.md` — user-facing v0.1.0 release notes: what's new, known limitations, all 30 closed issues, and M2 preview

## New CI issues created (Epic #14, M1)

- #62 — AsyncAPI spec and JSON Schema validation in CI pipeline (currently absent from `ci.yml`)
- #63 — Selective contract test execution: run only affected service tests on proto change
- #64 — Publish generated stubs on proto change merged to main (BSR push + GitHub Release)
- #65 — Contract test report comment on PR with per-service scenario summary

## Test plan

- [x] Documents render correctly in GitHub markdown
- [x] All internal links point to existing files
- [x] Architecture diagrams are ASCII (no external image dependencies)

Relates to milestone [Contracts Foundation (M1)](https://github.com/zynax-io/zynax/milestone/1).