### PR TITLE
chore: PR template — SPDD Canvas link field for feat: PRs (#209)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -37,6 +37,19 @@ Closes #
 
 ---
 
+## SPDD Canvas (feat: PRs only)
+
+> Skip this entire section for `fix:`, `refactor:`, `docs:`, `ci:`, `chore:` PRs.
+> For `feat:` PRs, a Canvas must be committed **before** any implementation code.
+> See `docs/patterns/spdd-guide.md` and ADR-019.
+
+- Canvas: `docs/spdd/<issue>-<slug>/canvas.md`
+- [ ] Canvas status is `Aligned` (human-reviewed, not Draft)
+- [ ] `/spdd-security-review` passed — result noted in Canvas Safeguards section
+- [ ] Canvas commit precedes all implementation commits in this branch
+
+---
+
 ## PR Size Self-Check
 
 Lines changed (excluding generated code, lock files, fixtures): ___


### PR DESCRIPTION
## Summary

Add a `## SPDD Canvas (feat: PRs only)` section to `.github/PULL_REQUEST_TEMPLATE.md`, positioned immediately after the Type of Change checkboxes so authors see it right after ticking `feat:`.

The section contains:
- Canvas path placeholder (`docs/spdd/<issue>-<slug>/canvas.md`)
- Checkbox: Canvas status is `Aligned`
- Checkbox: `/spdd-security-review` passed
- Checkbox: Canvas commit precedes all implementation commits
- Clear skip instruction for non-`feat:` PR types

## Why this placement

After ticking `feat:` in "Type of Change", the author immediately hits the Canvas section — making the gate visible at the moment of classification rather than buried in the checklist at the bottom.

## Test plan

- [ ] Open a new PR draft on GitHub — confirm the SPDD Canvas section appears in the template
- [ ] Verify skip instruction is clear for non-feat types
- [ ] CI passes (no generated code affected)

Closes #209

Assisted-by: Claude/claude-sonnet-4-6