### PR TITLE
docs: create docs/decisions/ with M1 tactical decision records

### DIFF
--- a/docs/decisions/001-engine-adapter-test-split.md
+++ b/docs/decisions/001-engine-adapter-test-split.md
@@ -1,0 +1,54 @@
+# 001: EngineAdapter Test Two-File Split
+
+**Date:** 2026-04-21  **Author:** M1 Engineering
+
+## Context
+
+`EngineAdapterService` is the most complex service contract in M1: it has a
+`StartWorkflow` / `CancelWorkflow` / `CompleteWorkflow` / `FailWorkflow` family
+(workflow lifecycle) and a separate `WatchWorkflow` bidirectional streaming RPC
+(signal delivery). Both share the same proto and the same stub server, but they
+exercise entirely different state: lifecycle RPCs manipulate `WorkflowRun` records
+while `WatchWorkflow` tests a pub/sub signal channel.
+
+The feature file for `EngineAdapterService` has 40+ scenarios. Putting all step
+definitions in a single `steps_test.go` would produce a ~600-line file with two
+logically separate concerns sharing a struct, making it hard to locate step
+definitions and hard to run a subset in isolation.
+
+## Decision
+
+Split the test suite into two files in the same Go package
+(`package engine_adapter_service_test`):
+
+- `lifecycle_steps_test.go` — `TestLifecycle` function, `@lifecycle` tag filter,
+  step definitions for Start/Cancel/Complete/Fail RPCs
+- `signals_steps_test.go` — `TestSignals` function, `@signals` tag filter,
+  step definitions for WatchWorkflow delivery
+
+Both files share the same `engineStub` and `runRecord` types defined in
+`lifecycle_steps_test.go`. Because they are in the same package, `signals_steps_test.go`
+can access those types directly without an import.
+
+Each `TestXxx` function passes a `Tags` option to godog so the two test functions
+exercise non-overlapping scenario sets even when run together with `./...`.
+
+## Alternatives considered
+
+- **Single file, all scenarios:** Rejected — would exceed 600 lines, mixing two
+  logically independent concerns.
+- **Separate packages:** Rejected — would require duplicating the `engineStub`
+  type and the `testserver` setup, adding maintenance burden. Shared types are the
+  point of the same-package pattern.
+- **Sub-directories:** Rejected — go test package granularity is the directory;
+  sub-directories would require separate `go.mod` scoping which conflicts with the
+  single `protos/tests/go.mod` design.
+
+## Consequences
+
+- Developers adding EngineAdapter lifecycle tests edit `lifecycle_steps_test.go`.
+  Developers adding signal delivery tests edit `signals_steps_test.go`.
+- Running `go test -run TestLifecycle` or `go test -run TestSignals` executes only
+  the relevant subset.
+- This pattern is available to any future service suite that grows beyond ~150 lines
+  of step definitions. See `protos/tests/AGENTS.md §Two-File Split Pattern`.

--- a/docs/decisions/002-pr-size-900-limit.md
+++ b/docs/decisions/002-pr-size-900-limit.md
@@ -1,0 +1,47 @@
+# 002: PR Size Limit — 900 Lines
+
+**Date:** 2026-04-21  **Author:** M1 Engineering
+
+## Context
+
+Large PRs are harder to review, more likely to contain subtle errors, and harder
+to revert cleanly. We needed a concrete numeric limit that CI could enforce and
+that contributors could plan against. The question was: what number?
+
+## Decision
+
+**900 lines changed** (additions + deletions, excluding generated files and
+lock files) is the PR size limit. PRs over 900 lines are blocked by CI.
+
+**What counts toward the limit:**
+- All hand-written source code (`.go`, `.py`, `.proto`, `.yaml`, `.ts`)
+- Documentation files (`.md`)
+- CI workflow files (`.yml`)
+
+**What is excluded:**
+- `protos/generated/**` (machine-generated stubs — excluded by `.gitattributes`)
+- `go.sum`, `poetry.lock`, `uv.lock` (dependency lock files)
+- Migrations files (bulk data, reviewed separately)
+
+## History
+
+The initial limit was 800. During M1, two PRs legitimately required 850–870 lines
+to implement a single cohesive feature slice (a proto contract + its BDD scenarios).
+After review, 900 was chosen as the ceiling: high enough to accommodate realistic
+feature slices, low enough to remain reviewable in a single sitting (~30 minutes
+at a reading pace of 30 lines/minute including context).
+
+Numbers considered and rejected:
+- **800:** Tripped on legitimate feature slices; caused unnecessary splits.
+- **1000:** Too large; a 1000-line PR requires multiple context switches to review.
+- **500:** Too restrictive for combined proto + BDD work (typically 300 + 200 lines).
+
+## Consequences
+
+- PRs that approach the limit should be decomposed first. The issue template and
+  CONTRIBUTING.md both document this constraint.
+- Exceptions (genuinely indivisible changes above 900 lines) require a maintainer
+  approval comment on the PR before review begins. These are tracked in git history
+  so the pattern can be evaluated over time.
+- The `protos/generated/` exclusion means a proto change + stub regen stays within
+  the limit even though the generated diff is large.

