### PR TITLE
feat(engine-adapter): DispatchCapabilityActivity + unit tests (#302)

### DIFF
--- a/services/engine-adapter/internal/domain/activity.go
+++ b/services/engine-adapter/internal/domain/activity.go
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package domain contains the core port definitions and value types for the
+// engine-adapter service. It has zero imports from api or infrastructure layers.
+package domain
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	zynaxv1 "github.com/zynax-io/zynax/protos/generated/go/zynax/v1"
+)
+
+// ActivityInput carries the parameters for a single capability execution.
+type ActivityInput struct {
+	CapabilityName string
+	InputPayload   []byte
+	WorkflowID     string
+	TimeoutSeconds int32
+}
+
+// ActivityResult carries the outcome of a completed capability execution.
+type ActivityResult struct {
+	EventType string
+	Payload   []byte
+}
+
+// CapabilityDispatcher dispatches capability activities to the task broker.
+// It is a plain Go struct — Temporal registers it as an activity source in
+// the infrastructure layer; no Temporal SDK is imported here (ADR-015).
+type CapabilityDispatcher struct {
+	broker       zynaxv1.TaskBrokerServiceClient
+	pollInterval time.Duration
+}
+
+// NewCapabilityDispatcher constructs a dispatcher backed by the given broker client.
+func NewCapabilityDispatcher(broker zynaxv1.TaskBrokerServiceClient) *CapabilityDispatcher {
+	return &CapabilityDispatcher{broker: broker, pollInterval: 500 * time.Millisecond}
+}
+
+// DispatchCapabilityActivity submits a task to the broker and polls until terminal.
+// It is a plain Go method registered as a Temporal activity function in infrastructure/.
+func (d *CapabilityDispatcher) DispatchCapabilityActivity(ctx context.Context, in ActivityInput) (*ActivityResult, error) {
+	taskID, err := d.dispatch(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+	return d.poll(ctx, taskID, in.CapabilityName)
+}
+
+func (d *CapabilityDispatcher) dispatch(ctx context.Context, in ActivityInput) (string, error) {
+	resp, err := d.broker.DispatchTask(ctx, &zynaxv1.DispatchTaskRequest{
+		Task: &zynaxv1.WorkflowTask{
+			WorkflowId:     in.WorkflowID,
+			CapabilityName: in.CapabilityName,
+			InputPayload:   in.InputPayload,
+			TimeoutSeconds: in.TimeoutSeconds,
+		},
+	})
+	if err != nil {
+		return "", fmt.Errorf("engine-adapter: dispatch capability %q: %w", in.CapabilityName, err)
+	}
+	return resp.GetTaskId(), nil
+}
+
+func (d *CapabilityDispatcher) poll(ctx context.Context, taskID, capabilityName string) (*ActivityResult, error) {
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, fmt.Errorf("engine-adapter: %w", ctx.Err())
+		case <-time.After(d.pollInterval):
+		}
+
+		task, err := d.broker.GetTask(ctx, &zynaxv1.GetTaskRequest{TaskId: taskID})
+		if err != nil {
+			return nil, fmt.Errorf("engine-adapter: get task %q: %w", taskID, err)
+		}
+
+		result, done, err := handleStatus(task, capabilityName)
+		if done {
+			return result, err
+		}
+	}
+}
+
+// handleStatus inspects the task status and returns (result, done, err).
+// done=false means the task is still in progress; caller should poll again.
+func handleStatus(task *zynaxv1.WorkflowTask, capabilityName string) (*ActivityResult, bool, error) {
+	switch task.GetStatus() {
+	case zynaxv1.TaskStatus_TASK_STATUS_COMPLETED:
+		result, err := extractResult(task.GetResultPayload(), capabilityName)
+		return result, true, err
+
+	case zynaxv1.TaskStatus_TASK_STATUS_FAILED:
+		msg := "unknown error"
+		if e := task.GetError(); e != nil {
+			msg = e.GetMessage()
+		}
+		return nil, true, fmt.Errorf("engine-adapter: capability %q failed: %s", capabilityName, msg)
+
+	case zynaxv1.TaskStatus_TASK_STATUS_CANCELLED:
+		return nil, true, fmt.Errorf("engine-adapter: capability %q task cancelled", capabilityName)
+
+	default:
+		return nil, false, nil
+	}
+}
+
+// extractResult reads the "_event" key from a JSON result payload.
+// If absent or the payload is empty, it defaults to "<capability>.completed".
+func extractResult(payload []byte, capabilityName string) (*ActivityResult, error) {
+	defaultEvent := capabilityName + ".completed"
+	if len(payload) == 0 {
+		return &ActivityResult{EventType: defaultEvent, Payload: payload}, nil
+	}
+
+	var envelope map[string]json.RawMessage
+	if err := json.Unmarshal(payload, &envelope); err != nil {
+		return nil, fmt.Errorf("engine-adapter: unmarshal result payload: %w", err)
+	}
+
+	eventType := defaultEvent
+	if raw, ok := envelope["_event"]; ok {
+		var s string
+		if err := json.Unmarshal(raw, &s); err == nil && s != "" {
+			eventType = s
+		}
+	}
+
+	return &ActivityResult{EventType: eventType, Payload: payload}, nil
+}

