### PR TITLE
docs: AGENTS.md completeness audit — AI mistakes tables and test commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -467,5 +467,26 @@ Breaking any of them is a hard blocker at code review.
 
 ---
 
+## Common AI Mistakes
+
+Mistakes observed in AI-assisted contributions to this repo. Consult before writing any code.
+
+| Mistake | Why it fails | Correct approach |
+|---------|-------------|-----------------|
+| Using `spec:`, `proto:`, `adr:`, `service:`, `make:`, `security:` as PR/commit type prefix | CI `conventional-commit` check rejects anything outside `feat fix refactor docs test ci chore` | Use `docs:` for specs/ADRs, `feat:`/`chore:` for proto, `chore:` for Makefile |
+| Running `go test ./...` inside `services/*/` or `protos/tests/` without `GOWORK=off` | `go.work` lists modules that don't exist yet; resolution fails with an unrelated error | Always: `GOWORK=off go test ./...` (ADR-017) |
+| Importing a domain type from one service into another | Breaks service isolation; two services cannot share an `internal/` package | Cross-service data flows through gRPC — define the message in proto, never share Go types |
+| Editing `protos/generated/` by hand | Generated files are overwritten by `make generate-protos`; edits are silently lost | Edit `.proto` source files, then run `make generate-protos` and commit the output |
+| Writing Python code inside `services/` | Platform services are Go only (ADR-009) | Python lives exclusively in `agents/`; use gRPC stubs to call services |
+| Adding `Co-Authored-By: Claude …` to commits | DCO bot treats it as a human certifying the Developer Certificate of Origin — AI cannot do this | Use `Assisted-by: Claude/claude-sonnet-4-6` (no angle brackets, no @) |
+| Omitting `Signed-off-by:` from a commit | DCO gate blocks merge | Every commit needs `Signed-off-by: Oscar Gómez Manresa <ogomezmanresa@gmail.com>` |
+| Adding a new gRPC method without a `.feature` file first | CI `bdd-first` gate enforces the feature-before-code contract (ADR-016) | Write and commit the `.feature` file, get it CI-green, then implement |
+| Adding `panic` in production code paths | A single unrecovered panic kills the entire service process | Return a gRPC status error; let the framework handle transport-level failures |
+| Hardcoding engine names (`"temporal"`, `"langgraph"`) in business logic | Breaks the pluggable engine contract (ADR-015) | Route through an engine interface; the string lives only in config |
+| Disabling TLS verification (`InsecureSkipVerify: true`) | Silently exposes all traffic to MITM attacks | TLS must be on by default; use test-only `credentials/insecure` only in bufconn tests |
+| Calling a platform service via HTTP instead of gRPC | Bypasses the contract layer; no protobuf type safety | Generate gRPC stubs with `make generate-protos`, import and use the Go client |
+
+---
+
 *Zynax — The control plane for AI-driven systems*
 *Apache 2.0 · CNCF Sandbox Candidate*