--- a/docs/decisions/003-bufconn-for-contract-tests.md
+++ b/docs/decisions/003-bufconn-for-contract-tests.md
@@ -1,0 +1,59 @@
+# 003: bufconn for In-Process gRPC Contract Tests
+
+**Date:** 2026-04-21  **Author:** M1 Engineering
+
+## Context
+
+The BDD contract tests in `protos/tests/` need to make real gRPC calls against
+stub server implementations without running an actual network server. The tests
+need to be:
+- Fast (no network round-trips)
+- Parallel-safe (no port conflicts between packages)
+- Teardown-safe (no leaked OS sockets after test failures)
+- Self-contained (no external processes or Docker in unit test CI)
+
+## Decision
+
+Use `google.golang.org/grpc/test/bufconn` — a Go in-memory net.Listener that
+implements the `net.Listener` interface but routes traffic through a byte buffer
+rather than a socket.
+
+The shared `testserver.NewBufconnServer(t)` helper in `protos/tests/testserver/`
+creates a `bufconn.Listen(1 << 20)` (1 MiB buffer), starts a `grpc.Server` in a
+goroutine, registers `t.Cleanup` to call `GracefulStop()` and `Close()`, and
+returns the server + a dial function that connects via `lis.DialContext`.
+
+Test packages call `grpc.NewClient("passthrough:///bufconn", grpc.WithContextDialer(dialer))`.
+
+## Alternatives considered
+
+- **Real TCP port (`:0`):** OS assigns a random free port. Works for single tests
+  but causes flaky failures when many test packages run in parallel and exhaust
+  ephemeral port ranges. `bufconn` uses no OS resources.
+- **Unix domain sockets:** Avoids port exhaustion but requires a temp file path,
+  cleanup logic, and doesn't work on Windows without WSL. `bufconn` is pure Go.
+- **`grpc.TestServer` (gRPC built-in test helper):** Does not exist as a stable
+  API; `bufconn` is the documented approach in the gRPC-Go repo.
+- **Docker-based real server:** Correct for integration tests but too heavy for
+  unit-level contract tests (slow startup, external process dependency, breaks
+  offline dev).
+
+## Setup cost
+
+Adding `bufconn` to a new test package:
+1. Import `testserver` (already in `protos/tests/go.mod`)
+2. Call `testserver.NewBufconnServer(t)` in `ctx.Before`
+3. Register the service stub: `pb.RegisterXxxServer(srv, &stubImpl{})`
+4. Dial: `grpc.NewClient("passthrough:///bufconn", grpc.WithContextDialer(dialer), ...)`
+
+Total boilerplate: ~10 lines. See `protos/tests/AGENTS.md §Adding a New Service
+Test Suite` for the full template.
+
+## Consequences
+
+- All 8 service test packages use the same pattern — consistent and copy-pasteable.
+- Tests run in CI without any Docker daemon or network access required.
+- `GracefulStop` blocks until all in-flight RPCs complete — no race conditions on
+  teardown even in streaming tests.
+- Buffer size (1 MiB) is sufficient for all current test payloads; increase if
+  tests start sending large binary proto messages.

