### PR TITLE
fix: renovate config — ignoreUnstable and baseBranchPatterns

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
-  "baseBranches": ["main"],
+  "baseBranchPatterns": ["main"],
   "labels": ["chore", "dependencies"],
   "reviewers": ["ogomezmanresa"],
   "prConcurrentLimit": 5,
@@ -75,7 +75,7 @@
         "github.com/bufbuild/buf",
         "google.golang.org/grpc"
       ],
-      "ignorePrerelease": true
+      "ignoreUnstable": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

Fixes the config validation error reported in the Renovate run log:

```
Invalid configuration option: packageRules[5].ignorePrerelease
```

Two changes:

1. `ignorePrerelease: true` → `ignoreUnstable: true` — `ignorePrerelease` is not a valid field inside `packageRules`; `ignoreUnstable` is the correct option and achieves the same result (skip pre-release/unstable versions for buf and grpc-go)
2. `baseBranches` → `baseBranchPatterns` — the log showed Renovate auto-migrating this on every run; using the current field name avoids the migration noise

## Test plan

- [ ] Renovate next run completes with `result: success` instead of `result: config-validation`
- [ ] No validation errors in the Renovate job log
- [ ] Dependency Dashboard issue appears in the repo once Renovate runs cleanly