### PR TITLE
ci(agents): add bandit and pip-audit scans for agents/sdk (#185)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -661,16 +661,27 @@ jobs:
         if: steps.py-detect.outputs.has_py != '0'
         run: pip install uv
 
-      - name: bandit + pip-audit (all Python agents)
+      - name: bandit + pip-audit (SDK + all Python agents)
         if: steps.py-detect.outputs.has_py != '0'
         run: |
           failed=false
+
+          if [ -f agents/sdk/pyproject.toml ]; then
+            echo "── bandit: agents/sdk"
+            cd agents/sdk
+            uv run bandit -r src/ -ll -f json -o bandit-report.json || failed=true
+            uv run bandit -r src/ -ll || true
+            echo "── pip-audit: agents/sdk"
+            uv run pip-audit || failed=true
+            cd ../..
+          fi
+
           for agent in ${{ env.AGENT_LIST }}; do
             if [ -f "agents/examples/${agent}/pyproject.toml" ]; then
               echo "── bandit: agents/examples/${agent}"
               cd "agents/examples/${agent}"
               uv run bandit -r src/ -ll -f json -o bandit-report.json || failed=true
-              uv run bandit -r src/ -ll || true  # human-readable repeat
+              uv run bandit -r src/ -ll || true
               echo "── pip-audit: agents/examples/${agent}"
               uv run pip-audit || failed=true
               cd ../../..

--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,8 @@ security: security-go security-agents ## Full security scan (govulncheck + bandi
 security-go: build-tools ## govulncheck on all Go services
 	@for svc in $(GO_SERVICES); do $(TOOLS_RUN) sh -c "cd services/$$svc && govulncheck ./..."; done
 
-security-agents: build-tools ## bandit + pip-audit on all agents
+security-agents: build-tools ## bandit + pip-audit on SDK + all agents
+	@$(TOOLS_RUN) sh -c "cd agents/sdk && uv run bandit -r src/ -ll && uv run pip-audit"
 	@for a in $(AGENTS); do [ -f "agents/examples/$$a/pyproject.toml" ] && \
 		$(TOOLS_RUN) sh -c "cd agents/examples/$$a && uv run bandit -r src/ -ll && uv run pip-audit" || true; done
 

--- a/agents/sdk/pyproject.toml
+++ b/agents/sdk/pyproject.toml
@@ -38,4 +38,6 @@ dev = [
     "pytest-cov>=5.0.0",
     "ruff>=0.4.0",
     "mypy>=1.10.0",
+    "bandit>=1.7.0",
+    "pip-audit>=2.7.0",
 ]


### PR DESCRIPTION
## Summary

The CI `security` job and `make security-agents` only scanned example agents (summarizer/researcher/calculator), none of which exist yet — `agents/sdk` was never checked by bandit or pip-audit.

- Adds `bandit>=1.7.0` and `pip-audit>=2.7.0` to SDK dev dependency group so `uv run bandit`/`uv run pip-audit` work from the SDK directory
- Updates CI `security` job to scan `agents/sdk` before the example agents loop
- Updates `Makefile` `security-agents` target to scan `agents/sdk` unconditionally

`govulncheck` on `services/workflow-compiler` already passes ("No vulnerabilities found").

## Test plan

- [ ] CI `security` job passes — bandit finds zero medium+ findings in `agents/sdk/src/`, pip-audit finds no CVEs
- [ ] `test-unit` still passes (no regression from new dev deps)

Closes #185