### PR TITLE
feat: add workflow state.entered and state.exited to AsyncAPI spec

### DIFF
--- a/spec/asyncapi/zynax-events.yaml
+++ b/spec/asyncapi/zynax-events.yaml
@@ -138,6 +138,68 @@ channels:
         payload:
           $ref: "#/components/schemas/CloudEvent"
 
+  zynax.workflow.state.entered:
+    description: >
+      Published by the EngineAdapterService each time the workflow's state
+      machine activates a new state. Fired after any transition completes
+      and before the state's actions begin executing.
+
+      The CloudEvent data payload carries:
+        run_id      — the workflow run identifier
+        workflow_id — the workflow definition identifier
+        namespace   — the namespace the workflow belongs to
+        state       — the name of the state now active (same as to_state)
+        from_state  — the state that was exited (empty on the first state)
+        to_state    — the state now entered
+
+      Consumers use this event to build audit trails, trigger downstream
+      reactions, and power real-time workflow progress views.
+    x-zynax-schema-version: v1
+    x-zynax-schema-rev: "workflow/state.entered@v1"
+    publish:
+      operationId: onWorkflowStateEntered
+      summary: The workflow state machine has entered a new state.
+      message:
+        name: WorkflowStateEntered
+        summary: >
+          Emitted after every state transition. Carries from_state and to_state
+          so consumers can reconstruct the full execution path.
+        contentType: application/json
+        payload:
+          $ref: "#/components/schemas/CloudEvent"
+
+  zynax.workflow.state.exited:
+    description: >
+      Published by the EngineAdapterService each time the workflow's state
+      machine leaves a state. Fired when a transition event is received and
+      processed, before the target state is entered.
+
+      The CloudEvent data payload carries:
+        run_id      — the workflow run identifier
+        workflow_id — the workflow definition identifier
+        namespace   — the namespace the workflow belongs to
+        state       — the name of the state being exited (same as from_state)
+        from_state  — the state being exited
+        to_state    — the next state (empty if transitioning to terminal)
+        trigger     — the event_type that caused the transition (e.g. "review.approved")
+
+      Together with zynax.workflow.state.entered, this pair gives consumers
+      a complete picture of every transition: exited fires first, entered fires
+      after the transition is committed.
+    x-zynax-schema-version: v1
+    x-zynax-schema-rev: "workflow/state.exited@v1"
+    publish:
+      operationId: onWorkflowStateExited
+      summary: The workflow state machine has exited a state due to a transition.
+      message:
+        name: WorkflowStateExited
+        summary: >
+          Emitted on every state transition before the target state is entered.
+          Carries the trigger event_type that caused the transition.
+        contentType: application/json
+        payload:
+          $ref: "#/components/schemas/CloudEvent"
+
   # ── Task lifecycle ──────────────────────────────────────────────────────────
 
   zynax.task.dispatched:

--- a/spec/tests/features/asyncapi_spec.feature
+++ b/spec/tests/features/asyncapi_spec.feature
@@ -66,6 +66,18 @@ Feature: AsyncAPI specification for all Zynax async events
     And the channel specifies a publish operation
     And the message payload references the CloudEvent schema
 
+  Scenario: Workflow state entered event channel is documented
+    When the AsyncAPI spec channels are inspected
+    Then it contains a channel for subject "zynax.workflow.state.entered"
+    And the channel specifies a publish operation
+    And the message payload references the CloudEvent schema
+
+  Scenario: Workflow state exited event channel is documented
+    When the AsyncAPI spec channels are inspected
+    Then it contains a channel for subject "zynax.workflow.state.exited"
+    And the channel specifies a publish operation
+    And the message payload references the CloudEvent schema
+
   # ─── Task lifecycle events ────────────────────────────────────────────────
 
   Scenario: Task dispatched event channel is documented


### PR DESCRIPTION
## Summary

Closes #69. Part of epic #98 (AsyncAPI & Event Schema Completeness).

Adds the two missing workflow state machine lifecycle events that event consumers need to track workflow progress:

**`zynax.workflow.state.entered`**
- Fired after every state transition, before the state's actions execute
- Payload: `run_id`, `workflow_id`, `namespace`, `state` (active state name), `from_state`, `to_state`
- `zynaxschemarev: "workflow/state.entered@v1"`

**`zynax.workflow.state.exited`**
- Fired when a transition event is received, before the target state is entered
- Payload: same fields plus `trigger` (the `event_type` that caused the transition, e.g. `"review.approved"`)
- `zynaxschemarev: "workflow/state.exited@v1"`

Both channels follow the versioning scheme from #70: stable channel names, `x-zynax-schema-version: v1`, `x-zynax-schema-rev` annotation.

Two BDD scenarios added to `spec/tests/features/asyncapi_spec.feature` (total: 17 scenarios).

## Test plan

- [x] `spec/asyncapi/zynax-events.yaml` has 13 channels (was 11)
- [x] Both new channels have `x-zynax-schema-version`, `x-zynax-schema-rev`, description, publish operation, CloudEvent payload ref
- [x] BDD feature file has scenarios for both new channels