### PR TITLE
fix(infra): upgrade mockery v2.53.6 and publish zynax-tools to GHCR (#191, #192)

### DIFF
--- a/.github/workflows/tools-publish.yml
+++ b/.github/workflows/tools-publish.yml
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: Apache-2.0
+# Zynax — Tools Image Publisher
+#
+# Builds zynax-tools and pushes to GHCR whenever Dockerfile.tools changes
+# on main. The resulting image (ghcr.io/zynax-io/zynax-tools:main) can be
+# pulled locally so developers skip the multi-minute local build:
+#
+#   docker pull ghcr.io/zynax-io/zynax-tools:main
+#   docker tag  ghcr.io/zynax-io/zynax-tools:main zynax-tools:local
+#
+# Image is also tagged with the short SHA for reproducible references.
+
+name: Publish Tools Image
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "infra/docker/Dockerfile.tools"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE: ghcr.io/zynax-io/zynax-tools
+
+jobs:
+  publish:
+    name: publish-tools
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set image metadata
+        id: meta
+        run: |
+          echo "sha7=${GITHUB_SHA:0:7}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push zynax-tools
+        run: |
+          docker build \
+            -f infra/docker/Dockerfile.tools \
+            -t "${{ env.IMAGE }}:main" \
+            -t "${{ env.IMAGE }}:${{ steps.meta.outputs.sha7 }}" \
+            .
+          docker push "${{ env.IMAGE }}:main"
+          docker push "${{ env.IMAGE }}:${{ steps.meta.outputs.sha7 }}"
+          echo "✅ Pushed ${{ env.IMAGE }}:main and :${{ steps.meta.outputs.sha7 }}"

--- a/infra/docker/Dockerfile.tools
+++ b/infra/docker/Dockerfile.tools
@@ -18,7 +18,7 @@
 #   protoc-gen-go       v1.36.5
 #   protoc-gen-go-grpc  v1.5.1
 #   govulncheck         latest stable from golang.org/x/vuln
-#   mockery             v2.43.0
+#   mockery             v2.53.6
 #   migrate             v4.17.1
 #   grpc-health-probe   v0.4.26
 #   uv                  0.5.10
@@ -49,7 +49,7 @@ RUN go install github.com/cucumber/godog/cmd/godog@v0.14.1
 
 # mockery — Go interface mock generator
 # renovate: datasource=github-releases depName=vektra/mockery
-RUN go install github.com/vektra/mockery/v2@v2.43.0
+RUN go install github.com/vektra/mockery/v2@v2.53.6
 
 # migrate — DB schema migrations (postgres driver)
 # renovate: datasource=github-releases depName=golang-migrate/migrate


### PR DESCRIPTION
## Summary

- **Fix #191**: Upgrades mockery `v2.43.0` → `v2.53.6` in `Dockerfile.tools`. The old version transitively depends on `golang.org/x/tools@v0.17.0` which fails to compile under Go 1.25 (`invalid array length -delta * delta`). v2.53.6 resolves this via `tools@v0.30.0+`.
- **Fix #192**: Adds `tools-publish.yml` CI workflow that builds and pushes `zynax-tools` to `ghcr.io/zynax-io/zynax-tools` whenever `Dockerfile.tools` changes on main. Tags both `:main` and `:<sha7>` for reproducible local pulls.

## Test plan

- [ ] PR checks (lint, dco, size) pass
- [ ] No proto or service files changed — `buf breaking` / stubs freshness are N/A
- [ ] After merge, `tools-publish.yml` fires and image appears at `ghcr.io/zynax-io/zynax-tools:main`

Closes #191
Closes #192