--- a/agents/sdk/AGENTS.md
+++ b/agents/sdk/AGENTS.md
@@ -283,3 +283,32 @@ autogen   = ["pyautogen>=0.2.0"]
 crewai    = ["crewai>=0.28.0"]
 all       = ["zynax-sdk[langgraph,autogen,crewai]"]
 ```
+
+---
+
+## When NOT to Use the SDK
+
+The SDK owns the asyncio event loop and starts a long-running gRPC server. It is the
+wrong tool in several common situations:
+
+| Situation | Why the SDK doesn't fit | What to use instead |
+|-----------|------------------------|---------------------|
+| One-off script that submits a workflow or queries the registry | SDK starts a server and blocks; you just need a client call | Raw generated stubs + `asyncio.run()` |
+| Wrapping an existing Django / FastAPI / Flask app | SDK owns the event loop; your framework also owns the event loop — conflict | Run the SDK agent in a separate process; communicate via queue or gRPC |
+| Pure library (no running server, just shared logic) | SDK registers an agent and exposes gRPC endpoints — meaningless for a library | Do not use the SDK; expose plain Python functions |
+| Go, TypeScript, Java, or Rust agent | No SDK edition exists or is planned for other languages | Use the generated gRPC stubs for that language directly |
+| Calling Zynax services FROM your code (client role) | SDK is server-side only — it receives tasks, it does not submit them | Import raw stubs from `protos/generated/python/` |
+| Testing in isolation without a live gRPC connection | SDK requires a live connection on startup | Use `unittest.mock` or `FakeAgentContext` from `agents/sdk/tests/` |
+
+---
+
+## Common AI Mistakes
+
+| Mistake | Why it fails | Correct approach |
+|---------|-------------|-----------------|
+| Adding a `pip install zynax-sdk` step | The SDK is a local module, not a published package | `uv add zynax-sdk` with the local path in `pyproject.toml` — see examples in `agents/examples/` |
+| Instantiating `AgentServer` inside a request handler | `AgentServer` is a long-running process — one per container | Instantiate once at module level; let the SDK manage its lifecycle |
+| Calling `context.memory_client` or `context.registry_client` directly | Platform clients are injected by the runtime, not constructed manually | Accept them via `AgentRuntime.execute(task, context)` — the SDK injects them |
+| Hardcoding the LLM model name inside `AgentRuntime.execute` | Breaks when the model is deprecated or rotated | Read from env var: `os.environ["ZYNAX_LLM_MODEL"]` |
+| Using `print()` instead of `structlog` | No structured fields; logs unreadable in Grafana / Loki | `log = structlog.get_logger(); log.info("event", key=value)` |
+| Catching bare `except:` | Silently swallows grpc errors, cancellation signals, and OOMKilled | Catch specific exception types; always re-raise `BaseException` subclasses |

--- a/protos/tests/AGENTS.md
+++ b/protos/tests/AGENTS.md
@@ -323,3 +323,17 @@ from the current `.proto` files:
 ```
 replace github.com/zynax-io/zynax/protos/generated/go => ../generated/go
 ```
+
+---
+
+## Common AI Mistakes
+
+| Mistake | Why it fails | Correct approach |
+|---------|-------------|-----------------|
+| `go test ./...` without `GOWORK=off` | Workspace resolves missing service modules → confusing resolution error unrelated to the test | `GOWORK=off go test ./...` — every invocation in this directory (ADR-017) |
+| Writing step definitions before the `.feature` file is committed | Violates BDD-first contract; CI checks feature-before-code ordering | Commit the `.feature` file alone first, get it CI-green, then add step definitions |
+| Registering the service-under-test as a real remote gRPC server | Introduces network, port, and lifecycle dependencies that make tests flaky | Use `bufconn` in-memory transport; the stub runs in the same process as the test |
+| Putting step state in package-level variables | Causes test pollution across scenarios; state leaks between runs | Keep all state in the per-suite context struct; re-initialise in `sc.Before` |
+| Implementing real business logic inside the in-process stub | Stub should only verify the contract shape, not reproduce the service | Return fixed or schema-valid responses; test the contract, not the implementation |
+| Importing the real service's `internal/` packages into the test stub | Creates a coupling that makes the contract test indistinguishable from a unit test | The stub is a hand-written fake that satisfies the proto interface — no service imports |
+| Running `go mod tidy` from the repo root with workspace active | Workspace-aware tidy modifies `go.work.sum`, not the test module's `go.sum` | `cd protos/tests && GOWORK=off go mod tidy` |

--- a/services/AGENTS.md
+++ b/services/AGENTS.md
@@ -413,6 +413,38 @@ golangci-lint run ./services/<service-name>/...
 Coverage requirement: ≥ 90% on `internal/domain/` (pure logic, no I/O to mock).
 Integration tests hitting real databases use `testcontainers-go`.
 
+**Always use `GOWORK=off`** — the workspace root lists modules not yet on disk:
+
+```bash
+cd services/<service-name>
+GOWORK=off go test ./... -race -timeout 60s
+GOWORK=off go test ./internal/domain/... -v -coverprofile=coverage.out
+```
+
+**Governing ADRs:**
+
+| ADR | Governs |
+|-----|---------|
+| [ADR-001](../docs/adr/ADR-001-grpc-inter-service-protocol.md) | gRPC as the only inter-service protocol |
+| [ADR-008](../docs/adr/ADR-008-no-shared-databases.md) | Each service owns its own schema; no shared tables |
+| [ADR-009](../docs/adr/ADR-009-language-strategy.md) | Go for all platform services |
+| [ADR-016](../docs/adr/ADR-016-layered-testing-strategy.md) | Testing pyramid: BDD at boundaries, unit in domain |
+| [ADR-017](../docs/adr/ADR-017-contract-test-isolation.md) | GOWORK=off for all `go test` inside service directories |
+
+---
+
+## Common AI Mistakes
+
+| Mistake | Why it fails | Correct approach |
+|---------|-------------|-----------------|
+| `go test ./...` without `GOWORK=off` | `go.work` resolves non-existent modules and breaks | `GOWORK=off go test ./...` — every time, no exceptions (ADR-017) |
+| Importing `internal/` from another service | Go toolchain blocks cross-module `internal/` imports | Use gRPC stubs; never share internal packages across service boundaries |
+| Putting business logic in `api/` | Violates layer separation; `api/` is a translation layer only | Move logic to `internal/domain/`; `api/` only marshals/unmarshals and calls domain |
+| Calling external packages in `internal/domain/` | Domain must be pure Go with zero I/O | Define an interface in domain; implement it in `internal/infrastructure/` |
+| Writing `go test` integration tests that reach a real DB without `testcontainers` | Flaky in CI; hard to reproduce locally | Use `testcontainers-go` to spin up real dependencies per test run (ADR-016) |
+| Returning a raw `error` from a gRPC handler instead of `status.Errorf` | Client receives `Unknown` status — not actionable | Always `return nil, status.Errorf(codes.InvalidArgument, "…")` |
+| Adding a new Makefile target that directly calls `go` or `python` commands | Breaks Docker-only workflow; contributors without the tool will fail | Wrap in `$(TOOLS_RUN) sh -c "…"` so it runs inside the zynax-tools Docker image |
+
 ---
 
 ## Health Probes

--- a/services/workflow-compiler/AGENTS.md
+++ b/services/workflow-compiler/AGENTS.md
@@ -249,3 +249,37 @@ Feature: Workflow Compilation
     And no workflow execution is started
     And agent-registry is NOT queried for capability validation
 ```
