### PR TITLE
feat(spec): JSON Schema for AgentDef manifest kind (#79)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,9 +146,9 @@ clean-tools: ## Remove tools image
 clean-all: clean dev-down clean-tools ## ⚠ Remove everything
 
 # ── Spec validation ───────────────────────────────────────────────────────────
-.PHONY: validate-spec validate-asyncapi validate-workflow-schema dry-run
+.PHONY: validate-spec validate-asyncapi validate-workflow-schema validate-agent-def-schema dry-run
 
-validate-spec: validate-asyncapi validate-capability-schemas validate-workflow-schema ## Validate all specs (AsyncAPI + capability schemas + workflow manifests)
+validate-spec: validate-asyncapi validate-capability-schemas validate-workflow-schema validate-agent-def-schema ## Validate all specs (AsyncAPI + capability schemas + workflow + agent-def manifests)
 
 validate-capability-schemas: ## Validate capability declarations in spec/ against capability.schema.json
 	docker run --rm \
@@ -169,6 +169,16 @@ validate-workflow-schema: ## Validate Workflow manifests in spec/workflows/examp
 			python tools/validate_workflows.py spec/schemas/workflow.schema.json spec/workflows/examples/ \
 		"
 	@echo "✅ Workflow schemas valid"
+
+validate-agent-def-schema: ## Validate AgentDef manifests in spec/workflows/examples/ against agent-def.schema.json
+	docker run --rm \
+		-v "$(PWD)":/workspace \
+		-w /workspace \
+		python:3.12-slim sh -c " \
+			pip install --quiet jsonschema pyyaml && \
+			python tools/validate_agent_defs.py spec/schemas/agent-def.schema.json spec/workflows/examples/ \
+		"
+	@echo "✅ AgentDef schemas valid"
 
 validate-asyncapi: ## Validate spec/asyncapi/zynax-events.yaml via AsyncAPI CLI (Docker)
 	docker run --rm \

--- a/spec/schemas/agent-def.schema.json
+++ b/spec/schemas/agent-def.schema.json
@@ -1,0 +1,248 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://zynax.io/schemas/agent-def/v1.0",
+  "title": "Zynax AgentDef Manifest",
+  "description": "JSON Schema for a Zynax AgentDef manifest (kind: AgentDef, apiVersion: zynax.io/v1alpha1). Declares the capabilities a gRPC agent provides, the container image to run, and the runtime configuration. Submitted to AgentRegistryService via 'zynax apply' or the CLI. The registry derives its AgentDef record from this manifest.",
+  "type": "object",
+  "required": ["kind", "apiVersion", "metadata", "spec"],
+  "additionalProperties": false,
+  "properties": {
+    "kind": {
+      "type": "string",
+      "const": "AgentDef",
+      "description": "Must be 'AgentDef'. Distinguishes agent declarations from Workflow and other Zynax resource kinds."
+    },
+    "apiVersion": {
+      "type": "string",
+      "const": "zynax.io/v1alpha1",
+      "description": "Schema version. The registry rejects manifests with an unrecognised apiVersion."
+    },
+    "metadata": {
+      "$ref": "#/$defs/metadata"
+    },
+    "spec": {
+      "$ref": "#/$defs/spec"
+    }
+  },
+  "$defs": {
+    "metadata": {
+      "type": "object",
+      "description": "Identifying information for the AgentDef resource.",
+      "required": ["name"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Unique agent name within the namespace. Used as agent_id in the registry.",
+          "minLength": 1,
+          "maxLength": 253,
+          "pattern": "^[a-z0-9]([a-z0-9-]*[a-z0-9])?$"
+        },
+        "namespace": {
+          "type": "string",
+          "description": "Logical namespace for multi-tenant isolation. Defaults to 'default' when omitted.",
+          "minLength": 1,
+          "maxLength": 63,
+          "pattern": "^[a-z0-9]([a-z0-9-]*[a-z0-9])?$"
+        },
+        "labels": {
+          "type": "object",
+          "description": "Key-value labels for filtering via ListAgents label selectors. Follows Kubernetes label syntax: alphanumeric, '-', '_', '.'; max 63 chars per key and value.",
+          "additionalProperties": {
+            "type": "string",
+            "maxLength": 63
+          }
+        }
+      }
+    },
+    "spec": {
+      "type": "object",
+      "description": "The agent's capability declarations and runtime configuration.",
+      "required": ["capabilities"],
+      "additionalProperties": false,
+      "properties": {
+        "capabilities": {
+          "type": "array",
+          "description": "Ordered list of capabilities this agent implements. The task broker routes work to this agent when a workflow action names one of these capabilities.",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/capability"
+          }
+        },
+        "runtime": {
+          "$ref": "#/$defs/runtime"
+        }
+      }
+    },
+    "capability": {
+      "type": "object",
+      "description": "A single named capability provided by this agent. Maps to CapabilityDef in AgentRegistryService.",
+      "required": ["name"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Unique routing key for this capability within the agent. Matched by the task broker when dispatching ActionIR.capability. Format: lowercase letters, digits, and underscores; 1–64 characters (matches ExecuteCapabilityRequest.capability_name).",
+          "minLength": 1,
+          "maxLength": 64,
+          "pattern": "^[a-z][a-z0-9_]*$"
+        },
+        "description": {
+          "type": "string",
+          "description": "Human-readable explanation of what this capability does. Shown in the agent registry UI and generated documentation."
+        },
+        "input_schema": {
+          "$ref": "#/$defs/jsonSchemaObject",
+          "description": "JSON Schema (draft-07 subset) describing the valid input_payload structure. The task broker validates dispatch payloads against this schema at runtime."
+        },
+        "output_schema": {
+          "$ref": "#/$defs/jsonSchemaObject",
+          "description": "JSON Schema (draft-07 subset) describing the result payload emitted in COMPLETED TaskEvent.payload."
+        },
+        "timeout_seconds": {
+          "type": "integer",
+          "description": "Maximum wall-clock seconds this capability may run before the task broker marks the task FAILED. Must be a positive integer.",
+          "minimum": 1
+        },
+        "max_retries": {
+          "type": "integer",
+          "description": "Maximum times the task broker will re-queue a failed task before marking it permanently FAILED. Zero means no retries.",
+          "minimum": 0
+        }
+      }
+    },
+    "runtime": {
+      "type": "object",
+      "description": "Container runtime configuration for deploying this agent. Used by the Zynax control plane to schedule and run the gRPC server.",
+      "required": ["image"],
+      "additionalProperties": false,
+      "properties": {
+        "image": {
+          "type": "string",
+          "description": "Fully qualified container image reference including tag or digest. Example: 'ghcr.io/zynax-io/code-review-agent:v1.2.3'.",
+          "minLength": 1
+        },
+        "env": {
+          "type": "object",
+          "description": "Environment variables injected into the container at runtime. Sensitive values should reference Kubernetes Secrets via the CLI, not be inlined here.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "resources": {
+          "$ref": "#/$defs/resources"
+        },
+        "replicas": {
+          "type": "integer",
+          "description": "Number of agent instances to run. Defaults to 1. The task broker distributes load across all healthy replicas.",
+          "minimum": 1,
+          "default": 1
+        }
+      }
+    },
+    "resources": {
+      "type": "object",
+      "description": "CPU and memory resource requests and limits for the agent container. Follows Kubernetes resource quantity syntax.",
+      "additionalProperties": false,
+      "properties": {
+        "requests": {
+          "$ref": "#/$defs/resourceQuantities"
+        },
+        "limits": {
+          "$ref": "#/$defs/resourceQuantities"
+        }
+      }
+    },
+    "resourceQuantities": {
+      "type": "object",
+      "description": "CPU and memory resource quantities. CPU in millicores (e.g. '100m', '0.5') or cores ('1'). Memory in bytes with SI/binary suffixes (e.g. '128Mi', '1Gi', '512M').",
+      "additionalProperties": false,
+      "properties": {
+        "cpu": {
+          "type": "string",
+          "description": "CPU quantity. Examples: '100m' (100 millicores), '0.5' (half a core), '2' (two cores).",
+          "minLength": 1
+        },
+        "memory": {
+          "type": "string",
+          "description": "Memory quantity. Examples: '128Mi', '1Gi', '512M', '2G'.",
+          "minLength": 1
+        }
+      }
+    },
+    "jsonSchemaObject": {
+      "type": "object",
+      "description": "A JSON Schema object (draft-07 subset). Must declare 'type: object' at the top level.",
+      "required": ["type"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "object"
+        },
+        "description": {
+          "type": "string"
+        },
+        "properties": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/jsonSchemaField"
+          }
+        },
+        "required": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true
+        },
+        "additionalProperties": {
+          "type": "boolean"
+        }
+      }
+    },
+    "jsonSchemaField": {
+      "type": "object",
+      "description": "A single field definition within a JSON Schema properties map.",
+      "required": ["type"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["string", "integer", "number", "boolean", "array", "object", "null"]
+        },
+        "description": {
+          "type": "string"
+        },
+        "default": {},
+        "enum": {
+          "type": "array"
+        },
+        "minimum": {
+          "type": "number"
+        },
+        "maximum": {
+          "type": "number"
+        },
+        "minLength": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "maxLength": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "items": {
+          "type": "object"
+        },
+        "properties": {
+          "type": "object"
+        },
+        "required": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/spec/workflows/examples/agent-def-example.yaml
+++ b/spec/workflows/examples/agent-def-example.yaml
@@ -1,75 +1,92 @@
 # SPDX-License-Identifier: Apache-2.0
-# Example AgentDef manifest — illustrates valid capability declarations.
-# Validated by: make validate-spec (against spec/schemas/capability.schema.json)
+# Example AgentDef manifest — illustrates valid capability declarations
+# and runtime configuration for a gRPC capability provider.
+# Validated by: make validate-spec (against spec/schemas/agent-def.schema.json)
 
 apiVersion: zynax.io/v1alpha1
 kind: AgentDef
+
 metadata:
   name: code-review-agent
   namespace: default
   labels:
     team: platform
 
-capabilities:
-  - name: summarize
-    description: >
-      Produces a concise summary of a pull request diff.
-      Returns a plain-text summary and an estimated word count.
-    input_schema:
-      type: object
-      required: [text]
-      properties:
-        text:
-          type: string
-          description: The raw diff or PR body text to summarize.
-        max_words:
-          type: integer
-          description: Upper bound on summary length in words.
-          default: 200
-          minimum: 10
-    output_schema:
-      type: object
-      required: [summary, word_count]
-      properties:
-        summary:
-          type: string
-          description: The generated summary text.
-        word_count:
-          type: integer
-          description: Number of words in the returned summary.
-    timeout_seconds: 30
-    max_retries: 2
+spec:
+  capabilities:
+    - name: summarize
+      description: >
+        Produces a concise summary of a pull request diff.
+        Returns a plain-text summary and an estimated word count.
+      input_schema:
+        type: object
+        required: [text]
+        properties:
+          text:
+            type: string
+            description: The raw diff or PR body text to summarize.
+          max_words:
+            type: integer
+            description: Upper bound on summary length in words.
+            default: 200
+            minimum: 10
+      output_schema:
+        type: object
+        required: [summary, word_count]
+        properties:
+          summary:
+            type: string
+            description: The generated summary text.
+          word_count:
+            type: integer
+            description: Number of words in the returned summary.
+      timeout_seconds: 30
+      max_retries: 2
 
-  - name: score-complexity
-    description: >
-      Assigns a complexity score (1–10) to a code change based on
-      cyclomatic complexity heuristics.
-    input_schema:
-      type: object
-      required: [diff]
-      properties:
-        diff:
-          type: string
-          description: Unified diff of the code change.
-        language:
-          type: string
-          description: Programming language hint (e.g. "go", "python").
-    output_schema:
-      type: object
-      required: [score]
-      properties:
-        score:
-          type: integer
-          description: Complexity score from 1 (trivial) to 10 (very complex).
-          minimum: 1
-          maximum: 10
-        rationale:
-          type: string
-          description: Human-readable explanation of the score.
-    timeout_seconds: 15
-    max_retries: 1
+    - name: score_complexity
+      description: >
+        Assigns a complexity score (1–10) to a code change based on
+        cyclomatic complexity heuristics.
+      input_schema:
+        type: object
+        required: [diff]
+        properties:
+          diff:
+            type: string
+            description: Unified diff of the code change.
+          language:
+            type: string
+            description: Programming language hint (e.g. "go", "python").
+      output_schema:
+        type: object
+        required: [score]
+        properties:
+          score:
+            type: integer
+            description: Complexity score from 1 (trivial) to 10 (very complex).
+            minimum: 1
+            maximum: 10
+          rationale:
+            type: string
+            description: Human-readable explanation of the score.
+      timeout_seconds: 15
+      max_retries: 1
 
-  - name: ping
-    description: Health-check capability. Returns immediately with no payload processing.
-    timeout_seconds: 5
-    max_retries: 0
+    - name: ping
+      description: Health-check capability. Returns immediately with no payload processing.
+      timeout_seconds: 5
+      max_retries: 0
+
+  runtime:
+    image: ghcr.io/zynax-io/code-review-agent:v0.1.0
+    env:
+      LOG_LEVEL: info
+      GRPC_PORT: "50051"
+    resources:
+      requests:
+        cpu: "100m"
+        memory: "128Mi"
+      limits:
+        cpu: "500m"
+        memory: "512Mi"
+    replicas: 2

--- a/tools/validate_agent_defs.py
+++ b/tools/validate_agent_defs.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Validates all AgentDef YAML manifests in a directory against
+# spec/schemas/agent-def.schema.json.
+# Usage: python tools/validate_agent_defs.py <schema-path> <yaml-dir>
+import json
+import sys
+from pathlib import Path
+
+import jsonschema
+import yaml
+
+
+def main() -> None:
+    if len(sys.argv) != 3:
+        print("Usage: validate_agent_defs.py <schema.json> <yaml-dir>")
+        sys.exit(1)
+
+    schema_path = Path(sys.argv[1])
+    yaml_dir = Path(sys.argv[2])
+
+    schema = json.loads(schema_path.read_text())
+    validator = jsonschema.Draft202012Validator(schema)
+
+    errors_found = False
+    validated = 0
+    for yaml_file in sorted(yaml_dir.glob("*.yaml")):
+        doc = yaml.safe_load(yaml_file.read_text())
+        if not isinstance(doc, dict) or doc.get("kind") != "AgentDef":
+            continue
+        errs = sorted(validator.iter_errors(doc), key=lambda e: str(e.path))
+        if errs:
+            errors_found = True
+            print(f"FAIL {yaml_file.name}:")
+            for e in errs:
+                print(f"  {e.json_path}: {e.message}")
+        else:
+            print(f"  OK  {yaml_file.name}")
+            validated += 1
+
+    if not errors_found and validated == 0:
+        print(f"  (no AgentDef manifests found in {yaml_dir})")
+
+    if errors_found:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/validate_capabilities.py
+++ b/tools/validate_capabilities.py
@@ -25,7 +25,8 @@ def main() -> None:
     errors_found = False
     for yaml_file in sorted(yaml_dir.glob("*.yaml")):
         doc = yaml.safe_load(yaml_file.read_text())
-        capabilities = doc.get("capabilities", [])
+        # Support both legacy top-level and current spec.capabilities structure.
+        capabilities = doc.get("spec", {}).get("capabilities") or doc.get("capabilities", [])
         if not capabilities:
             continue
         for cap in capabilities:


### PR DESCRIPTION
## Summary

- Add `spec/schemas/agent-def.schema.json` (draft 2020-12) covering: `kind`/`apiVersion` constants, `metadata`, `spec.capabilities` (minItems: 1, name pattern `^[a-z][a-z0-9_]*$` per proto constraint), and `spec.runtime` (`image` required, `env`, `resources` cpu/memory requests/limits, `replicas`)
- Update `spec/workflows/examples/agent-def-example.yaml` to the new `spec`-wrapped structure; rename `score-complexity` → `score_complexity` to comply with `ExecuteCapabilityRequest.capability_name` format (hyphens not allowed per proto)
- Add `tools/validate_agent_defs.py` (full document validator) and wire `validate-agent-def-schema` into `validate-spec`
- Update `validate_capabilities.py` to read from `spec.capabilities` with fallback to legacy top-level field

## Test plan

- [ ] `make validate-agent-def-schema` — exits 0 against updated example
- [ ] `make validate-capability-schemas` — still passes (reads from `spec.capabilities`)
- [ ] `make validate-spec` — all four targets pass
- [ ] Introduce invalid capability name with hyphen (e.g. `score-complexity`) — confirm FAIL with pattern error
- [ ] Remove `runtime.image` — confirm FAIL with required-field error
- [ ] Remove all capabilities from `spec.capabilities` — confirm FAIL with minItems error

Closes #79