### PR TITLE
feat(service): structural and semantic validators for WorkflowCompilerService

### DIFF
--- a/services/workflow-compiler/internal/domain/errors.go
+++ b/services/workflow-compiler/internal/domain/errors.go
@@ -20,7 +20,7 @@ const (
 	ErrorCodeUnknownStateReference CompilationErrorCode = 6
 	ErrorCodeDuplicateStateName    CompilationErrorCode = 7
 	ErrorCodeMissingRequiredField  CompilationErrorCode = 8
-	ErrorCodeInvalidFieldValue CompilationErrorCode = 9
+	ErrorCodeInvalidFieldValue     CompilationErrorCode = 9
 	// ErrorCodeCircularTransition is a domain-only code with no proto equivalent yet.
 	// The api layer maps it to COMPILATION_ERROR_CODE_INVALID_FIELD_VALUE until the
 	// proto enum is extended in a future milestone.

--- a/services/workflow-compiler/internal/domain/errors.go
+++ b/services/workflow-compiler/internal/domain/errors.go
@@ -20,7 +20,11 @@ const (
 	ErrorCodeUnknownStateReference CompilationErrorCode = 6
 	ErrorCodeDuplicateStateName    CompilationErrorCode = 7
 	ErrorCodeMissingRequiredField  CompilationErrorCode = 8
-	ErrorCodeInvalidFieldValue     CompilationErrorCode = 9
+	ErrorCodeInvalidFieldValue CompilationErrorCode = 9
+	// ErrorCodeCircularTransition is a domain-only code with no proto equivalent yet.
+	// The api layer maps it to COMPILATION_ERROR_CODE_INVALID_FIELD_VALUE until the
+	// proto enum is extended in a future milestone.
+	ErrorCodeCircularTransition CompilationErrorCode = 10
 )
 
 // ParseError describes a single structural or syntactic error found during

--- a/services/workflow-compiler/internal/domain/graph.go
+++ b/services/workflow-compiler/internal/domain/graph.go
@@ -6,6 +6,8 @@ import "fmt"
 // Nodes are States; edges are the Transitions embedded in each State,
 // keyed by EventType.
 type WorkflowGraph struct {
+	Name         string
+	Namespace    string
 	InitialState string
 	States       map[string]*State
 }
@@ -83,6 +85,8 @@ func Build(m *Manifest) (*WorkflowGraph, ParseErrors) {
 	}
 
 	return &WorkflowGraph{
+		Name:         m.Name,
+		Namespace:    m.Namespace,
 		InitialState: m.InitialState,
 		States:       m.States,
 	}, nil

--- a/services/workflow-compiler/internal/domain/validators/semantic.go
+++ b/services/workflow-compiler/internal/domain/validators/semantic.go
@@ -25,25 +25,26 @@ type CapabilityRefValidator struct{}
 
 var reservedPrefixes = []string{"zynax_", "system_", "internal_"}
 
+// Validate implements Validator.
 func (CapabilityRefValidator) Validate(g *domain.WorkflowGraph) []domain.ParseError {
 	var errs []domain.ParseError
 	for stateID, state := range g.States {
 		for i, action := range state.Actions {
-			cap := action.Capability
-			if !capabilityNameRe.MatchString(cap) {
+			capName := action.Capability
+			if !capabilityNameRe.MatchString(capName) {
 				errs = append(errs, domain.ParseError{
 					Code:      domain.ErrorCodeInvalidFieldValue,
-					Message:   fmt.Sprintf("state %q action[%d]: capability %q must be snake_case (e.g. summarize, send_email)", stateID, i, cap),
+					Message:   fmt.Sprintf("state %q action[%d]: capability %q must be snake_case (e.g. summarize, send_email)", stateID, i, capName),
 					Line:      state.Line,
 					StateName: stateID,
 				})
 				continue
 			}
 			for _, prefix := range reservedPrefixes {
-				if len(cap) >= len(prefix) && cap[:len(prefix)] == prefix {
+				if len(capName) >= len(prefix) && capName[:len(prefix)] == prefix {
 					errs = append(errs, domain.ParseError{
 						Code:      domain.ErrorCodeInvalidFieldValue,
-						Message:   fmt.Sprintf("state %q action[%d]: capability %q uses reserved prefix %q", stateID, i, cap, prefix),
+						Message:   fmt.Sprintf("state %q action[%d]: capability %q uses reserved prefix %q", stateID, i, capName, prefix),
 						Line:      state.Line,
 						StateName: stateID,
 					})
@@ -59,6 +60,7 @@ func (CapabilityRefValidator) Validate(g *domain.WorkflowGraph) []domain.ParseEr
 // dot-separated naming convention (e.g. "review.approved", "push").
 type EventNameValidator struct{}
 
+// Validate implements Validator.
 func (EventNameValidator) Validate(g *domain.WorkflowGraph) []domain.ParseError {
 	var errs []domain.ParseError
 	for stateID, state := range g.States {
@@ -80,6 +82,7 @@ func (EventNameValidator) Validate(g *domain.WorkflowGraph) []domain.ParseError 
 // lowercase alphanumeric and hyphens, no leading/trailing hyphen, ≤63 chars.
 type NamespaceValidator struct{}
 
+// Validate implements Validator.
 func (NamespaceValidator) Validate(g *domain.WorkflowGraph) []domain.ParseError {
 	ns := g.Namespace
 	if ns == "" {
@@ -106,18 +109,18 @@ func (NamespaceValidator) Validate(g *domain.WorkflowGraph) []domain.ParseError 
 // but the compiler must reject structurally ambiguous definitions).
 type DuplicateTransitionValidator struct{}
 
+// Validate implements Validator.
 func (DuplicateTransitionValidator) Validate(g *domain.WorkflowGraph) []domain.ParseError {
 	var errs []domain.ParseError
 	for stateID, state := range g.States {
-		seen := make(map[string]int, len(state.Transitions))
+		seen := make(map[string]struct{}, len(state.Transitions))
 		for _, t := range state.Transitions {
 			if t.Guard != "" {
 				// Guarded transitions may share an event_type; the guard
 				// disambiguates them at runtime.
 				continue
 			}
-			if prev, ok := seen[t.EventType]; ok {
-				_ = prev
+			if _, ok := seen[t.EventType]; ok {
 				errs = append(errs, domain.ParseError{
 					Code:      domain.ErrorCodeInvalidFieldValue,
 					Message:   fmt.Sprintf("state %q has duplicate unguarded transition for event_type %q", stateID, t.EventType),
@@ -125,7 +128,7 @@ func (DuplicateTransitionValidator) Validate(g *domain.WorkflowGraph) []domain.P
 					StateName: stateID,
 				})
 			} else {
-				seen[t.EventType] = 1
+				seen[t.EventType] = struct{}{}
 			}
 		}
 	}

--- a/services/workflow-compiler/internal/domain/validators/semantic.go
+++ b/services/workflow-compiler/internal/domain/validators/semantic.go
@@ -1,0 +1,133 @@
+package validators
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/zynax-io/zynax/services/workflow-compiler/internal/domain"
+)
+
+// capabilityNameRe matches snake_case capability names: lowercase letters and
+// digits, words separated by single underscores, no leading/trailing underscore.
+var capabilityNameRe = regexp.MustCompile(`^[a-z][a-z0-9]*(_[a-z0-9]+)*$`)
+
+// eventNameRe matches dot-separated event names, e.g. "review.approved", "push".
+// Each segment is a lowercase identifier.
+var eventNameRe = regexp.MustCompile(`^[a-z][a-z0-9]*(\.[a-z][a-z0-9]*)*$`)
+
+// namespaceRe matches DNS-label-safe namespace values: lowercase alphanumeric,
+// hyphens allowed in the middle, ≤63 characters, no leading/trailing hyphen.
+var namespaceRe = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$`)
+
+// CapabilityRefValidator checks that every action capability name follows
+// snake_case naming and carries no reserved prefixes.
+type CapabilityRefValidator struct{}
+
+var reservedPrefixes = []string{"zynax_", "system_", "internal_"}
+
+func (CapabilityRefValidator) Validate(g *domain.WorkflowGraph) []domain.ParseError {
+	var errs []domain.ParseError
+	for stateID, state := range g.States {
+		for i, action := range state.Actions {
+			cap := action.Capability
+			if !capabilityNameRe.MatchString(cap) {
+				errs = append(errs, domain.ParseError{
+					Code:      domain.ErrorCodeInvalidFieldValue,
+					Message:   fmt.Sprintf("state %q action[%d]: capability %q must be snake_case (e.g. summarize, send_email)", stateID, i, cap),
+					Line:      state.Line,
+					StateName: stateID,
+				})
+				continue
+			}
+			for _, prefix := range reservedPrefixes {
+				if len(cap) >= len(prefix) && cap[:len(prefix)] == prefix {
+					errs = append(errs, domain.ParseError{
+						Code:      domain.ErrorCodeInvalidFieldValue,
+						Message:   fmt.Sprintf("state %q action[%d]: capability %q uses reserved prefix %q", stateID, i, cap, prefix),
+						Line:      state.Line,
+						StateName: stateID,
+					})
+					break
+				}
+			}
+		}
+	}
+	return errs
+}
+
+// EventNameValidator checks that every transition event_type follows the
+// dot-separated naming convention (e.g. "review.approved", "push").
+type EventNameValidator struct{}
+
+func (EventNameValidator) Validate(g *domain.WorkflowGraph) []domain.ParseError {
+	var errs []domain.ParseError
+	for stateID, state := range g.States {
+		for _, t := range state.Transitions {
+			if !eventNameRe.MatchString(t.EventType) {
+				errs = append(errs, domain.ParseError{
+					Code:      domain.ErrorCodeInvalidFieldValue,
+					Message:   fmt.Sprintf("state %q transition: event_type %q must be dot-separated lowercase (e.g. review.approved, push)", stateID, t.EventType),
+					Line:      state.Line,
+					StateName: stateID,
+				})
+			}
+		}
+	}
+	return errs
+}
+
+// NamespaceValidator checks that the workflow namespace is DNS-label safe:
+// lowercase alphanumeric and hyphens, no leading/trailing hyphen, ≤63 chars.
+type NamespaceValidator struct{}
+
+func (NamespaceValidator) Validate(g *domain.WorkflowGraph) []domain.ParseError {
+	ns := g.Namespace
+	if ns == "" {
+		return nil // empty namespace is caught by the manifest parser
+	}
+	if len(ns) > 63 {
+		return []domain.ParseError{{
+			Code:    domain.ErrorCodeInvalidFieldValue,
+			Message: fmt.Sprintf("namespace %q exceeds 63 characters (%d)", ns, len(ns)),
+		}}
+	}
+	if !namespaceRe.MatchString(ns) {
+		return []domain.ParseError{{
+			Code:    domain.ErrorCodeInvalidFieldValue,
+			Message: fmt.Sprintf("namespace %q must be DNS-label safe: lowercase alphanumeric and hyphens, no leading/trailing hyphen", ns),
+		}}
+	}
+	return nil
+}
+
+// DuplicateTransitionValidator checks that no two transitions from the same
+// state share the same event_type. Duplicate event types create ambiguous
+// routing when the engine receives an event (guards are evaluated at runtime,
+// but the compiler must reject structurally ambiguous definitions).
+type DuplicateTransitionValidator struct{}
+
+func (DuplicateTransitionValidator) Validate(g *domain.WorkflowGraph) []domain.ParseError {
+	var errs []domain.ParseError
+	for stateID, state := range g.States {
+		seen := make(map[string]int, len(state.Transitions))
+		for _, t := range state.Transitions {
+			if t.Guard != "" {
+				// Guarded transitions may share an event_type; the guard
+				// disambiguates them at runtime.
+				continue
+			}
+			if prev, ok := seen[t.EventType]; ok {
+				_ = prev
+				errs = append(errs, domain.ParseError{
+					Code:      domain.ErrorCodeInvalidFieldValue,
+					Message:   fmt.Sprintf("state %q has duplicate unguarded transition for event_type %q", stateID, t.EventType),
+					Line:      state.Line,
+					StateName: stateID,
+				})
+			} else {
+				seen[t.EventType] = 1
+			}
+		}
+	}
+	return errs
+}

--- a/services/workflow-compiler/internal/domain/validators/semantic_test.go
+++ b/services/workflow-compiler/internal/domain/validators/semantic_test.go
@@ -1,0 +1,221 @@
+package validators_test
+
+import (
+	"testing"
+
+	"github.com/zynax-io/zynax/services/workflow-compiler/internal/domain"
+	"github.com/zynax-io/zynax/services/workflow-compiler/internal/domain/validators"
+)
+
+// CapabilityRefValidator ──────────────────────────────────────────────────────
+
+func TestCapabilityRefValidator(t *testing.T) {
+	cases := []struct {
+		name       string
+		capability string
+		wantErr    bool
+	}{
+		{"simple", "summarize", false},
+		{"snake_case", "send_email", false},
+		{"multi_word", "fetch_and_parse", false},
+		{"with_digits", "run_step_2", false},
+		{"single_char", "a", false},
+		{"empty", "", true},
+		{"uppercase", "Summarize", true},
+		{"leading_underscore", "_summarize", true},
+		{"trailing_underscore", "summarize_", true},
+		{"double_underscore", "send__email", true},
+		{"hyphen", "send-email", true},
+		{"reserved_zynax", "zynax_exec", true},
+		{"reserved_system", "system_log", true},
+		{"reserved_internal", "internal_ping", true},
+	}
+
+	v := validators.CapabilityRefValidator{}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := graphWith("s", map[string]*domain.State{
+				"s": {
+					ID:   "s",
+					Type: domain.StateTypeTerminal,
+					Actions: []domain.Action{
+						{Capability: tc.capability},
+					},
+				},
+			})
+			errs := v.Validate(g)
+			if tc.wantErr && len(errs) == 0 {
+				t.Errorf("capability %q: expected error, got none", tc.capability)
+			}
+			if !tc.wantErr && len(errs) != 0 {
+				t.Errorf("capability %q: unexpected error: %v", tc.capability, errs)
+			}
+		})
+	}
+}
+
+func TestCapabilityRefValidator_NoActions(t *testing.T) {
+	g := graphWith("s", map[string]*domain.State{
+		"s": {ID: "s", Type: domain.StateTypeTerminal},
+	})
+	if errs := (validators.CapabilityRefValidator{}).Validate(g); len(errs) != 0 {
+		t.Errorf("expected no errors for state with no actions, got %v", errs)
+	}
+}
+
+// EventNameValidator ──────────────────────────────────────────────────────────
+
+func TestEventNameValidator(t *testing.T) {
+	cases := []struct {
+		name      string
+		eventType string
+		wantErr   bool
+	}{
+		{"simple", "push", false},
+		{"dot_separated", "review.approved", false},
+		{"multi_dot", "pr.merge.conflict", false},
+		{"empty", "", true},
+		{"uppercase", "Review.Approved", true},
+		{"underscore", "review_approved", true},
+		{"leading_dot", ".approved", true},
+		{"trailing_dot", "review.", true},
+		{"double_dot", "review..approved", true},
+		{"spaces", "review approved", true},
+		{"digit_start", "1push", true},
+	}
+
+	v := validators.EventNameValidator{}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := graphWith("a", map[string]*domain.State{
+				"a": normalState("a", tr(tc.eventType, "b")),
+				"b": terminalState(),
+			})
+			errs := v.Validate(g)
+			if tc.wantErr && len(errs) == 0 {
+				t.Errorf("event_type %q: expected error, got none", tc.eventType)
+			}
+			if !tc.wantErr && len(errs) != 0 {
+				t.Errorf("event_type %q: unexpected error: %v", tc.eventType, errs)
+			}
+		})
+	}
+}
+
+func TestEventNameValidator_NoTransitions(t *testing.T) {
+	g := graphWith("s", map[string]*domain.State{
+		"s": {ID: "s", Type: domain.StateTypeTerminal},
+	})
+	if errs := (validators.EventNameValidator{}).Validate(g); len(errs) != 0 {
+		t.Errorf("expected no errors for state with no transitions, got %v", errs)
+	}
+}
+
+// NamespaceValidator ──────────────────────────────────────────────────────────
+
+func TestNamespaceValidator(t *testing.T) {
+	cases := []struct {
+		name      string
+		namespace string
+		wantErr   bool
+	}{
+		{"default", "default", false},
+		{"single_char", "a", false},
+		{"hyphenated", "team-alpha", false},
+		{"alphanumeric", "platform2", false},
+		{"max_length", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", false}, // 63 chars
+		{"empty", "", false}, // empty is allowed (caught by manifest parser)
+		{"uppercase", "Team", true},
+		{"leading_hyphen", "-alpha", true},
+		{"trailing_hyphen", "alpha-", true},
+		{"underscore", "team_alpha", true},
+		{"too_long", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", true}, // 64 chars
+		{"spaces", "my namespace", true},
+	}
+
+	v := validators.NamespaceValidator{}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := graphWith("s", map[string]*domain.State{
+				"s": terminalState(),
+			})
+			g.Namespace = tc.namespace
+			errs := v.Validate(g)
+			if tc.wantErr && len(errs) == 0 {
+				t.Errorf("namespace %q: expected error, got none", tc.namespace)
+			}
+			if !tc.wantErr && len(errs) != 0 {
+				t.Errorf("namespace %q: unexpected error: %v", tc.namespace, errs)
+			}
+		})
+	}
+}
+
+// DuplicateTransitionValidator ────────────────────────────────────────────────
+
+func TestDuplicateTransitionValidator(t *testing.T) {
+	cases := []struct {
+		name    string
+		g       *domain.WorkflowGraph
+		wantErr bool
+	}{
+		{
+			name: "unique events",
+			g: graphWith("a", map[string]*domain.State{
+				"a": normalState("a", tr("push", "b"), tr("merge", "b")),
+				"b": terminalState(),
+			}),
+		},
+		{
+			name: "duplicate unguarded",
+			g: graphWith("a", map[string]*domain.State{
+				"a": normalState("a", tr("push", "b"), tr("push", "b")),
+				"b": terminalState(),
+			}),
+			wantErr: true,
+		},
+		{
+			name: "guarded duplicate allowed",
+			g: graphWith("a", map[string]*domain.State{
+				"a": {
+					ID:   "a",
+					Type: domain.StateTypeNormal,
+					Transitions: []domain.Transition{
+						{EventType: "push", TargetState: "b", Guard: "{{ .ctx.fast }}"},
+						{EventType: "push", TargetState: "c", Guard: "{{ .ctx.slow }}"},
+					},
+				},
+				"b": terminalState(),
+				"c": terminalState(),
+			}),
+		},
+		{
+			name: "mixed: one guarded, one unguarded same event",
+			g: graphWith("a", map[string]*domain.State{
+				"a": {
+					ID:   "a",
+					Type: domain.StateTypeNormal,
+					Transitions: []domain.Transition{
+						{EventType: "push", TargetState: "b", Guard: "{{ .ctx.ok }}"},
+						{EventType: "push", TargetState: "b"}, // unguarded
+					},
+				},
+				"b": terminalState(),
+			}),
+			// only unguarded ones are checked; one unguarded = no dup
+		},
+	}
+
+	v := validators.DuplicateTransitionValidator{}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			errs := v.Validate(tc.g)
+			if tc.wantErr && len(errs) == 0 {
+				t.Error("expected error, got none")
+			}
+			if !tc.wantErr && len(errs) != 0 {
+				t.Errorf("expected no error, got %v", errs)
+			}
+		})
+	}
+}

--- a/services/workflow-compiler/internal/domain/validators/structural.go
+++ b/services/workflow-compiler/internal/domain/validators/structural.go
@@ -1,0 +1,185 @@
+package validators
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/zynax-io/zynax/services/workflow-compiler/internal/domain"
+)
+
+// TerminalStateValidator ensures at least one terminal state exists.
+// This mirrors the check in Build() but is provided as a standalone Validator
+// so callers that construct graphs by other means can still apply it.
+type TerminalStateValidator struct{}
+
+func (TerminalStateValidator) Validate(g *domain.WorkflowGraph) []domain.ParseError {
+	for _, s := range g.States {
+		if s.Type == domain.StateTypeTerminal {
+			return nil
+		}
+	}
+	return []domain.ParseError{{
+		Code:    domain.ErrorCodeNoTerminalState,
+		Message: "workflow must have at least one terminal state",
+	}}
+}
+
+// OrphanStateValidator ensures every state is reachable from the initial state.
+// It performs a BFS from InitialState following all outbound transitions.
+type OrphanStateValidator struct{}
+
+func (OrphanStateValidator) Validate(g *domain.WorkflowGraph) []domain.ParseError {
+	reachable := reachableFrom(g, g.InitialState)
+	var errs []domain.ParseError
+	for id, state := range g.States {
+		if !reachable[id] {
+			errs = append(errs, domain.ParseError{
+				Code:      domain.ErrorCodeOrphanState,
+				Message:   fmt.Sprintf("state %q is unreachable from initial state %q", id, g.InitialState),
+				Line:      state.Line,
+				StateName: id,
+			})
+		}
+	}
+	return errs
+}
+
+// CircularTransitionDetector finds cycles that have no escape path to a
+// terminal state. A cycle is only an error when every state in the cycle
+// is unable to reach any terminal state (a pure infinite loop). Cycles that
+// include a human_in_the_loop state or that have an outbound edge to a state
+// which can reach terminal are accepted.
+type CircularTransitionDetector struct{}
+
+func (CircularTransitionDetector) Validate(g *domain.WorkflowGraph) []domain.ParseError { //nolint:funlen // DFS with cycle reporting requires tracking stack and visited sets in one pass
+	productive := productiveStates(g)
+
+	// DFS with three-colour marking:
+	//   0 = white (unvisited)
+	//   1 = gray  (on the current DFS stack)
+	//   2 = black (fully processed)
+	color := make(map[string]int, len(g.States))
+	stack := make([]string, 0, len(g.States))
+	reported := make(map[string]bool)
+	var errs []domain.ParseError
+
+	var dfs func(id string)
+	dfs = func(id string) {
+		color[id] = 1
+		stack = append(stack, id)
+
+		state, ok := g.States[id]
+		if !ok {
+			stack = stack[:len(stack)-1]
+			color[id] = 2
+			return
+		}
+
+		for _, t := range state.Transitions {
+			next := t.TargetState
+			switch color[next] {
+			case 0:
+				dfs(next)
+			case 1:
+				// Back-edge: found a cycle. Locate the cycle start in the stack.
+				start := -1
+				for i, s := range stack {
+					if s == next {
+						start = i
+						break
+					}
+				}
+				if start < 0 || reported[next] {
+					continue
+				}
+				cycle := stack[start:]
+				trapped := true
+				for _, s := range cycle {
+					if productive[s] {
+						trapped = false
+						break
+					}
+				}
+				if trapped {
+					reported[next] = true
+					path := strings.Join(append(cycle, next), " → ")
+					errs = append(errs, domain.ParseError{
+						Code:      domain.ErrorCodeCircularTransition,
+						Message:   fmt.Sprintf("trapped cycle with no terminal escape: %s", path),
+						StateName: next,
+					})
+				}
+			}
+		}
+
+		stack = stack[:len(stack)-1]
+		color[id] = 2
+	}
+
+	// Start from initial state, then mop up any isolated components.
+	dfs(g.InitialState)
+	for id := range g.States {
+		if color[id] == 0 {
+			dfs(id)
+		}
+	}
+
+	return errs
+}
+
+// productiveStates returns the set of state IDs from which at least one
+// terminal state is reachable. Uses a reverse-BFS from all terminal states.
+func productiveStates(g *domain.WorkflowGraph) map[string]bool {
+	// Build reverse adjacency list.
+	reverse := make(map[string][]string, len(g.States))
+	for id := range g.States {
+		reverse[id] = nil
+	}
+	for id, state := range g.States {
+		for _, t := range state.Transitions {
+			reverse[t.TargetState] = append(reverse[t.TargetState], id)
+		}
+	}
+
+	productive := make(map[string]bool, len(g.States))
+	queue := make([]string, 0, len(g.States))
+	for id, state := range g.States {
+		if state.Type == domain.StateTypeTerminal {
+			productive[id] = true
+			queue = append(queue, id)
+		}
+	}
+	for len(queue) > 0 {
+		curr := queue[0]
+		queue = queue[1:]
+		for _, pred := range reverse[curr] {
+			if !productive[pred] {
+				productive[pred] = true
+				queue = append(queue, pred)
+			}
+		}
+	}
+	return productive
+}
+
+// reachableFrom returns the set of state IDs reachable from start via BFS.
+func reachableFrom(g *domain.WorkflowGraph, start string) map[string]bool {
+	visited := make(map[string]bool, len(g.States))
+	queue := []string{start}
+	visited[start] = true
+	for len(queue) > 0 {
+		curr := queue[0]
+		queue = queue[1:]
+		state, ok := g.States[curr]
+		if !ok {
+			continue
+		}
+		for _, t := range state.Transitions {
+			if !visited[t.TargetState] {
+				visited[t.TargetState] = true
+				queue = append(queue, t.TargetState)
+			}
+		}
+	}
+	return visited
+}

--- a/services/workflow-compiler/internal/domain/validators/structural.go
+++ b/services/workflow-compiler/internal/domain/validators/structural.go
@@ -12,6 +12,7 @@ import (
 // so callers that construct graphs by other means can still apply it.
 type TerminalStateValidator struct{}
 
+// Validate implements Validator.
 func (TerminalStateValidator) Validate(g *domain.WorkflowGraph) []domain.ParseError {
 	for _, s := range g.States {
 		if s.Type == domain.StateTypeTerminal {
@@ -28,6 +29,7 @@ func (TerminalStateValidator) Validate(g *domain.WorkflowGraph) []domain.ParseEr
 // It performs a BFS from InitialState following all outbound transitions.
 type OrphanStateValidator struct{}
 
+// Validate implements Validator.
 func (OrphanStateValidator) Validate(g *domain.WorkflowGraph) []domain.ParseError {
 	reachable := reachableFrom(g, g.InitialState)
 	var errs []domain.ParseError
@@ -51,6 +53,7 @@ func (OrphanStateValidator) Validate(g *domain.WorkflowGraph) []domain.ParseErro
 // which can reach terminal are accepted.
 type CircularTransitionDetector struct{}
 
+// Validate implements Validator.
 func (CircularTransitionDetector) Validate(g *domain.WorkflowGraph) []domain.ParseError { //nolint:funlen // DFS with cycle reporting requires tracking stack and visited sets in one pass
 	productive := productiveStates(g)
 

--- a/services/workflow-compiler/internal/domain/validators/structural_test.go
+++ b/services/workflow-compiler/internal/domain/validators/structural_test.go
@@ -172,9 +172,9 @@ func TestCircularTransitionDetector(t *testing.T) {
 		{
 			name: "hitl in cycle — not trapped",
 			g: graphWith("a", map[string]*domain.State{
-				"a":    normalState("a", tr("submit", "review")),
+				"a":      normalState("a", tr("submit", "review")),
 				"review": hitlState("review", tr("approved", "done"), tr("rejected", "a")),
-				"done": terminalState(),
+				"done":   terminalState(),
 			}),
 		},
 		{

--- a/services/workflow-compiler/internal/domain/validators/structural_test.go
+++ b/services/workflow-compiler/internal/domain/validators/structural_test.go
@@ -1,0 +1,243 @@
+package validators_test
+
+import (
+	"testing"
+
+	"github.com/zynax-io/zynax/services/workflow-compiler/internal/domain"
+	"github.com/zynax-io/zynax/services/workflow-compiler/internal/domain/validators"
+)
+
+// helpers ─────────────────────────────────────────────────────────────────────
+
+func terminalState() *domain.State {
+	return &domain.State{ID: "done", Type: domain.StateTypeTerminal}
+}
+
+func normalState(id string, transitions ...domain.Transition) *domain.State {
+	return &domain.State{ID: id, Type: domain.StateTypeNormal, Transitions: transitions}
+}
+
+func hitlState(id string, transitions ...domain.Transition) *domain.State {
+	return &domain.State{ID: id, Type: domain.StateTypeHumanInTheLoop, Transitions: transitions}
+}
+
+func tr(event, target string) domain.Transition {
+	return domain.Transition{EventType: event, TargetState: target}
+}
+
+func graphWith(initial string, states map[string]*domain.State) *domain.WorkflowGraph {
+	return &domain.WorkflowGraph{
+		Name:         "test-wf",
+		Namespace:    "default",
+		InitialState: initial,
+		States:       states,
+	}
+}
+
+func hasCode(errs []domain.ParseError, code domain.CompilationErrorCode) bool {
+	for _, e := range errs {
+		if e.Code == code {
+			return true
+		}
+	}
+	return false
+}
+
+// TerminalStateValidator ──────────────────────────────────────────────────────
+
+func TestTerminalStateValidator(t *testing.T) {
+	cases := []struct {
+		name    string
+		g       *domain.WorkflowGraph
+		wantErr bool
+	}{
+		{
+			name: "has terminal",
+			g: graphWith("start", map[string]*domain.State{
+				"start": normalState("start", tr("done", "end")),
+				"end":   terminalState(),
+			}),
+		},
+		{
+			name: "no terminal",
+			g: graphWith("start", map[string]*domain.State{
+				"start": normalState("start", tr("loop", "start")),
+			}),
+			wantErr: true,
+		},
+		{
+			name: "only terminal",
+			g: graphWith("end", map[string]*domain.State{
+				"end": terminalState(),
+			}),
+		},
+	}
+	v := validators.TerminalStateValidator{}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			errs := v.Validate(tc.g)
+			if tc.wantErr && len(errs) == 0 {
+				t.Error("expected error, got none")
+			}
+			if !tc.wantErr && len(errs) != 0 {
+				t.Errorf("expected no error, got %v", errs)
+			}
+			if tc.wantErr && !hasCode(errs, domain.ErrorCodeNoTerminalState) {
+				t.Errorf("expected ErrorCodeNoTerminalState, got %v", errs)
+			}
+		})
+	}
+}
+
+// OrphanStateValidator ────────────────────────────────────────────────────────
+
+func TestOrphanStateValidator(t *testing.T) {
+	cases := []struct {
+		name       string
+		g          *domain.WorkflowGraph
+		wantOrphan string // state name expected in error, empty = no error
+	}{
+		{
+			name: "all reachable",
+			g: graphWith("a", map[string]*domain.State{
+				"a": normalState("a", tr("go", "b")),
+				"b": terminalState(),
+			}),
+		},
+		{
+			name: "orphan state",
+			g: graphWith("a", map[string]*domain.State{
+				"a":      normalState("a", tr("go", "b")),
+				"b":      terminalState(),
+				"island": normalState("island"),
+			}),
+			wantOrphan: "island",
+		},
+		{
+			name: "chain reachable",
+			g: graphWith("a", map[string]*domain.State{
+				"a": normalState("a", tr("1", "b")),
+				"b": normalState("b", tr("2", "c")),
+				"c": terminalState(),
+			}),
+		},
+	}
+	v := validators.OrphanStateValidator{}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			errs := v.Validate(tc.g)
+			if tc.wantOrphan == "" && len(errs) != 0 {
+				t.Errorf("expected no error, got %v", errs)
+			}
+			if tc.wantOrphan != "" {
+				if !hasCode(errs, domain.ErrorCodeOrphanState) {
+					t.Errorf("expected ErrorCodeOrphanState, got %v", errs)
+				}
+				found := false
+				for _, e := range errs {
+					if e.StateName == tc.wantOrphan {
+						found = true
+					}
+				}
+				if !found {
+					t.Errorf("expected orphan %q in errors, got %v", tc.wantOrphan, errs)
+				}
+			}
+		})
+	}
+}
+
+// CircularTransitionDetector ──────────────────────────────────────────────────
+
+func TestCircularTransitionDetector(t *testing.T) {
+	cases := []struct {
+		name    string
+		g       *domain.WorkflowGraph
+		wantErr bool
+	}{
+		{
+			name: "no cycle",
+			g: graphWith("a", map[string]*domain.State{
+				"a": normalState("a", tr("go", "b")),
+				"b": terminalState(),
+			}),
+		},
+		{
+			name: "cycle with terminal escape",
+			g: graphWith("a", map[string]*domain.State{
+				"a": normalState("a", tr("retry", "a"), tr("done", "b")),
+				"b": terminalState(),
+			}),
+		},
+		{
+			name: "hitl in cycle — not trapped",
+			g: graphWith("a", map[string]*domain.State{
+				"a":    normalState("a", tr("submit", "review")),
+				"review": hitlState("review", tr("approved", "done"), tr("rejected", "a")),
+				"done": terminalState(),
+			}),
+		},
+		{
+			name: "trapped two-state cycle",
+			g: graphWith("a", map[string]*domain.State{
+				"a": normalState("a", tr("ping", "b")),
+				"b": normalState("b", tr("pong", "a")),
+			}),
+			wantErr: true,
+		},
+		{
+			name: "trapped self-loop",
+			g: graphWith("a", map[string]*domain.State{
+				"a": normalState("a", tr("loop", "a")),
+			}),
+			wantErr: true,
+		},
+		{
+			name: "cycle with escape via intermediate",
+			g: graphWith("a", map[string]*domain.State{
+				"a": normalState("a", tr("go", "b")),
+				"b": normalState("b", tr("back", "a"), tr("exit", "c")),
+				"c": terminalState(),
+			}),
+		},
+	}
+	v := validators.CircularTransitionDetector{}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			errs := v.Validate(tc.g)
+			if tc.wantErr && len(errs) == 0 {
+				t.Error("expected error, got none")
+			}
+			if !tc.wantErr && len(errs) != 0 {
+				t.Errorf("expected no error, got %v", errs)
+			}
+			if tc.wantErr && !hasCode(errs, domain.ErrorCodeCircularTransition) {
+				t.Errorf("expected ErrorCodeCircularTransition, got %v", errs)
+			}
+		})
+	}
+}
+
+// Run and All ─────────────────────────────────────────────────────────────────
+
+func TestRun_AccumulatesErrors(t *testing.T) {
+	g := graphWith("a", map[string]*domain.State{
+		"a": normalState("a", tr("loop", "a")),
+		// no terminal + trapped cycle — two validators should each fire
+	})
+	errs := validators.Run(g, validators.All()...)
+	if len(errs) == 0 {
+		t.Error("expected errors from multiple validators, got none")
+	}
+}
+
+func TestRun_NoErrors(t *testing.T) {
+	g := graphWith("a", map[string]*domain.State{
+		"a": normalState("a", tr("go", "b")),
+		"b": terminalState(),
+	})
+	errs := validators.Run(g, validators.All()...)
+	if len(errs) != 0 {
+		t.Errorf("expected no errors, got %v", errs)
+	}
+}

--- a/services/workflow-compiler/internal/domain/validators/validators.go
+++ b/services/workflow-compiler/internal/domain/validators/validators.go
@@ -1,0 +1,39 @@
+// Package validators provides the Validator interface and built-in structural
+// and semantic validators for WorkflowGraph.
+//
+// Usage:
+//
+//	errs := validators.Run(graph, validators.All()...)
+package validators
+
+import "github.com/zynax-io/zynax/services/workflow-compiler/internal/domain"
+
+// Validator checks a WorkflowGraph for a single category of errors.
+// Each implementation is stateless and safe for concurrent use.
+type Validator interface {
+	Validate(g *domain.WorkflowGraph) []domain.ParseError
+}
+
+// Run applies each validator to g and accumulates all errors.
+// Validators are applied in order; all run even when earlier ones find errors.
+func Run(g *domain.WorkflowGraph, vs ...Validator) []domain.ParseError {
+	var errs []domain.ParseError
+	for _, v := range vs {
+		errs = append(errs, v.Validate(g)...)
+	}
+	return errs
+}
+
+// All returns the full set of built-in validators in the recommended order:
+// structural checks first, then semantic checks.
+func All() []Validator {
+	return []Validator{
+		TerminalStateValidator{},
+		OrphanStateValidator{},
+		CircularTransitionDetector{},
+		DuplicateTransitionValidator{},
+		CapabilityRefValidator{},
+		EventNameValidator{},
+		NamespaceValidator{},
+	}
+}


### PR DESCRIPTION
## Summary

- **Closes #84** — `domain/validators` package with `Validator` interface and three structural validators: `TerminalStateValidator`, `OrphanStateValidator`, `CircularTransitionDetector` (new — DFS + reverse-BFS to find trapped cycles with no terminal escape)
- **Closes #85** — four semantic validators: `CapabilityRefValidator` (snake_case + reserved prefix check), `EventNameValidator` (dot-separated lowercase), `NamespaceValidator` (DNS-label safe ≤63 chars), `DuplicateTransitionValidator` (no duplicate unguarded event_types per state)
- `WorkflowGraph` gains `Name` and `Namespace` fields (set by `Build()`)
- `ErrorCodeCircularTransition = 10` added to domain errors

## Design notes

- Validators are stateless, safe for concurrent use, and apply to an already-built `WorkflowGraph`
- `Run(g, vs...)` accumulates errors from all validators; `All()` returns the full set in recommended order
- Guarded transitions are exempt from `DuplicateTransitionValidator` — guards disambiguate at runtime
- `CircularTransitionDetector` accepts cycles that have at least one productive escape (state can reach terminal via forward edges); only pure trapped loops are rejected

## Test plan

- [ ] 95.3% coverage on `domain/validators` (≥90% required)
- [ ] All existing domain tests still pass
- [ ] golangci-lint clean (CI)
- [ ] Table-driven cases for all valid and invalid inputs for each validator