### PR TITLE
ci: Docker Compose testing profile — NATS JetStream and Redis (#32)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,10 +104,23 @@ test-unit-agents: build-tools ## pytest-bdd for SDK + all Python agents
 test-unit-agent: build-tools ## pytest for one agent: make test-unit-agent AGENT=summarizer
 	$(TOOLS_RUN) sh -c "cd agents/examples/$(AGENT) && uv run pytest tests/ -v"
 
-test-integration: check-docker ## Integration tests against real backing services
+test-integration: check-docker ## Integration tests against NATS JetStream and Redis backing services
+	@echo "Starting testing backing services..."
+	$(COMPOSE) --profile testing up -d
+	@echo "Waiting for services to be healthy (up to 60s)..."
+	@timeout 60 sh -c \
+		'until docker compose -f infra/docker/docker-compose.yml ps --format json 2>/dev/null \
+		  | python3 -c "import sys,json; data=sys.stdin.read(); rows=json.loads(data) if data.strip().startswith(\"[\") else [json.loads(l) for l in data.strip().splitlines() if l]; exit(0 if all(r.get(\"Health\")==\"healthy\" for r in rows if r.get(\"Health\")) and len(rows)>0 else 1)" \
+		  2>/dev/null; do sleep 2; done' || true
 	@for svc in $(GO_SERVICES); do \
-		$(COMPOSE_TOOLS) run --rm test-runner sh -c "cd services/$$svc && go test ./tests/integration/... -v -timeout 120s"; \
+		if [ -f "services/$$svc/tests/integration" ] || find "services/$$svc" -name "*integration*" -name "*.go" 2>/dev/null | grep -q .; then \
+			echo "Integration tests: $$svc"; \
+			$(TOOLS_RUN) sh -c "cd services/$$svc && GOWORK=off go test ./tests/integration/... -v -timeout 120s" || exit 1; \
+		fi; \
 	done
+	@echo "Stopping testing backing services..."
+	$(COMPOSE) --profile testing down --remove-orphans
+	@echo "Integration tests passed"
 
 # ── Proto generation + lint ────────────────────────────────────────────────
 .PHONY: generate-protos lint-protos

--- a/infra/docker/docker-compose.test.yml
+++ b/infra/docker/docker-compose.test.yml
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+# CI-only ephemeral overlay for integration tests.
+#
+# No persistent volumes — all data is discarded after the compose down.
+# Combine with docker-compose.yml:
+#
+#   docker compose \
+#     -f infra/docker/docker-compose.yml \
+#     -f infra/docker/docker-compose.test.yml \
+#     --profile testing up -d
+
+services:
+  nats:
+    volumes: []
+
+  redis:
+    volumes: []

--- a/infra/docker/docker-compose.yml
+++ b/infra/docker/docker-compose.yml
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+# Zynax — service compose file
+#
+# Profiles:
+#   testing  — backing stores only (NATS JetStream + Redis); used by make test-integration
+#   dev      — (future) full local stack
+#
+# Usage:
+#   make test-integration                           # starts testing profile, runs tests, stops
+#   docker compose --profile testing up -d          # manual start
+#   docker compose --profile testing down           # manual stop
+
+services:
+  nats:
+    profiles: [testing]
+    image: nats:2.10-alpine
+    ports:
+      - "4222:4222"
+      - "8222:8222"
+    command: ["--jetstream", "--store_dir=/data", "--http_port=8222"]
+    volumes:
+      - nats-data:/data
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8222/healthz"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 5s
+
+  redis:
+    profiles: [testing]
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    command: ["redis-server", "--save", "", "--appendonly", "no"]
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+      start_period: 3s
+
+volumes:
+  nats-data:


### PR DESCRIPTION
## Summary

- Adds `infra/docker/docker-compose.yml` with a `testing` profile containing `nats:2.10-alpine` (JetStream enabled) and `redis:7-alpine`, both with `healthcheck:` definitions
- Adds `infra/docker/docker-compose.test.yml` — CI-only ephemeral overlay (no persistent volumes)
- Updates `make test-integration` to start backing services, wait for healthy status, run integration tests, then stop services

## Test plan

- [ ] `docker compose -f infra/docker/docker-compose.yml --profile testing up -d` starts only NATS and Redis
- [ ] Both services report `healthy` within 60 seconds
- [ ] `docker compose -f infra/docker/docker-compose.yml --profile testing down` removes containers cleanly
- [ ] `make test-integration` completes without error (skips services with no integration tests)

Closes #32
Part of epic #14

🤖 Generated with [Claude Code](https://claude.ai/claude-code)