### PR TITLE
docs: AGENTS.md audit — KB index and Go version (#263 #265)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -203,6 +203,8 @@ Observed mistakes in AI-assisted contributions — check before writing code.
 | Current milestone and active PRs | `state/current-milestone.md` |
 | SPDD workflow guide and REASONS Canvas methodology | `docs/patterns/spdd-guide.md` |
 | REASONS Canvas artifacts (one per `feat:` issue) | `docs/spdd/` |
+| Dependency version policy, security scanning, upgrade cadence | `docs/engineering/dependency-strategy.md` |
+| Renovate bot CI failure fix procedure (go.sum, go directive) | `docs/engineering/renovate-fix-sop.md` |
 | Per-layer rules | `services/AGENTS.md` · `agents/AGENTS.md` · `protos/AGENTS.md` · `spec/AGENTS.md` · `infra/AGENTS.md` |
 
 ---

--- a/services/workflow-compiler/AGENTS.md
+++ b/services/workflow-compiler/AGENTS.md
@@ -1,6 +1,6 @@
 # services/workflow-compiler — AGENTS.md
 
-> Go 1.22+. Inherits rules from root `AGENTS.md` and `services/AGENTS.md`.
+> Go 1.25+. Inherits rules from root `AGENTS.md` and `services/AGENTS.md`.
 > **Status: M2 Complete.** The only fully implemented platform service.
 
 ---


### PR DESCRIPTION
## Summary

Two accuracy fixes found during the AGENTS.md audit (#263, #265):

- **Root AGENTS.md KB Index** — two operational SOPs landed in `docs/engineering/` without KB index entries: `renovate-fix-sop.md` (PR #269) and `dependency-strategy.md`. Both are now indexed so AI assistants and contributors can discover them on demand.
- **`services/workflow-compiler/AGENTS.md`** — header declared "Go 1.22+" but `go.mod` is at `go 1.25.0` (bumped in PRs #254 and #258 when grpc v1.80 and otelgrpc v0.68 required Go 1.24+ and 1.25+ respectively). Corrected to "Go 1.25+".

All other AGENTS.md files (16 total) were audited and found accurate:
- All per-service files are within the ≤ 150 line target (52–105 lines)
- Root AGENTS.md is 212 lines — well under the 300-line target
- AI anti-patterns tables, KB index, and Hard Constraints are current

## Test plan

- [ ] Root AGENTS.md KB index has entries for both `docs/engineering/` files
- [ ] `services/workflow-compiler/AGENTS.md` header reads "Go 1.25+"
- [ ] CI passes (lint, dco)

Closes #263
Closes #265

Assisted-by: Claude/claude-sonnet-4-6