### PR TITLE
feat(engine-adapter): gRPC handler wiring + main.go bootstrap (#305)

### DIFF
--- a/services/engine-adapter/cmd/engine-adapter/main.go
+++ b/services/engine-adapter/cmd/engine-adapter/main.go
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package main is the entry point for the engine-adapter service.
+// It wires the Temporal worker (IRInterpreterWorkflow + activities) and the
+// gRPC server (EngineAdapterService). All business logic lives in internal/.
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"strconv"
+	"syscall"
+	"time"
+
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/worker"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/health"
+	"google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/reflection"
+
+	zynaxv1 "github.com/zynax-io/zynax/protos/generated/go/zynax/v1"
+	"github.com/zynax-io/zynax/services/engine-adapter/internal/api"
+	"github.com/zynax-io/zynax/services/engine-adapter/internal/domain"
+	"github.com/zynax-io/zynax/services/engine-adapter/internal/infrastructure"
+)
+
+type config struct {
+	GRPCPort          int
+	MetricsPort       int
+	LogLevel          string
+	TemporalHostPort  string
+	TemporalNamespace string
+	TemporalTaskQueue string
+	TaskBrokerAddr    string
+	ActiveEngine      string
+}
+
+func loadConfig() config {
+	return config{
+		GRPCPort:          getEnvInt("ZYNAX_ENGINE_ADAPTER_GRPC_PORT", 50055),
+		MetricsPort:       getEnvInt("ZYNAX_ENGINE_ADAPTER_METRICS_PORT", 9095),
+		LogLevel:          getEnv("ZYNAX_ENGINE_ADAPTER_LOG_LEVEL", "info"),
+		TemporalHostPort:  getEnv("ZYNAX_ENGINE_ADAPTER_TEMPORAL_HOST_PORT", "localhost:7233"),
+		TemporalNamespace: getEnv("ZYNAX_ENGINE_ADAPTER_TEMPORAL_NAMESPACE", "default"),
+		TemporalTaskQueue: getEnv("ZYNAX_ENGINE_ADAPTER_TEMPORAL_TASK_QUEUE", "engine-adapter"),
+		TaskBrokerAddr:    getEnv("ZYNAX_ENGINE_ADAPTER_TASK_BROKER_ADDR", "localhost:50053"),
+		ActiveEngine:      getEnv("ZYNAX_ENGINE_ACTIVE_ENGINE", "temporal"),
+	}
+}
+
+func main() {
+	cfg := loadConfig()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+		Level: parseLogLevel(cfg.LogLevel),
+	})))
+
+	if err := run(cfg); err != nil {
+		slog.Error("fatal error", "err", err)
+		os.Exit(1)
+	}
+}
+
+// run contains the service lifecycle. Deferred cleanups execute before returning.
+func run(cfg config) error {
+	engine, cleanup, err := buildEngine(cfg)
+	if err != nil {
+		return fmt.Errorf("engine setup: %w", err)
+	}
+	defer cleanup()
+
+	grpcSrv, err := startGRPC(cfg, engine)
+	if err != nil {
+		return fmt.Errorf("gRPC start: %w", err)
+	}
+
+	httpSrv := startHTTP(cfg)
+
+	slog.Info("engine-adapter started",
+		"grpc_port", cfg.GRPCPort,
+		"metrics_port", cfg.MetricsPort,
+		"engine", cfg.ActiveEngine,
+	)
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+	defer stop()
+	<-ctx.Done()
+
+	slog.Info("shutting down")
+	grpcSrv.GracefulStop()
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if shutdownErr := httpSrv.Shutdown(shutdownCtx); shutdownErr != nil {
+		slog.Error("http shutdown error", "err", shutdownErr)
+	}
+	slog.Info("shutdown complete")
+	return nil
+}
+
+// buildEngine creates the WorkflowEngine and its underlying Temporal worker.
+// The returned cleanup function stops the worker and closes connections.
+func buildEngine(cfg config) (domain.WorkflowEngine, func(), error) {
+	if cfg.ActiveEngine != "temporal" {
+		return nil, func() {}, fmt.Errorf("unsupported engine %q: only \"temporal\" is supported in M3", cfg.ActiveEngine)
+	}
+
+	tc, err := client.Dial(client.Options{
+		HostPort:  cfg.TemporalHostPort,
+		Namespace: cfg.TemporalNamespace,
+	})
+	if err != nil {
+		return nil, func() {}, fmt.Errorf("temporal client: %w", err)
+	}
+
+	brokerConn, err := grpc.NewClient(
+		cfg.TaskBrokerAddr,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		tc.Close()
+		return nil, func() {}, fmt.Errorf("task-broker dial: %w", err)
+	}
+
+	dispatcher := domain.NewCapabilityDispatcher(zynaxv1.NewTaskBrokerServiceClient(brokerConn))
+
+	w := worker.New(tc, cfg.TemporalTaskQueue, worker.Options{})
+	w.RegisterWorkflow(infrastructure.IRInterpreterWorkflow)
+	w.RegisterActivity(dispatcher.DispatchCapabilityActivity)
+	w.RegisterActivity(infrastructure.PublishLifecycleEventActivity)
+
+	if err := w.Start(); err != nil {
+		tc.Close()
+		_ = brokerConn.Close()
+		return nil, func() {}, fmt.Errorf("temporal worker: %w", err)
+	}
+
+	cleanup := func() {
+		w.Stop()
+		tc.Close()
+		_ = brokerConn.Close()
+	}
+
+	return infrastructure.NewTemporalEngine(tc, cfg.TemporalTaskQueue, cfg.TemporalNamespace), cleanup, nil
+}
+
+func startGRPC(cfg config, engine domain.WorkflowEngine) (*grpc.Server, error) {
+	srv := grpc.NewServer()
+	reflection.Register(srv)
+
+	healthSvc := health.NewServer()
+	grpc_health_v1.RegisterHealthServer(srv, healthSvc)
+	healthSvc.SetServingStatus("", grpc_health_v1.HealthCheckResponse_SERVING)
+	zynaxv1.RegisterEngineAdapterServiceServer(srv, api.NewHandler(engine))
+
+	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", cfg.GRPCPort))
+	if err != nil {
+		return nil, fmt.Errorf("listen :%d: %w", cfg.GRPCPort, err)
+	}
+
+	go func() {
+		if serveErr := srv.Serve(lis); serveErr != nil {
+			slog.Error("grpc serve error", "err", serveErr)
+		}
+	}()
+
+	return srv, nil
+}
+
+func startHTTP(cfg config) *http.Server {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("/readyz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("/startupz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	srv := &http.Server{
+		Addr:         fmt.Sprintf(":%d", cfg.MetricsPort),
+		Handler:      mux,
+		ReadTimeout:  5 * time.Second,
+		WriteTimeout: 5 * time.Second,
+	}
+	go func() {
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			slog.Error("http server error", "err", err)
+		}
+	}()
+	return srv
+}
+
+func getEnv(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}
+
+func getEnvInt(key string, fallback int) int {
+	if v := os.Getenv(key); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			return n
+		}
+	}
+	return fallback
+}
+
+func parseLogLevel(level string) slog.Level {
+	switch level {
+	case "debug":
+		return slog.LevelDebug
+	case "warn":
+		return slog.LevelWarn
+	case "error":
+		return slog.LevelError
+	default:
+		return slog.LevelInfo
+	}
+}

