### PR TITLE
feat(api-gateway): CancelWorkflow endpoint + zynax CLI apply/get/delete/status (#317)

### DIFF
--- a/cmd/zynax/client/gateway.go
+++ b/cmd/zynax/client/gateway.go
@@ -1,0 +1,197 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package client provides an HTTP client for the Zynax api-gateway.
+package client
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// Sentinel errors returned by Gateway methods.
+var ErrNotFound = errors.New("zynax: not found")
+
+// WorkflowStatus is the api-gateway's workflow run summary.
+type WorkflowStatus struct {
+	RunID        string `json:"run_id"`
+	WorkflowID   string `json:"workflow_id"`
+	Status       string `json:"status"`
+	CurrentState string `json:"current_state"`
+}
+
+// CompileError is a single diagnostic from the workflow compiler.
+type CompileError struct {
+	Code    string `json:"code,omitempty"`
+	Message string `json:"message"`
+	Line    int32  `json:"line,omitempty"`
+}
+
+// Gateway is an HTTP client for the Zynax api-gateway REST API.
+type Gateway struct {
+	base   string
+	client *http.Client
+}
+
+// New creates a Gateway pointing at baseURL.
+// When insecure is true TLS certificate verification is skipped (local dev only).
+func New(baseURL string, insecure bool) *Gateway {
+	tr := http.DefaultTransport
+	if insecure {
+		tr = &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
+		}
+	}
+	return &Gateway{
+		base:   strings.TrimRight(baseURL, "/"),
+		client: &http.Client{Transport: tr},
+	}
+}
+
+// Apply submits a manifest for execution. Returns run_id (Workflow) or
+// agent_id (AgentDef) and any compiler warnings on success.
+// Returns a descriptive error for 4xx/5xx responses.
+func (g *Gateway) Apply(ctx context.Context, body []byte, engineHint string) (string, string, []string, error) {
+	q := url.Values{}
+	if engineHint != "" {
+		q.Set("engine", engineHint)
+	}
+	resp, err := g.post(ctx, "/api/v1/apply", q, body)
+	if err != nil {
+		return "", "", nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	raw, _ := io.ReadAll(resp.Body)
+	switch resp.StatusCode {
+	case http.StatusAccepted:
+		var r struct {
+			RunID    string   `json:"run_id"`
+			Warnings []string `json:"warnings"`
+		}
+		if err := json.Unmarshal(raw, &r); err != nil {
+			return "", "", nil, fmt.Errorf("zynax: decode apply response: %w", err)
+		}
+		return r.RunID, "", r.Warnings, nil
+	case http.StatusCreated:
+		var r struct {
+			AgentID string `json:"agent_id"`
+		}
+		if err := json.Unmarshal(raw, &r); err != nil {
+			return "", "", nil, fmt.Errorf("zynax: decode apply response: %w", err)
+		}
+		return "", r.AgentID, nil, nil
+	case http.StatusUnprocessableEntity:
+		var r struct {
+			Errors []CompileError `json:"errors"`
+		}
+		_ = json.Unmarshal(raw, &r)
+		return "", "", nil, fmt.Errorf("zynax: compilation failed with %d error(s)", len(r.Errors))
+	default:
+		return "", "", nil, fmt.Errorf("zynax: apply: HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(raw)))
+	}
+}
+
+// ApplyDryRun validates a manifest without submitting.
+// Returns (nil, warnings, nil) when valid; (errors, nil, nil) when the
+// compiler finds issues; (nil, nil, err) for transport/server errors.
+func (g *Gateway) ApplyDryRun(ctx context.Context, body []byte) ([]CompileError, []string, error) {
+	q := url.Values{"dry_run": []string{"true"}}
+	resp, err := g.post(ctx, "/api/v1/apply", q, body)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	raw, _ := io.ReadAll(resp.Body)
+	switch resp.StatusCode {
+	case http.StatusOK:
+		var r struct {
+			Warnings []string `json:"warnings"`
+		}
+		_ = json.Unmarshal(raw, &r)
+		return nil, r.Warnings, nil
+	case http.StatusUnprocessableEntity:
+		var r struct {
+			Errors []CompileError `json:"errors"`
+		}
+		_ = json.Unmarshal(raw, &r)
+		return r.Errors, nil, nil
+	default:
+		return nil, nil, fmt.Errorf("zynax: dry-run: HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(raw)))
+	}
+}
+
+// GetWorkflow returns the current status of a workflow run.
+func (g *Gateway) GetWorkflow(ctx context.Context, runID string) (*WorkflowStatus, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, g.base+"/api/v1/workflows/"+runID, nil)
+	if err != nil {
+		return nil, fmt.Errorf("zynax: build request: %w", err)
+	}
+	resp, err := g.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("zynax: get workflow: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	raw, _ := io.ReadAll(resp.Body)
+	switch resp.StatusCode {
+	case http.StatusOK:
+		var s WorkflowStatus
+		if err := json.Unmarshal(raw, &s); err != nil {
+			return nil, fmt.Errorf("zynax: decode workflow status: %w", err)
+		}
+		return &s, nil
+	case http.StatusNotFound:
+		return nil, ErrNotFound
+	default:
+		return nil, fmt.Errorf("zynax: get workflow: HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(raw)))
+	}
+}
+
+// DeleteWorkflow cancels a running workflow run.
+func (g *Gateway) DeleteWorkflow(ctx context.Context, runID string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, g.base+"/api/v1/workflows/"+runID, nil)
+	if err != nil {
+		return fmt.Errorf("zynax: build request: %w", err)
+	}
+	resp, err := g.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("zynax: delete workflow: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	switch resp.StatusCode {
+	case http.StatusNoContent:
+		return nil
+	case http.StatusNotFound:
+		return ErrNotFound
+	default:
+		raw, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("zynax: delete workflow: HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(raw)))
+	}
+}
+
+func (g *Gateway) post(ctx context.Context, path string, q url.Values, body []byte) (*http.Response, error) {
+	u := g.base + path
+	if len(q) > 0 {
+		u += "?" + q.Encode()
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("zynax: build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/yaml")
+	resp, err := g.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("zynax: post %s: %w", path, err)
+	}
+	return resp, nil
+}

--- a/cmd/zynax/client/gateway_test.go
+++ b/cmd/zynax/client/gateway_test.go
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package client_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/zynax-io/zynax/cmd/zynax/client"
+)
+
+func newGW(t *testing.T, handler http.HandlerFunc) *client.Gateway {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	return client.New(srv.URL, false)
+}
+
+func TestApply_Workflow_Returns202(t *testing.T) {
+	gw := newGW(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/api/v1/apply" {
+			http.Error(w, "unexpected", http.StatusBadRequest)
+			return
+		}
+		w.WriteHeader(http.StatusAccepted)
+		_ = json.NewEncoder(w).Encode(map[string]any{"run_id": "wf-001", "warnings": []string{"w1"}})
+	})
+	runID, agentID, warnings, err := gw.Apply(context.Background(), []byte("kind: Workflow"), "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if runID != "wf-001" {
+		t.Errorf("run_id = %q; want wf-001", runID)
+	}
+	if agentID != "" {
+		t.Errorf("agent_id should be empty for Workflow apply")
+	}
+	if len(warnings) != 1 || warnings[0] != "w1" {
+		t.Errorf("warnings = %v; want [w1]", warnings)
+	}
+}
+
+func TestApply_AgentDef_Returns201(t *testing.T) {
+	gw := newGW(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]string{"agent_id": "agent-xyz"})
+	})
+	runID, agentID, _, err := gw.Apply(context.Background(), []byte("kind: AgentDef"), "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if agentID != "agent-xyz" {
+		t.Errorf("agent_id = %q; want agent-xyz", agentID)
+	}
+	if runID != "" {
+		t.Errorf("run_id should be empty for AgentDef apply")
+	}
+}
+
+func TestApply_CompileErrors_Returns422(t *testing.T) {
+	gw := newGW(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"errors": []map[string]any{{"code": "MISSING_FIELD", "message": "missing name", "line": 3}},
+		})
+	})
+	_, _, _, err := gw.Apply(context.Background(), []byte("bad yaml"), "")
+	if err == nil {
+		t.Fatal("expected error for 422 response")
+	}
+}
+
+func TestApplyDryRun_Valid_ReturnsWarnings(t *testing.T) {
+	gw := newGW(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{"dry_run": true, "warnings": []string{"unused state"}})
+	})
+	errs, warnings, err := gw.ApplyDryRun(context.Background(), []byte("kind: Workflow"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(errs) != 0 {
+		t.Errorf("expected no errors, got %v", errs)
+	}
+	if len(warnings) != 1 {
+		t.Errorf("warnings = %v; want 1 entry", warnings)
+	}
+}
+
+func TestApplyDryRun_CompileErrors_Returned(t *testing.T) {
+	gw := newGW(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"errors": []map[string]any{{"message": "bad field", "line": 5}},
+		})
+	})
+	errs, _, err := gw.ApplyDryRun(context.Background(), []byte("bad"))
+	if err != nil {
+		t.Fatalf("unexpected transport error: %v", err)
+	}
+	if len(errs) != 1 {
+		t.Errorf("expected 1 compile error, got %d", len(errs))
+	}
+}
+
+func TestGetWorkflow_ReturnsStatus(t *testing.T) {
+	gw := newGW(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/workflows/run-123" {
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"run_id": "run-123", "status": "WORKFLOW_STATUS_RUNNING",
+		})
+	})
+	s, err := gw.GetWorkflow(context.Background(), "run-123")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if s.Status != "WORKFLOW_STATUS_RUNNING" {
+		t.Errorf("status = %q", s.Status)
+	}
+}
+
+func TestGetWorkflow_NotFound(t *testing.T) {
+	gw := newGW(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+	_, err := gw.GetWorkflow(context.Background(), "missing")
+	if err != client.ErrNotFound {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestDeleteWorkflow_Returns204(t *testing.T) {
+	gw := newGW(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	if err := gw.DeleteWorkflow(context.Background(), "run-abc"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestDeleteWorkflow_NotFound(t *testing.T) {
+	gw := newGW(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+	err := gw.DeleteWorkflow(context.Background(), "missing")
+	if err != client.ErrNotFound {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}

--- a/cmd/zynax/cmd/apply.go
+++ b/cmd/zynax/cmd/apply.go
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/zynax-io/zynax/cmd/zynax/client"
+)
+
+var (
+	applyDryRun bool
+	applyEngine string
+)
+
+var applyCmd = &cobra.Command{
+	Use:   "apply <file>",
+	Short: "Apply a YAML manifest (Workflow or AgentDef)",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		data, err := os.ReadFile(args[0])
+		if err != nil {
+			return fmt.Errorf("read %s: %w", args[0], err)
+		}
+		gw := newGateway()
+		if applyDryRun {
+			return runDryRun(cmd, gw, data)
+		}
+		return runApply(cmd, gw, data)
+	},
+}
+
+func init() {
+	applyCmd.Flags().BoolVar(&applyDryRun, "dry-run", false, "validate manifest without submitting")
+	applyCmd.Flags().StringVar(&applyEngine, "engine", "", "engine hint forwarded to SubmitWorkflow (ADR-015)")
+	rootCmd.AddCommand(applyCmd)
+}
+
+func runApply(cmd *cobra.Command, gw *client.Gateway, body []byte) error {
+	runID, agentID, warnings, err := gw.Apply(cmd.Context(), body, applyEngine)
+	if err != nil {
+		return err
+	}
+	for _, w := range warnings {
+		fmt.Fprintf(cmd.OutOrStdout(), "warning: %s\n", w)
+	}
+	if runID != "" {
+		fmt.Fprintf(cmd.OutOrStdout(), "run_id: %s\n", runID)
+	}
+	if agentID != "" {
+		fmt.Fprintf(cmd.OutOrStdout(), "agent_id: %s\n", agentID)
+	}
+	return nil
+}
+
+func runDryRun(cmd *cobra.Command, gw *client.Gateway, body []byte) error {
+	errs, warnings, err := gw.ApplyDryRun(cmd.Context(), body)
+	if err != nil {
+		return err
+	}
+	for _, w := range warnings {
+		fmt.Fprintf(cmd.OutOrStdout(), "warning: %s\n", w)
+	}
+	if len(errs) == 0 {
+		fmt.Fprintln(cmd.OutOrStdout(), "ok (dry-run: no errors)")
+		return nil
+	}
+	for _, e := range errs {
+		fmt.Fprintf(cmd.ErrOrStderr(), "error (line %d): [%s] %s\n", e.Line, e.Code, e.Message)
+	}
+	return fmt.Errorf("compilation failed with %d error(s)", len(errs))
+}

--- a/cmd/zynax/cmd/delete.go
+++ b/cmd/zynax/cmd/delete.go
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var deleteCmd = &cobra.Command{
+	Use:   "delete",
+	Short: "Delete (cancel) resources",
+}
+
+var deleteWorkflowCmd = &cobra.Command{
+	Use:   "workflow <run-id>",
+	Short: "Cancel a running workflow",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		gw := newGateway()
+		if err := gw.DeleteWorkflow(cmd.Context(), args[0]); err != nil {
+			return err
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "cancelled: %s\n", args[0])
+		return nil
+	},
+}
+
+func init() {
+	deleteCmd.AddCommand(deleteWorkflowCmd)
+	rootCmd.AddCommand(deleteCmd)
+}

--- a/cmd/zynax/cmd/get.go
+++ b/cmd/zynax/cmd/get.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var getCmd = &cobra.Command{
+	Use:   "get",
+	Short: "Get resources",
+}
+
+var getWorkflowCmd = &cobra.Command{
+	Use:   "workflow <run-id>",
+	Short: "Get the current status of a workflow run",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		gw := newGateway()
+		run, err := gw.GetWorkflow(cmd.Context(), args[0])
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "run_id:        %s\n", run.RunID)
+		fmt.Fprintf(cmd.OutOrStdout(), "workflow_id:   %s\n", run.WorkflowID)
+		fmt.Fprintf(cmd.OutOrStdout(), "status:        %s\n", run.Status)
+		fmt.Fprintf(cmd.OutOrStdout(), "current_state: %s\n", run.CurrentState)
+		return nil
+	},
+}
+
+func init() {
+	getCmd.AddCommand(getWorkflowCmd)
+	rootCmd.AddCommand(getCmd)
+}

--- a/cmd/zynax/cmd/root.go
+++ b/cmd/zynax/cmd/root.go
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package cmd implements the zynax CLI commands.
+package cmd
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/zynax-io/zynax/cmd/zynax/client"
+)
+
+var rootCmd = &cobra.Command{
+	Use:          "zynax",
+	Short:        "Zynax CLI — apply, manage, and monitor Zynax workflows",
+	SilenceUsage: true,
+}
+
+var (
+	apiURL   string
+	insecure bool
+)
+
+// Execute runs the root command and exits on error.
+func Execute() {
+	if err := rootCmd.Execute(); err != nil {
+		os.Exit(1)
+	}
+}
+
+func init() {
+	defaultURL := os.Getenv("ZYNAX_API_URL")
+	if defaultURL == "" {
+		defaultURL = "http://localhost:8080"
+	}
+	rootCmd.PersistentFlags().StringVar(&apiURL, "api-url", defaultURL, "api-gateway base URL ($ZYNAX_API_URL)")
+	rootCmd.PersistentFlags().BoolVar(&insecure, "insecure", false, "skip TLS certificate verification")
+}
+
+func newGateway() *client.Gateway {
+	return client.New(apiURL, insecure)
+}

--- a/cmd/zynax/cmd/status.go
+++ b/cmd/zynax/cmd/status.go
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// terminalStatuses is the set of workflow statuses that indicate a finished run.
+var terminalStatuses = map[string]bool{
+	"WORKFLOW_STATUS_COMPLETED": true,
+	"WORKFLOW_STATUS_FAILED":    true,
+	"WORKFLOW_STATUS_CANCELLED": true,
+}
+
+var statusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Check the status of resources",
+}
+
+var statusWorkflowCmd = &cobra.Command{
+	Use:   "workflow <run-id>",
+	Short: "Check workflow status (exits 0 if terminal, 2 if still running)",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		gw := newGateway()
+		run, err := gw.GetWorkflow(cmd.Context(), args[0])
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "%s\n", run.Status)
+		if !terminalStatuses[run.Status] {
+			os.Exit(2)
+		}
+		return nil
+	},
+}
+
+func init() {
+	statusCmd.AddCommand(statusWorkflowCmd)
+	rootCmd.AddCommand(statusCmd)
+}

