### PR TITLE
ci(agents): mypy --strict zero-error baseline for agents/sdk (#231)

### DIFF
--- a/agents/sdk/pyproject.toml
+++ b/agents/sdk/pyproject.toml
@@ -26,6 +26,24 @@ dependencies = [
 ]
 
 
+[tool.mypy]
+python_version = "3.12"
+strict         = true
+# Resolve imports from the src/ layout without requiring package installation.
+mypy_path      = "src"
+
+# Third-party packages declared as dependencies that ship without PEP 561
+# inline types or a companion -stubs package. Add entries here as real imports
+# are introduced — never suppress with inline  # type: ignore[import].
+[[tool.mypy.overrides]]
+module = [
+    "grpc",
+    "grpc.*",
+    "opentelemetry.*",
+    "prometheus_client",
+]
+ignore_missing_imports = true
+
 [tool.pytest.ini_options]
 testpaths   = ["tests"]
 addopts     = "-v --tb=short"


### PR DESCRIPTION
## Summary

Closes #231. Part of Epic #173 (Pillar 4 — Python Quality).

Adds `[tool.mypy]` to `agents/sdk/pyproject.toml` so that `uv run mypy src/` locally produces the same strict result as CI without any flags:

- **`strict = true`** — enables all strict checks: `disallow-untyped-defs`, `warn-return-any`, `no-implicit-reexport`, `strict-equality`, etc.
- **`python_version = "3.12"`** — matches `requires-python` and `PYTHON_VERSION` in CI
- **`mypy_path = "src"`** — resolves the src-layout without package installation
- **`[[tool.mypy.overrides]]`** — documents the four dependency packages that ship without PEP 561 stubs (`grpc`, `opentelemetry.*`, `prometheus_client`); future imports must be listed here, never suppressed with inline `# type: ignore[import]`

CI already runs `uv run mypy src/ --strict` in the `lint-python` job and the Makefile `lint-agents` target — the explicit `--strict` flag is kept for clarity; the config makes it the no-argument default for local dev.

## Test plan

- [ ] CI `lint-python` passes (changes only touch `agents/sdk/pyproject.toml`, no Python source touched — `lint-python` skips via path filter; verify the check is green on push to main or a follow-up PR that touches `agents/`)
- [ ] `cd agents/sdk && uv run mypy src/` exits 0 with no flags (config-driven strict)
- [ ] `make lint` passes cleanly

Assisted-by: Claude/claude-sonnet-4-6