### PR TITLE
ci: add gitleaks scan gate for AI context files and fix DCO commit template

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,42 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # ── Security: AI context file scan ──────────────────────────────────
+      - name: Detect AI context file changes
+        id: ai-detect
+        run: |
+          changed=$(git diff --name-only origin/main...HEAD -- \
+            'CLAUDE.md' '*/AGENTS.md' 'AGENTS.md' \
+            'docs/ai-assistant-setup.md' '.ai/' '.claude/' 2>/dev/null | wc -l)
+          echo "has_changes=$changed" >> "$GITHUB_OUTPUT"
+
+      - name: Install gitleaks
+        if: steps.ai-detect.outputs.has_changes != '0'
+        run: |
+          curl -sSfL \
+            "https://github.com/gitleaks/gitleaks/releases/download/v8.21.2/gitleaks_8.21.2_linux_x64.tar.gz" \
+            | tar -xz -C /usr/local/bin gitleaks
+
+      - name: Scan AI context files for secrets and PII
+        if: steps.ai-detect.outputs.has_changes != '0'
+        run: |
+          files=$(git diff --name-only origin/main...HEAD -- \
+            'CLAUDE.md' '*/AGENTS.md' 'AGENTS.md' \
+            'docs/ai-assistant-setup.md' '.ai/' '.claude/')
+          echo "── scanning AI context files for secrets / PII / local paths"
+          echo "$files"
+          gitleaks detect --no-git --source . \
+            --config tools/gitleaks-ai-context.toml \
+            --report-format json \
+            --report-path /tmp/gitleaks-report.json 2>/dev/null || {
+            echo "❌ Sensitive content detected in AI context files:"
+            cat /tmp/gitleaks-report.json
+            echo ""
+            echo "See docs/knowledge-base-policy.md for sanitization guidance."
+            exit 1
+          }
+          echo "✅ AI context files passed security scan"
+
       # ── Proto: buf lint + format check ──────────────────────────────────
       - name: Detect proto workspace
         id: proto-detect

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,15 @@ validators (#85), IR serialization (#86), gRPC API layer (#87).
 
 ## AI attribution
 
-- Use `Assisted-by: Claude/claude-sonnet-4-6` in commit footers.
+Every commit **must** carry both trailers or the DCO check fails:
+
+```
+Signed-off-by: Your Name <your@email.com>
+Assisted-by: Claude/claude-sonnet-4-6
+```
+
+- `Signed-off-by` — required by the DCO gate on every commit, human or AI-assisted.
+- `Assisted-by` — records AI involvement; use the exact model ID from the session.
 - **Never** use `Co-Authored-By:` for AI — reserved for humans certifying DCO.
 - **Never** add `🤖 Generated with [Claude Code]` lines to commit messages.
 - See `docs/ai-assistant-setup.md` and `CONTRIBUTING.md §AI Contribution`.
@@ -109,6 +117,7 @@ Things that have gone wrong in this repo — avoid these:
 | Mocking the database in integration tests | Use `testcontainers-go` for real DB (ADR-016) |
 | Adding complexity beyond the issue scope | Implement exactly what the issue asks; open a follow-up for anything extra |
 | Using `Co-Authored-By:` for AI | Use `Assisted-by: Claude/<model>` — DCO is human-only |
+| Omitting `Signed-off-by:` from a commit | Every commit needs `Signed-off-by: Name <email>` or the DCO gate fails — include it even on AI-assisted commits |
 | PR title prefix `spec:` / `proto:` / `adr:` | Use `docs:` for spec/ADR changes, `feat:`/`chore:` for proto changes |
 | Running `go test` in `protos/tests/` without `GOWORK=off` | Always prefix: `GOWORK=off go test ./...` (ADR-017) |
 | Running `go test` in `services/<svc>/` without `GOWORK=off` | Same rule — applies to ALL go commands in any service directory |

--- a/tools/gitleaks-ai-context.toml
+++ b/tools/gitleaks-ai-context.toml
@@ -1,0 +1,55 @@
+# gitleaks config for scanning AI context files (CLAUDE.md, AGENTS.md, docs/ai-assistant-setup.md).
+# Focused on patterns that are safe in source code but dangerous in public documentation:
+# local paths, credentials, PII, and internal infrastructure details.
+#
+# Run manually: gitleaks detect --no-git --source . --config tools/gitleaks-ai-context.toml
+# CI: triggered on any PR touching CLAUDE.md, AGENTS.md, docs/ai-assistant-setup.md, .ai/, .claude/
+
+title = "Zynax AI context security scan"
+
+[extend]
+# Inherit the default gitleaks ruleset for token/key detection, then add our own rules.
+useDefault = true
+
+[[rules]]
+id          = "local-absolute-path"
+description = "Absolute local filesystem path — must not appear in public AI context files"
+regex       = '''(?i)(\/home\/[a-z0-9_\-\.]+\/|\/mnt\/[a-z0-9_\-\.]+\/|\/Users\/[a-zA-Z0-9_\-\.]+\/|C:\\[Uu]sers\\[a-zA-Z0-9_\-\.]+\\)'''
+tags        = ["pii", "local-path"]
+
+[[rules]]
+id          = "email-address"
+description = "Email address — must not appear in public AI context files"
+regex       = '''[a-zA-Z0-9._%+\-]{2,}@[a-zA-Z0-9.\-]{2,}\.[a-zA-Z]{2,6}'''
+tags        = ["pii", "email"]
+[rules.allowlist]
+# Python decorators look like email addresses
+regexes     = ['''@pytest\.|@app\.|@router\.|@celery\.|@task\.|@property|@staticmethod|@classmethod|@abstractmethod|@override|@dataclass|@asynccontextmanager''']
+
+[[rules]]
+id          = "internal-hostname"
+description = "Hostname with internal TLD (.internal, .local, .corp, .lan) — infrastructure detail"
+regex       = '''[a-zA-Z0-9\-]+\.(internal|local|corp|lan|intranet)\b'''
+tags        = ["infrastructure"]
+[rules.allowlist]
+# 'local' as a standalone word or in NATS URLs is fine (dev environment docs)
+regexes     = ['''nats://localhost|nats://local\b|description.*[Ll]ocal''']
+
+[[rules]]
+id          = "private-ip-range"
+description = "Private IP address range — infrastructure detail"
+regex       = '''(10\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}|172\.(1[6-9]|2[0-9]|3[01])\.[0-9]{1,3}\.[0-9]{1,3}|192\.168\.[0-9]{1,3}\.[0-9]{1,3})'''
+tags        = ["infrastructure", "ip"]
+
+[allowlist]
+# These paths are Docker Alpine container paths documented as known pitfalls — not local machine paths
+regexes     = ['''\/go\/bin\/|\/usr\/local\/go|golang:[0-9\.]+-alpine|/root/go/bin/''']
+# RFC 5737 documentation addresses are safe
+regexes     = ['''192\.0\.2\.|198\.51\.100\.|203\.0\.113\.''']
+paths       = [
+  # Never scan generated files or vendored dependencies
+  '''generated/''',
+  '''vendor/''',
+  '''go\.sum''',
+  '''.*\.lock''',
+]


### PR DESCRIPTION
## Summary

- Adds a `gitleaks` CI gate that scans AI context files on every PR for secrets, PII, and local paths before they can merge to the public repo
- Retroactive audit of all existing `CLAUDE.md` and `AGENTS.md` files — zero findings
- Fixes the DCO failure pattern: CLAUDE.md now shows both required commit trailers together

## Changes

### `tools/gitleaks-ai-context.toml` (new)
Custom ruleset targeting patterns dangerous in public docs:
- Absolute local paths (`/home/user/`, `/Users/name/`, `C:\Users\`)
- Email addresses (Python decorators allowlisted)
- Internal hostnames (`.internal`, `.corp`, `.lan`)
- Private IP ranges
- Extends default gitleaks ruleset for standard credentials

### `.github/workflows/ci.yml`
New step in the `lint` job:
1. Detects whether the PR touches any AI context path
2. Installs gitleaks only when needed (no overhead on non-KB PRs)
3. Scans changed files and fails with a clear message on any finding
4. Skipped entirely on PRs that don't touch `CLAUDE.md`, `AGENTS.md`, `docs/ai-assistant-setup.md`, `.ai/`, `.claude/`

### `CLAUDE.md`
- Shows `Signed-off-by` and `Assisted-by` together in the attribution section with clear explanation that both are required
- Adds anti-pattern entry for omitting `Signed-off-by`

## Retroactive audit result

All existing AI context files pass the scanner with zero findings:
- `/CLAUDE.md` ✅
- `/AGENTS.md` and all 15 per-directory `AGENTS.md` files ✅
- `docs/ai-assistant-setup.md` ✅

The only matches during manual grep were false positives: `task-broker` matching token patterns, Python `@pytest` decorators matching email patterns, and Alpine Docker paths (`/go/bin/`) which are allowlisted.

## Test plan

- [ ] CI lint job passes on this PR (no AI context changes trigger the scanner since the config itself is in `tools/`)
- [ ] Manually test: add a fake secret to a CLAUDE.md line in a throwaway branch → CI gate catches it
- [ ] Verify scanner is skipped on a PR that only touches Go source files

## Closes

Closes #159
Closes #163
Closes #132

## Part of

#157 — [Epic] Public Knowledge Base Security