### PR TITLE
chore: add make audit target for dependency vulnerability scanning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,8 +120,8 @@ lint-protos: build-tools ## buf lint + format check on all proto files
 	@echo "✅ Proto lint passed"
 
 # ── Security ───────────────────────────────────────────────────────────────
-.PHONY: security security-go security-agents
-security: security-go security-agents ## All security scans
+.PHONY: security security-go security-agents audit
+security: security-go security-agents ## Full security scan (govulncheck + bandit + pip-audit)
 
 security-go: build-tools ## govulncheck on all Go services
 	@for svc in $(GO_SERVICES); do $(TOOLS_RUN) sh -c "cd services/$$svc && govulncheck ./..."; done
@@ -129,6 +129,22 @@ security-go: build-tools ## govulncheck on all Go services
 security-agents: build-tools ## bandit + pip-audit on all agents
 	@for a in $(AGENTS); do [ -f "agents/examples/$$a/pyproject.toml" ] && \
 		$(TOOLS_RUN) sh -c "cd agents/examples/$$a && uv run bandit -r src/ -ll && uv run pip-audit" || true; done
+
+audit: build-tools ## Dependency vulnerability audit (govulncheck + pip-audit); exits 1 on any finding
+	@failed=false; \
+	for svc in $(GO_SERVICES); do \
+		if [ -f "services/$$svc/go.mod" ]; then \
+			echo "🔍 govulncheck: $$svc"; \
+			$(TOOLS_RUN) sh -c "cd services/$$svc && GOWORK=off govulncheck ./..." || failed=true; \
+		fi; \
+	done; \
+	for a in $(AGENTS); do \
+		if [ -f "agents/examples/$$a/pyproject.toml" ]; then \
+			echo "🔍 pip-audit: $$a"; \
+			$(TOOLS_RUN) sh -c "cd agents/examples/$$a && uv run pip-audit" || failed=true; \
+		fi; \
+	done; \
+	$$failed && exit 1 || echo "✅ Audit passed — no known vulnerabilities"
 
 # ── Build images ───────────────────────────────────────────────────────────
 .PHONY: build build-svc build-agent

--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ make dev-up      # start the full local stack
 | `make test-unit-go` | Go unit tests with coverage report for all services |
 | `make test-bdd` | Godog BDD contract tests for all `protos/tests/` packages |
 | `make lint` | Proto + Go + Python lint |
+| `make audit` | Dependency vulnerability audit — govulncheck (Go) + pip-audit (Python); exits 1 on any finding |
+| `make security` | Full security scan — adds bandit SAST to the audit checks |
 | `make validate-spec` | Validate all YAML manifests against JSON schemas |
 | `make generate-protos` | Regenerate Go + Python stubs from `.proto` files |
 | `make build-tools` | Build the `zynax-tools:local` Docker image (run once after clone) |


### PR DESCRIPTION
## Why

`make security` runs govulncheck + bandit + pip-audit but mixes SAST (bandit) with dependency CVE scanning. There was no single command to answer "are my dependencies vulnerable?" with a clean exit code. This makes it harder to run a quick pre-push audit without also running source-level analysis.

Closes #137

## What Changed

- `Makefile` — adds `make audit` target: iterates over all Go service modules with `govulncheck` (GOWORK=off) and all Python agents with `pip-audit`; collects all failures and exits 1 if any finding; skips modules/agents that don't exist yet
- `README.md` — adds `make audit` and `make security` rows to the Key make commands table with one-line descriptions distinguishing them

## Type of Change

- [x] `chore` — maintenance (deps, tooling)

## PR Size Self-Check

Lines changed: ~22

- [x] ≤ 400 lines — proceed

## Engineering Checklist

**Git hygiene**
- [x] Every commit follows Conventional Commits format
- [x] Every commit has `Signed-off-by:` (DCO)
- [x] No WIP / fixup commits remain
- [x] Branch rebased onto current `main`

**Security**
- [x] No secrets, tokens, or PII

**Documentation**
- [x] README updated with `make audit` and `make security`

## AI Assistance

- [x] AI-assisted — tool/model: Claude Code / claude-sonnet-4-6