--- a/services/engine-adapter/internal/domain/activity_test.go
+++ b/services/engine-adapter/internal/domain/activity_test.go
@@ -1,0 +1,191 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package domain contains the core port definitions and value types for the
+// engine-adapter service. It has zero imports from api or infrastructure layers.
+package domain
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	zynaxv1 "github.com/zynax-io/zynax/protos/generated/go/zynax/v1"
+	"google.golang.org/grpc"
+)
+
+// stubBroker is a hand-written mock of TaskBrokerServiceClient.
+// It is unexported; it covers only the two methods used by CapabilityDispatcher.
+type stubBroker struct {
+	dispatchResp *zynaxv1.DispatchTaskResponse
+	dispatchErr  error
+
+	// tasks is a sequence of responses returned by successive GetTask calls.
+	tasks   []*zynaxv1.WorkflowTask
+	taskErr error
+	callIdx int
+}
+
+func (s *stubBroker) DispatchTask(_ context.Context, _ *zynaxv1.DispatchTaskRequest, _ ...grpc.CallOption) (*zynaxv1.DispatchTaskResponse, error) {
+	return s.dispatchResp, s.dispatchErr
+}
+
+func (s *stubBroker) GetTask(_ context.Context, _ *zynaxv1.GetTaskRequest, _ ...grpc.CallOption) (*zynaxv1.WorkflowTask, error) {
+	if s.taskErr != nil {
+		return nil, s.taskErr
+	}
+	if s.callIdx >= len(s.tasks) {
+		return s.tasks[len(s.tasks)-1], nil
+	}
+	t := s.tasks[s.callIdx]
+	s.callIdx++
+	return t, nil
+}
+
+// Remaining TaskBrokerServiceClient methods — not used; satisfy the interface.
+func (s *stubBroker) AcknowledgeTask(_ context.Context, _ *zynaxv1.AcknowledgeTaskRequest, _ ...grpc.CallOption) (*zynaxv1.AcknowledgeTaskResponse, error) {
+	return nil, nil
+}
+func (s *stubBroker) CancelTask(_ context.Context, _ *zynaxv1.CancelTaskRequest, _ ...grpc.CallOption) (*zynaxv1.CancelTaskResponse, error) {
+	return nil, nil
+}
+func (s *stubBroker) ListTasks(_ context.Context, _ *zynaxv1.ListTasksRequest, _ ...grpc.CallOption) (*zynaxv1.ListTasksResponse, error) {
+	return nil, nil
+}
+
+func newDispatcher(broker *stubBroker) *CapabilityDispatcher {
+	d := NewCapabilityDispatcher(broker)
+	d.pollInterval = time.Millisecond
+	return d
+}
+
+func TestDispatchCapabilityActivity_SuccessWithEvent(t *testing.T) {
+	broker := &stubBroker{
+		dispatchResp: &zynaxv1.DispatchTaskResponse{TaskId: "t1"},
+		tasks: []*zynaxv1.WorkflowTask{
+			{Status: zynaxv1.TaskStatus_TASK_STATUS_DISPATCHED},
+			{
+				Status:        zynaxv1.TaskStatus_TASK_STATUS_COMPLETED,
+				ResultPayload: []byte(`{"_event":"review.approved","data":"ok"}`),
+			},
+		},
+	}
+	d := newDispatcher(broker)
+
+	result, err := d.DispatchCapabilityActivity(context.Background(), ActivityInput{
+		CapabilityName: "summarize",
+		WorkflowID:     "wf-1",
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.EventType != "review.approved" {
+		t.Errorf("EventType = %q; want %q", result.EventType, "review.approved")
+	}
+}
+
+func TestDispatchCapabilityActivity_SuccessNoEvent(t *testing.T) {
+	broker := &stubBroker{
+		dispatchResp: &zynaxv1.DispatchTaskResponse{TaskId: "t2"},
+		tasks: []*zynaxv1.WorkflowTask{
+			{
+				Status:        zynaxv1.TaskStatus_TASK_STATUS_COMPLETED,
+				ResultPayload: []byte(`{"data":"result"}`),
+			},
+		},
+	}
+	d := newDispatcher(broker)
+
+	result, err := d.DispatchCapabilityActivity(context.Background(), ActivityInput{
+		CapabilityName: "summarize",
+		WorkflowID:     "wf-2",
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.EventType != "summarize.completed" {
+		t.Errorf("EventType = %q; want %q", result.EventType, "summarize.completed")
+	}
+}
+
+func TestDispatchCapabilityActivity_Failed(t *testing.T) {
+	broker := &stubBroker{
+		dispatchResp: &zynaxv1.DispatchTaskResponse{TaskId: "t3"},
+		tasks: []*zynaxv1.WorkflowTask{
+			{
+				Status: zynaxv1.TaskStatus_TASK_STATUS_FAILED,
+				Error:  &zynaxv1.TaskError{Message: "agent crashed"},
+			},
+		},
+	}
+	d := newDispatcher(broker)
+
+	_, err := d.DispatchCapabilityActivity(context.Background(), ActivityInput{
+		CapabilityName: "summarize",
+		WorkflowID:     "wf-3",
+	})
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "agent crashed") {
+		t.Errorf("error %q does not mention agent error message", err.Error())
+	}
+}
+
+func TestDispatchCapabilityActivity_DispatchError(t *testing.T) {
+	broker := &stubBroker{
+		dispatchErr: errors.New("broker unavailable"),
+	}
+	d := newDispatcher(broker)
+
+	_, err := d.DispatchCapabilityActivity(context.Background(), ActivityInput{
+		CapabilityName: "summarize",
+		WorkflowID:     "wf-4",
+	})
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "broker unavailable") {
+		t.Errorf("error %q does not mention broker error", err.Error())
+	}
+}
+
+func TestDispatchCapabilityActivity_ContextCancelled(t *testing.T) {
+	broker := &stubBroker{
+		dispatchResp: &zynaxv1.DispatchTaskResponse{TaskId: "t5"},
+		tasks: []*zynaxv1.WorkflowTask{
+			{Status: zynaxv1.TaskStatus_TASK_STATUS_PENDING},
+		},
+	}
+	d := newDispatcher(broker)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := d.DispatchCapabilityActivity(ctx, ActivityInput{
+		CapabilityName: "summarize",
+		WorkflowID:     "wf-5",
+	})
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled in chain, got: %v", err)
+	}
+}
+
+func TestExtractResult_EmptyPayload(t *testing.T) {
+	result, err := extractResult(nil, "classify")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.EventType != "classify.completed" {
+		t.Errorf("EventType = %q; want %q", result.EventType, "classify.completed")
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `CapabilityDispatcher` struct to `internal/domain/activity.go` — plain Go, no Temporal SDK import (ADR-015 safeguard)
- `DispatchCapabilityActivity` calls `TaskBrokerService.DispatchTask` (unary) then polls `GetTask` until a terminal status
- Extracts `_event` key from COMPLETED `result_payload` JSON; defaults to `<capability>.completed` when absent or payload empty
- Six unit tests with hand-written broker stub cover: success with `_event`, success without `_event`, FAILED task, dispatch error, context cancellation, empty payload default

## Canvas reference

Step 2 of `docs/spdd/214-temporal-execution/canvas.md` (Status: Aligned).

## Test plan

- [x] `GOWORK=off go test ./internal/domain/... -race` — 6/6 PASS
- [x] No Temporal SDK import in `internal/domain/` (ADR-015)
- [x] All errors wrapped with `%w` (wrapcheck compliant)
- [x] Package doc comments on all files (revive compliant)

Closes #302

Assisted-by: Claude/claude-sonnet-4-6