### PR TITLE
docs: ADR-018 and CODEOWNERS for AI KB authorization model

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,6 +7,17 @@
 /spec/                          @zynax-io/maintainers
 /.github/                       @zynax-io/maintainers
 /SECURITY.md                    @zynax-io/maintainers
+
+# AI knowledge base paths — ADR-018
+# These files are auto-loaded by AI assistants (Claude Code, Copilot, custom
+# agents) and published to a public repo. Changes require maintainer approval.
+# See docs/adr/ADR-018-ai-kb-authorization-model.md
+/CLAUDE.md                      @zynax-io/maintainers
+/AGENTS.md                      @zynax-io/maintainers
+**/AGENTS.md                    @zynax-io/maintainers
+/docs/ai-assistant-setup.md     @zynax-io/maintainers
+/.ai/                           @zynax-io/maintainers
+/.claude/                       @zynax-io/maintainers
 /services/agent-registry/       @zynax-io/maintainers
 /services/task-broker/          @zynax-io/maintainers
 /services/memory-service/       @zynax-io/maintainers

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -776,6 +776,34 @@ If you are using Claude Code (the Anthropic CLI) to contribute:
 - Review every file changed before pushing. Pay particular attention to comments and
   docstrings — Claude tends to be more verbose than this project's standards require.
 
+### AI Knowledge Base Authorization Policy
+
+The files that AI assistants auto-load (`CLAUDE.md`, all `AGENTS.md` files,
+`docs/ai-assistant-setup.md`, and the future `.ai/` and `.claude/` directories)
+are **restricted paths** governed by ADR-018.
+
+**Why this matters:** these files are published to a public repository. Merged
+content cannot be reliably unpublished. Content that looks like documentation
+can act as a prompt injection payload that silently shifts AI assistant behavior
+for every contributor who clones the repo.
+
+**Rules for KB path changes:**
+
+1. **Maintainer approval required** — `@zynax-io/maintainers` must review and
+   approve all changes to KB paths. Branch protection enforces this via
+   CODEOWNERS. You cannot self-approve a KB change.
+2. **Secret and PII scan must pass** — the `gitleaks-ai-context` CI gate scans
+   KB file content on every PR. Red gate = no merge.
+3. **No prompt-injection payloads** — KB content must be neutral engineering
+   documentation. Avoid instruction-like phrasing ("always respond with…",
+   "ignore previous instructions"). Reviewers check for this explicitly.
+4. **Content must match reviewed source material** — KB entries should be
+   derived from merged code, ADRs, or documented decisions. Do not add
+   speculative or aspirational content.
+
+See [docs/adr/ADR-018-ai-kb-authorization-model.md](docs/adr/ADR-018-ai-kb-authorization-model.md)
+for the full rationale and threat model.
+
 ---
 
 ## 12. Adding a New Service