--- a/docs/decisions/004-gowork-off-isolation.md
+++ b/docs/decisions/004-gowork-off-isolation.md
@@ -1,0 +1,24 @@
+# 004: GOWORK=off for Contract Test Isolation
+
+**Date:** 2026-04-21  **Author:** M1 Engineering
+
+## Summary
+
+This decision is fully documented in **ADR-017** (`docs/adr/ADR-017-contract-test-isolation.md`).
+
+The short version: `go.work` lists M2–M4 service modules that do not exist on disk
+during M1. Running `go test ./...` in `protos/tests/` without disabling the workspace
+causes the Go toolchain to fail resolving those non-existent modules. `GOWORK=off`
+disables workspace resolution for the duration of the command without affecting any
+other tooling.
+
+## Quick reference
+
+```bash
+# Always run contract tests like this:
+cd protos/tests
+GOWORK=off go test ./... -v -timeout 60s
+```
+
+See ADR-017 for the full rationale, alternatives analysis, and consequences.
+See `protos/tests/AGENTS.md` for the operational guide.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -1,0 +1,51 @@
+# docs/decisions/ — Tactical Decision Records
+
+This directory captures **tactical decisions** — the "why we did it this specific
+way" for implementation choices that are not architectural in nature but would
+surprise or block a future contributor without context.
+
+## ADRs vs Decision Records
+
+| | ADR (`docs/adr/`) | Decision Record (`docs/decisions/`) |
+|--|---|---|
+| **Scope** | Strategic, cross-cutting | Tactical, localised |
+| **Examples** | "Use gRPC for all inter-service comms", "Go for platform services" | "Split EngineAdapter tests into two files", "PR size limit is 900" |
+| **Longevity** | Stable — rarely changes | Can be superseded easily |
+| **RFC required** | Yes (for new ADRs) | No |
+| **Format** | Full ADR template | Short (see below) |
+
+If a decision would affect multiple milestones or multiple teams, write an ADR.
+If it's a one-time judgment call within a module or workflow, write a decision record.
+
+## Format
+
+```markdown
+# NNN: Short Title
+
+**Date:** YYYY-MM-DD  **Author:** name or "M1 Engineering"
+
+## Context
+
+One paragraph: what was the situation, what was the question being answered.
+
+## Decision
+
+What we chose and the specific parameters (numbers, names, patterns).
+
+## Alternatives considered
+
+Brief bullets on what else was evaluated and why it was not chosen.
+
+## Consequences
+
+What this means for contributors going forward.
+```
+
+## Index
+
+| # | Title | Scope |
+|---|-------|-------|
+| [001](001-engine-adapter-test-split.md) | EngineAdapter test two-file split | `protos/tests/engine_adapter_service/` |
+| [002](002-pr-size-900-limit.md) | PR size limit 900 lines | Repository-wide |
+| [003](003-bufconn-for-contract-tests.md) | bufconn for in-process gRPC tests | `protos/tests/` |
+| [004](004-gowork-off-isolation.md) | GOWORK=off for contract tests | `protos/tests/` |

--- a/protos/tests/AGENTS.md
+++ b/protos/tests/AGENTS.md
@@ -6,7 +6,8 @@
 >
 > See `protos/AGENTS.md §7` for the contract testing mandate and `CLAUDE.md §testing`
 > for the CI enforcement rules. The architectural decision is in ADR-016 and
-> ADR-017.
+> ADR-017. Tactical decisions (test split pattern, bufconn rationale, GOWORK=off)
+> are in `docs/decisions/`.
 
 ---
 


### PR DESCRIPTION
## Summary

Creates `docs/decisions/` — a lightweight format for tactical decisions that don't warrant a full ADR but whose rationale would otherwise be lost in git history.

- **README.md** — explains ADR vs decision record distinction, format template, index table
- **001** — EngineAdapter two-file split: why lifecycle/signals are separated, same-package type sharing, `go test -run TestLifecycle` tag filtering
- **002** — PR size limit 900 lines: history of 800→900 change, what counts vs excluded (`protos/generated/`, lock files), exception process
- **003** — bufconn for in-process gRPC: why over real TCP port / unix socket / Docker, 10-line setup cost, teardown safety
- **004** — GOWORK=off: brief summary pointing to ADR-017 and `protos/tests/AGENTS.md`

Cross-reference added to `protos/tests/AGENTS.md` header.

Closes #95

## Test plan

- [ ] `docs/decisions/README.md` renders with index table pointing to all 4 records
- [ ] Each decision record has Context / Decision / Alternatives / Consequences sections
- [ ] `protos/tests/AGENTS.md` header references `docs/decisions/`
- [ ] No code files modified