### PR TITLE
chore: private context vault convention in knowledge-base-policy (#216)

### DIFF
--- a/docs/knowledge-base-policy.md
+++ b/docs/knowledge-base-policy.md
@@ -207,6 +207,62 @@ Before committing a KB change, apply these steps in order:
 
 ---
 
+## Private Context Vault
+
+When a REASONS Canvas requires Tier 2 context to be useful — real hostnames,
+internal service names, security-sensitive design — that context lives in a
+**private companion file** alongside the public Canvas. It is never committed.
+
+### File layout
+
+```
+docs/spdd/<issue>-<slug>/
+  canvas.md               ← Tier 1, committed, public
+  canvas.private.md       ← Tier 2, gitignored, NEVER committed
+```
+
+The gitignore rule `docs/spdd/**/canvas.private.md` is enforced in `.gitignore`
+and verified by `tools/validate_canvas.py` (which fails if `canvas.private.md`
+is found alongside a committed Canvas).
+
+### Creating a private companion
+
+1. Copy `docs/spdd/PRIVATE_CANVAS_TEMPLATE.md` to
+   `docs/spdd/<issue>-<slug>/canvas.private.md`.
+2. Fill in the Tier 2 sections: deployment targets, internal service names,
+   security-sensitive notes, customer constraints.
+3. Verify it is gitignored: `git status` must not show the file.
+4. Note in the public Canvas that a private companion exists:
+   ```markdown
+   > **Private companion:** Tier 2 deployment context exists in
+   > `canvas.private.md` (gitignored). See `docs/knowledge-base-policy.md
+   > §"Private Context Vault"`.
+   ```
+
+### Sharing private context with collaborators
+
+The private file must never travel over unencrypted channels. Three sanctioned
+options (in preference order):
+
+| Option | How |
+|--------|-----|
+| **A — Private repo** | Push to `zynax-io/zynax-private-context` under the same `docs/spdd/` path |
+| **B — Encrypted file** | Encrypt with `age` or `gpg` using the recipient's public key |
+| **C — Session paste** | Paste relevant sections as Tier 3 ephemeral context at session start |
+
+### Injecting private context into an AI session
+
+```bash
+# At the start of a Claude Code session, paste relevant sections:
+cat docs/spdd/<issue>-<slug>/canvas.private.md
+# Copy the relevant sections and provide them in the session prompt.
+```
+
+Private context stays Tier 3 (ephemeral) within the session. The AI assistant
+must never write Tier 2 content back to any committed file.
+
+---
+
 ## Reviewer Verification Process
 
 When reviewing a PR that touches KB paths, verify each of the following before


### PR DESCRIPTION
## Summary

Adds the **Private Context Vault** section to `docs/knowledge-base-policy.md`, completing the Tier 2 governance story started in #215.

The infrastructure was already in place from prior PRs:
- `.gitignore`: `docs/spdd/**/canvas.private.md` ✅
- `docs/spdd/PRIVATE_CANVAS_TEMPLATE.md` ✅
- `tools/validate_canvas.py` fails if `canvas.private.md` is committed alongside a Canvas ✅

This PR adds the **normative policy section** that ties them together and gives contributors a single reference for:

1. **File layout** — `canvas.md` (committed) alongside `canvas.private.md` (gitignored)
2. **How to create** a private companion from the template
3. **How to reference it** from the public Canvas without leaking content
4. **Three sanctioned sharing options** — private repo, encrypted file, or session paste
5. **Injection pattern** — Tier 2 → Tier 3 ephemeral at session start, never written back

## Test plan

- [ ] CI green (docs-only PR)
- [ ] `docs/knowledge-base-policy.md` reads coherently end-to-end (Tier classification → vault → sanitization → review process)

Closes #216

Assisted-by: Claude/claude-sonnet-4-6