--- a/services/engine-adapter/internal/api/handler.go
+++ b/services/engine-adapter/internal/api/handler.go
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package api implements the EngineAdapterService gRPC server handler.
+package api
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	zynaxv1 "github.com/zynax-io/zynax/protos/generated/go/zynax/v1"
+	"github.com/zynax-io/zynax/services/engine-adapter/internal/domain"
+)
+
+const runIDRequired = "run_id is required"
+
+// Handler implements EngineAdapterServiceServer, delegating all calls to
+// a domain.WorkflowEngine. The concrete engine is injected at startup;
+// this handler has no dependency on any engine-specific package (ADR-015).
+type Handler struct {
+	zynaxv1.UnimplementedEngineAdapterServiceServer
+	engine domain.WorkflowEngine
+}
+
+// NewHandler constructs a Handler wrapping the given WorkflowEngine.
+func NewHandler(engine domain.WorkflowEngine) *Handler {
+	return &Handler{engine: engine}
+}
+
+// SubmitWorkflow starts a compiled workflow and returns the adapter-assigned run ID.
+func (h *Handler) SubmitWorkflow(ctx context.Context, req *zynaxv1.SubmitWorkflowRequest) (*zynaxv1.SubmitWorkflowResponse, error) {
+	if req.GetWorkflowIr() == nil {
+		return nil, status.Error(codes.InvalidArgument, "workflow_ir is required")
+	}
+	run, err := h.engine.Submit(ctx, req.GetWorkflowIr(), req.GetLabels())
+	if err != nil {
+		return nil, grpcErr(err)
+	}
+	return &zynaxv1.SubmitWorkflowResponse{
+		RunId:       run.RunID,
+		SubmittedAt: timestamppb.New(time.Now()),
+	}, nil
+}
+
+// SignalWorkflow delivers a named event to a running workflow.
+func (h *Handler) SignalWorkflow(ctx context.Context, req *zynaxv1.SignalWorkflowRequest) (*zynaxv1.SignalWorkflowResponse, error) {
+	if req.GetRunId() == "" {
+		return nil, status.Error(codes.InvalidArgument, runIDRequired)
+	}
+	if err := h.engine.Signal(ctx, req.GetRunId(), req.GetEventType(), req.GetPayload()); err != nil {
+		return nil, grpcErr(err)
+	}
+	return &zynaxv1.SignalWorkflowResponse{SignalledAt: timestamppb.New(time.Now())}, nil
+}
+
+// CancelWorkflow requests graceful cancellation of a running workflow.
+func (h *Handler) CancelWorkflow(ctx context.Context, req *zynaxv1.CancelWorkflowRequest) (*zynaxv1.CancelWorkflowResponse, error) {
+	if req.GetRunId() == "" {
+		return nil, status.Error(codes.InvalidArgument, runIDRequired)
+	}
+	if err := h.engine.Cancel(ctx, req.GetRunId(), req.GetReason()); err != nil {
+		return nil, grpcErr(err)
+	}
+	return &zynaxv1.CancelWorkflowResponse{CancelledAt: timestamppb.New(time.Now())}, nil
+}
+
+// GetWorkflowStatus returns the current run metadata for a workflow.
+func (h *Handler) GetWorkflowStatus(ctx context.Context, req *zynaxv1.GetWorkflowStatusRequest) (*zynaxv1.WorkflowRun, error) {
+	if req.GetRunId() == "" {
+		return nil, status.Error(codes.InvalidArgument, runIDRequired)
+	}
+	run, err := h.engine.GetStatus(ctx, req.GetRunId())
+	if err != nil {
+		return nil, grpcErr(err)
+	}
+	return runToProto(run), nil
+}
+
+// WatchWorkflow streams WorkflowEvents until the workflow reaches a terminal state.
+func (h *Handler) WatchWorkflow(req *zynaxv1.WatchWorkflowRequest, stream grpc.ServerStreamingServer[zynaxv1.WorkflowEvent]) error {
+	if req.GetRunId() == "" {
+		return status.Error(codes.InvalidArgument, runIDRequired)
+	}
+	err := h.engine.Watch(stream.Context(), req.GetRunId(), func(ev *domain.WorkflowEvent) error {
+		return stream.Send(eventToProto(ev))
+	})
+	return grpcErr(err)
+}
+
+func runToProto(r *domain.WorkflowRun) *zynaxv1.WorkflowRun {
+	return &zynaxv1.WorkflowRun{
+		RunId:              r.RunID,
+		WorkflowId:         r.WorkflowID,
+		Namespace:          r.Namespace,
+		Status:             zynaxv1.WorkflowStatus(r.Status), //nolint:gosec
+		CurrentState:       r.CurrentState,
+		Engine:             r.Engine,
+		Labels:             r.Labels,
+		SubmittedAt:        tsOrNil(r.SubmittedAt),
+		StartedAt:          tsOrNil(r.StartedAt),
+		FinishedAt:         tsOrNil(r.FinishedAt),
+		CancellationReason: r.CancellationReason,
+	}
+}
+
+func eventToProto(ev *domain.WorkflowEvent) *zynaxv1.WorkflowEvent {
+	return &zynaxv1.WorkflowEvent{
+		RunId:     ev.RunID,
+		EventType: ev.EventType,
+		FromState: ev.FromState,
+		ToState:   ev.ToState,
+		Status:    zynaxv1.WorkflowStatus(ev.Status), //nolint:gosec
+		Payload:   ev.Payload,
+		Timestamp: timestamppb.New(ev.Timestamp),
+	}
+}
+
+func tsOrNil(t time.Time) *timestamppb.Timestamp {
+	if t.IsZero() {
+		return nil
+	}
+	return timestamppb.New(t)
+}
+
+func grpcErr(err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, domain.ErrExecutionNotFound) {
+		return status.Errorf(codes.NotFound, "%v", err)
+	}
+	if errors.Is(err, domain.ErrTerminalState) {
+		return status.Errorf(codes.FailedPrecondition, "%v", err)
+	}
+	if errors.Is(err, domain.ErrEngineUnavailable) {
+		return status.Errorf(codes.Unavailable, "%v", err)
+	}
+	if errors.Is(err, context.Canceled) {
+		return status.Errorf(codes.Canceled, "%v", err)
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return status.Errorf(codes.DeadlineExceeded, "%v", err)
+	}
+	return status.Errorf(codes.Internal, "%v", err)
+}

