### PR TITLE
feat(api-gateway): kind: AgentDef routing via AgentRegistryService (#316)

### DIFF
--- a/services/api-gateway/cmd/api-gateway/main.go
+++ b/services/api-gateway/cmd/api-gateway/main.go
@@ -26,6 +26,7 @@ type config struct {
 	HTTPPort     int    `envconfig:"HTTP_PORT" default:"8080"`
 	CompilerAddr string `envconfig:"COMPILER_ADDR" default:"localhost:50051"`
 	EngineAddr   string `envconfig:"ENGINE_ADDR" default:"localhost:50055"`
+	RegistryAddr string `envconfig:"REGISTRY_ADDR" default:"localhost:50052"`
 	LogLevel     string `envconfig:"LOG_LEVEL" default:"info"`
 }
 
@@ -46,13 +47,13 @@ func main() {
 
 // run contains the service lifecycle. Deferred cleanups execute before returning.
 func run(cfg config) error {
-	clients, cleanup, err := infrastructure.NewGatewayClients(cfg.CompilerAddr, cfg.EngineAddr)
+	clients, cleanup, err := infrastructure.NewGatewayClients(cfg.CompilerAddr, cfg.EngineAddr, cfg.RegistryAddr)
 	if err != nil {
 		return fmt.Errorf("gateway clients: %w", err)
 	}
 	defer cleanup()
 
-	svc := domain.NewApplyService(clients, clients)
+	svc := domain.NewApplyService(clients, clients, clients)
 	handler := api.NewHandler(svc)
 
 	mux := http.NewServeMux()

--- a/services/api-gateway/internal/api/handler.go
+++ b/services/api-gateway/internal/api/handler.go
@@ -50,6 +50,8 @@ func (h *Handler) handleApply(w http.ResponseWriter, r *http.Request) {
 	switch kind {
 	case domain.KindWorkflow:
 		h.applyWorkflow(w, r, body)
+	case domain.KindAgentDef:
+		h.applyAgentDef(w, r, body)
 	default:
 		writeError(w, http.StatusBadRequest, fmt.Sprintf("kind %q: not yet supported", kind), "UNSUPPORTED_KIND")
 	}
@@ -74,6 +76,22 @@ func (h *Handler) applyWorkflow(w http.ResponseWriter, r *http.Request, body []b
 		writeJSON(w, http.StatusOK, dryRunResp{DryRun: true, Warnings: result.Warnings})
 	default:
 		writeJSON(w, http.StatusAccepted, applyResp{RunID: result.RunID, Warnings: result.Warnings})
+	}
+}
+
+func (h *Handler) applyAgentDef(w http.ResponseWriter, r *http.Request, body []byte) {
+	req := domain.ApplyRequest{
+		ManifestYAML: body,
+		Namespace:    r.URL.Query().Get("namespace"),
+	}
+	result, err := h.svc.ApplyAgentDef(r.Context(), req)
+	switch {
+	case errors.Is(err, domain.ErrAgentAlreadyExists):
+		writeError(w, http.StatusConflict, "agent already registered", "ALREADY_EXISTS")
+	case err != nil:
+		writeError(w, http.StatusInternalServerError, "internal error", "INTERNAL")
+	default:
+		writeJSON(w, http.StatusCreated, agentDefResp{AgentID: result.AgentID})
 	}
 }
 
@@ -124,6 +142,10 @@ type compileErrItem struct {
 
 type compileErrsResp struct {
 	Errors []compileErrItem `json:"errors"`
+}
+
+type agentDefResp struct {
+	AgentID string `json:"agent_id"`
 }
 
 type workflowStatusResp struct {

--- a/services/api-gateway/internal/api/handler_test.go
+++ b/services/api-gateway/internal/api/handler_test.go
@@ -41,10 +41,23 @@ func (s *stubEngine) GetWorkflowStatus(_ context.Context, _ string) (domain.Work
 	return s.statusRun, s.statusErr
 }
 
+type stubRegistry struct {
+	reg domain.AgentRegistration
+	err error
+}
+
+func (s *stubRegistry) RegisterAgent(_ context.Context, _ []byte, _ string) (domain.AgentRegistration, error) {
+	return s.reg, s.err
+}
+
 // ── helpers ───────────────────────────────────────────────────────────────
 
 func newServer(c domain.CompilerPort, e domain.EnginePort) *httptest.Server {
-	svc := domain.NewApplyService(c, e)
+	return newServerWithRegistry(c, e, &stubRegistry{})
+}
+
+func newServerWithRegistry(c domain.CompilerPort, e domain.EnginePort, r domain.RegistryPort) *httptest.Server {
+	svc := domain.NewApplyService(c, e, r)
 	h := api.NewHandler(svc)
 	mux := http.NewServeMux()
 	h.RegisterRoutes(mux)
@@ -248,5 +261,55 @@ func TestHandler_GetWorkflow_NotFound_Returns404(t *testing.T) {
 
 	if resp.StatusCode != http.StatusNotFound {
 		t.Errorf("status: got %d, want 404", resp.StatusCode)
+	}
+}
+
+// ── POST /api/v1/apply (kind: AgentDef) ──────────────────────────────────
+
+const agentDefYAML = "kind: AgentDef\napiVersion: zynax.io/v1alpha1\nmetadata:\n  name: test-agent\n"
+
+func TestHandler_Apply_ValidAgentDef_Returns201(t *testing.T) {
+	srv := newServerWithRegistry(
+		&stubCompiler{},
+		&stubEngine{},
+		&stubRegistry{reg: domain.AgentRegistration{AgentID: "agent-001"}},
+	)
+	defer srv.Close()
+
+	resp, err := http.Post(srv.URL+"/api/v1/apply", "application/yaml", bytes.NewBufferString(agentDefYAML))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusCreated {
+		t.Errorf("status: got %d, want 201", resp.StatusCode)
+	}
+	body := decodeBody(t, resp)
+	if body["agent_id"] != "agent-001" {
+		t.Errorf("agent_id: got %v, want agent-001", body["agent_id"])
+	}
+}
+
+func TestHandler_Apply_DuplicateAgentDef_Returns409(t *testing.T) {
+	srv := newServerWithRegistry(
+		&stubCompiler{},
+		&stubEngine{},
+		&stubRegistry{err: domain.ErrAgentAlreadyExists},
+	)
+	defer srv.Close()
+
+	resp, err := http.Post(srv.URL+"/api/v1/apply", "application/yaml", bytes.NewBufferString(agentDefYAML))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusConflict {
+		t.Errorf("status: got %d, want 409", resp.StatusCode)
+	}
+	body := decodeBody(t, resp)
+	if body["code"] != "ALREADY_EXISTS" {
+		t.Errorf("code: got %v, want ALREADY_EXISTS", body["code"])
 	}
 }

--- a/services/api-gateway/internal/domain/apply.go
+++ b/services/api-gateway/internal/domain/apply.go
@@ -10,9 +10,10 @@ import (
 
 // Sentinel errors surfaced to the HTTP handler for status-code mapping.
 var (
-	ErrCompilationFailed = errors.New("api-gateway: compilation failed")
-	ErrEngineUnavailable = errors.New("api-gateway: engine unavailable")
-	ErrNotFound          = errors.New("api-gateway: not found")
+	ErrCompilationFailed  = errors.New("api-gateway: compilation failed")
+	ErrEngineUnavailable  = errors.New("api-gateway: engine unavailable")
+	ErrNotFound           = errors.New("api-gateway: not found")
+	ErrAgentAlreadyExists = errors.New("api-gateway: agent already registered")
 )
 
 // ApplyRequest carries the parameters for a manifest apply operation.
@@ -26,20 +27,21 @@ type ApplyRequest struct {
 // ApplyResult carries the outcome of an apply operation.
 type ApplyResult struct {
 	RunID    string
+	AgentID  string
 	Warnings []string
 	Errors   []CompileError
 }
 
 // ApplyService orchestrates manifest apply operations.
-// Step 1 handles kind: Workflow; step 2 extends it for kind: AgentDef.
 type ApplyService struct {
 	compiler CompilerPort
 	engine   EnginePort
+	registry RegistryPort
 }
 
 // NewApplyService constructs an ApplyService with the given ports.
-func NewApplyService(compiler CompilerPort, engine EnginePort) *ApplyService {
-	return &ApplyService{compiler: compiler, engine: engine}
+func NewApplyService(compiler CompilerPort, engine EnginePort, registry RegistryPort) *ApplyService {
+	return &ApplyService{compiler: compiler, engine: engine, registry: registry}
 }
 
 // ApplyWorkflow compiles a Workflow manifest and, unless dry_run, submits it
@@ -65,6 +67,16 @@ func (s *ApplyService) submit(ctx context.Context, compiled CompileResult, engin
 		return ApplyResult{}, fmt.Errorf("api-gateway: %w", err)
 	}
 	return ApplyResult{RunID: runID, Warnings: compiled.Warnings}, nil
+}
+
+// ApplyAgentDef registers an AgentDef manifest with the agent registry.
+// Returns ErrAgentAlreadyExists when the registry reports ALREADY_EXISTS.
+func (s *ApplyService) ApplyAgentDef(ctx context.Context, req ApplyRequest) (ApplyResult, error) {
+	reg, err := s.registry.RegisterAgent(ctx, req.ManifestYAML, req.Namespace)
+	if err != nil {
+		return ApplyResult{}, fmt.Errorf("api-gateway: %w", err)
+	}
+	return ApplyResult{AgentID: reg.AgentID}, nil
 }
 
 // GetWorkflowStatus returns the current status of a workflow run.

--- a/services/api-gateway/internal/domain/apply_test.go
+++ b/services/api-gateway/internal/domain/apply_test.go
@@ -36,10 +36,21 @@ func (s *stubEngine) GetWorkflowStatus(_ context.Context, _ string) (domain.Work
 	return s.statusRun, s.statusErr
 }
 
+// stubRegistry is a test double for RegistryPort.
+type stubRegistry struct {
+	reg domain.AgentRegistration
+	err error
+}
+
+func (s *stubRegistry) RegisterAgent(_ context.Context, _ []byte, _ string) (domain.AgentRegistration, error) {
+	return s.reg, s.err
+}
+
 func TestApplyService_ApplyWorkflow_Success(t *testing.T) {
 	svc := domain.NewApplyService(
 		&stubCompiler{result: domain.CompileResult{IRBytes: []byte("ir"), Warnings: []string{"w1"}}},
 		&stubEngine{submitID: "run-001"},
+		&stubRegistry{},
 	)
 	result, err := svc.ApplyWorkflow(context.Background(), domain.ApplyRequest{
 		ManifestYAML: []byte("kind: Workflow"),
@@ -61,6 +72,7 @@ func TestApplyService_ApplyWorkflow_CompilationErrors(t *testing.T) {
 			Errors: []domain.CompileError{{Code: "YAML_PARSE_ERROR", Message: "bad yaml", Line: 3}},
 		}},
 		&stubEngine{},
+		&stubRegistry{},
 	)
 	result, err := svc.ApplyWorkflow(context.Background(), domain.ApplyRequest{
 		ManifestYAML: []byte("bad yaml"),
@@ -83,6 +95,7 @@ func TestApplyService_ApplyWorkflow_DryRun_NoSubmit(t *testing.T) {
 	svc := domain.NewApplyService(
 		&stubCompiler{result: domain.CompileResult{IRBytes: []byte("ir"), Warnings: []string{"w"}}},
 		engine,
+		&stubRegistry{},
 	)
 	engine.submitErr = nil // reset — test checks RunID is empty, not that submit errors
 
@@ -103,6 +116,7 @@ func TestApplyService_ApplyWorkflow_CompilerError_Propagates(t *testing.T) {
 	svc := domain.NewApplyService(
 		&stubCompiler{err: domain.ErrEngineUnavailable},
 		&stubEngine{},
+		&stubRegistry{},
 	)
 	_, err := svc.ApplyWorkflow(context.Background(), domain.ApplyRequest{ManifestYAML: []byte("y")})
 	if !errors.Is(err, domain.ErrEngineUnavailable) {
@@ -114,6 +128,7 @@ func TestApplyService_ApplyWorkflow_EngineUnavailable(t *testing.T) {
 	svc := domain.NewApplyService(
 		&stubCompiler{result: domain.CompileResult{IRBytes: []byte("ir")}},
 		&stubEngine{submitErr: domain.ErrEngineUnavailable},
+		&stubRegistry{},
 	)
 	_, err := svc.ApplyWorkflow(context.Background(), domain.ApplyRequest{ManifestYAML: []byte("y")})
 	if !errors.Is(err, domain.ErrEngineUnavailable) {
@@ -125,7 +140,7 @@ func TestApplyService_GetWorkflowStatus_Success(t *testing.T) {
 	want := domain.WorkflowRunSummary{
 		RunID: "r1", WorkflowID: "w1", Status: "RUNNING", CurrentState: "review",
 	}
-	svc := domain.NewApplyService(&stubCompiler{}, &stubEngine{statusRun: want})
+	svc := domain.NewApplyService(&stubCompiler{}, &stubEngine{statusRun: want}, &stubRegistry{})
 	got, err := svc.GetWorkflowStatus(context.Background(), "r1")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -136,9 +151,40 @@ func TestApplyService_GetWorkflowStatus_Success(t *testing.T) {
 }
 
 func TestApplyService_GetWorkflowStatus_NotFound(t *testing.T) {
-	svc := domain.NewApplyService(&stubCompiler{}, &stubEngine{statusErr: domain.ErrNotFound})
+	svc := domain.NewApplyService(&stubCompiler{}, &stubEngine{statusErr: domain.ErrNotFound}, &stubRegistry{})
 	_, err := svc.GetWorkflowStatus(context.Background(), "unknown")
 	if !errors.Is(err, domain.ErrNotFound) {
 		t.Fatalf("got %v, want ErrNotFound", err)
+	}
+}
+
+func TestApplyService_ApplyAgentDef_Success(t *testing.T) {
+	svc := domain.NewApplyService(
+		&stubCompiler{},
+		&stubEngine{},
+		&stubRegistry{reg: domain.AgentRegistration{AgentID: "agent-001"}},
+	)
+	result, err := svc.ApplyAgentDef(context.Background(), domain.ApplyRequest{
+		ManifestYAML: []byte("kind: AgentDef\n"),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.AgentID != "agent-001" {
+		t.Errorf("agent_id: got %q, want agent-001", result.AgentID)
+	}
+}
+
+func TestApplyService_ApplyAgentDef_AlreadyExists(t *testing.T) {
+	svc := domain.NewApplyService(
+		&stubCompiler{},
+		&stubEngine{},
+		&stubRegistry{err: domain.ErrAgentAlreadyExists},
+	)
+	_, err := svc.ApplyAgentDef(context.Background(), domain.ApplyRequest{
+		ManifestYAML: []byte("kind: AgentDef\n"),
+	})
+	if !errors.Is(err, domain.ErrAgentAlreadyExists) {
+		t.Errorf("expected ErrAgentAlreadyExists, got %v", err)
 	}
 }

--- a/services/api-gateway/internal/domain/ports.go
+++ b/services/api-gateway/internal/domain/ports.go
@@ -41,3 +41,13 @@ type EnginePort interface {
 	SubmitWorkflow(ctx context.Context, irBytes []byte, engineHint string) (string, error)
 	GetWorkflowStatus(ctx context.Context, runID string) (WorkflowRunSummary, error)
 }
+
+// AgentRegistration is the domain view of a successful RegisterAgent response.
+type AgentRegistration struct {
+	AgentID string
+}
+
+// RegistryPort is the gateway's outbound dependency on AgentRegistryService.
+type RegistryPort interface {
+	RegisterAgent(ctx context.Context, manifestYAML []byte, namespace string) (AgentRegistration, error)
+}

--- a/services/api-gateway/internal/infrastructure/clients.go
+++ b/services/api-gateway/internal/infrastructure/clients.go
@@ -15,18 +15,20 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
+	"gopkg.in/yaml.v3"
 )
 
-// GatewayClients implements domain.CompilerPort and domain.EnginePort using
-// gRPC connections to WorkflowCompilerService and EngineAdapterService.
+// GatewayClients implements domain.CompilerPort, domain.EnginePort, and
+// domain.RegistryPort using gRPC connections to downstream services.
 type GatewayClients struct {
 	compiler zynaxv1.WorkflowCompilerServiceClient
 	engine   zynaxv1.EngineAdapterServiceClient
+	registry zynaxv1.AgentRegistryServiceClient
 }
 
-// NewGatewayClients dials both downstream gRPC services. The returned cleanup
-// function closes both connections and must be deferred by the caller.
-func NewGatewayClients(compilerAddr, engineAddr string) (*GatewayClients, func(), error) {
+// NewGatewayClients dials all three downstream gRPC services. The returned
+// cleanup function closes all connections and must be deferred by the caller.
+func NewGatewayClients(compilerAddr, engineAddr, registryAddr string) (*GatewayClients, func(), error) {
 	compConn, err := grpc.NewClient(compilerAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return nil, func() {}, fmt.Errorf("api-gateway: compiler dial: %w", err)
@@ -36,11 +38,19 @@ func NewGatewayClients(compilerAddr, engineAddr string) (*GatewayClients, func()
 		_ = compConn.Close()
 		return nil, func() {}, fmt.Errorf("api-gateway: engine dial: %w", err)
 	}
+	regConn, err := grpc.NewClient(registryAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		_ = compConn.Close()
+		_ = engConn.Close()
+		return nil, func() {}, fmt.Errorf("api-gateway: registry dial: %w", err)
+	}
 	c := &GatewayClients{
 		compiler: zynaxv1.NewWorkflowCompilerServiceClient(compConn),
 		engine:   zynaxv1.NewEngineAdapterServiceClient(engConn),
+		registry: zynaxv1.NewAgentRegistryServiceClient(regConn),
 	}
-	return c, func() { _ = compConn.Close(); _ = engConn.Close() }, nil
+	cleanup := func() { _ = compConn.Close(); _ = engConn.Close(); _ = regConn.Close() }
+	return c, cleanup, nil
 }
 
 // CompileWorkflow implements domain.CompilerPort.
@@ -88,6 +98,56 @@ func (c *GatewayClients) GetWorkflowStatus(ctx context.Context, runID string) (d
 	}, nil
 }
 
+// RegisterAgent implements domain.RegistryPort.
+// The raw YAML is parsed here in the infrastructure layer; the domain never
+// sees proto types or YAML-parsed structs (ADR-011, ADR-001).
+func (c *GatewayClients) RegisterAgent(ctx context.Context, manifestYAML []byte, _ string) (domain.AgentRegistration, error) {
+	var m agentDefManifest
+	if err := yaml.Unmarshal(manifestYAML, &m); err != nil {
+		return domain.AgentRegistration{}, fmt.Errorf("api-gateway: parse AgentDef: %w", err)
+	}
+	caps := make([]*zynaxv1.CapabilityDef, len(m.Spec.Capabilities))
+	for i, cap := range m.Spec.Capabilities {
+		caps[i] = &zynaxv1.CapabilityDef{Name: cap.Name, Description: cap.Description}
+	}
+	req := &zynaxv1.RegisterAgentRequest{
+		Agent: &zynaxv1.AgentDef{
+			AgentId:      m.Metadata.Name,
+			Name:         m.Metadata.Name,
+			Endpoint:     m.Spec.Endpoint,
+			Capabilities: caps,
+			Labels:       m.Metadata.Labels,
+		},
+	}
+	resp, err := c.registry.RegisterAgent(ctx, req)
+	if err != nil {
+		return domain.AgentRegistration{}, mapRegistryGRPCError(err)
+	}
+	return domain.AgentRegistration{AgentID: resp.GetAgentId()}, nil
+}
+
+// ── YAML manifest structs (infrastructure-private) ────────────────────────
+
+type agentDefManifest struct {
+	Metadata agentDefMetadata `yaml:"metadata"`
+	Spec     agentDefSpec     `yaml:"spec"`
+}
+
+type agentDefMetadata struct {
+	Name   string            `yaml:"name"`
+	Labels map[string]string `yaml:"labels"`
+}
+
+type agentDefSpec struct {
+	Endpoint     string           `yaml:"endpoint"`
+	Capabilities []capabilitySpec `yaml:"capabilities"`
+}
+
+type capabilitySpec struct {
+	Name        string `yaml:"name"`
+	Description string `yaml:"description"`
+}
+
 // ── error mapping ─────────────────────────────────────────────────────────
 
 func mapCompilerGRPCError(err error) (domain.CompileResult, error) {
@@ -109,6 +169,16 @@ func mapEngineGRPCError(err error) error {
 		return fmt.Errorf("api-gateway: %w", domain.ErrEngineUnavailable)
 	default:
 		return fmt.Errorf("api-gateway: engine: %w", err)
+	}
+}
+
+func mapRegistryGRPCError(err error) error {
+	st, _ := status.FromError(err)
+	switch st.Code() {
+	case codes.AlreadyExists:
+		return fmt.Errorf("api-gateway: %w", domain.ErrAgentAlreadyExists)
+	default:
+		return fmt.Errorf("api-gateway: registry: %w", err)
 	}
 }
 

--- a/services/api-gateway/tests/features/api_gateway.feature
+++ b/services/api-gateway/tests/features/api_gateway.feature
@@ -92,3 +92,17 @@ Feature: API Gateway
     Given the engine adapter does not know about run_id "ghost-run"
     When GET /api/v1/workflows/ghost-run is called
     Then the HTTP status is 404
+
+  # ── POST /api/v1/apply — AgentDef kind (M4 step 2, issue #316) ──────────
+
+  Scenario: POST /api/v1/apply with valid AgentDef YAML returns 201 with agent_id
+    Given an AgentRegistryService that accepts the registration
+    When POST /api/v1/apply is called with a valid kind: AgentDef YAML body
+    Then the HTTP status is 201
+    And the response contains a non-empty agent_id
+
+  Scenario: POST /api/v1/apply with duplicate AgentDef returns 409
+    Given an AgentRegistryService that returns ALREADY_EXISTS
+    When POST /api/v1/apply is called with a valid kind: AgentDef YAML body
+    Then the HTTP status is 409
+    And the response code is "ALREADY_EXISTS"


### PR DESCRIPTION
## Summary

- Extends `POST /api/v1/apply` to route `kind: AgentDef` manifests to `AgentRegistryService.RegisterAgent` — returns **201** with `agent_id` on success, **409** on duplicate
- Adds `RegistryPort` interface + `AgentRegistration` value object to `internal/domain/ports.go` (domain never imports gRPC types — ADR-001)
- Adds `ErrAgentAlreadyExists` sentinel; maps `codes.AlreadyExists` → 409 in the handler
- `GatewayClients.RegisterAgent` parses the AgentDef YAML in the infrastructure layer: `metadata.name` → `agent_id`, `spec.capabilities[*]` → `CapabilityDef` protos
- Adds `ZYNAX_GW_REGISTRY_ADDR` config (default `localhost:50052`)
- `KindRouter` allowlist `{Workflow, AgentDef}` fully exercised — unknown kinds still return 400

## PR structure

| Commit | Content |
|--------|---------|
| `test(api-gateway)` | BDD scenarios (ADR-016 — contracts before code) |
| `feat(api-gateway)` | Full implementation: domain → handler → infrastructure → wiring |

## Test plan

- [ ] `GOWORK=off go test ./internal/domain/... ./internal/api/... -race` — 9 domain + 12 handler tests pass
- [ ] `GOWORK=off go build ./cmd/api-gateway/...` — clean build
- [ ] Layer boundary: `internal/domain/` imports no gRPC or yaml packages
- [ ] `make lint` clean

Closes #316

Assisted-by: Claude/claude-sonnet-4-6