### PR TITLE
fix: commit missing protos/generated/go go.sum (#262)

### DIFF
--- a/protos/generated/go/go.mod
+++ b/protos/generated/go/go.mod
@@ -6,3 +6,10 @@ require (
 	google.golang.org/grpc v1.64.0
 	google.golang.org/protobuf v1.34.2
 )
+
+require (
+	golang.org/x/net v0.22.0 // indirect
+	golang.org/x/sys v0.18.0 // indirect
+	golang.org/x/text v0.14.0 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20240318140521-94a12d6c2237 // indirect
+)

--- a/protos/generated/go/go.sum
+++ b/protos/generated/go/go.sum
@@ -1,0 +1,14 @@
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+golang.org/x/net v0.22.0 h1:9sGLhx7iRIHEiX0oAJ3MRZMUCElJgy7Br1nO+AMN3Tc=
+golang.org/x/net v0.22.0/go.mod h1:JKghWKKOSdJwpW2GEx0Ja7fmaKnMsbu+MWVZTokSYmg=
+golang.org/x/sys v0.18.0 h1:DBdB3niSjOA/O0blCZBqDefyWNYveAYMNF1Wum0DYQ4=
+golang.org/x/sys v0.18.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
+golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20240318140521-94a12d6c2237 h1:NnYq6UN9ReLM9/Y01KWNOWyI5xQ9kbIms5GGJVwS/Yc=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20240318140521-94a12d6c2237/go.mod h1:WtryC6hu0hhx87FDGxWCDptyssuo68sk10vYjF+T9fY=
+google.golang.org/grpc v1.64.0 h1:KH3VH9y/MgNQg1dE7b3XfVK0GsPSIzJwdF617gUSbvY=
+google.golang.org/grpc v1.64.0/go.mod h1:oxjF8E3FBnjp+/gVFYdWacaLDx9na1aqy9oovLpxQYg=
+google.golang.org/protobuf v1.34.2 h1:6xV6lTsCfpGD21XK49h7MhtcApnLqkfYgPcdHftf6hg=
+google.golang.org/protobuf v1.34.2/go.mod h1:qYOHts0dSfpeUzUFpOMr/WGzszTmLH+DiWniOlNbLDw=


### PR DESCRIPTION
## Summary

`protos/generated/go/go.sum` was never committed to the repository. This caused all Go module update PRs from Renovate to fail `lint` and `security` CI jobs with:

```
missing go.sum entry for module providing package google.golang.org/protobuf/reflect/protoreflect
(imported by github.com/zynax-io/zynax/protos/generated/go/zynax/v1)
```

The root cause: `services/workflow-compiler/go.mod` has a `replace` directive pointing to `../../protos/generated/go`. When Go resolves that local module, it verifies checksums against `protos/generated/go/go.sum` — which didn't exist.

Also adds explicit indirect dependencies to `protos/generated/go/go.mod` via `go mod tidy`.

**Impact:** Once merged, all three failing Renovate Go module PRs (#254 grpc-go, #257 prometheus, #258 otelgrpc) will inherit the committed go.sum when Renovate rebases them on main, and their CI will pass.

## Test plan

- [ ] CI passes on this PR (no missing go.sum errors in lint/security)
- [ ] After merge, Renovate rebases PRs #254, #257, #258 on the new main — their CI should pass