### PR TITLE
chore: Renovate automated dependency upgrade config (#136)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,81 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "baseBranches": ["main"],
+  "labels": ["chore", "dependencies"],
+  "reviewers": ["ogomezmanresa"],
+  "prConcurrentLimit": 5,
+  "commitMessagePrefix": "",
+  "packageRules": [
+    {
+      "description": "Go services and proto modules — weekly PRs, automerge patch",
+      "groupName": "go-services",
+      "matchManagers": ["gomod"],
+      "matchFileNames": [
+        "services/**/go.mod",
+        "protos/**/go.mod"
+      ],
+      "schedule": ["every weekend"],
+      "commitMessageTopic": "{{depName}}",
+      "semanticCommitType": "chore",
+      "semanticCommitScope": "deps",
+      "automerge": true,
+      "automergeType": "pr",
+      "matchUpdateTypes": ["patch"]
+    },
+    {
+      "description": "Python agents and SDK — weekly PRs, automerge patch",
+      "groupName": "python-agents",
+      "matchManagers": ["pep621", "pip_requirements"],
+      "matchFileNames": [
+        "agents/**/pyproject.toml"
+      ],
+      "schedule": ["every weekend"],
+      "semanticCommitType": "chore",
+      "semanticCommitScope": "deps",
+      "automerge": true,
+      "automergeType": "pr",
+      "matchUpdateTypes": ["patch"]
+    },
+    {
+      "description": "Docker base images — monthly PRs, no automerge",
+      "groupName": "docker-images",
+      "matchManagers": ["dockerfile"],
+      "schedule": ["on the first day of the month"],
+      "semanticCommitType": "chore",
+      "semanticCommitScope": "infra",
+      "automerge": false
+    },
+    {
+      "description": "GitHub Actions — monthly PRs, pin to digest (SHA), no automerge",
+      "groupName": "github-actions",
+      "matchManagers": ["github-actions"],
+      "schedule": ["on the first day of the month"],
+      "semanticCommitType": "ci",
+      "pinDigests": true,
+      "automerge": false
+    },
+    {
+      "description": "gRPC ecosystem — group minor+major Go gRPC updates together",
+      "groupName": "grpc-go",
+      "matchManagers": ["gomod"],
+      "matchPackageNames": [
+        "google.golang.org/grpc",
+        "google.golang.org/protobuf",
+        "github.com/bufbuild/buf"
+      ],
+      "schedule": ["every weekend"],
+      "semanticCommitType": "chore",
+      "semanticCommitScope": "deps",
+      "automerge": false
+    },
+    {
+      "description": "Ignore pre-release versions for buf and grpc-go",
+      "matchPackageNames": [
+        "github.com/bufbuild/buf",
+        "google.golang.org/grpc"
+      ],
+      "ignorePrerelease": true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Creates `renovate.json` in repo root with four dependency scope groups:
  - **go-services** — `services/**/go.mod`, `protos/**/go.mod` — weekly, automerge patch
  - **python-agents** — `agents/**/pyproject.toml` — weekly, automerge patch
  - **docker-images** — all `Dockerfile*` `FROM` lines — monthly, no automerge
  - **github-actions** — all `uses:` references — monthly, SHA-pinned, no automerge
- Extra rules: gRPC ecosystem grouped (`grpc-go`), pre-release ignored for buf and grpc-go
- `prConcurrentLimit: 5` prevents PR flood on first run
- References `docs/engineering/dependency-strategy.md` for the full policy rationale

> **Note:** Renovate requires the [Renovate GitHub App](https://github.com/apps/renovate) to be installed on `zynax-io/zynax` to activate. This PR adds the config; the app installation is a separate step.

Closes #136

## Test plan

- [ ] `renovate.json` is valid JSON (no JSONC)
- [ ] Scope groups match actual file paths in the repo
- [ ] `$schema` URL resolves to the Renovate schema
- [ ] After app installation: Renovate opens a welcome/onboarding PR that matches the configured groups