### PR TITLE
docs: /spdd-story creates GitHub issues by default

### DIFF
--- a/.claude/commands/spdd-security-review.md
+++ b/.claude/commands/spdd-security-review.md
@@ -33,7 +33,7 @@ Flag anything that belongs in `canvas.private.md` instead of the public Canvas:
 | **Infrastructure** | Real hostnames, cluster/namespace names, internal TLDs (`.internal` `.local` `.corp`), private IPs (`10.x`, `172.16–31.x`, `192.168.x`), VPN/bastion references |
 | **Credentials** | API keys, passwords, tokens, secrets — even expired, placeholder-looking, or redacted |
 | **Deployment specifics** | Exact failover thresholds, WAF rules, rate-limit values, replica counts from a real environment |
-| **PII** | Full names linked to sensitive context, personal emails, corporate emails not in a public commit |
+| **PII** | Any email address literal (all email addresses are BLOCK — gitleaks will fail CI regardless of whether the address is already public; reference commit-hygiene rules by name, e.g. "per AGENTS.md §Hard Constraints", never inline the address) · Full names linked to sensitive context |
 | **Unpublished strategy** | Unannounced features, acquisition plans, private roadmap milestones, internal project codenames |
 | **Operational security** | Credential rotation schedules, access control details, incident details with attacker-observable data |
 

--- a/.claude/commands/spdd-story.md
+++ b/.claude/commands/spdd-story.md
@@ -1,6 +1,7 @@
 # /spdd-story
 
-Break a raw feature description or GitHub issue into INVEST-compliant user stories.
+Break a raw feature description or GitHub issue into INVEST-compliant user stories,
+then create one GitHub issue per story as a child of the parent epic.
 
 ## Instructions
 
@@ -16,10 +17,15 @@ Read the feature description or GitHub issue provided in $ARGUMENTS.
    - **E**stimable: can be sized relatively
    - **S**mall: fits in one PR (≤ 400 lines excluding generated code)
    - **T**estable: has clear, verifiable acceptance criteria
+5. After presenting the stories, create one GitHub issue per story using `gh issue create`.
+   - Title format: `feat(<scope>): <story title> (#<parent-issue>, step <N>)`
+   - Body includes: Story (as-a/I-want/so-that), Context (link to canvas if it exists), Scope, Acceptance criteria, Out of scope, Size estimate, Dependencies on other steps
+   - End each body with: `Assisted-by: Claude/claude-sonnet-4-6`
+   - Report the created issue URL after each creation
 
 ## Output Format
 
-For each story:
+For each story (display first, then create issues):
 
 **Story N: <title>**
 - As a `<actor>`, I want `<capability>` so that `<outcome>`.
@@ -29,7 +35,8 @@ For each story:
   - [ ] <concrete, testable criterion>
 - Out of scope: <what this story explicitly does NOT cover>
 
-End with a recommended implementation order and any dependency between stories.
+End with a recommended implementation order, any dependency between stories,
+and a summary table of the created GitHub issues.
 
 ## Input
 

--- a/docs/patterns/spdd-guide.md
+++ b/docs/patterns/spdd-guide.md
@@ -59,7 +59,8 @@ Canvas generation in step 3 draws from it.
 
 ## Step 2 — `/spdd-story <issue>`
 
-Breaks the feature into 2–5 INVEST-compliant user stories:
+Breaks the feature into 2–5 INVEST-compliant user stories and creates one GitHub
+issue per story as a child of the parent epic:
 
 - **I**ndependent — deliverable separately
 - **N**egotiable — details are flexible
@@ -70,6 +71,11 @@ Breaks the feature into 2–5 INVEST-compliant user stories:
 
 Each story maps to one Operations step in the Canvas. The recommended implementation
 order from this command feeds directly into Canvas section O.
+
+**GitHub issue creation (default behaviour):** after displaying the stories,
+`/spdd-story` opens one `gh issue` per story. Title format:
+`feat(<scope>): <title> (#<parent>, step <N>)`. The Canvas O section must link
+to these issue numbers once they exist — update the canvas after running this command.
 
 ---
 


### PR DESCRIPTION
## Summary

- `/spdd-story` now creates one GitHub issue per story after decomposition (previously stories were session-only and lost when the conversation ended)
- `docs/patterns/spdd-guide.md` Step 2 updated to document the default issue-creation behaviour
- `/spdd-security-review` now treats any email address literal as **BLOCK** (not WARN) — gitleaks will fail CI on any email in `docs/spdd/`, even public maintainer addresses; Canvas N sections must reference commit-hygiene rules by name (e.g. "per AGENTS.md §Hard Constraints") not inline the address

## Motivation

Discovered during PR #300 (M3 Canvas): stories from `/spdd-story 214` existed only in chat history and were not persisted anywhere. Creating GitHub issues makes each story trackable, assignable, and closeable from a PR description.

The gitleaks BLOCK on emails was found when CI rejected the canvas for containing the maintainer's email in the N section Signed-off-by example — the security review tool had rated it WARN, which was insufficient.

## Test plan

- [x] `/spdd-story` command file updated with issue-creation instructions
- [x] `docs/patterns/spdd-guide.md` Step 2 reflects new default behaviour
- [x] `/spdd-security-review` PII row escalated to BLOCK for all email literals
- [x] Issues #301–#305 created for M3 canvas O steps (real-world test of this flow)

Assisted-by: Claude/claude-sonnet-4-6