+
+---
+
+## Running Tests
+
+```bash
+# All unit tests for this service (always use GOWORK=off — ADR-017)
+cd services/workflow-compiler
+GOWORK=off go test ./... -race -timeout 60s
+
+# With coverage
+GOWORK=off go test ./... -coverprofile=coverage.out -covermode=atomic
+GOWORK=off go tool cover -func=coverage.out | grep total:
+
+# BDD contract tests (in protos/tests/ — separate module)
+cd ../../protos/tests
+GOWORK=off go test ./workflow_compiler_service/... -v -timeout 60s
+
+# Via Makefile (runs inside Docker — no local Go needed)
+make test-unit-svc SVC=workflow-compiler
+make test-bdd
+```
+
+---
+
+## Common AI Mistakes
+
+| Mistake | Why it fails | Correct approach |
+|---------|-------------|-----------------|
+| `go test` without `GOWORK=off` | Workspace resolves missing modules → unrelated error | `GOWORK=off go test ./...` — every time (ADR-017) |
+| Calling `ParseManifest` with YAML that uses `transitions:` / `event_type:` / `target_state:` | The parser expects `on:` / `event:` / `goto:` — wrong keys silently produce zero transitions | Check the `yamlTransition` struct field tags in `domain/parser.go` |
+| Returning a raw `error` from `CompileWorkflow` instead of a gRPC status | Client receives `Unknown` status — no actionable error code | Map domain errors to `status.Errorf(codes.InvalidArgument, …)` |
+| Adding business logic to `internal/api/server.go` | `api/` is a translation layer only; logic in the wrong layer bypasses validators | Put new logic in `internal/domain/`; the server just calls domain functions |
+| Writing `ToIR` output that is non-deterministic (e.g. unsorted states) | Flaky tests; same input produces different proto byte sequences | Sort map keys before iterating — see `sort.Strings(ids)` in `ir/ir.go` |


### PR DESCRIPTION
## Why

AI assistants and new engineers frequently violate constraints they never found. All 16 AGENTS.md files were audited; the universal gap was missing "Common AI Mistakes" tables — despite AGENTS.md explicitly stating it is read by Claude Code, Cursor, and Copilot. This PR addresses the five highest-priority files per the issue's stated order.

Closes #140

## What Changed

| File | Added |
|------|-------|
| `/AGENTS.md` | 12-row Common AI Mistakes table: GOWORK=off, import isolation, DCO, BDD-first, TLS, layer boundaries, gRPC-not-HTTP |
| `services/AGENTS.md` | Governing ADRs table with links; `GOWORK=off` test commands; 7-row Common AI Mistakes table |
| `services/workflow-compiler/AGENTS.md` | Copy-pasteable unit + BDD + Makefile test commands; 5-row Common AI Mistakes table |
| `protos/tests/AGENTS.md` | 7-row Common AI Mistakes table (bufconn, stub isolation, package state, mod tidy) |
| `agents/sdk/AGENTS.md` | "When NOT to use the SDK" 6-row decision table; 6-row Common AI Mistakes table |

The remaining 11 files (service-specific, `spec/`, `infra/`, `protos/`, etc.) have narrower gaps and are tracked for a follow-up pass.

## Type of Change

- [x] `docs` — documentation only

## PR Size Self-Check

Lines changed: ~130

- [x] ≤ 400 lines — proceed

## Engineering Checklist

**Git hygiene**
- [x] Every commit follows Conventional Commits format
- [x] Every commit has `Signed-off-by:` (DCO)
- [x] No WIP / fixup commits remain
- [x] Branch rebased onto current `main`

**Security**
- [x] No secrets, tokens, or PII

## Knowledge Base Security Review

- [x] `gitleaks-ai-context` CI step passed
- [x] `kb-content-previsualized` status check is visible
- [x] Read the KB preview comment
- [x] No secrets, PII, or prompt injection in new content
- [x] Content derived from existing ADRs and observed CI failures
- [x] All examples use placeholder values
- [x] Previsualization reviewed — confirmed safe before approving

## AI Assistance

- [x] AI-assisted — tool/model: Claude Code / claude-sonnet-4-6