### PR TITLE
ci: post BDD contract test report as PR comment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,6 +265,9 @@ except Exception as e:
     name: test-unit
     runs-on: ubuntu-24.04
     needs: [lint]
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
 
@@ -388,6 +391,73 @@ except Exception as e:
             echo "ℹ️  No proto or contract test files changed — BDD suite skipped."
           fi
           echo "✅ BDD contract tests passed"
+
+      # ── BDD results: post PR comment ──────────────────────────────────────
+      - name: Post BDD contract test report on PR
+        if: always() && github.event_name == 'pull_request' && steps.go-detect.outputs.has_bdd_impl != '0'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- zynax-bdd-report -->';
+
+            let body;
+            const resultsFile = 'protos/tests/bdd-results.txt';
+
+            if (fs.existsSync(resultsFile)) {
+              const raw = fs.readFileSync(resultsFile, 'utf8');
+              const lines = raw.split('\n');
+
+              const pkgResults = [];
+              let passed = 0, failed = 0;
+              for (const line of lines) {
+                const okMatch  = line.match(/^ok\s+\S+\/protos\/tests\/(\S+)\s+(\S+)/);
+                const failMatch = line.match(/^FAIL\s+\S+\/protos\/tests\/(\S+)/);
+                // Count sub-test lines (individual scenarios, not top-level TestXxx)
+                if (line.match(/\s+--- PASS: Test\w+\/.+/)) passed++;
+                if (line.match(/\s+--- FAIL: Test\w+\/.+/)) failed++;
+                if (okMatch)   pkgResults.push({ pkg: okMatch[1],   status: '✅', time: okMatch[2] });
+                if (failMatch) pkgResults.push({ pkg: failMatch[1], status: '❌', time: '—' });
+              }
+
+              const total = passed + failed;
+              const headline = failed === 0
+                ? `✅ **${total} scenarios passed** across ${pkgResults.length} package(s)`
+                : `❌ **${failed} scenario(s) failed** (${passed} passed) across ${pkgResults.length} package(s)`;
+
+              const rows = pkgResults.length > 0
+                ? pkgResults.map(r => `| \`${r.pkg}\` | ${r.status} | ${r.time} |`).join('\n')
+                : '| — | ⏭️ skipped | — |';
+
+              body = `${marker}\n## Contract Test Report\n\n${headline}\n\n| Package | Result | Time |\n|---------|--------|------|\n${rows}\n\n<sub>Run [#${{ github.run_number }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) · \`${{ github.sha }}`.slice(0,7) + `\`</sub>`;
+            } else {
+              body = `${marker}\n## Contract Test Report\n\nℹ️ BDD suite skipped — no proto or contract test files changed in this PR.\n\n<sub>Run [#${{ github.run_number }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})</sub>`;
+            }
+
+            // Find existing marker comment and update it, or create new
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
 
       # ── Python: pytest-bdd with coverage ─────────────────────────────────
       - name: Detect Python agents


### PR DESCRIPTION
## Summary

Closes #65. Part of epic #97 (Contract Freshness & Distribution).

### What this adds

A new step in `test-unit` (after the Godog step) that posts a PR comment every time BDD contract tests run or are skipped. Uses `if: always()` so failures are reported — not swallowed.

**When tests ran (`bdd-results.txt` exists):**
```
## Contract Test Report

✅ 24 scenarios passed across 1 package(s)

| Package                  | Result | Time   |
|--------------------------|--------|--------|
| `engine_adapter_service` | ✅     | 0.456s |
```

**When suite was skipped (no proto files changed):**
```
## Contract Test Report

ℹ️ BDD suite skipped — no proto or contract test files changed in this PR.
```

### Key design decisions

- **Find-or-update** — uses `<!-- zynax-bdd-report -->` marker to locate the existing comment; updates it on re-runs rather than creating duplicates
- **Scenario counting** — counts sub-test lines (`--- PASS: TestXxx/scenario_name`) not top-level `TestXxx` functions, so the number reflects actual scenario count
- **`pull-requests: write` scoped to `test-unit` job only** — global permission stays `contents: read`
- **`if: always()`** — step runs even when the Godog step failed, so the failure is visible in the PR comment

## Test plan

- [ ] CI passes on this branch
- [ ] Opening a PR that changes a `.proto` file triggers a comment with the package table
- [ ] Re-running CI updates the existing comment rather than creating a new one
- [ ] Opening a PR with no proto changes posts the "skipped" notice