### PR TITLE
docs: audit and fix AGENTS.md cross-layer consistency

### DIFF
--- a/agents/AGENTS.md
+++ b/agents/AGENTS.md
@@ -1,8 +1,12 @@
 # agents/ — AGENTS.md
 
-> **Agents are contracts + capabilities. Everything else is a plugin.**
-> See `docs/adr/ADR-010-pluggable-agent-runtime.md`.
+> **Agents are contracts + capabilities. Everything else is an adapter.**
+> See `docs/adr/ADR-010-pluggable-agent-runtime.md` and `ADR-013-adapter-first-no-sdk.md`.
 > Read this file entirely before writing any agent code.
+>
+> **M1 status:** gRPC contracts and Python stub generation are complete.
+> The SDK and adapter patterns in this file describe the target design for M2+.
+> Generated stubs live in `protos/generated/python/`.
 
 ---
 
@@ -485,7 +489,7 @@ whether the agent receiving it is a Python SDK agent, a Go raw-stub agent, or
 a TypeScript adapter. The `ExecuteCapabilityRequest` message is identical in
 every case. The stream of `TaskEvent` responses is identical in every case.
 
-A workflow written in YAML, compiled to IR by the Go workflow-compiler, executed
+A workflow written in YAML, compiled to WorkflowIR by the Go workflow-compiler, executed
 by Temporal via the Go engine-adapter, and dispatching to a Python SDK agent is
 a fully cross-language execution path — by design, not by accident.
 
@@ -521,6 +525,6 @@ generation output and the CI pipeline.
 | Nodes (LangGraph) are pure: no mixed I/O + logic | Single responsibility |
 | `AgentRuntime` is a Protocol — never subclass it | Structural subtyping, no coupling |
 | `main.py` is wiring only | Clean architecture |
-| `.feature` file before implementation | BDD-first |
+| `.feature` file before implementation | BDD-first (ADR-016) |
 | LLM model always from `context.config` | 12-Factor, easy model upgrades |
 | Never log `SecretStr` fields | Security |

--- a/agents/adapters/AGENTS.md
+++ b/agents/adapters/AGENTS.md
@@ -1,10 +1,13 @@
 # agents/adapters/ — AGENTS.md
 
 > **Adapter-First Integration. No SDK Required.**
-> See `ARCHITECTURE.md §7` and `docs/adr/ADR-013-adapter-first.md`.
+> See `ARCHITECTURE.md §7` and `docs/adr/ADR-013-adapter-first-no-sdk.md`.
 >
 > This directory contains execution adapters — thin wrappers that expose
 > external systems as Zynax capabilities WITHOUT requiring the SDK.
+>
+> **M1 status:** Python stub generation is complete (`protos/generated/python/`).
+> Adapter implementations begin in M2. Feature files are written first (ADR-016).
 
 ---
 
@@ -98,7 +101,7 @@ one that fits the external system:
 
 For any language, the workflow is:
 1. Generate `AgentService` stubs from `protos/zynax/v1/` using `buf generate`
-   with your language's gRPC plugin. See `protos/AGENTS.md §8`.
+   with your language's gRPC stub generator. See `protos/AGENTS.md §8`.
 2. Implement `ExecuteCapability` and `GetCapabilities` against those stubs.
 3. Start a gRPC server on the adapter's port.
 4. Register capabilities via `AgentDef` YAML (the same format used by Python

--- a/agents/sdk/AGENTS.md
+++ b/agents/sdk/AGENTS.md
@@ -3,6 +3,9 @@
 > The Zynax Python SDK.
 > Published as `zynax-sdk` on PyPI.
 > Framework-agnostic core. AI runtimes are optional extras.
+>
+> **M1 status:** Python gRPC stubs are generated (`protos/generated/python/`).
+> SDK implementation begins in M2. Write `.feature` files first (ADR-016).
 
 ---
 

--- a/spec/AGENTS.md
+++ b/spec/AGENTS.md
@@ -247,7 +247,7 @@ make validate-spec
 # Validate a single file
 make validate-spec FILE=spec/workflows/examples/code-review.yaml
 
-# Dry-run a workflow (compile to IR without executing)
+# Dry-run a workflow (compile to WorkflowIR without executing)
 make dry-run WORKFLOW=spec/workflows/examples/code-review.yaml
 ```
 


### PR DESCRIPTION
## Summary

Full consistency audit across all AGENTS.md files. Changes made and why:

### agents/AGENTS.md
| Change | Reason |
|--------|--------|
| "plugin" → "adapter" in header | ADR-013 establishes "adapter" as the correct term; "plugin" implies optional extension, "adapter" implies contractual boundary |
| Add ADR-013 cross-ref | Was missing alongside ADR-010; both are relevant to agent design |
| Add M1 status callout | Readers need to know stubs exist but SDK implementation is M2+ |
| "compiled to IR" → "compiled to WorkflowIR" | Avoid ambiguous standalone "IR"; consistent with ARCHITECTURE.md §3 terminology |
| `.feature file before implementation` rule cites ADR-016 | Makes BDD-first mandate traceable to the decision |

### agents/adapters/AGENTS.md
| Change | Reason |
|--------|--------|
| "gRPC plugin" → "gRPC stub generator" | "plugin" is not Zynax terminology; "stub generator" (buf generate) is accurate |
| Fix ADR-013 filename | Was `ADR-013-adapter-first.md`, actual file is `ADR-013-adapter-first-no-sdk.md` — broken link |
| Add M1 status callout with ADR-016 ref | Adapters are M2+; readers need to know stubs are ready and BDD-first applies |

### agents/sdk/AGENTS.md
| Change | Reason |
|--------|--------|
| Add M1 status callout | SDK implementation begins M2; generated stubs are already available |

### spec/AGENTS.md
| Change | Reason |
|--------|--------|
| "compile to IR" → "compile to WorkflowIR" | Consistency with ARCHITECTURE.md §3 |

### No changes needed
- **root AGENTS.md** — correctly references ADR-016 only, no ADR-004 traces
- **services/AGENTS.md** — fully rewritten in #89
- **protos/AGENTS.md** — updated with `protos/tests/AGENTS.md` cross-ref in #90
- **protos/tests/AGENTS.md** — created in #90
- Per-service `services/*/AGENTS.md` — all Go-only, no stale content found

Closes #96

## Test plan

- [ ] No `ADR-004` references remain in any AGENTS.md (superseded by ADR-016)
- [ ] No `plugin` used as Zynax terminology (replaced with `adapter`)
- [ ] No standalone `IR` without `Workflow` prefix in agent/spec AGENTS.md files
- [ ] All ADR filenames in cross-refs exist on disk
- [ ] M1 status callouts present in agents/, agents/adapters/, agents/sdk/ AGENTS.md
- [ ] Documentation-only change — no code files modified