### PR TITLE
ci: add AsyncAPI and JSON Schema validation to lint job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,52 @@ jobs:
           fi
           echo "✅ Generated stubs are up to date"
 
+      # ── Spec: AsyncAPI + JSON Schema validation ──────────────────────────
+      - name: Detect spec files
+        id: spec-detect
+        run: |
+          if [ -f spec/asyncapi/zynax-events.yaml ]; then
+            echo "has_spec=1" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_spec=0" >> "$GITHUB_OUTPUT"
+            echo "ℹ️  spec/asyncapi/zynax-events.yaml not found — spec validation skipped."
+          fi
+
+      - uses: actions/setup-node@v4
+        if: steps.spec-detect.outputs.has_spec == '1'
+        with:
+          node-version: "20"
+
+      - name: Install AsyncAPI CLI
+        if: steps.spec-detect.outputs.has_spec == '1'
+        run: npm install -g @asyncapi/cli --quiet
+
+      - name: Validate AsyncAPI spec
+        if: steps.spec-detect.outputs.has_spec == '1'
+        run: |
+          echo "── asyncapi validate: spec/asyncapi/zynax-events.yaml"
+          asyncapi validate spec/asyncapi/zynax-events.yaml
+          echo "✅ AsyncAPI spec is valid"
+
+      - name: Validate JSON Schemas are well-formed
+        if: steps.spec-detect.outputs.has_spec == '1'
+        run: |
+          failed=false
+          for schema in spec/schemas/*.json; do
+            echo "── json parse: $schema"
+            python3 -c "
+import json, sys
+try:
+    data = json.load(open('$schema'))
+    assert '\$schema' in data, 'missing \$schema field'
+    print('  ok')
+except Exception as e:
+    print(f'  ❌ {e}')
+    sys.exit(1)
+" || failed=true
+          done
+          $failed && exit 1 || echo "✅ JSON Schemas are well-formed"
+
       # ── Go: golangci-lint ────────────────────────────────────────────────
       - name: Detect Go services
         id: go-detect


### PR DESCRIPTION
## Summary

Closes #62. Part of epic #97 (Contract Freshness & Distribution).

Adds a **Spec validation** section to the `lint` job in `ci.yml`, between the proto stubs freshness check and the Go lint section.

### New CI steps

**Detect spec files** — guards the entire section; skips if `spec/asyncapi/zynax-events.yaml` is absent (safe on branches without the spec).

**AsyncAPI validate** — installs `@asyncapi/cli` via npm and runs:
```
asyncapi validate spec/asyncapi/zynax-events.yaml
```
Catches: structural errors, unresolved `$ref`s, invalid channel definitions, schema violations against the AsyncAPI 2.6 spec.

**JSON Schemas well-formed** — loops `spec/schemas/*.json`, parses each with `python3 json.load`, asserts `$schema` is present. Catches: malformed JSON, missing required meta-fields. Extends automatically as new schemas are added.

### What this does NOT do yet

- Does not validate YAML manifests against the Workflow/AgentDef/Policy schemas (those schemas land in #78–#80 during M2)
- Does not validate example workflows against their JSON Schemas (blocked by same)

## Test plan

- [ ] CI `lint` job passes on this branch
- [ ] Both new steps appear in the lint job log
- [ ] Introducing a syntax error in `zynax-events.yaml` makes the AsyncAPI step fail
- [ ] Introducing malformed JSON in a schema file makes the JSON step fail