### PR TITLE
ci: post-merge proto stub auto-regen and freshness gate hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,13 +167,26 @@ jobs:
         if: steps.gen-detect.outputs.has_gen == '1'
         working-directory: protos
         run: |
+          # First pass: detect committed stubs drift
           buf generate --template buf.gen.yaml
           if ! git diff --quiet -- generated/; then
-            echo "❌ Generated stubs are out of date. Run 'make generate-protos' and commit."
+            echo "❌ Generated stubs are out of date."
+            echo "   Run 'make generate-protos' locally and commit the result."
             git diff --stat -- generated/
             exit 1
           fi
-          echo "✅ Generated stubs are up to date"
+          echo "✅ Generated stubs are up to date (first pass)"
+
+          # Second pass: determinism check — buf generate must produce identical
+          # output on repeat runs (no timestamps, no random ordering).
+          buf generate --template buf.gen.yaml
+          if ! git diff --quiet -- generated/; then
+            echo "❌ buf generate is not deterministic — second run produced a diff."
+            echo "   This is a bug in the buf plugin or buf.gen.yaml configuration."
+            git diff --stat -- generated/
+            exit 1
+          fi
+          echo "✅ buf generate is deterministic (second pass identical)"
 
       # ── Spec: AsyncAPI + JSON Schema validation ──────────────────────────
       - name: Detect spec files

--- a/.github/workflows/proto-generate.yml
+++ b/.github/workflows/proto-generate.yml
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: Apache-2.0
+# Zynax — Post-merge Proto Stub Auto-regeneration
+#
+# Fires on every push to main that modifies .proto files or buf config.
+# Runs buf generate, then commits and pushes the updated stubs back to main
+# using [skip ci] so the commit does not trigger another CI run.
+#
+# Relationship to the pre-merge freshness gate in ci.yml:
+#   Pre-merge  — ci.yml "Generate stubs and check for drift" fails the PR if
+#                stubs are not committed alongside the proto change.
+#   Post-merge — this workflow regenerates stubs automatically after merge,
+#                closing the gap when a PR author forgets to run make generate-protos.
+#
+# The two together: stubs verified before merge AND auto-corrected after merge.
+
+name: Proto Stub Auto-regeneration
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "protos/zynax/**/*.proto"
+      - "protos/buf.yaml"
+      - "protos/buf.gen.yaml"
+
+permissions:
+  contents: write
+
+env:
+  BUF_VERSION: "1.47.2"
+
+jobs:
+  regenerate-stubs:
+    name: regenerate-stubs
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          # Use GITHUB_TOKEN so the push back to main is authenticated.
+          # Branch protection must allow github-actions[bot] pushes, or use
+          # a PAT stored in secrets.BOT_GITHUB_TOKEN instead.
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 1
+
+      - name: Install buf
+        run: |
+          curl -fsSL \
+            "https://github.com/bufbuild/buf/releases/download/v${BUF_VERSION}/buf-Linux-x86_64" \
+            -o /usr/local/bin/buf
+          chmod +x /usr/local/bin/buf
+          buf --version
+
+      - name: Regenerate Go and Python stubs
+        working-directory: protos
+        run: |
+          buf generate --template buf.gen.yaml
+          echo "✅ buf generate complete"
+
+      - name: Commit regenerated stubs if changed
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          if git diff --quiet -- protos/generated/; then
+            echo "ℹ️  Stubs already up to date — no commit needed."
+            exit 0
+          fi
+
+          git diff --stat -- protos/generated/
+          git add protos/generated/
+
+          git commit -m "chore(protos): regenerate Go and Python stubs [skip ci]
+
+Triggered automatically by proto change on main (${GITHUB_SHA:0:7}).
+Assisted-by: github-actions[bot]"
+
+          git push
+          echo "✅ Regenerated stubs committed and pushed to main."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,8 @@ make bootstrap       # one-time setup (builds zynax-tools Docker image)
 make lint            # proto + Go + Python lint
 make test            # all unit tests
 make generate-protos # regenerate Go + Python stubs (commit the output)
+                     # Note: stubs auto-regenerate on main via proto-generate.yml
+                     # when .proto or buf config files change (post-merge gate).
 make validate-spec   # AsyncAPI + capability schema validation
 ```
 

--- a/docs/ai-assistant-setup.md
+++ b/docs/ai-assistant-setup.md
@@ -138,6 +138,26 @@ See `CONTRIBUTING.md §11` for the complete AI contribution policy.
 
 ---
 
+## Proto Stub Regeneration
+
+Generated stubs in `protos/generated/` are committed to the repository and kept
+fresh by two complementary CI gates:
+
+| Gate | Where | When it fires |
+|------|-------|---------------|
+| Pre-merge freshness | `ci.yml` lint job | Every PR — fails if stubs are out of sync with `.proto` changes |
+| Post-merge auto-regen | `proto-generate.yml` | After merge to `main` when `.proto` or `buf` config changes |
+
+**For contributors:** run `make generate-protos` and commit the output before
+opening a PR that modifies any `.proto` file. The pre-merge gate will fail
+the PR if you forget. The post-merge workflow auto-corrects on `main` if a
+commit slips through, but the PR gate is the primary enforcement point.
+
+**For AI tools:** never edit files in `protos/generated/` directly. Run
+`make generate-protos` (inside Docker) and commit the regenerated output.
+
+---
+
 ## What AI Tools Must Not Do
 
 These constraints from `AGENTS.md §12` apply to AI-generated output as strictly


### PR DESCRIPTION
## Summary

- **Closes #152** — adds `.github/workflows/proto-generate.yml`: fires on any push to `main` touching `.proto` or `buf` config, runs `buf generate`, commits updated stubs back to `main` with `[skip ci]`. Uses `GITHUB_TOKEN` with `contents: write` — no PAT required.
- **Closes #153** — hardens the pre-merge freshness gate in `ci.yml` with a second `buf generate` pass that verifies deterministic output. Gate now catches stale stubs (first pass) and non-deterministic generation (second pass). Error message explicitly directs contributors to `make generate-protos`.
- Documents the dual-gate strategy in `CLAUDE.md` and `docs/ai-assistant-setup.md`.

## Dual-gate strategy

| Gate | File | When | What |
|------|------|------|------|
| Pre-merge | `ci.yml` lint job | Every PR | Fails if stubs drift from proto changes; verifies determinism |
| Post-merge | `proto-generate.yml` | Push to `main` with proto changes | Auto-regenerates and commits stubs with `[skip ci]` |

## Test plan

- [ ] CI passes on this PR (no proto changes → freshness gate runs and passes)
- [ ] Determinism check: second `buf generate` produces identical output (verified in gate output)
- [ ] `proto-generate.yml` workflow appears in Actions tab
- [ ] Manually verify: modifying a `.proto` file in a future PR triggers the gate correctly