### PR TITLE
ci: pin GitHub Actions to Node.js 24-compatible versions (#196)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
     name: dco
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
@@ -85,7 +85,7 @@ jobs:
     name: lint
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       # ── Security: AI context file scan ──────────────────────────────────
       - name: Detect AI context file changes
@@ -304,7 +304,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       # ── BDD contract spec: scenario count summary ────────────────────────
       - name: Report BDD contract scenario counts
@@ -576,7 +576,7 @@ jobs:
     runs-on: ubuntu-24.04
     needs: [test-unit]
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Detect integration tests
         id: int-detect
@@ -616,7 +616,7 @@ jobs:
     name: security
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       # ── Go: govulncheck ───────────────────────────────────────────────────
       - name: Detect Go services

--- a/.github/workflows/kb-preview.yml
+++ b/.github/workflows/kb-preview.yml
@@ -43,7 +43,7 @@ jobs:
     name: kb-content-previsualized
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -59,7 +59,7 @@ jobs:
     name: PR size label
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
@@ -131,7 +131,7 @@ jobs:
     name: Proto backward compatibility
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Detect proto changes
         id: proto-detect
@@ -169,7 +169,7 @@ jobs:
     name: Proto generated stubs freshness
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Check stubs are not stale
         run: |
@@ -206,7 +206,7 @@ jobs:
     name: Layer boundary enforcement
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 

--- a/.github/workflows/proto-generate.yml
+++ b/.github/workflows/proto-generate.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: main
           # Use GITHUB_TOKEN so the push back to main is authenticated.

--- a/.github/workflows/proto-stubs-publish.yml
+++ b/.github/workflows/proto-stubs-publish.yml
@@ -35,7 +35,7 @@ jobs:
     name: publish-stubs
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 2
 

--- a/.github/workflows/tools-publish.yml
+++ b/.github/workflows/tools-publish.yml
@@ -32,10 +32,10 @@ jobs:
     name: publish-tools
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Log in to GHCR
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}


### PR DESCRIPTION
## Summary

- Upgrades `actions/checkout` from v4 (`34e114...`) to v6.0.2 (`de0fac...`) across all 6 workflow files (14 occurrences)
- Upgrades `docker/login-action` from v3 (`74a5d1...`) to v4.1.0 (`4907a6...`) in `tools-publish.yml`

These actions ran on Node.js 20, which is deprecated on GitHub Actions runners (forced to Node.js 24 from June 2, 2026; removed September 16, 2026). The deprecation warning appeared after PR #195 merged.

## Test plan

- [ ] All CI checks pass (PR checks + ci.yml jobs)
- [ ] No Node.js 20 deprecation warnings in the workflow run logs

Closes #196