--- a/cmd/zynax/go.mod
+++ b/cmd/zynax/go.mod
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+module github.com/zynax-io/zynax/cmd/zynax
+
+go 1.25.0
+
+require github.com/spf13/cobra v1.9.1
+
+require (
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.6 // indirect
+)

--- a/cmd/zynax/go.sum
+++ b/cmd/zynax/go.sum
@@ -1,0 +1,10 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=
+github.com/spf13/cobra v1.9.1/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wxYW0=
+github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
+github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/cmd/zynax/main.go
+++ b/cmd/zynax/main.go
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import "github.com/zynax-io/zynax/cmd/zynax/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/services/api-gateway/internal/api/handler.go
+++ b/services/api-gateway/internal/api/handler.go
@@ -31,6 +31,7 @@ func NewHandler(svc *domain.ApplyService) *Handler {
 func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("POST /api/v1/apply", h.handleApply)
 	mux.HandleFunc("GET /api/v1/workflows/{id}", h.handleGetWorkflow)
+	mux.HandleFunc("DELETE /api/v1/workflows/{id}", h.handleDeleteWorkflow)
 }
 
 func (h *Handler) handleApply(w http.ResponseWriter, r *http.Request) {
@@ -114,6 +115,23 @@ func (h *Handler) handleGetWorkflow(w http.ResponseWriter, r *http.Request) {
 			Status:       run.Status,
 			CurrentState: run.CurrentState,
 		})
