### PR TITLE
ci: coverage gate (≥90%), test-bdd target, and make test pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -353,6 +353,30 @@ jobs:
           done
           $failed && exit 1 || echo "✅ Go service tests passed"
 
+      - name: Go service coverage gate (≥90%)
+        if: steps.go-detect.outputs.has_services != '0'
+        run: |
+          failed=false
+          for svc in ${{ env.SERVICE_LIST }}; do
+            if [ -f "services/${svc}/coverage.out" ]; then
+              total=$(GOWORK=off go tool cover -func="services/${svc}/coverage.out" \
+                      | grep "^total:" | awk '{print $3}' | tr -d '%')
+              if [ -z "$total" ]; then
+                echo "  ⚠ no coverage total for services/${svc} — skipping"
+                continue
+              fi
+              GOWORK=off go tool cover -func="services/${svc}/coverage.out" | grep "^total:" \
+                | awk -v svc="${svc}" '{printf "── coverage: services/%s  %s\n", svc, $3}'
+              if awk "BEGIN{exit !(${total} < 90)}"; then
+                echo "  ❌ ${total}% < 90% — coverage gate failed for services/${svc}"
+                failed=true
+              else
+                echo "  ✅ ${total}% ≥ 90% for services/${svc}"
+              fi
+            fi
+          done
+          $failed && exit 1 || true
+
       - name: Godog BDD contract tests (selective by changed proto)
         if: steps.go-detect.outputs.has_bdd_impl != '0'
         run: |

--- a/Makefile
+++ b/Makefile
@@ -76,18 +76,24 @@ lint-fix: build-tools ## Auto-fix Python agent lint errors
 		$(TOOLS_RUN) sh -c "cd agents/examples/$$a && uv run ruff check --fix src/ tests/ && uv run ruff format src/ tests/" || true; done
 
 # ── Tests ──────────────────────────────────────────────────────────────────
-.PHONY: test test-unit test-unit-go test-unit-svc test-unit-agents test-unit-agent test-integration
-test: test-unit ## Run all unit tests
+.PHONY: test test-unit test-unit-go test-unit-svc test-unit-agents test-unit-agent test-bdd test-integration
+test: validate-spec test-unit test-bdd ## Run full test suite (spec + Go + Python + BDD contracts)
 test-unit: test-unit-go test-unit-agents ## All unit tests (Go + Python)
 
-test-unit-go: build-tools ## Go unit tests for all services
+test-unit-go: build-tools ## Go unit tests + coverage report for all services
 	@for svc in $(GO_SERVICES); do \
-		echo "🧪 $$svc"; \
-		$(TOOLS_RUN) sh -c "cd services/$$svc && go test ./... -v -race -timeout 60s"; \
+		if [ -f "services/$$svc/go.mod" ]; then \
+			echo "🧪 $$svc"; \
+			$(TOOLS_RUN) sh -c "cd services/$$svc && GOWORK=off go test ./... -v -race -timeout 60s -count=1 -coverprofile=coverage.out -covermode=atomic && echo '── coverage:' && GOWORK=off go tool cover -func=coverage.out | grep '^total:'" || exit 1; \
+		fi; \
 	done && echo "✅ Go tests passed"
 
-test-unit-svc: build-tools ## Go tests for one service: make test-unit-svc SVC=agent-registry
-	$(TOOLS_RUN) sh -c "cd services/$(SVC) && go test ./... -v -race -timeout 60s"
+test-unit-svc: build-tools ## Go tests for one service: make test-unit-svc SVC=workflow-compiler
+	$(TOOLS_RUN) sh -c "cd services/$(SVC) && GOWORK=off go test ./... -v -race -timeout 60s"
+
+test-bdd: build-tools ## Godog BDD contract tests for all protos/tests/ packages
+	$(TOOLS_RUN) sh -c "cd protos/tests && GOWORK=off go test ./... -timeout 120s"
+	@echo "✅ BDD contract tests passed"
 
 test-unit-agents: build-tools ## pytest-bdd for SDK + all Python agents
 	$(TOOLS_RUN) sh -c "cd agents/sdk && uv run pytest tests/ --cov=src --cov-fail-under=90 -v"

--- a/README.md
+++ b/README.md
@@ -116,19 +116,21 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for the full design.
 ```bash
 git clone https://github.com/zynax-io/zynax.git
 cd zynax
-
-# Build the dev tools image (Go + Python + all tooling)
-make build-tools
-
-# Start the full local stack
-make dev-up
-
-# Apply a workflow
-zynax apply spec/workflows/examples/code-review.yaml
-
-# Check status
-zynax get workflows -n engineering
+make bootstrap   # one-time: build the zynax-tools Docker image
+make dev-up      # start the full local stack
 ```
+
+### Key make commands
+
+| Command | What it does |
+|---------|-------------|
+| `make test` | Full test suite — spec validation + Go unit tests + BDD contracts + Python tests |
+| `make test-unit-go` | Go unit tests with coverage report for all services |
+| `make test-bdd` | Godog BDD contract tests for all `protos/tests/` packages |
+| `make lint` | Proto + Go + Python lint |
+| `make validate-spec` | Validate all YAML manifests against JSON schemas |
+| `make generate-protos` | Regenerate Go + Python stubs from `.proto` files |
+| `make build-tools` | Build the `zynax-tools:local` Docker image (run once after clone) |
 
 ---
 


### PR DESCRIPTION
## Summary

- **CI coverage gate** — new step after Go service unit tests reads `coverage.out` per service; fails if total < 90%. Uses `go tool cover -func` + awk comparison (no external tools). Services without a `go.mod` are skipped cleanly.
- **`make test-unit-go`** — now runs with `GOWORK=off` (matches CI) and emits a coverage summary line per service (`total: X.X%`)
- **`make test-bdd`** — new target that runs all `protos/tests/` godog packages inside Docker (`GOWORK=off go test ./... -timeout 120s`)
- **`make test`** — updated to run the full pipeline in order: `validate-spec → test-unit (Go+Python) → test-bdd`
- **`make test-unit-svc`** — `GOWORK=off` added for consistency with CI
- **README quickstart** — replaces the non-functional `zynax apply` placeholder with working `make bootstrap` + `make dev-up`, adds a "Key make commands" table documenting `make test`, `make test-bdd`, etc.

Closes #155, #142, #88

## Test plan

- [ ] CI passes — coverage gate shows `✅ XX.X% ≥ 90% for services/workflow-compiler`
- [ ] No other service has a `go.mod` yet, so gate only runs for `workflow-compiler`
- [ ] Existing BDD and unit test steps unaffected