### PR TITLE
ci: exempt bot authors from DCO Signed-off-by check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,11 @@ jobs:
 
           MISSING=""
           for sha in $(git log "${BASE}..${HEAD}" --format="%H"); do
+            author_email=$(git log -1 --format="%ae" "$sha")
+            if echo "$author_email" | grep -qE "\[bot\]"; then
+              echo "  ⏭ Skipping bot commit: ${sha:0:12} (author: $author_email)"
+              continue
+            fi
             body=$(git log -1 --format="%B" "$sha")
             if ! echo "$body" | grep -qE "^Signed-off-by: .+ <.+>$"; then
               subject=$(git log -1 --format="%s" "$sha")


### PR DESCRIPTION
## Summary

Renovate[bot] (and any future bots like dependabot[bot]) cannot certify the Developer Certificate of Origin — DCO is a human attestation of authorship. The current DCO check fails on all Renovate PRs because bot commits never carry `Signed-off-by:`.

This PR adds a bot exemption: any commit whose author email contains `[bot]` is skipped in the DCO loop. Human commits are still fully checked.

**Affected Renovate PRs that will unblock:** #254 #255 #256 #257 #258 #259 #260

## Test plan

- [ ] DCO check passes on this PR itself (human commit, has Signed-off-by)
- [ ] After merge, re-run CI on any Renovate PR — DCO check passes
- [ ] A human commit without Signed-off-by still fails the DCO check