### PR TITLE
ci: extend KB scan to Canvas files and add prompt injection rules (#217)

### DIFF
--- a/.github/workflows/kb-preview.yml
+++ b/.github/workflows/kb-preview.yml
@@ -26,6 +26,8 @@ on:
       - '**/AGENTS.md'
       - 'docs/ai-assistant-setup.md'
       - 'docs/knowledge-base-policy.md'
+      - 'docs/patterns/spdd-guide.md'
+      - 'docs/spdd/**'
       - '.ai/**'
       - '.claude/**'
 
@@ -54,6 +56,7 @@ jobs:
             "origin/${{ github.base_ref }}...HEAD" -- \
             CLAUDE.md AGENTS.md '*/AGENTS.md' \
             'docs/ai-assistant-setup.md' 'docs/knowledge-base-policy.md' \
+            'docs/patterns/spdd-guide.md' 'docs/spdd/**' \
             '.ai/**' '.claude/**' \
             | grep '^+' | grep -v '^+++' | sed 's/^+//' | head -300)
           if [ -z "$additions" ]; then

--- a/tools/gitleaks-ai-context.toml
+++ b/tools/gitleaks-ai-context.toml
@@ -41,6 +41,20 @@ description = "Private IP address range — infrastructure detail"
 regex       = '''(10\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}|172\.(1[6-9]|2[0-9]|3[01])\.[0-9]{1,3}\.[0-9]{1,3}|192\.168\.[0-9]{1,3}\.[0-9]{1,3})'''
 tags        = ["infrastructure", "ip"]
 
+[[rules]]
+id          = "prompt-injection"
+description = "Prompt injection payload — text instructing an AI to override governance rules"
+regex       = '''(?i)(ignore\s+(previous|prior|all)\s+(instructions?|prompts?|rules?)|forget\s+(everything|all\s+previous|all\s+prior)\s*(instructions?|context)?|you\s+are\s+now\s+(a|an)\s+[a-z][a-z]+|you\s+(have\s+)?no\s+(restrictions?|ethical\s+guidelines?|safety\s+rules?)|disregard\s+(all\s+)?(previous|system)\s+(instructions?|rules?))'''
+tags        = ["injection", "security"]
+[rules.allowlist]
+# Skip files that intentionally document injection patterns as examples or rules
+paths       = [
+  '''tools/gitleaks-ai-context\.toml''',
+  '''docs/knowledge-base-policy\.md''',
+  '''\.claude/commands/''',
+  '''\.claude/settings''',
+]
+
 [allowlist]
 regexes     = [
   # Docker Alpine container paths documented as known pitfalls — not local machine paths


### PR DESCRIPTION
## Summary

- **`kb-preview.yml`**: adds `docs/spdd/**` and `docs/patterns/spdd-guide.md` to both the trigger `paths:` and the `git diff` extract command — Canvas files became Tier 1 KB artifacts in `knowledge-base-policy.md` v2.0 (#215/#216) and must receive the same previsualization gate as `CLAUDE.md` / `AGENTS.md`
- **`gitleaks-ai-context.toml`**: adds a `prompt-injection` rule that flags override attempts (`ignore previous instructions`), context resets (`forget everything`), persona injection (`you are now a …`), and restriction bypasses (`you have no restrictions`) in committed KB files; path allowlist skips the security policy doc and `.claude/commands/` which intentionally document these patterns as examples

Closes #217

## Test plan

- [ ] CI passes on this PR (no false positives from the new prompt-injection rule against existing KB files)
- [ ] `gitleaks detect --no-git --source . --config tools/gitleaks-ai-context.toml` passes locally
- [ ] KB Previsualization workflow triggers on a test PR that touches `docs/spdd/**`
- [ ] Verify `docs/knowledge-base-policy.md` and `.claude/commands/spdd-security-review.md` are excluded from the prompt-injection rule (they describe injection patterns, not inject them)

Assisted-by: Claude/claude-sonnet-4-6