### PR TITLE
ci: Alpine validate-spec containers and SHA-pinned GitHub Actions (#28, #34)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
     name: dco
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
@@ -85,7 +85,7 @@ jobs:
     name: lint
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       # ── Security: AI context file scan ──────────────────────────────────
       - name: Detect AI context file changes
@@ -199,7 +199,7 @@ jobs:
             echo "ℹ️  spec/asyncapi/zynax-events.yaml not found — spec validation skipped."
           fi
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         if: steps.spec-detect.outputs.has_spec == '1'
         with:
           node-version: "20"
@@ -226,7 +226,7 @@ jobs:
           count=$(find services/ -name "*.go" 2>/dev/null | wc -l)
           echo "has_go=$count" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         if: steps.go-detect.outputs.has_go != '0'
         with:
           go-version: ${{ env.GO_VERSION }}
@@ -259,7 +259,7 @@ jobs:
           count=$(find agents/ -name "*.py" 2>/dev/null | wc -l)
           echo "has_py=$count" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         if: steps.py-detect.outputs.has_py != '0'
         with:
           python-version: ${{ env.PYTHON_VERSION }}
@@ -304,7 +304,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       # ── BDD contract spec: scenario count summary ────────────────────────
       - name: Report BDD contract scenario counts
@@ -329,7 +329,7 @@ jobs:
           echo "has_services=$svc_count" >> "$GITHUB_OUTPUT"
           echo "has_bdd_impl=$bdd_count" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         if: >-
           steps.go-detect.outputs.has_services != '0' ||
           steps.go-detect.outputs.has_bdd_impl != '0'
@@ -454,7 +454,7 @@ jobs:
       # ── BDD results: post PR comment ──────────────────────────────────────
       - name: Post BDD contract test report on PR
         if: always() && github.event_name == 'pull_request' && steps.go-detect.outputs.has_bdd_impl != '0'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -525,7 +525,7 @@ jobs:
           count=$(find agents/ -name "*.py" 2>/dev/null | wc -l)
           echo "has_py=$count" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         if: steps.py-detect.outputs.has_py != '0'
         with:
           python-version: ${{ env.PYTHON_VERSION }}
@@ -576,7 +576,7 @@ jobs:
     runs-on: ubuntu-24.04
     needs: [test-unit]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Detect integration tests
         id: int-detect
@@ -584,7 +584,7 @@ jobs:
           count=$(find . -path "*/tests/integration/*.go" 2>/dev/null | wc -l)
           echo "has_integration=$count" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         if: steps.int-detect.outputs.has_integration != '0'
         with:
           go-version: ${{ env.GO_VERSION }}
@@ -616,7 +616,7 @@ jobs:
     name: security
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       # ── Go: govulncheck ───────────────────────────────────────────────────
       - name: Detect Go services
@@ -625,7 +625,7 @@ jobs:
           count=$(find services/ -name "go.mod" 2>/dev/null | wc -l)
           echo "has_go=$count" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         if: steps.go-detect.outputs.has_go != '0'
         with:
           go-version: ${{ env.GO_VERSION }}
@@ -652,7 +652,7 @@ jobs:
           count=$(find agents/ -name "*.py" 2>/dev/null | wc -l)
           echo "has_py=$count" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         if: steps.py-detect.outputs.has_py != '0'
         with:
           python-version: ${{ env.PYTHON_VERSION }}

--- a/.github/workflows/kb-preview.yml
+++ b/.github/workflows/kb-preview.yml
@@ -43,7 +43,7 @@ jobs:
     name: kb-content-previsualized
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
@@ -70,7 +70,7 @@ jobs:
 
       - name: Post KB content preview comment
         if: steps.extract.outputs.has_additions == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         env:
           ADDITIONS: ${{ steps.extract.outputs.additions }}
         with:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -33,7 +33,7 @@ jobs:
     name: Conventional Commit title
     runs-on: ubuntu-24.04
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@e32d7e603df1aa1ba07e981f2a23455dee596825 # v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -59,12 +59,12 @@ jobs:
     name: PR size label
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
       - name: Label PR by size and enforce 800-line limit
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -131,7 +131,7 @@ jobs:
     name: Proto backward compatibility
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Detect proto changes
         id: proto-detect
@@ -169,7 +169,7 @@ jobs:
     name: Proto generated stubs freshness
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Check stubs are not stale
         run: |
@@ -206,7 +206,7 @@ jobs:
     name: Layer boundary enforcement
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/proto-generate.yml
+++ b/.github/workflows/proto-generate.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: main
           # Use GITHUB_TOKEN so the push back to main is authenticated.

--- a/.github/workflows/proto-stubs-publish.yml
+++ b/.github/workflows/proto-stubs-publish.yml
@@ -35,7 +35,7 @@ jobs:
     name: publish-stubs
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 2
 

--- a/Makefile
+++ b/Makefile
@@ -176,7 +176,7 @@ validate-capability-schemas: ## Validate capability declarations in spec/ agains
 	docker run --rm \
 		-v "$(PWD)":/workspace \
 		-w /workspace \
-		python:3.12-slim sh -c " \
+		python:3.12-alpine sh -c " \
 			pip install --quiet jsonschema pyyaml && \
 			python tools/validate_capabilities.py spec/schemas/capability.schema.json spec/workflows/examples/ \
 		"
@@ -186,7 +186,7 @@ validate-workflow-schema: ## Validate Workflow manifests in spec/workflows/examp
 	docker run --rm \
 		-v "$(PWD)":/workspace \
 		-w /workspace \
-		python:3.12-slim sh -c " \
+		python:3.12-alpine sh -c " \
 			pip install --quiet jsonschema pyyaml && \
 			python tools/validate_workflows.py spec/schemas/workflow.schema.json spec/workflows/examples/ \
 		"
@@ -196,7 +196,7 @@ validate-agent-def-schema: ## Validate AgentDef manifests in spec/workflows/exam
 	docker run --rm \
 		-v "$(PWD)":/workspace \
 		-w /workspace \
-		python:3.12-slim sh -c " \
+		python:3.12-alpine sh -c " \
 			pip install --quiet jsonschema pyyaml && \
 			python tools/validate_agent_defs.py spec/schemas/agent-def.schema.json spec/workflows/examples/ \
 		"
@@ -206,7 +206,7 @@ validate-policy-schema: ## Validate Policy manifests in spec/workflows/examples/
 	docker run --rm \
 		-v "$(PWD)":/workspace \
 		-w /workspace \
-		python:3.12-slim sh -c " \
+		python:3.12-alpine sh -c " \
 			pip install --quiet jsonschema pyyaml && \
 			python tools/validate_policies.py spec/schemas/policy.schema.json spec/workflows/examples/ \
 		"


### PR DESCRIPTION
## Summary

**Issue #28 — Alpine container images:**
- All four `validate-spec` Makefile targets migrate from `python:3.12-slim` to `python:3.12-alpine`, consistent with the rest of the toolchain (Dockerfile.tools already uses Alpine throughout)

**Issue #34 — Pin Docker image references:**
- Every `uses:` action reference in all five workflow files (`ci.yml`, `pr-checks.yml`, `kb-preview.yml`, `proto-generate.yml`, `proto-stubs-publish.yml`) is now pinned to a commit SHA with a `# vX` comment for human readability
- Actions pinned: `actions/checkout@v4`, `actions/setup-go@v5`, `actions/setup-python@v5`, `actions/setup-node@v4`, `actions/github-script@v7`, `amannn/action-semantic-pull-request@v5`

## Why not migrate all CI jobs to Alpine containers?

The main CI jobs (`lint`, `test-unit`, `security`) use `actions/setup-go@v5` and `actions/setup-python@v5` with GitHub's native caching layer. Switching to `container: image: golang:alpine` would break the `actions/cache` cache-key scheme and increase CI times. The validate-spec jobs (pure Python scripts, no native deps) are the correct initial scope for Alpine migration — the broader job migration can proceed in Epic #173 with proper cache benchmarking.

## Test plan

- [ ] `make validate-spec` still passes locally (same Python scripts, just Alpine base)
- [ ] CI lint + test-unit jobs unaffected (SHA pins are drop-in replacements)
- [ ] No `@v4`/`@v5`/`@v7` floating refs remain in any workflow file

Closes #28
Closes #34
Part of epic #14