### PR TITLE
feat(spec): JSON Schema for Policy manifest kind (#80)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,9 +146,9 @@ clean-tools: ## Remove tools image
 clean-all: clean dev-down clean-tools ## ⚠ Remove everything
 
 # ── Spec validation ───────────────────────────────────────────────────────────
-.PHONY: validate-spec validate-asyncapi validate-workflow-schema validate-agent-def-schema dry-run
+.PHONY: validate-spec validate-asyncapi validate-workflow-schema validate-agent-def-schema validate-policy-schema dry-run
 
-validate-spec: validate-asyncapi validate-capability-schemas validate-workflow-schema validate-agent-def-schema ## Validate all specs (AsyncAPI + capability schemas + workflow + agent-def manifests)
+validate-spec: validate-asyncapi validate-capability-schemas validate-workflow-schema validate-agent-def-schema validate-policy-schema ## Validate all specs (AsyncAPI + capability schemas + workflow + agent-def + policy manifests)
 
 validate-capability-schemas: ## Validate capability declarations in spec/ against capability.schema.json
 	docker run --rm \
@@ -179,6 +179,16 @@ validate-agent-def-schema: ## Validate AgentDef manifests in spec/workflows/exam
 			python tools/validate_agent_defs.py spec/schemas/agent-def.schema.json spec/workflows/examples/ \
 		"
 	@echo "✅ AgentDef schemas valid"
+
+validate-policy-schema: ## Validate Policy manifests in spec/workflows/examples/ against policy.schema.json
+	docker run --rm \
+		-v "$(PWD)":/workspace \
+		-w /workspace \
+		python:3.12-slim sh -c " \
+			pip install --quiet jsonschema pyyaml && \
+			python tools/validate_policies.py spec/schemas/policy.schema.json spec/workflows/examples/ \
+		"
+	@echo "✅ Policy schemas valid"
 
 validate-asyncapi: ## Validate spec/asyncapi/zynax-events.yaml via AsyncAPI CLI (Docker)
 	docker run --rm \

--- a/spec/schemas/policy.schema.json
+++ b/spec/schemas/policy.schema.json
@@ -1,0 +1,141 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://zynax.io/schemas/policy/v1.0",
+  "title": "Zynax Policy Manifest",
+  "description": "JSON Schema for a Zynax Policy manifest (kind: Policy, apiVersion: zynax.io/v1alpha1). Defines routing, rate-limiting, and quota rules that govern workflow execution. Policy enforcement is implemented in M6 (Kubernetes operator); this schema is committed in M2 so the workflow compiler can validate policy references. See ROADMAP.md §M6 and ADR-011.",
+  "type": "object",
+  "required": ["kind", "apiVersion", "metadata", "spec"],
+  "additionalProperties": false,
+  "properties": {
+    "kind": {
+      "type": "string",
+      "const": "Policy",
+      "description": "Must be 'Policy'. Distinguishes policy manifests from Workflow, AgentDef, and other Zynax resource kinds."
+    },
+    "apiVersion": {
+      "type": "string",
+      "const": "zynax.io/v1alpha1",
+      "description": "Schema version. The policy enforcer rejects manifests with an unrecognised apiVersion."
+    },
+    "metadata": {
+      "$ref": "#/$defs/metadata"
+    },
+    "spec": {
+      "$ref": "#/$defs/spec"
+    }
+  },
+  "$defs": {
+    "metadata": {
+      "type": "object",
+      "description": "Identifying information for the Policy resource.",
+      "required": ["name"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Unique policy name within the namespace.",
+          "minLength": 1,
+          "maxLength": 253,
+          "pattern": "^[a-z0-9]([a-z0-9-]*[a-z0-9])?$"
+        },
+        "namespace": {
+          "type": "string",
+          "description": "Logical namespace this policy is scoped to. Defaults to 'default' when omitted.",
+          "minLength": 1,
+          "maxLength": 63,
+          "pattern": "^[a-z0-9]([a-z0-9-]*[a-z0-9])?$"
+        },
+        "labels": {
+          "type": "object",
+          "description": "Key-value labels for filtering and grouping policies.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "spec": {
+      "type": "object",
+      "description": "The policy rule set.",
+      "required": ["rules"],
+      "additionalProperties": false,
+      "properties": {
+        "rules": {
+          "type": "array",
+          "description": "Ordered list of policy rules. Rules are evaluated in order; the first matching rule wins. Each rule must declare exactly one rule type (capability_routing, rate_limit, or quota).",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/rule"
+          }
+        }
+      }
+    },
+    "rule": {
+      "type": "object",
+      "description": "A single policy rule. The 'type' field determines which additional fields are required. Scope fields ('capability_selector', 'namespace_selector') support glob patterns.",
+      "required": ["type", "capability_selector"],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "Rule type discriminator. Determines which enforcement fields are required.",
+          "enum": ["capability_routing", "rate_limit", "quota"]
+        },
+        "capability_selector": {
+          "type": "string",
+          "description": "Glob pattern matching capability names this rule applies to. Use '*' to match all capabilities, 'review_*' to match a prefix, or an exact name like 'summarize'.",
+          "minLength": 1
+        },
+        "namespace_selector": {
+          "type": "string",
+          "description": "Optional glob pattern matching the workflow namespace this rule applies to. Omit to match all namespaces. Examples: 'platform', 'team-*', '*'.",
+          "minLength": 1
+        },
+        "target_namespace": {
+          "type": "string",
+          "description": "Required for type 'capability_routing'. The namespace to route matching capability invocations to. Allows cross-namespace capability delegation.",
+          "minLength": 1,
+          "maxLength": 63,
+          "pattern": "^[a-z0-9]([a-z0-9-]*[a-z0-9])?$"
+        },
+        "max_rps": {
+          "type": "number",
+          "description": "Required for type 'rate_limit'. Maximum requests per second allowed for matching capabilities across all workflow instances in scope. Must be greater than zero.",
+          "exclusiveMinimum": 0
+        },
+        "burst": {
+          "type": "integer",
+          "description": "Optional for type 'rate_limit'. Maximum number of requests allowed to exceed max_rps momentarily (token-bucket burst size). Must be at least 1. Defaults to ceil(max_rps) when omitted.",
+          "minimum": 1
+        },
+        "max_concurrent": {
+          "type": "integer",
+          "description": "Required for type 'quota'. Maximum number of simultaneously executing capability invocations in scope. Requests beyond this limit are queued or rejected.",
+          "minimum": 1
+        }
+      },
+      "if": {
+        "properties": { "type": { "const": "capability_routing" } }
+      },
+      "then": {
+        "required": ["target_namespace"]
+      },
+      "else": {
+        "if": {
+          "properties": { "type": { "const": "rate_limit" } }
+        },
+        "then": {
+          "required": ["max_rps"]
+        },
+        "else": {
+          "if": {
+            "properties": { "type": { "const": "quota" } }
+          },
+          "then": {
+            "required": ["max_concurrent"]
+          }
+        }
+      }
+    }
+  }
+}