--- a/docs/adr/ADR-018-ai-kb-authorization-model.md
+++ b/docs/adr/ADR-018-ai-kb-authorization-model.md
@@ -1,0 +1,114 @@
+# ADR-018: AI Knowledge Base Authorization Model
+
+**Status:** Accepted  **Date:** 2026-04-24
+**Related:** ADR-016 (Layered Testing Strategy), Epic #157 (Public KB Security)
+
+---
+
+## Context
+
+Zynax stores engineering context in files that AI assistants auto-load on every
+interaction:
+
+| Path | Auto-loaded by |
+|------|----------------|
+| `CLAUDE.md` | Claude Code (all contributors) |
+| `AGENTS.md` (root + every subdirectory) | Claude Code, Copilot, custom agents |
+| `docs/ai-assistant-setup.md` | Referenced from CLAUDE.md |
+| `.ai/` (future — Epic #148) | Claude Code, custom agents |
+| `.claude/` (future — Epic #148) | Claude Code |
+
+These files sit in a **public GitHub repository**. Every byte committed is
+visible to the internet immediately on merge. This is a one-way door — once
+content is published, it cannot be reliably unpublished (forks, mirrors, search
+indexes, AI training sets).
+
+Without an explicit authorization model, any contributor with PR rights can
+modify KB files and silently influence AI assistant behavior for every engineer
+in the repo. The threat vectors are concrete:
+
+| ID | Threat |
+|----|--------|
+| T1 | Accidental secret exposure — API keys, tokens, or local paths in KB files |
+| T2 | PII leakage — engineer names, emails, or roles committed to a public repo |
+| T3 | Infrastructure fingerprinting — internal topology or credential details |
+| T4 | Prompt injection via PR — content that looks like documentation but steers AI assistant behavior |
+| T5 | Authorization bypass — contributor silently shifts AI behavior over time via KB PRs |
+
+---
+
+## Decision
+
+AI knowledge base files are **restricted paths** governed by a mandatory
+authorization policy:
+
+1. **CODEOWNERS** — all KB paths require explicit approval from
+   `@zynax-io/maintainers`. Even if branch protection already routes all PRs
+   through maintainers, listing KB paths explicitly makes the security intent
+   legible to contributors and tooling.
+
+2. **Branch protection** — `Require review from Code Owners` must be enabled on
+   `main`. A PR author cannot self-approve a KB change.
+
+3. **Dedicated review checklist** — KB PRs require additional scrutiny beyond the
+   standard engineering checklist. The checklist (ADR-related issue #160) covers:
+   - Secret / PII scan passed
+   - No prompt-injection payloads
+   - Content matches reviewed source material
+   - Previsualization approved (issue #162)
+
+4. **CI gating** — the `gitleaks-ai-context` CI step (already in place since
+   PR #164) scans KB files for secrets and PII on every PR that touches them.
+   Policy document issue #161 formalizes what the scanner must catch.
+
+### Canonical KB paths
+
+The following paths are designated AI knowledge base paths for CODEOWNERS and
+CI scanning purposes:
+
+```
+/CLAUDE.md
+/AGENTS.md
+**/AGENTS.md
+/docs/ai-assistant-setup.md
+/.ai/
+/.claude/
+```
+
+Note: `.ai/` and `.claude/` do not yet exist on disk. They are pre-declared
+here so that when Epic #148 adds them, protection is already in effect.
+
+---
+
+## Rationale
+
+| Option | Assessment |
+|--------|------------|
+| No access control (anyone with PR rights) | ✗ T4 and T5 threats are open; a single malicious or careless PR shifts AI behavior globally |
+| `@zynax-io/maintainers` required for KB paths | ✅ Minimal blast radius; maintainers are already the approval authority for architecture decisions |
+| Separate `@zynax-io/kb-owners` team | ✗ Adds team management overhead; until KB is a major workstream, a dedicated team is premature |
+| CI-only enforcement (no CODEOWNERS) | ✗ CI cannot block a determined maintainer who self-approves a PR; CODEOWNERS + branch protection is the correct control plane |
+| Require two maintainer approvals for KB paths | Acceptable escalation path if T4 proves a real attack vector; deferred until a KB incident or policy review (issue #160 can revisit) |
+
+The wildcard `*` already points all changes to `@zynax-io/maintainers` in the
+current CODEOWNERS. Adding explicit KB path entries does not change enforcement
+today — it documents intent, enables tooling to identify KB PRs, and allows a
+future stricter rule (e.g., a two-maintainer requirement) to be applied only to
+KB paths without touching general code review policy.
+
+---
+
+## Consequences
+
+- **`CODEOWNERS`** — explicit entries added for all KB paths.
+- **`CONTRIBUTING.md §11`** — AI-Assisted Contributions section references this
+  ADR and the KB authorization policy so contributors understand why KB PRs
+  require additional steps.
+- **`PULL_REQUEST_TEMPLATE.md`** — a KB-specific review checklist will be added
+  in issue #160 (S4 — PR reviewer checklist for prompt injection).
+- **`#161` (S5)** and **`#162` (previsualization gate)** depend on this ADR
+  being merged first.
+- **Knowledge base issues (#143–#148)** remain blocked until Epic #157 is fully
+  closed (all controls merged and verified).
+- When `.ai/` and `.claude/` are created (Epic #148), no CODEOWNERS change is
+  needed — the entries declared here take effect automatically.


### PR DESCRIPTION
## Why

AI knowledge base files (`CLAUDE.md`, `AGENTS.md` files, `docs/ai-assistant-setup.md`, future `.ai/` and `.claude/`) are auto-loaded by AI assistants and published to a public repo. Without an explicit authorization model, any contributor with PR rights can silently shift AI behavior for all engineers, introduce prompt injection payloads, or expose sensitive data in a way that cannot be reliably unpublished.

This is the S1 prerequisite for Epic #157 — all other KB security controls (#159, #160, #161, #162) depend on this authorization boundary being settled.

Closes #158

## What Changed

- `docs/adr/ADR-018-ai-kb-authorization-model.md` — ADR documenting KB paths, threat model, decision, and rationale for maintainer-only access control
- `.github/CODEOWNERS` — explicit entries for all KB paths pointing to `@zynax-io/maintainers`; `.ai/` and `.claude/` pre-declared for when Epic #148 creates them
- `CONTRIBUTING.md §11` — new "AI Knowledge Base Authorization Policy" subsection explaining the rules and linking to ADR-018

## Type of Change

- [x] `docs` — documentation only

## PR Size Self-Check

Lines changed (excluding generated code, lock files, fixtures): ~153

- [x] ≤ 400 lines — proceed

## Engineering Checklist

**Git hygiene**
- [x] Every commit follows Conventional Commits format
- [x] Every commit has `Signed-off-by:` (DCO)
- [x] No WIP / fixup commits remain
- [x] Branch rebased onto current `main`

**Security**
- [x] No secrets, tokens, or PII in code or fixtures

**Documentation**
- [x] ADR created: `docs/adr/ADR-018-ai-kb-authorization-model.md`
- [x] CONTRIBUTING.md updated to reference the KB authorization policy

## AI Assistance

- [x] AI-assisted — tool/model: Claude Code / claude-sonnet-4-6
      (Add label `ai-assisted`. Add `Assisted-by: <tool>/<model>` to squash commit footer.
      Do NOT use `Co-Authored-By:` for AI tools — that tag is reserved for humans.)