### PR TITLE
ci: test-integration parallel with test-unit after lint (#284)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -636,7 +636,7 @@ jobs:
   test-integration:
     name: test-integration
     runs-on: ubuntu-24.04
-    needs: [test-unit]
+    needs: [lint-go, lint-proto]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 


### PR DESCRIPTION
## Summary

Change `test-integration` from `needs: [test-unit]` to `needs: [lint-go, lint-proto]`.

Unit tests and integration tests are independent correctness gates — neither result should block the other from starting.

**Before:**
```
lint-go + lint-proto → test-unit → test-integration   (serial, +N minutes)
```

**After:**
```
lint-go + lint-proto ──→ test-unit
                     └──→ test-integration             (parallel)
```

## Why now

`test-integration` is a no-op skeleton today, so this has zero runtime impact right now. Fixing the dependency before M3 integration tests land prevents the wrong graph from becoming load-bearing.

## Test plan

- [ ] CI green on this PR
- [ ] `test-unit` and `test-integration` appear as parallel jobs in the Actions run timeline

Closes #284

Assisted-by: Claude/claude-sonnet-4-6