### PR TITLE
ci: dco gates lint and security for fail-fast (#286)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,7 @@ jobs:
   lint:
     name: lint
     runs-on: ubuntu-24.04
+    needs: [dco]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -658,6 +659,7 @@ jobs:
   security:
     name: security
     runs-on: ubuntu-24.04
+    needs: [dco]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 


### PR DESCRIPTION
## Summary

Add `needs: [dco]` to both `lint` and `security` jobs.

**Before:** `dco`, `lint`, and `security` all start simultaneously. A PR with a missing `Signed-off-by` still runs 2–5 minutes of lint before the DCO failure is surfaced.

**After:** lint and security wait for DCO (~5s). A bad sign-off fails the pipeline in under 15 seconds total, saving runner minutes on every bad commit.

```
Before:  dco ─╮
               ╰─ (independent)
        lint ──┤
      security ╯

After:   dco (<10s) ──→ lint ──→ test-unit ──→ test-integration
                    └──→ security
```

## Trade-off

~5–10s added to the critical path for PRs that pass DCO (net zero for passing PRs since DCO and lint both need checkout). Worth it: DCO failures from new contributors are common; lint is the expensive gate.

## Test plan

- [ ] CI green on this PR
- [ ] A test PR with a missing `Signed-off-by` fails within 15 seconds

Closes #286

Assisted-by: Claude/claude-sonnet-4-6