### PR TITLE
docs: ADR index, ADR template, and CLAUDE.md improvements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,16 +9,17 @@ any layer.
 | Milestone | Status | Version | Review |
 |-----------|--------|---------|--------|
 | M1 — Contracts Foundation | **Complete** | v0.1.0 | [Engineering Review](docs/milestones/M1-engineering-review.md) · [Release Notes](docs/milestones/M1-release-notes.md) |
-| M2 — Workflow IR | **In progress** | v0.1.0 | Epic #101 |
+| M2 — Workflow IR | **Complete** | v0.1.0 | [Epic #101](https://github.com/zynax-io/zynax/issues/101) |
 | M3 — Temporal Execution | Not started | v0.2.0 | — |
 | M4 — YAML System + CLI | Not started | v0.3.0 | — |
 
 M1 delivered: 8 gRPC contracts, AsyncAPI spec, JSON schemas, Go + Python generated stubs,
 140+ BDD scenarios across all services, 5 CI gates. All work tracked in Epic #1 (closed).
 
-M2 progress: workflow-compiler bootstrap (#82), domain types + YAML parser (#83 part 1),
-WorkflowGraph builder (#83 part 2). Remaining: structural validators (#84), semantic
-validators (#85), IR serialization (#86), gRPC API layer (#87).
+M2 delivered: YAML parser + WorkflowGraph builder (#83), structural validators (#84),
+semantic validators (#85), WorkflowGraph → WorkflowIR serialization (#86), gRPC API
+layer with CompileWorkflow / ValidateManifest / GetCompiledWorkflow (#87), BDD contract
+steps (#154), coverage gate ≥90% + make test pipeline (#155, #142).
 
 ## Key pointers
 
@@ -38,15 +39,57 @@ validators (#85), IR serialization (#86), gRPC API layer (#87).
 Every commit **must** carry both trailers or the DCO check fails:
 
 ```
-Signed-off-by: Your Name <your@email.com>
+Signed-off-by: Oscar Gómez Manresa <ogomezmanresa@gmail.com>
 Assisted-by: Claude/claude-sonnet-4-6
 ```
 
-- `Signed-off-by` — required by the DCO gate on every commit, human or AI-assisted.
+- `Signed-off-by` — the **human author's** DCO certification. AI cannot certify DCO.
 - `Assisted-by` — records AI involvement; use the exact model ID from the session.
 - **Never** use `Co-Authored-By:` for AI — reserved for humans certifying DCO.
 - **Never** add `🤖 Generated with [Claude Code]` lines to commit messages.
 - See `docs/ai-assistant-setup.md` and `CONTRIBUTING.md §AI Contribution`.
+
+## Conventional commit scope rules
+
+PR titles and commit subjects must use a valid type. Scope is optional but recommended.
+
+| Type | When to use |
+|------|-------------|
+| `feat` | New capability visible to users or callers |
+| `fix` | Bug fix |
+| `docs` | `AGENTS.md`, `README`, ADR, or any documentation-only change |
+| `ci` | GitHub Actions workflows, Makefile CI targets |
+| `chore` | Dependency updates, tooling, housekeeping |
+| `refactor` | Code restructuring with no behaviour change |
+| `test` | Test-only changes |
+
+| Scope | Maps to |
+|-------|---------|
+| `(workflow-compiler)` | `services/workflow-compiler/` |
+| `(agent-registry)` | `services/agent-registry/` and other named services |
+| `(protos)` | `protos/` — proto or generated stub changes |
+| `(spec)` | `spec/` — YAML schemas or example manifests |
+| `(infra)` | `infra/`, Docker, Helm |
+| `(agents)` | `agents/` — Python adapters or SDK |
+| `(ci)` | Omit scope when type is already `ci` |
+| `(docs)` | Omit scope when type is already `docs` |
+
+Rejected prefixes (CI will fail): `spec:`, `proto:`, `adr:`, `service:`, `security:`, `make:`.
+
+## PR size quick-reference
+
+| Lines changed | Status |
+|--------------|--------|
+| ≤ 200 | Ideal |
+| 201–400 | Acceptable — no explanation needed |
+| 401–900 | Justify in PR description why it cannot be split |
+| > 900 | **Blocked** — decompose before opening PR |
+
+Exclusions from the count: generated stubs (`*.pb.go`, `*_pb2.py`), lock files,
+CI workflow files (`.github/workflows/`), schema fixtures.
+
+Split strategy: one commit per logical change; one PR per issue or tightly related
+issue group. Never squash unrelated work.
 
 ## Development workflow
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,8 @@ validators (#85), IR serialization (#86), gRPC API layer (#87).
 | `protos/` | Proto naming, backward-compatibility rules |
 | `spec/` | YAML manifest schemas |
 | `infra/` | Docker, env var conventions |
-| `docs/architecture/` | Architecture reviews, competitive analysis, ADR index |
+| `docs/adr/INDEX.md` | Searchable ADR register — check here before proposing a design change |
+| `docs/architecture/` | Architecture reviews, competitive analysis |
 
 ## AI attribution
 

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -1,0 +1,42 @@
+# ADR Index — Architecture Decision Records
+
+All decisions that shape Zynax are recorded here. Before proposing a design change,
+search this index for the ADR that already governs the area. One-way doors always
+get ADRs; reversible implementation choices do not.
+
+To add a new ADR, copy [TEMPLATE.md](TEMPLATE.md), assign the next number, and open
+a PR against `docs/adr/`.
+
+---
+
+| ADR | Title | Status | Date | Governs |
+|-----|-------|--------|------|---------|
+| [ADR-001](ADR-001-grpc-inter-service-protocol.md) | gRPC as the inter-service protocol | Accepted | 2026-04-01 | `protos/`, all service-to-service calls |
+| [ADR-002](ADR-002-python-312.md) | Python 3.12 as the agent runtime | Accepted | 2026-04-01 | `agents/`, Python toolchain |
+| [ADR-003](ADR-003-uv-package-manager.md) | uv as the Python package manager | Accepted | 2026-04-01 | `agents/`, `pyproject.toml`, lock files |
+| [ADR-004](ADR-004-bdd-testing.md) | BDD as the primary testing methodology | Superseded | 2026-04-01 | Superseded by ADR-016 |
+| [ADR-005](ADR-005-apache-license.md) | Apache 2.0 license | Accepted | 2026-04-01 | `LICENSE`, SPDX headers on all files |
+| [ADR-006](ADR-006-monorepo.md) | Monorepo structure | Accepted | 2026-04-01 | Repository layout, `go.work`, `buf.work.yaml` |
+| [ADR-007](ADR-007-pydantic-settings.md) | Pydantic Settings for agent configuration | Accepted | 2026-04-01 | `agents/` config management |
+| [ADR-008](ADR-008-no-shared-databases.md) | No shared databases across services | Accepted | 2026-04-01 | All services — cross-service data access |
+| [ADR-009](ADR-009-language-strategy.md) | Language strategy: Go for services, Python for agents | Accepted | 2026-04-01 | `services/` (Go only), `agents/` (Python only) |
+| [ADR-010](ADR-010-pluggable-agent-runtime.md) | Pluggable agent runtime | Accepted | 2026-04-01 | `agents/`, `AgentService` gRPC contract |
+| [ADR-011](ADR-011-declarative-yaml-control-plane.md) | Declarative YAML control plane | Accepted | 2026-04-01 | `spec/`, Layer 1 → Layer 2 boundary |
+| [ADR-012](ADR-012-workflow-ir.md) | Workflow IR as the engine-agnostic intermediate representation | Accepted | 2026-04-01 | `WorkflowIR` proto, `services/workflow-compiler/` |
+| [ADR-013](ADR-013-adapter-first-no-sdk.md) | Adapter-first — no mandatory SDK | Accepted | 2026-04-01 | `agents/sdk/` (optional), `AgentService` gRPC |
+| [ADR-014](ADR-014-event-driven-state-machine.md) | Event-driven state machine workflow model | Accepted | 2026-04-01 | `spec/workflows/`, `WorkflowIR` state model |
+| [ADR-015](ADR-015-pluggable-workflow-engines.md) | Pluggable workflow engines | Accepted | 2026-04-01 | `services/engine-adapter/`, M3+ |
+| [ADR-016](ADR-016-layered-testing-strategy.md) | Layered testing strategy | Accepted | 2026-04-21 | Test placement, BDD scope, coverage gates |
+| [ADR-017](ADR-017-contract-test-isolation.md) | Contract test isolation — GOWORK=off | Accepted | 2026-04-21 | `protos/tests/`, `services/*/` — all `go test` invocations |
+| [ADR-018](ADR-018-ai-kb-authorization-model.md) | AI knowledge base authorization model | Accepted | 2026-04-24 | `CLAUDE.md`, `AGENTS.md`, `.ai/`, `.claude/` — KB paths |
+
+---
+
+## Status definitions
+
+| Status | Meaning |
+|--------|---------|
+| **Proposed** | Open for discussion — not yet binding |
+| **Accepted** | Binding — all new code must comply |
+| **Deprecated** | No longer recommended — existing code may still follow it |
+| **Superseded** | Replaced by a newer ADR (noted in the entry) |

--- a/docs/adr/TEMPLATE.md
+++ b/docs/adr/TEMPLATE.md
@@ -1,0 +1,41 @@
+# ADR-NNN: Title
+
+**Status:** Proposed  **Date:** YYYY-MM-DD
+**Related:** ADR-NNN (short description of relationship)
+
+---
+
+## Context
+
+What is the situation that forces a decision? Describe the forces at play:
+constraints, requirements, prior decisions, and the problem space. Do not include
+the decision itself here.
+
+---
+
+## Decision
+
+State the decision clearly. Use active voice: "We will…", "This project uses…".
+
+If the decision has multiple parts, list them with sub-headings or bullet points.
+
+---
+
+## Rationale
+
+| Option | Assessment |
+|--------|------------|
+| Option A | ✅ Chosen — reason |
+| Option B | ✗ Rejected — reason |
+| Option C | ✗ Deferred — reason |
+
+---
+
+## Consequences
+
+What becomes easier or harder as a result of this decision? What must change in
+the codebase, documentation, or process?
+
+- **Positive:** …
+- **Negative / trade-off:** …
+- **Neutral / follow-up required:** …


### PR DESCRIPTION
## Why

ADR-001 through ADR-018 are discoverable only by browsing the directory — AI assistants and new engineers frequently violate constraints they never found. CLAUDE.md's commit footer used a generic placeholder instead of the actual owner name, causing DCO-failing commits.

Closes #141
Closes #138

## What Changed

- `docs/adr/INDEX.md` (#141) — searchable register of all 18 ADRs with status, date, and a Governs column mapping each ADR to the paths it constrains
- `docs/adr/TEMPLATE.md` (#141) — canonical starting point for new ADRs with Context / Decision / Rationale / Consequences sections
- `CLAUDE.md` (#141) — Key pointers table updated to reference the index directly
- `CLAUDE.md` (#138) — M2 milestone updated to Complete; commit footer template uses real name + email; conventional commit scope table added; rejected prefix list added; PR size quick-reference table added

## Type of Change

- [x] `docs` — documentation only

## PR Size Self-Check

Lines changed: ~130

- [x] ≤ 400 lines — proceed

## Engineering Checklist

**Git hygiene**
- [x] Every commit follows Conventional Commits format
- [x] Every commit has `Signed-off-by:` (DCO)
- [x] No WIP / fixup commits remain
- [x] Branch rebased onto current `main`

**Security**
- [x] No secrets, tokens, or PII in code or fixtures

**Documentation**
- [x] ADR index lists all 18 ADRs with correct status and dates

## AI Assistance

- [x] AI-assisted — tool/model: Claude Code / claude-sonnet-4-6