### PR TITLE
ci: fix proto-generate.yml YAML syntax error (#200)

### DIFF
--- a/.github/workflows/proto-generate.yml
+++ b/.github/workflows/proto-generate.yml
@@ -71,10 +71,7 @@ jobs:
           git diff --stat -- protos/generated/
           git add protos/generated/
 
-          git commit -m "chore(protos): regenerate Go and Python stubs [skip ci]
-
-Triggered automatically by proto change on main (${GITHUB_SHA:0:7}).
-Assisted-by: github-actions[bot]"
+          git commit -m "$(printf 'chore(protos): regenerate Go and Python stubs [skip ci]\n\nTriggered automatically by proto change on main (%s).\nAssisted-by: github-actions[bot]' "${GITHUB_SHA:0:7}")"
 
           git push
           echo "✅ Regenerated stubs committed and pushed to main."


### PR DESCRIPTION
## Summary

- Fixes a YAML syntax error in `proto-generate.yml` that has caused the workflow to fail on every push to main since it was introduced (5 consecutive failures: runs 25080684242, 25080985683, 25081352863, 25081379376, 25081566656)
- The `git commit -m` message spanned 4 lines with continuation lines at column 1, which YAML interprets as outside the `run: |` block scalar — the same anti-pattern documented in CLAUDE.md

**Before:** multi-line shell string breaking the YAML block scalar  
**After:** single-line `printf` expansion producing the same commit message body

## Test plan

- [ ] CI checks pass on this PR (verifies the YAML is now parseable)
- [ ] After merge, next push to main that touches `.proto` files runs `regenerate-stubs` to completion instead of "workflow file issue"

Closes #200