### PR TITLE
docs: reflect M1 completion in CLAUDE.md, README, and ROADMAP

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,18 @@ Claude Code reads this file automatically. The full engineering contracts live
 in `AGENTS.md` files throughout the repository — read those before working in
 any layer.
 
+## Milestone Status
+
+| Milestone | Status | Version | Review |
+|-----------|--------|---------|--------|
+| M1 — Contracts Foundation | **Complete** | v0.1.0 | [Engineering Review](docs/milestones/M1-engineering-review.md) · [Release Notes](docs/milestones/M1-release-notes.md) |
+| M2 — Workflow IR | Not started | v0.1.0 | — |
+| M3 — Temporal Execution | Not started | v0.2.0 | — |
+| M4 — YAML System + CLI | Not started | v0.3.0 | — |
+
+M1 delivered: 8 gRPC contracts, AsyncAPI spec, JSON schemas, Go + Python generated stubs,
+140+ BDD scenarios across all services, 5 CI gates. All work tracked in Epic #1 (closed).
+
 ## Key pointers
 
 | Directory | AGENTS.md covers |
@@ -33,4 +45,24 @@ make validate-spec   # AsyncAPI + capability schema validation
 ```
 
 All commands run inside Docker — only prerequisite is Docker Desktop.
-BDD `.feature` files must be committed before implementation (ADR-004).
+
+## Testing approach (M1 contracts layer)
+
+BDD `.feature` files are committed before any boundary implementation (ADR-016).
+Go BDD tests live in `protos/tests/<service>/` and use [godog](https://github.com/cucumber/godog).
+
+**Critical:** run contract tests with `GOWORK=off` — the `go.work` workspace lists
+service modules not yet created (M2+), which break `go test` without this flag:
+
+```bash
+cd protos/tests/<service>
+GOWORK=off go test ./... -v -timeout 60s
+```
+
+CI enforces this in `.github/workflows/ci.yml` `test-unit` job (Godog BDD step).
+
+Testing tiers per ADR-016:
+- BDD (10–15%): system boundaries, gRPC contracts — `protos/tests/`
+- Unit/property (≥40%): domain logic — per-service `_test.go`
+- Contract (CI gate): `buf breaking` on every proto PR
+- Simulation (M3+): fault injection, retry storms

--- a/README.md
+++ b/README.md
@@ -132,15 +132,31 @@ zynax get workflows -n engineering
 
 ---
 
+## Milestone Status
+
+| Milestone | Status | Version | Docs |
+|-----------|--------|---------|------|
+| **M1 — Contracts Foundation** | **Complete** | v0.1.0 | [Engineering Review](docs/milestones/M1-engineering-review.md) · [Release Notes](docs/milestones/M1-release-notes.md) |
+| M2 — Workflow IR | Planned | v0.1.0 | — |
+| M3 — Temporal Execution | Planned | v0.2.0 | — |
+| M4 — YAML System + CLI | Planned | v0.3.0 | — |
+
+M1 is the contracts-only foundation: 8 gRPC services, AsyncAPI spec, generated Go + Python stubs,
+140+ BDD contract test scenarios, and 5 CI gates. No service implementation yet — M2 onwards.
+
+---
+
 ## Repository Structure
 
 ```
-spec/           Workflow YAML manifests and schemas
-services/       Go platform services (7 services)
-agents/         Python execution adapters + optional SDK
-protos/         gRPC contracts (Go + Python stubs generated)
-infra/          Docker-first dev environment + Helm charts
-docs/adr/       Architecture Decision Records (ADR-001 – ADR-015)
+spec/                Workflow YAML manifests and schemas
+services/            Go platform services (8 services — M2+)
+agents/              Python execution adapters + optional SDK
+protos/              gRPC contracts (Go + Python stubs generated)
+protos/tests/        BDD contract test suites (godog)
+infra/               Docker-first dev environment + Helm charts
+docs/adr/            Architecture Decision Records (ADR-001 – ADR-016)
+docs/milestones/     Per-milestone engineering reviews and release notes
 ```
 
 ---

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -58,18 +58,19 @@ Each roadmap milestone maps to a GitHub Milestone:
 
 ---
 
-## Milestone 1 — Contracts Foundation
+## Milestone 1 — Contracts Foundation ✅ Complete (v0.1.0)
 
 **Goal:** All communication contracts defined. Nothing builds on sand.
 
-> An issue must exist for each item. Label: `milestone: M1`
+> Released 2026-04-21. See [Engineering Review](docs/milestones/M1-engineering-review.md)
+> and [Release Notes](docs/milestones/M1-release-notes.md).
 
-- [ ] gRPC proto definitions: `AgentService`, `AgentRegistryService`, `TaskBrokerService`, `MemoryService`, `EventBusService`, `WorkflowCompilerService`, `EngineAdapterService`
-- [ ] AsyncAPI spec: all async events documented (workflow events, task events, agent events)
-- [ ] Event envelope schema: `CloudEvents`-compatible wrapper for all events
-- [ ] Capability schema: JSON Schema for capability input/output declarations
-- [ ] `buf generate` produces Go stubs + Python stubs in one command
-- [ ] Contract tests: every proto method has a BDD scenario
+- [x] gRPC proto definitions: `AgentService`, `AgentRegistryService`, `TaskBrokerService`, `MemoryService`, `EventBusService`, `WorkflowCompilerService`, `EngineAdapterService`
+- [x] AsyncAPI spec: all async events documented (workflow events, task events, agent events)
+- [x] Event envelope schema: `CloudEvents`-compatible wrapper for all events
+- [x] Capability schema: JSON Schema for capability input/output declarations
+- [x] `buf generate` produces Go stubs + Python stubs in one command
+- [x] Contract tests: every proto method has a BDD scenario (140+ scenarios across all services)
 
 ---
 


### PR DESCRIPTION
## Summary

- Marks all M1 checklist items as `[x]` in ROADMAP.md
- Adds milestone status table to README.md with links to engineering review and release notes
- Updates CLAUDE.md: adds M1 status section, correct testing guidance (ADR-016, GOWORK=off requirement for godog tests), removes stale ADR-004 BDD-first reference

## Links

- [M1 Engineering Review](docs/milestones/M1-engineering-review.md)
- [M1 Release Notes](docs/milestones/M1-release-notes.md)
- Closes Epic #1

## Test plan

- [ ] No code changes — docs only
- [ ] CI dco, lint, test-unit, test-integration, security all pass