--- a/services/engine-adapter/internal/api/handler_test.go
+++ b/services/engine-adapter/internal/api/handler_test.go
@@ -1,0 +1,310 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package api_test verifies the EngineAdapterService gRPC handler via a real
+// in-memory gRPC server (bufconn), exercising the full request/response path
+// for each of the 5 BDD scenarios in engine_adapter.feature.
+package api_test
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
+
+	zynaxv1 "github.com/zynax-io/zynax/protos/generated/go/zynax/v1"
+	"github.com/zynax-io/zynax/services/engine-adapter/internal/api"
+	"github.com/zynax-io/zynax/services/engine-adapter/internal/domain"
+)
+
+// ─── stub engine ─────────────────────────────────────────────────────────────
+
+type stubEngine struct {
+	submitRun *domain.WorkflowRun
+	submitErr error
+	signalErr error
+	cancelErr error
+	statusRun *domain.WorkflowRun
+	statusErr error
+	watchEvts []*domain.WorkflowEvent
+	watchErr  error
+}
+
+func (s *stubEngine) Submit(_ context.Context, _ *zynaxv1.WorkflowIR, labels map[string]string) (*domain.WorkflowRun, error) {
+	if s.submitErr != nil {
+		return nil, s.submitErr
+	}
+	run := *s.submitRun
+	run.Labels = labels
+	return &run, nil
+}
+
+func (s *stubEngine) Signal(_ context.Context, _, _ string, _ []byte) error { return s.signalErr }
+func (s *stubEngine) Cancel(_ context.Context, _, _ string) error           { return s.cancelErr }
+
+func (s *stubEngine) GetStatus(_ context.Context, _ string) (*domain.WorkflowRun, error) {
+	return s.statusRun, s.statusErr
+}
+
+func (s *stubEngine) Watch(_ context.Context, _ string, send func(*domain.WorkflowEvent) error) error {
+	for _, ev := range s.watchEvts {
+		if err := send(ev); err != nil {
+			return err
+		}
+	}
+	return s.watchErr
+}
+
+// ─── test server helper ───────────────────────────────────────────────────────
+
+func dialTestServer(t *testing.T, engine domain.WorkflowEngine) zynaxv1.EngineAdapterServiceClient {
+	t.Helper()
+	lis := bufconn.Listen(1 << 20)
+	srv := grpc.NewServer()
+	zynaxv1.RegisterEngineAdapterServiceServer(srv, api.NewHandler(engine))
+	go func() { _ = srv.Serve(lis) }()
+	t.Cleanup(func() {
+		srv.GracefulStop()
+		_ = lis.Close()
+	})
+	conn, err := grpc.NewClient(
+		"passthrough://bufnet",
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+			return lis.DialContext(ctx)
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	return zynaxv1.NewEngineAdapterServiceClient(conn)
+}
+
+// ─── BDD Scenario 1: Submit IR creates a running execution ───────────────────
+
+func TestHandler_SubmitWorkflow_Success(t *testing.T) {
+	engine := &stubEngine{
+		submitRun: &domain.WorkflowRun{
+			RunID:     "run-1",
+			Status:    domain.WorkflowStatusRunning,
+			Namespace: "default",
+		},
+	}
+	client := dialTestServer(t, engine)
+	ir := &zynaxv1.WorkflowIR{WorkflowId: "wf-1", InitialState: "review"}
+	resp, err := client.SubmitWorkflow(context.Background(), &zynaxv1.SubmitWorkflowRequest{WorkflowIr: ir})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.RunId == "" {
+		t.Error("expected non-empty RunId")
+	}
+}
+
+func TestHandler_SubmitWorkflow_NilIR(t *testing.T) {
+	client := dialTestServer(t, &stubEngine{})
+	_, err := client.SubmitWorkflow(context.Background(), &zynaxv1.SubmitWorkflowRequest{})
+	if code := status.Code(err); code != codes.InvalidArgument {
+		t.Errorf("expected InvalidArgument, got %v", code)
+	}
+}
+
+func TestHandler_SubmitWorkflow_EngineError(t *testing.T) {
+	engine := &stubEngine{submitErr: domain.ErrEngineUnavailable}
+	client := dialTestServer(t, engine)
+	ir := &zynaxv1.WorkflowIR{WorkflowId: "wf-2"}
+	_, err := client.SubmitWorkflow(context.Background(), &zynaxv1.SubmitWorkflowRequest{WorkflowIr: ir})
+	if code := status.Code(err); code != codes.Unavailable {
+		t.Errorf("expected Unavailable, got %v", code)
+	}
+}
+
+// ─── BDD Scenario 2: Signal transitions workflow ──────────────────────────────
+
+func TestHandler_SignalWorkflow_Success(t *testing.T) {
+	client := dialTestServer(t, &stubEngine{})
+	_, err := client.SignalWorkflow(context.Background(), &zynaxv1.SignalWorkflowRequest{
+		RunId:     "run-1",
+		EventType: "review.approved",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestHandler_SignalWorkflow_EmptyRunID(t *testing.T) {
+	client := dialTestServer(t, &stubEngine{})
+	_, err := client.SignalWorkflow(context.Background(), &zynaxv1.SignalWorkflowRequest{})
+	if code := status.Code(err); code != codes.InvalidArgument {
+		t.Errorf("expected InvalidArgument, got %v", code)
+	}
+}
+
+func TestHandler_SignalWorkflow_NotFound(t *testing.T) {
+	engine := &stubEngine{signalErr: domain.ErrExecutionNotFound}
+	client := dialTestServer(t, engine)
+	_, err := client.SignalWorkflow(context.Background(), &zynaxv1.SignalWorkflowRequest{RunId: "missing"})
+	if code := status.Code(err); code != codes.NotFound {
+		t.Errorf("expected NotFound, got %v", code)
+	}
+}
+
+// ─── BDD Scenario 4: Cancel terminates a running execution ───────────────────
+
+func TestHandler_CancelWorkflow_Success(t *testing.T) {
+	client := dialTestServer(t, &stubEngine{})
+	_, err := client.CancelWorkflow(context.Background(), &zynaxv1.CancelWorkflowRequest{
+		RunId:  "run-1",
+		Reason: "user requested",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestHandler_CancelWorkflow_EmptyRunID(t *testing.T) {
+	client := dialTestServer(t, &stubEngine{})
+	_, err := client.CancelWorkflow(context.Background(), &zynaxv1.CancelWorkflowRequest{})
+	if code := status.Code(err); code != codes.InvalidArgument {
+		t.Errorf("expected InvalidArgument, got %v", code)
+	}
+}
+
+func TestHandler_CancelWorkflow_TerminalState(t *testing.T) {
+	engine := &stubEngine{cancelErr: domain.ErrTerminalState}
+	client := dialTestServer(t, engine)
+	_, err := client.CancelWorkflow(context.Background(), &zynaxv1.CancelWorkflowRequest{RunId: "run-1"})
+	if code := status.Code(err); code != codes.FailedPrecondition {
+		t.Errorf("expected FailedPrecondition, got %v", code)
+	}
+}
+
+// ─── GetWorkflowStatus (supports Scenarios 1 and 4) ──────────────────────────
+
+func TestHandler_GetWorkflowStatus_Running(t *testing.T) {
+	engine := &stubEngine{
+		statusRun: &domain.WorkflowRun{
+			RunID:  "run-1",
+			Status: domain.WorkflowStatusRunning,
+		},
+	}
+	client := dialTestServer(t, engine)
+	resp, err := client.GetWorkflowStatus(context.Background(), &zynaxv1.GetWorkflowStatusRequest{RunId: "run-1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Status != zynaxv1.WorkflowStatus_WORKFLOW_STATUS_RUNNING {
+		t.Errorf("expected RUNNING, got %v", resp.Status)
+	}
+}
+
+func TestHandler_GetWorkflowStatus_Cancelled(t *testing.T) {
+	engine := &stubEngine{
+		statusRun: &domain.WorkflowRun{
+			RunID:  "run-1",
+			Status: domain.WorkflowStatusCancelled,
+		},
+	}
+	client := dialTestServer(t, engine)
+	resp, err := client.GetWorkflowStatus(context.Background(), &zynaxv1.GetWorkflowStatusRequest{RunId: "run-1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Status != zynaxv1.WorkflowStatus_WORKFLOW_STATUS_CANCELLED {
+		t.Errorf("expected CANCELLED, got %v", resp.Status)
+	}
+}
+
+func TestHandler_GetWorkflowStatus_EmptyRunID(t *testing.T) {
+	client := dialTestServer(t, &stubEngine{})
+	_, err := client.GetWorkflowStatus(context.Background(), &zynaxv1.GetWorkflowStatusRequest{})
+	if code := status.Code(err); code != codes.InvalidArgument {
+		t.Errorf("expected InvalidArgument, got %v", code)
+	}
+}
+
+func TestHandler_GetWorkflowStatus_NotFound(t *testing.T) {
+	engine := &stubEngine{statusErr: domain.ErrExecutionNotFound}
+	client := dialTestServer(t, engine)
+	_, err := client.GetWorkflowStatus(context.Background(), &zynaxv1.GetWorkflowStatusRequest{RunId: "missing"})
+	if code := status.Code(err); code != codes.NotFound {
+		t.Errorf("expected NotFound, got %v", code)
+	}
+}
+
+// ─── WatchWorkflow ─────────────────────────────────────────────────────────────
+
+func TestHandler_WatchWorkflow_StreamsEventsToTerminal(t *testing.T) {
+	engine := &stubEngine{
+		watchEvts: []*domain.WorkflowEvent{
+			{RunID: "run-1", Status: domain.WorkflowStatusRunning, Timestamp: time.Now()},
+			{RunID: "run-1", Status: domain.WorkflowStatusCompleted, Timestamp: time.Now()},
+		},
+	}
+	client := dialTestServer(t, engine)
+	stream, err := client.WatchWorkflow(context.Background(), &zynaxv1.WatchWorkflowRequest{RunId: "run-1"})
+	if err != nil {
+		t.Fatalf("watch setup error: %v", err)
+	}
+	var events []*zynaxv1.WorkflowEvent
+	for {
+		ev, recvErr := stream.Recv()
+		if recvErr != nil {
+			break
+		}
+		events = append(events, ev)
+	}
+	if len(events) < 2 {
+		t.Fatalf("expected ≥2 events, got %d", len(events))
+	}
+	if events[len(events)-1].Status != zynaxv1.WorkflowStatus_WORKFLOW_STATUS_COMPLETED {
+		t.Errorf("last status = %v; want COMPLETED", events[len(events)-1].Status)
+	}
+}
+
+func TestHandler_WatchWorkflow_EmptyRunID(t *testing.T) {
+	client := dialTestServer(t, &stubEngine{})
+	stream, err := client.WatchWorkflow(context.Background(), &zynaxv1.WatchWorkflowRequest{})
+	if err != nil {
+		t.Fatalf("watch setup error: %v", err)
+	}
+	_, err = stream.Recv()
+	if code := status.Code(err); code != codes.InvalidArgument {
+		t.Errorf("expected InvalidArgument, got %v", code)
+	}
+}
+
+// ─── BDD Scenario 5: Engine swappability ─────────────────────────────────────
+
+func TestHandler_EngineSwappability(t *testing.T) {
+	temporalEng := &stubEngine{submitRun: &domain.WorkflowRun{RunID: "run-temporal", Engine: "temporal"}}
+	langgraphEng := &stubEngine{submitRun: &domain.WorkflowRun{RunID: "run-langgraph", Engine: "langgraph"}}
+
+	ir := &zynaxv1.WorkflowIR{WorkflowId: "wf-swap"}
+	req := &zynaxv1.SubmitWorkflowRequest{WorkflowIr: ir}
+
+	clientA := dialTestServer(t, temporalEng)
+	clientB := dialTestServer(t, langgraphEng)
+
+	respA, err := clientA.SubmitWorkflow(context.Background(), req)
+	if err != nil {
+		t.Fatalf("temporal engine error: %v", err)
+	}
+	respB, err := clientB.SubmitWorkflow(context.Background(), req)
+	if err != nil {
+		t.Fatalf("langgraph engine error: %v", err)
+	}
+	// Both engines produce the same gRPC response structure.
+	if respA.RunId == "" || respB.RunId == "" {
+		t.Error("expected non-empty RunId from both engines")
+	}
+	if respA.SubmittedAt == nil || respB.SubmittedAt == nil {
+		t.Error("expected SubmittedAt from both engines")
+	}
+}

--- a/services/engine-adapter/internal/infrastructure/activities.go
+++ b/services/engine-adapter/internal/infrastructure/activities.go
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package infrastructure provides concrete implementations of domain ports backed by
+// external services and SDKs. Only this package may import engine-specific dependencies
+// such as the Temporal Go SDK (ADR-015).
+package infrastructure
+
+import (
+	"context"
+	"log/slog"
+)
+
+// PublishLifecycleEventActivity is registered with the Temporal worker and called
+// by IRInterpreterWorkflow to emit workflow lifecycle events. Publication is
+// best-effort: the workflow suppresses errors from this activity (see
+// temporalEventPublisher.Publish). Full EventBus integration is deferred to M4.
+func PublishLifecycleEventActivity(_ context.Context, eventType, workflowID, stateID string) error {
+	slog.Debug("lifecycle event", "event_type", eventType, "workflow_id", workflowID, "state_id", stateID)
+	return nil
+}


### PR DESCRIPTION
## Summary

- Implements `internal/api/handler.go` — `EngineAdapterService` gRPC handler delegating all 5 methods to `domain.WorkflowEngine` (ADR-015: zero engine-specific imports in the api layer)
- Adds `internal/infrastructure/activities.go` — `PublishLifecycleEventActivity` placeholder registered with the Temporal worker (best-effort, errors suppressed by `temporalEventPublisher`)
- Adds `cmd/engine-adapter/main.go` — wires Temporal worker (`IRInterpreterWorkflow` + `DispatchCapabilityActivity` + `PublishLifecycleEventActivity`), gRPC server, and HTTP health-probe server (`/healthz`, `/readyz`, `/startupz`)
- 16 handler unit tests via in-memory bufconn gRPC server, covering all 5 BDD scenarios: Submit, Signal, Cancel, GetWorkflowStatus, Watch, and engine swappability

## Test plan

- [x] `GOWORK=off go test ./... -race` green (38 tests total across api/domain/infrastructure)
- [x] `golangci-lint run` 0 issues
- [x] `GOWORK=off go build ./...` clean

Canvas: `docs/spdd/214-temporal-execution/canvas.md` · Step 5 of 5 · Issue #305