+	}
+}
+
+func (h *Handler) handleDeleteWorkflow(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if id == "" {
+		writeError(w, http.StatusBadRequest, "run_id is required", "INVALID_ARGUMENT")
+		return
+	}
+	err := h.svc.CancelWorkflow(r.Context(), id)
+	switch {
+	case errors.Is(err, domain.ErrNotFound):
+		writeError(w, http.StatusNotFound, "workflow run not found", "NOT_FOUND")
+	case err != nil:
+		writeError(w, http.StatusInternalServerError, "internal error", "INTERNAL")
+	default:
+		w.WriteHeader(http.StatusNoContent)
 	}
 }
 

--- a/services/api-gateway/internal/api/handler_test.go
+++ b/services/api-gateway/internal/api/handler_test.go
@@ -31,6 +31,7 @@ type stubEngine struct {
 	submitErr error
 	statusRun domain.WorkflowRunSummary
 	statusErr error
+	cancelErr error
 }
 
 func (s *stubEngine) SubmitWorkflow(_ context.Context, _ []byte, _ string) (string, error) {
@@ -39,6 +40,10 @@ func (s *stubEngine) SubmitWorkflow(_ context.Context, _ []byte, _ string) (stri
 
 func (s *stubEngine) GetWorkflowStatus(_ context.Context, _ string) (domain.WorkflowRunSummary, error) {
 	return s.statusRun, s.statusErr
+}
+
+func (s *stubEngine) CancelWorkflow(_ context.Context, _ string) error {
+	return s.cancelErr
 }
 
 type stubRegistry struct {
@@ -311,5 +316,37 @@ func TestHandler_Apply_DuplicateAgentDef_Returns409(t *testing.T) {
 	body := decodeBody(t, resp)
 	if body["code"] != "ALREADY_EXISTS" {
 		t.Errorf("code: got %v, want ALREADY_EXISTS", body["code"])
+	}
+}
+
+func TestHandler_DeleteWorkflow_Returns204(t *testing.T) {
+	srv := newServer(&stubCompiler{}, &stubEngine{})
+	defer srv.Close()
+
+	req, _ := http.NewRequest(http.MethodDelete, srv.URL+"/api/v1/workflows/run-abc", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusNoContent {
+		t.Errorf("status: got %d, want 204", resp.StatusCode)
+	}
+}
+
+func TestHandler_DeleteWorkflow_NotFound_Returns404(t *testing.T) {
+	srv := newServer(&stubCompiler{}, &stubEngine{cancelErr: domain.ErrNotFound})
+	defer srv.Close()
+
+	req, _ := http.NewRequest(http.MethodDelete, srv.URL+"/api/v1/workflows/run-missing", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("status: got %d, want 404", resp.StatusCode)
 	}
 }

--- a/services/api-gateway/internal/domain/apply.go
+++ b/services/api-gateway/internal/domain/apply.go
@@ -87,3 +87,11 @@ func (s *ApplyService) GetWorkflowStatus(ctx context.Context, runID string) (Wor
 	}
 	return run, nil
 }
+
+// CancelWorkflow requests cancellation of a running workflow.
+func (s *ApplyService) CancelWorkflow(ctx context.Context, runID string) error {
+	if err := s.engine.CancelWorkflow(ctx, runID); err != nil {
+		return fmt.Errorf("api-gateway: %w", err)
+	}
+	return nil
+}

--- a/services/api-gateway/internal/domain/apply_test.go
+++ b/services/api-gateway/internal/domain/apply_test.go
@@ -26,6 +26,7 @@ type stubEngine struct {
 	submitErr error
 	statusRun domain.WorkflowRunSummary
 	statusErr error
+	cancelErr error
 }
 
 func (s *stubEngine) SubmitWorkflow(_ context.Context, _ []byte, _ string) (string, error) {
@@ -34,6 +35,10 @@ func (s *stubEngine) SubmitWorkflow(_ context.Context, _ []byte, _ string) (stri
 
 func (s *stubEngine) GetWorkflowStatus(_ context.Context, _ string) (domain.WorkflowRunSummary, error) {
 	return s.statusRun, s.statusErr
+}
+
+func (s *stubEngine) CancelWorkflow(_ context.Context, _ string) error {
+	return s.cancelErr
 }
 
 // stubRegistry is a test double for RegistryPort.

--- a/services/api-gateway/internal/domain/ports.go
+++ b/services/api-gateway/internal/domain/ports.go
@@ -40,6 +40,7 @@ type CompilerPort interface {
 type EnginePort interface {
 	SubmitWorkflow(ctx context.Context, irBytes []byte, engineHint string) (string, error)
 	GetWorkflowStatus(ctx context.Context, runID string) (WorkflowRunSummary, error)
+	CancelWorkflow(ctx context.Context, runID string) error
 }
 
 // AgentRegistration is the domain view of a successful RegisterAgent response.

--- a/services/api-gateway/internal/infrastructure/clients.go
+++ b/services/api-gateway/internal/infrastructure/clients.go
@@ -98,6 +98,15 @@ func (c *GatewayClients) GetWorkflowStatus(ctx context.Context, runID string) (d
 	}, nil
 }
 
+// CancelWorkflow implements domain.EnginePort.
+func (c *GatewayClients) CancelWorkflow(ctx context.Context, runID string) error {
+	_, err := c.engine.CancelWorkflow(ctx, &zynaxv1.CancelWorkflowRequest{RunId: runID})
+	if err != nil {
+		return mapEngineGRPCError(err)
+	}
+	return nil
+}
+
 // RegisterAgent implements domain.RegistryPort.
 // The raw YAML is parsed here in the infrastructure layer; the domain never
 // sees proto types or YAML-parsed structs (ADR-011, ADR-001).


### PR DESCRIPTION
## Summary

Canvas step 3 of 6 — [docs/spdd/314-yaml-system-cli/canvas.md](docs/spdd/314-yaml-system-cli/canvas.md)

**api-gateway** (minimal additions to support CLI `delete`):
- `CancelWorkflow` added to `EnginePort` interface, `ApplyService`, and `GatewayClients`
- `DELETE /api/v1/workflows/{id}` → `204 No Content` (or `404` if not found)

**`cmd/zynax/`** — new standalone Go module (no workspace, communicates via HTTP REST per ADR-008):
- `zynax apply <file>` — `POST /api/v1/apply`; prints `run_id` (Workflow) or `agent_id` (AgentDef)
- `zynax apply --dry-run <file>` — validates without submitting; prints compile errors; exits 1 on errors
- `zynax apply --engine <hint>` — passes `engine_hint` through; never hardcodes engine name (ADR-015)
- `zynax get workflow <id>` — prints status table
- `zynax delete workflow <id>` — cancels run via `DELETE /api/v1/workflows/{id}`
- `zynax status workflow <id>` — exits `0` if terminal, `2` if still running (scriptable)
- `ZYNAX_API_URL` env var; `--insecure` flag for local dev
- 9 client unit tests covering all four HTTP methods

## Test plan

- [x] `GOWORK=off go test ./...` green in `services/api-gateway/`
- [x] `GOWORK=off go build ./... && go test ./...` green in `cmd/zynax/`
- [x] `make test` green end-to-end (all service + BDD + coverage gates)
- [x] DELETE handler tests: 204 success, 404 not found

Closes #317

Assisted-by: Claude/claude-sonnet-4-6