### PR TITLE
ci: pin asyncapi/cli:latest to immutable tag 6.0.0 (#187)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -213,9 +213,10 @@ validate-policy-schema: ## Validate Policy manifests in spec/workflows/examples/
 	@echo "✅ Policy schemas valid"
 
 validate-asyncapi: ## Validate spec/asyncapi/zynax-events.yaml via AsyncAPI CLI (Docker)
+	# renovate: datasource=docker depName=asyncapi/cli
 	docker run --rm \
 		-v "$(PWD)/spec":/spec \
-		asyncapi/cli:latest \
+		asyncapi/cli:6.0.0 \
 		validate /spec/asyncapi/zynax-events.yaml
 	@echo "✅ AsyncAPI spec valid"
 


### PR DESCRIPTION
## Summary

- Replaces `asyncapi/cli:latest` with `asyncapi/cli:6.0.0` in the `validate-asyncapi` Makefile target
- Adds a `# renovate: datasource=docker` comment so Renovate (issue #136) will auto-PR future upgrades
- After this merges, `grep -rn ':latest' infra/ .github/ Makefile` returns nothing — AC-7 of Epic #14 is satisfied

## Test plan
- [ ] `make validate-asyncapi` still passes with the pinned tag
- [ ] `grep -rn ':latest' infra/ .github/ Makefile` returns no output

Closes #187
Part of epic #14 (AC-7)