--- a/spec/workflows/examples/policy-example.yaml
+++ b/spec/workflows/examples/policy-example.yaml
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: Apache-2.0
+# Example Policy manifest — illustrates capability routing, rate limiting,
+# and quota rules for the platform namespace.
+# Validated by: make validate-spec (against spec/schemas/policy.schema.json)
+# Note: Policy enforcement is implemented in M6. This manifest is valid for
+# schema validation and compiler policy-reference checks in M2+.
+
+apiVersion: zynax.io/v1alpha1
+kind: Policy
+
+metadata:
+  name: platform-policy
+  namespace: platform
+  labels:
+    tier: production
+    managed-by: platform-team
+
+spec:
+  rules:
+    # Route all LLM inference capabilities from the platform namespace
+    # to the shared ml-infra namespace where GPU agents are registered.
+    - type: capability_routing
+      capability_selector: "llm_*"
+      namespace_selector: "platform"
+      target_namespace: ml-infra
+
+    # Rate-limit the summarize capability globally to protect against
+    # runaway workflow loops that spam the LLM gateway.
+    - type: rate_limit
+      capability_selector: "summarize"
+      max_rps: 10.0
+      burst: 20
+
+    # Limit concurrent code review invocations per workflow namespace
+    # to prevent one team from exhausting the review agent pool.
+    - type: quota
+      capability_selector: "review_*"
+      namespace_selector: "team-*"
+      max_concurrent: 5
+
+    # Hard quota on all capabilities in the staging namespace to prevent
+    # runaway test workflows from affecting production throughput.
+    - type: quota
+      capability_selector: "*"
+      namespace_selector: "staging"
+      max_concurrent: 20

--- a/tools/validate_policies.py
+++ b/tools/validate_policies.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Validates all Policy YAML manifests in a directory against
+# spec/schemas/policy.schema.json.
+# Usage: python tools/validate_policies.py <schema-path> <yaml-dir>
+import json
+import sys
+from pathlib import Path
+
+import jsonschema
+import yaml
+
+
+def main() -> None:
+    if len(sys.argv) != 3:
+        print("Usage: validate_policies.py <schema.json> <yaml-dir>")
+        sys.exit(1)
+
+    schema_path = Path(sys.argv[1])
+    yaml_dir = Path(sys.argv[2])
+
+    schema = json.loads(schema_path.read_text())
+    validator = jsonschema.Draft202012Validator(schema)
+
+    errors_found = False
+    validated = 0
+    for yaml_file in sorted(yaml_dir.glob("*.yaml")):
+        doc = yaml.safe_load(yaml_file.read_text())
+        if not isinstance(doc, dict) or doc.get("kind") != "Policy":
+            continue
+        errs = sorted(validator.iter_errors(doc), key=lambda e: str(e.path))
+        if errs:
+            errors_found = True
+            print(f"FAIL {yaml_file.name}:")
+            for e in errs:
+                print(f"  {e.json_path}: {e.message}")
+        else:
+            print(f"  OK  {yaml_file.name}")
+            validated += 1
+
+    if not errors_found and validated == 0:
+        print(f"  (no Policy manifests found in {yaml_dir})")
+
+    if errors_found:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Add `spec/schemas/policy.schema.json` (draft 2020-12) with three rule types:
  - `capability_routing` — routes matching capabilities to a `target_namespace`
  - `rate_limit` — enforces `max_rps` with optional `burst` (token-bucket)
  - `quota` — caps `max_concurrent` invocations in scope
- Scope fields `capability_selector` and `namespace_selector` support glob patterns (`*`, `prefix_*`, exact names)
- Conditional required fields enforced via `if/then/else` per rule type
- Add `spec/workflows/examples/policy-example.yaml` exercising all three rule types
- Add `tools/validate_policies.py` and wire `validate-policy-schema` into `validate-spec`

Policy enforcement is M6 (Kubernetes operator). This schema is committed in M2 so the compiler can validate policy references without implementing enforcement.

## Test plan

- [ ] `make validate-policy-schema` — exits 0 against example
- [ ] `make validate-spec` — all five targets pass
- [ ] Remove `target_namespace` from a `capability_routing` rule — confirm FAIL
- [ ] Remove `max_rps` from a `rate_limit` rule — confirm FAIL
- [ ] Remove `max_concurrent` from a `quota` rule — confirm FAIL
- [ ] Use invalid `capability_selector: ""` — confirm FAIL (minLength)

Closes #80