### PR TITLE
ci: cache CI tool binaries and Go modules across all jobs (#220)

### DIFF
--- a/.github/workflows/ai-context-budget.yml
+++ b/.github/workflows/ai-context-budget.yml
@@ -20,9 +20,9 @@ permissions:
 jobs:
   count:
     name: Count AI context lines
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Count AI context lines
         id: count

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,8 +101,16 @@ jobs:
             'docs/ai-assistant-setup.md' '.ai/' '.claude/' 2>/dev/null | wc -l)
           echo "has_changes=$changed" >> "$GITHUB_OUTPUT"
 
-      - name: Install gitleaks
+      - name: Cache gitleaks
+        id: gitleaks-cache
         if: steps.ai-detect.outputs.has_changes != '0'
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+        with:
+          path: /usr/local/bin/gitleaks
+          key: gitleaks-8.21.2-linux-x64
+
+      - name: Install gitleaks
+        if: steps.ai-detect.outputs.has_changes != '0' && steps.gitleaks-cache.outputs.cache-hit != 'true'
         run: |
           curl -fsSL \
             "https://github.com/gitleaks/gitleaks/releases/download/v8.21.2/gitleaks_8.21.2_linux_x64.tar.gz" \
@@ -140,8 +148,16 @@ jobs:
             echo "ℹ️  protos/buf.yaml not found — buf lint skipped until proto branch merges."
           fi
 
-      - name: Install buf
+      - name: Cache buf
+        id: buf-cache
         if: steps.proto-detect.outputs.has_protos == '1'
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+        with:
+          path: /usr/local/bin/buf
+          key: buf-${{ env.BUF_VERSION }}-linux-x86_64
+
+      - name: Install buf
+        if: steps.proto-detect.outputs.has_protos == '1' && steps.buf-cache.outputs.cache-hit != 'true'
         run: |
           curl -fsSL \
             "https://github.com/bufbuild/buf/releases/download/v${{ env.BUF_VERSION }}/buf-Linux-x86_64" \
@@ -236,10 +252,19 @@ jobs:
         if: steps.go-detect.outputs.has_go != '0'
         with:
           go-version: ${{ env.GO_VERSION }}
-          cache: false
+          cache: true
+          cache-dependency-path: "**/go.sum"
+
+      - name: Cache golangci-lint
+        id: golangci-cache
+        if: steps.go-detect.outputs.has_go != '0'
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+        with:
+          path: /usr/local/bin/golangci-lint
+          key: golangci-${{ env.GOLANGCI_VERSION }}-linux-amd64
 
       - name: Install golangci-lint
-        if: steps.go-detect.outputs.has_go != '0'
+        if: steps.go-detect.outputs.has_go != '0' && steps.golangci-cache.outputs.cache-hit != 'true'
         run: |
           VERSION="${{ env.GOLANGCI_VERSION }}"
           VERSION_BARE="${VERSION#v}"
@@ -280,6 +305,8 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         if: steps.py-detect.outputs.has_py != '0'
+        with:
+          enable-cache: true
 
       - name: ruff + mypy (SDK + all Python agents)
         if: steps.py-detect.outputs.has_py != '0'
@@ -348,6 +375,7 @@ jobs:
           steps.go-detect.outputs.has_bdd_impl != '0'
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: "**/go.sum"
 
       - name: Go service unit tests
         if: steps.go-detect.outputs.has_services != '0'
@@ -546,6 +574,8 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         if: steps.py-detect.outputs.has_py != '0'
+        with:
+          enable-cache: true
 
       - name: pytest-bdd (SDK + all Python agents)
         if: steps.py-detect.outputs.has_py != '0'
@@ -642,11 +672,23 @@ jobs:
         if: steps.go-detect.outputs.has_go != '0'
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: "**/go.sum"
+
+      - name: Cache govulncheck
+        id: govulncheck-cache
+        if: steps.go-detect.outputs.has_go != '0'
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+        with:
+          path: ~/go/bin/govulncheck
+          key: govulncheck-${{ env.GOVULNCHECK_VERSION }}-go${{ env.GO_VERSION }}
+
+      - name: Install govulncheck
+        if: steps.go-detect.outputs.has_go != '0' && steps.govulncheck-cache.outputs.cache-hit != 'true'
+        run: go install golang.org/x/vuln/cmd/govulncheck@${{ env.GOVULNCHECK_VERSION }}
 
       - name: govulncheck (all Go services)
         if: steps.go-detect.outputs.has_go != '0'
         run: |
-          go install golang.org/x/vuln/cmd/govulncheck@${{ env.GOVULNCHECK_VERSION }}
           failed=false
           for svc in ${{ env.SERVICE_LIST }}; do
             if [ -f "services/${svc}/go.mod" ]; then
@@ -673,6 +715,8 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         if: steps.py-detect.outputs.has_py != '0'
+        with:
+          enable-cache: true
 
       - name: bandit + pip-audit (SDK + all Python agents)
         if: steps.py-detect.outputs.has_py != '0'

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -141,8 +141,16 @@ jobs:
           changed=$(git diff --name-only "${BASE}..${HEAD}" -- 'protos/**/*.proto' | wc -l)
           echo "proto_changed=$changed" >> "$GITHUB_OUTPUT"
 
-      - name: Install buf
+      - name: Cache buf
+        id: buf-cache
         if: steps.proto-detect.outputs.proto_changed != '0'
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+        with:
+          path: /usr/local/bin/buf
+          key: buf-1.47.2-linux-x86_64
+
+      - name: Install buf
+        if: steps.proto-detect.outputs.proto_changed != '0' && steps.buf-cache.outputs.cache-hit != 'true'
         run: |
           curl -fsSL \
             "https://github.com/bufbuild/buf/releases/download/v1.47.2/buf-Linux-x86_64" \


### PR DESCRIPTION
## Summary

- Cache `gitleaks`, `buf`, `golangci-lint`, and `govulncheck` binaries with `actions/cache@v4` — each binary is downloaded at most once per version across all runs on the same runner OS
- Enable Go module cache in the `lint` job (`cache: false` → `cache: true` with `cache-dependency-path: "**/go.sum"`) — this was the biggest cache miss
- Add `cache-dependency-path: "**/go.sum"` to `test-unit` and `security` `setup-go` steps to scope the cache key accurately
- Add `enable-cache: true` to all three `setup-uv` calls (`lint`, `test-unit`, `security`) for uv's virtual environment cache
- Cache `buf` in `pr-checks.yml` proto-breaking job
- Pin `ai-context-budget.yml` to `ubuntu-24.04` and a pinned `actions/checkout` (was using floating `ubuntu-latest` and `@v4`)

## Expected impact

| Tool | Before | After |
|------|--------|-------|
| gitleaks | ~5s curl every run | 0s on cache hit |
| buf | ~3s curl, 5× across workflows | 0s on cache hit |
| golangci-lint | ~8s curl every lint run | 0s on cache hit |
| govulncheck | ~10s `go install` every security run | 0s on cache hit |
| Go modules | full re-download on lint (cache: false) | cached per go.sum hash |
| uv venvs | rebuilt every run | restored from cache |

## Test plan

- [ ] CI green on this PR
- [ ] Second run of CI shows cache hits (`Cache restored` log lines) for all five tools
- [ ] `lint`, `test-unit`, `security` job durations decrease noticeably on repeat runs

Closes #220

Assisted-by: Claude/claude-sonnet-4-6