### PR TITLE
ci: AI context line budget — count, warn, and README badge (#275)

### DIFF
--- a/.github/workflows/ai-context-budget.yml
+++ b/.github/workflows/ai-context-budget.yml
@@ -1,0 +1,39 @@
+name: AI Context Budget
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'CLAUDE.md'
+      - '**/AGENTS.md'
+      - 'docs/ai-assistant-setup.md'
+  pull_request:
+    paths:
+      - 'CLAUDE.md'
+      - '**/AGENTS.md'
+      - 'docs/ai-assistant-setup.md'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  count:
+    name: Count AI context lines
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Count AI context lines
+        id: count
+        run: |
+          chmod +x tools/count-ai-context.sh
+          OUTPUT=$(sh tools/count-ai-context.sh)
+          echo "$OUTPUT"
+          {
+            echo "## AI Context Budget"
+            echo ""
+            echo "$OUTPUT"
+          } >> "$GITHUB_STEP_SUMMARY"
+        # Advisory only — never fail CI
+        continue-on-error: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -207,6 +207,7 @@ Observed mistakes in AI-assisted contributions — check before writing code.
 | Competitive analysis and Kestra/Temporal/LangGraph positioning | `docs/architecture/competitive-analysis-2026.md` |
 | Dependency version policy, security scanning, upgrade cadence | `docs/engineering/dependency-strategy.md` |
 | Renovate bot CI failure fix procedure (go.sum, go directive) | `docs/engineering/renovate-fix-sop.md` |
+| AI context line counts and budget thresholds (advisory, non-blocking) | `tools/count-ai-context.sh` |
 | Per-layer rules | `services/AGENTS.md` · `agents/AGENTS.md` · `protos/AGENTS.md` · `spec/AGENTS.md` · `infra/AGENTS.md` |
 
 ---

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 **The declarative control plane for AI agent workflows**
 
 [![CI](https://github.com/zynax-io/zynax/actions/workflows/ci.yml/badge.svg)](https://github.com/zynax-io/zynax/actions/workflows/ci.yml)
+[![AI Context Budget](https://github.com/zynax-io/zynax/actions/workflows/ai-context-budget.yml/badge.svg)](https://github.com/zynax-io/zynax/actions/workflows/ai-context-budget.yml)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![CNCF Sandbox Candidate](https://img.shields.io/badge/CNCF-Sandbox_Candidate-026be0.svg)](https://cncf.io)
 [![Go 1.22+](https://img.shields.io/badge/go-1.22+-00add8.svg)](https://go.dev)
@@ -195,6 +196,22 @@ terminal state required, valid capability refs), WorkflowGraph → WorkflowIR se
 (protobuf), gRPC API layer (`CompileWorkflow` / `ValidateManifest` / `GetCompiledWorkflow`),
 JSON Schemas for `Workflow`, `AgentDef`, and `Policy` manifest kinds, `make validate-spec`
 target, and reference workflow YAML examples. Coverage gate ≥ 90% on all domain packages.
+
+---
+
+## AI Context Architecture
+
+AI assistants working in this repo load context in layers. Smaller budgets = higher signal density.
+
+| File | Role | Limit |
+|------|------|-------|
+| `CLAUDE.md` | Session bootstrap — milestone status, dev workflow, anti-patterns | 200 lines |
+| `AGENTS.md` (root) | Engineering constitution — immutable principles, hard constraints | 300 lines |
+| `docs/ai-assistant-setup.md` | Onboarding guide for AI contributors | 150 lines |
+| `services/*/AGENTS.md` | Per-service rules (layout, tests, service-specific mistakes) | 150 lines each |
+| `agents/*/AGENTS.md` | Per-adapter rules (Python patterns, gRPC stub usage) | 150 lines each |
+
+Total budget: **2000 lines** across all files. The [AI Context Budget](https://github.com/zynax-io/zynax/actions/workflows/ai-context-budget.yml) workflow reports current totals on every relevant PR (advisory, non-blocking). Counted by [tools/count-ai-context.sh](tools/count-ai-context.sh).
 
 ---
 

--- a/tools/count-ai-context.sh
+++ b/tools/count-ai-context.sh
@@ -1,0 +1,95 @@
+#!/bin/sh
+# Counts lines in all AI context files (CLAUDE.md, AGENTS.md files, ai-assistant-setup.md).
+# Always exits 0 — non-blocking advisory only.
+set -e
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# Per-file thresholds
+THRESHOLD_CLAUDE=200
+THRESHOLD_ROOT_AGENTS=300
+THRESHOLD_AI_SETUP=150
+THRESHOLD_SERVICE_AGENTS=150
+THRESHOLD_TOTAL=2000
+
+total=0
+warnings=0
+
+print_row() {
+  file="$1"
+  lines="$2"
+  threshold="$3"
+  if [ "$lines" -gt "$threshold" ]; then
+    status="WARN"
+    warnings=$((warnings + 1))
+  else
+    status="OK"
+  fi
+  printf "| %-55s | %5d | %5d | %-4s |\n" "$file" "$lines" "$threshold" "$status"
+}
+
+echo "| File                                                    | Lines | Limit | Status |"
+echo "|----------------------------------------------------------|-------|-------|--------|"
+
+# CLAUDE.md (root only)
+if [ -f "CLAUDE.md" ]; then
+  n=$(wc -l < "CLAUDE.md")
+  total=$((total + n))
+  print_row "CLAUDE.md" "$n" "$THRESHOLD_CLAUDE"
+fi
+
+# Root AGENTS.md
+if [ -f "AGENTS.md" ]; then
+  n=$(wc -l < "AGENTS.md")
+  total=$((total + n))
+  print_row "AGENTS.md" "$n" "$THRESHOLD_ROOT_AGENTS"
+fi
+
+# docs/ai-assistant-setup.md
+if [ -f "docs/ai-assistant-setup.md" ]; then
+  n=$(wc -l < "docs/ai-assistant-setup.md")
+  total=$((total + n))
+  print_row "docs/ai-assistant-setup.md" "$n" "$THRESHOLD_AI_SETUP"
+fi
+
+# Per-directory AGENTS.md files (all except root)
+find . -name "AGENTS.md" ! -path "./AGENTS.md" | sort | while IFS= read -r f; do
+  rel="${f#./}"
+  n=$(wc -l < "$f")
+  # Use a temp file to accumulate total and warnings across subshell boundary
+  printf "%s %d\n" "$rel" "$n" >> /tmp/ai_context_sub.$$
+  print_row "$rel" "$n" "$THRESHOLD_SERVICE_AGENTS"
+done
+
+# Re-read sub-files to get total (find+while runs in subshell)
+if [ -f "/tmp/ai_context_sub.$$" ]; then
+  while read -r _rel n; do
+    total=$((total + n))
+    if [ "$n" -gt "$THRESHOLD_SERVICE_AGENTS" ]; then
+      warnings=$((warnings + 1))
+    fi
+  done < "/tmp/ai_context_sub.$$"
+  rm -f "/tmp/ai_context_sub.$$"
+fi
+
+echo "|----------------------------------------------------------|-------|-------|--------|"
+
+if [ "$total" -gt "$THRESHOLD_TOTAL" ]; then
+  total_status="WARN"
+  warnings=$((warnings + 1))
+else
+  total_status="OK"
+fi
+printf "| %-55s | %5d | %5d | %-4s |\n" "TOTAL" "$total" "$THRESHOLD_TOTAL" "$total_status"
+echo ""
+
+if [ "$warnings" -gt 0 ]; then
+  echo "WARNING: $warnings file(s) exceed their line threshold."
+  echo "Consider trimming AI context files — smaller budgets improve signal density."
+else
+  echo "All AI context files are within budget."
+fi
+
+# Always exit 0 — this check is advisory only
+exit 0


### PR DESCRIPTION
## Summary

- Add `tools/count-ai-context.sh` — POSIX shell script that discovers all AI context files, counts lines per file and total, compares against per-file thresholds, and prints a formatted Markdown table. Always exits 0 (advisory only — never blocks CI).
- Add `.github/workflows/ai-context-budget.yml` — triggered on push to `main` or PRs touching any AI context file; runs the script and writes the table to `$GITHUB_STEP_SUMMARY`. Non-blocking.
- Update `README.md` — add AI Context Budget workflow badge + "AI Context Architecture" section with the layered context model and per-file line budgets.
- Update `AGENTS.md` KB Index — add pointer to `tools/count-ai-context.sh`.

## Thresholds

| File | Limit |
|------|-------|
| `CLAUDE.md` | 200 lines |
| `AGENTS.md` (root) | 300 lines |
| `docs/ai-assistant-setup.md` | 150 lines |
| Per-service/per-adapter `AGENTS.md` | 150 lines each |
| **Total** | **2000 lines** |

Current state: **1621 lines** across 18 files. One warning: `docs/ai-assistant-setup.md` at 172 lines (limit 150).

## Test plan

- [ ] `sh tools/count-ai-context.sh` runs without error and prints the table
- [ ] Script exits 0 even when files are over threshold
- [ ] CI workflow triggers on a PR touching `CLAUDE.md` or any `AGENTS.md`
- [ ] Job summary shows the formatted table
- [ ] README badge resolves to the new workflow

Closes #275

Assisted-by: Claude/claude-sonnet-4-6