### PR TITLE
ci: add GOWORK=off to godog test step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -275,8 +275,7 @@ jobs:
         run: |
           echo "── BDD: protos/tests (godog)"
           cd protos/tests
-          go test ./... -v -timeout 60s \
-            -format=pretty \
+          GOWORK=off go test ./... -v -timeout 60s \
             2>&1 | tee bdd-results.txt
           echo "✅ BDD contract tests passed"
 


### PR DESCRIPTION
## Summary

One-line fix: prepend `GOWORK=off` to the `go test` command in the godog BDD step of `ci.yml`.

The workspace `go.work` lists seven service modules that have no `go.mod` yet (M1 is contracts-only). Without `GOWORK=off`, Go tries to load all workspace modules when running tests inside `protos/tests/`, producing seven `cannot load module` errors on every CI run. The tests still pass, but the output is misleading and the `bdd-results.txt` artifact is polluted.

`protos/tests/` has its own isolated `go.mod`; all local development and every step definition already uses `GOWORK=off`. This aligns CI with local usage.

Also removes the stray `-format=pretty` flag which is not a valid `go test` flag (godog format is controlled via `godog.Options` in the test code).

## Test plan

- [x] One-line change, no logic affected
- [x] `go test` output will no longer contain `cannot load module` lines
- [x] All godog scenarios continue to pass

Closes #67.