### PR TITLE
feat(api-gateway): gRPC infrastructure + main.go wiring (#315, step 3/3)

### DIFF
--- a/services/api-gateway/cmd/api-gateway/main.go
+++ b/services/api-gateway/cmd/api-gateway/main.go
@@ -83,7 +83,10 @@ func serveUntilShutdown(srv *http.Server, port int) error {
 	slog.Info("shutting down")
 	shutCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	return srv.Shutdown(shutCtx)
+	if err := srv.Shutdown(shutCtx); err != nil {
+		return fmt.Errorf("api-gateway: shutdown: %w", err)
+	}
+	return nil
 }
 
 func registerProbes(mux *http.ServeMux) {

--- a/services/api-gateway/cmd/api-gateway/main.go
+++ b/services/api-gateway/cmd/api-gateway/main.go
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package main is the entry point for the api-gateway service.
+// It wires gRPC clients to WorkflowCompilerService and EngineAdapterService,
+// creates the domain ApplyService, and starts the HTTP server.
+// All business logic lives in internal/.
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/kelseyhightower/envconfig"
+	"github.com/zynax-io/zynax/services/api-gateway/internal/api"
+	"github.com/zynax-io/zynax/services/api-gateway/internal/domain"
+	"github.com/zynax-io/zynax/services/api-gateway/internal/infrastructure"
+)
+
+type config struct {
+	HTTPPort     int    `envconfig:"HTTP_PORT" default:"8080"`
+	CompilerAddr string `envconfig:"COMPILER_ADDR" default:"localhost:50051"`
+	EngineAddr   string `envconfig:"ENGINE_ADDR" default:"localhost:50055"`
+	LogLevel     string `envconfig:"LOG_LEVEL" default:"info"`
+}
+
+func main() {
+	var cfg config
+	if err := envconfig.Process("ZYNAX_GW", &cfg); err != nil {
+		slog.Error("config error", "err", err)
+		os.Exit(1)
+	}
+	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+		Level: parseLogLevel(cfg.LogLevel),
+	})))
+	if err := run(cfg); err != nil {
+		slog.Error("fatal error", "err", err)
+		os.Exit(1)
+	}
+}
+
+// run contains the service lifecycle. Deferred cleanups execute before returning.
+func run(cfg config) error {
+	clients, cleanup, err := infrastructure.NewGatewayClients(cfg.CompilerAddr, cfg.EngineAddr)
+	if err != nil {
+		return fmt.Errorf("gateway clients: %w", err)
+	}
+	defer cleanup()
+
+	svc := domain.NewApplyService(clients, clients)
+	handler := api.NewHandler(svc)
+
+	mux := http.NewServeMux()
+	handler.RegisterRoutes(mux)
+	registerProbes(mux)
+
+	srv := &http.Server{
+		Addr:         fmt.Sprintf(":%d", cfg.HTTPPort),
+		Handler:      mux,
+		ReadTimeout:  30 * time.Second,
+		WriteTimeout: 30 * time.Second,
+	}
+	return serveUntilShutdown(srv, cfg.HTTPPort)
+}
+
+func serveUntilShutdown(srv *http.Server, port int) error {
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+	defer stop()
+
+	go func() {
+		slog.Info("api-gateway started", "port", port)
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			slog.Error("http serve error", "err", err)
+		}
+	}()
+
+	<-ctx.Done()
+	slog.Info("shutting down")
+	shutCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	return srv.Shutdown(shutCtx)
+}
+
+func registerProbes(mux *http.ServeMux) {
+	ok := func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }
+	mux.HandleFunc("GET /healthz", ok)
+	mux.HandleFunc("GET /readyz", ok)
+	mux.HandleFunc("GET /startupz", ok)
+}
+
+func parseLogLevel(level string) slog.Level {
+	switch level {
+	case "debug":
+		return slog.LevelDebug
+	case "warn":
+		return slog.LevelWarn
+	case "error":
+		return slog.LevelError
+	default:
+		return slog.LevelInfo
+	}
+}

--- a/services/api-gateway/internal/infrastructure/clients.go
+++ b/services/api-gateway/internal/infrastructure/clients.go
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package infrastructure implements the domain ports using real gRPC clients.
+// Only this package may import gRPC SDK types or proto-generated stubs.
+package infrastructure
+
+import (
+	"context"
+	"fmt"
+
+	zynaxv1 "github.com/zynax-io/zynax/protos/generated/go/zynax/v1"
+	"github.com/zynax-io/zynax/services/api-gateway/internal/domain"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+)
+
+// GatewayClients implements domain.CompilerPort and domain.EnginePort using
+// gRPC connections to WorkflowCompilerService and EngineAdapterService.
+type GatewayClients struct {
+	compiler zynaxv1.WorkflowCompilerServiceClient
+	engine   zynaxv1.EngineAdapterServiceClient
+}
+
+// NewGatewayClients dials both downstream gRPC services. The returned cleanup
+// function closes both connections and must be deferred by the caller.
+func NewGatewayClients(compilerAddr, engineAddr string) (*GatewayClients, func(), error) {
+	compConn, err := grpc.NewClient(compilerAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return nil, func() {}, fmt.Errorf("api-gateway: compiler dial: %w", err)
+	}
+	engConn, err := grpc.NewClient(engineAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		_ = compConn.Close()
+		return nil, func() {}, fmt.Errorf("api-gateway: engine dial: %w", err)
+	}
+	c := &GatewayClients{
+		compiler: zynaxv1.NewWorkflowCompilerServiceClient(compConn),
+		engine:   zynaxv1.NewEngineAdapterServiceClient(engConn),
+	}
+	return c, func() { _ = compConn.Close(); _ = engConn.Close() }, nil
+}
+
+// CompileWorkflow implements domain.CompilerPort.
+// When the compiler returns codes.InvalidArgument the gRPC error message is
+// surfaced as a CompileError so the handler can return a structured 422.
+func (c *GatewayClients) CompileWorkflow(ctx context.Context, manifestYAML []byte, namespace string, dryRun bool) (domain.CompileResult, error) {
+	resp, err := c.compiler.CompileWorkflow(ctx, &zynaxv1.CompileWorkflowRequest{
+		ManifestYaml: manifestYAML,
+		Namespace:    namespace,
+		DryRun:       dryRun,
+	})
+	if err != nil {
+		return mapCompilerGRPCError(err)
+	}
+	return compileResultFromProto(resp), nil
+}
+
+// SubmitWorkflow implements domain.EnginePort.
+func (c *GatewayClients) SubmitWorkflow(ctx context.Context, irBytes []byte, engineHint string) (string, error) {
+	ir := &zynaxv1.WorkflowIR{}
+	if err := proto.Unmarshal(irBytes, ir); err != nil {
+		return "", fmt.Errorf("api-gateway: unmarshal IR: %w", err)
+	}
+	resp, err := c.engine.SubmitWorkflow(ctx, &zynaxv1.SubmitWorkflowRequest{
+		WorkflowIr: ir,
+		EngineHint: engineHint,
+	})
+	if err != nil {
+		return "", mapEngineGRPCError(err)
+	}
+	return resp.GetRunId(), nil
+}
+
+// GetWorkflowStatus implements domain.EnginePort.
+func (c *GatewayClients) GetWorkflowStatus(ctx context.Context, runID string) (domain.WorkflowRunSummary, error) {
+	run, err := c.engine.GetWorkflowStatus(ctx, &zynaxv1.GetWorkflowStatusRequest{RunId: runID})
+	if err != nil {
+		return domain.WorkflowRunSummary{}, mapEngineGRPCError(err)
+	}
+	return domain.WorkflowRunSummary{
+		RunID:        run.GetRunId(),
+		WorkflowID:   run.GetWorkflowId(),
+		Status:       run.GetStatus().String(),
+		CurrentState: run.GetCurrentState(),
+	}, nil
+}
+
+// ── error mapping ─────────────────────────────────────────────────────────
+
+func mapCompilerGRPCError(err error) (domain.CompileResult, error) {
+	st, _ := status.FromError(err)
+	if st.Code() == codes.InvalidArgument {
+		return domain.CompileResult{
+			Errors: []domain.CompileError{{Code: "COMPILER_ERROR", Message: st.Message()}},
+		}, nil
+	}
+	return domain.CompileResult{}, fmt.Errorf("api-gateway: compiler: %w", err)
+}
+
+func mapEngineGRPCError(err error) error {
+	st, _ := status.FromError(err)
+	switch st.Code() {
+	case codes.NotFound:
+		return fmt.Errorf("api-gateway: %w", domain.ErrNotFound)
+	case codes.Unavailable:
+		return fmt.Errorf("api-gateway: %w", domain.ErrEngineUnavailable)
+	default:
+		return fmt.Errorf("api-gateway: engine: %w", err)
+	}
+}
+
+// ── proto conversion ──────────────────────────────────────────────────────
+
+func compileResultFromProto(resp *zynaxv1.CompileWorkflowResponse) domain.CompileResult {
+	result := domain.CompileResult{Warnings: resp.GetWarnings()}
+	for _, e := range resp.GetErrors() {
+		result.Errors = append(result.Errors, domain.CompileError{
+			Code:    e.GetCode().String(),
+			Message: e.GetMessage(),
+			Line:    e.GetLineNumber(),
+		})
+	}
+	if ir := resp.GetWorkflowIr(); ir != nil {
+		result.IRBytes, _ = proto.Marshal(ir)
+	}
+	return result
+}


### PR DESCRIPTION
## Summary

- `GatewayClients` implements `CompilerPort` and `EnginePort` via gRPC to `WorkflowCompilerService` and `EngineAdapterService`
- `proto.Marshal`/`proto.Unmarshal` keeps `WorkflowIR` opaque to the domain layer (no proto type leaks across the boundary)
- gRPC error mapping: `INVALID_ARGUMENT` → `CompileResult.Errors` (nil error return), `UNAVAILABLE` → `ErrEngineUnavailable`, `NOT_FOUND` → `ErrNotFound`
- `main.go`: `ZYNAX_GW_` envconfig struct, HTTP server + gRPC dial setup, health probes (`/healthz`, `/readyz`, `/startupz`), graceful shutdown on `SIGTERM`/`SIGINT`

## Stacking

- Base: #324 (HTTP handler layer)
- Base: #323 (BDD + domain layer)

Merge order: #323 → #324 → this PR (each re-targets to `main` as the base merges).

## Test plan

- [ ] `GOWORK=off go build ./cmd/api-gateway/...` succeeds
- [ ] `GOWORK=off go vet ./...` clean
- [ ] No domain or api package imported directly in `internal/infrastructure/`
- [ ] Health probe endpoints respond 200 when wired to a live server

Assisted-by: Claude/claude-sonnet-4-6