### PR TITLE
feat(api-gateway): zynax logs SSE streaming endpoint and CLI command (#318)

### DIFF
--- a/cmd/zynax/client/gateway.go
+++ b/cmd/zynax/client/gateway.go
@@ -4,6 +4,7 @@
 package client
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"crypto/tls"
@@ -177,6 +178,59 @@ func (g *Gateway) DeleteWorkflow(ctx context.Context, runID string) error {
 		raw, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("zynax: delete workflow: HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(raw)))
 	}
+}
+
+// LogEvent is a single workflow lifecycle event received from the SSE stream.
+type LogEvent struct {
+	RunID     string `json:"run_id"`
+	EventType string `json:"event_type"`
+	FromState string `json:"from_state,omitempty"`
+	ToState   string `json:"to_state,omitempty"`
+	Status    string `json:"status"`
+	Timestamp string `json:"timestamp,omitempty"`
+	Payload   string `json:"payload,omitempty"`
+}
+
+// WatchWorkflowLogs streams SSE events from GET /api/v1/workflows/{id}/logs,
+// calling send for each event. Returns when the stream closes or ctx is cancelled.
+func (g *Gateway) WatchWorkflowLogs(ctx context.Context, runID string, send func(LogEvent) error) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, g.base+"/api/v1/workflows/"+runID+"/logs", nil)
+	if err != nil {
+		return fmt.Errorf("zynax: build request: %w", err)
+	}
+	req.Header.Set("Accept", "text/event-stream")
+	resp, err := g.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("zynax: watch workflow: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return ErrNotFound
+	}
+	if resp.StatusCode != http.StatusOK {
+		raw, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("zynax: watch workflow: HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(raw)))
+	}
+	return readSSEStream(resp.Body, send)
+}
+
+func readSSEStream(r io.Reader, send func(LogEvent) error) error {
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+		var ev LogEvent
+		if err := json.Unmarshal([]byte(strings.TrimPrefix(line, "data: ")), &ev); err != nil {
+			return fmt.Errorf("zynax: decode SSE event: %w", err)
+		}
+		if err := send(ev); err != nil {
+			return err
+		}
+	}
+	return scanner.Err()
 }
 
 func (g *Gateway) post(ctx context.Context, path string, q url.Values, body []byte) (*http.Response, error) {

--- a/cmd/zynax/client/gateway_test.go
+++ b/cmd/zynax/client/gateway_test.go
@@ -5,6 +5,7 @@ package client_test
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -149,6 +150,53 @@ func TestDeleteWorkflow_NotFound(t *testing.T) {
 		w.WriteHeader(http.StatusNotFound)
 	})
 	err := gw.DeleteWorkflow(context.Background(), "missing")
+	if err != client.ErrNotFound {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestWatchWorkflowLogs_StreamsEvents(t *testing.T) {
+	gw := newGW(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/workflows/run-sse/logs" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		events := []map[string]any{
+			{"run_id": "run-sse", "event_type": "state.entered", "to_state": "review", "status": "WORKFLOW_STATUS_RUNNING"},
+			{"run_id": "run-sse", "event_type": "workflow.completed", "status": "WORKFLOW_STATUS_COMPLETED"},
+		}
+		for _, ev := range events {
+			b, _ := json.Marshal(ev)
+			fmt.Fprintf(w, "data: %s\n\n", b)
+		}
+	})
+
+	var got []client.LogEvent
+	err := gw.WatchWorkflowLogs(context.Background(), "run-sse", func(ev client.LogEvent) error {
+		got = append(got, ev)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d events, want 2", len(got))
+	}
+	if got[0].EventType != "state.entered" {
+		t.Errorf("event[0].EventType = %q; want state.entered", got[0].EventType)
+	}
+	if got[1].EventType != "workflow.completed" {
+		t.Errorf("event[1].EventType = %q; want workflow.completed", got[1].EventType)
+	}
+}
+
+func TestWatchWorkflowLogs_NotFound(t *testing.T) {
+	gw := newGW(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+	err := gw.WatchWorkflowLogs(context.Background(), "ghost", func(_ client.LogEvent) error { return nil })
 	if err != client.ErrNotFound {
 		t.Errorf("expected ErrNotFound, got %v", err)
 	}

--- a/cmd/zynax/cmd/logs.go
+++ b/cmd/zynax/cmd/logs.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/zynax-io/zynax/cmd/zynax/client"
+)
+
+var logsFormat string
+
+var logsCmd = &cobra.Command{
+	Use:   "logs <run-id>",
+	Short: "Stream lifecycle events for a workflow run",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		gw := newGateway()
+		return gw.WatchWorkflowLogs(cmd.Context(), args[0], func(ev client.LogEvent) error {
+			if logsFormat == "json" {
+				b, err := json.Marshal(ev)
+				if err != nil {
+					return err
+				}
+				fmt.Fprintln(cmd.OutOrStdout(), string(b))
+				return nil
+			}
+			ts := ev.Timestamp
+			if ts == "" {
+				ts = "-"
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "[%s] %-30s %s → %s (%s)\n",
+				ts, ev.EventType, ev.FromState, ev.ToState, ev.Status)
+			return nil
+		})
+	},
+}
+
+func init() {
+	logsCmd.Flags().StringVar(&logsFormat, "format", "text", "output format: text|json")
+	rootCmd.AddCommand(logsCmd)
+}

--- a/services/api-gateway/internal/api/handler.go
+++ b/services/api-gateway/internal/api/handler.go
@@ -142,9 +142,9 @@ func (h *Handler) handleWorkflowLogs(w http.ResponseWriter, r *http.Request) {
 		}
 		data, merr := json.Marshal(sseWatchEvent(ev))
 		if merr != nil {
-			return merr
+			return fmt.Errorf("api-gateway: marshal event: %w", merr)
 		}
-		fmt.Fprintf(w, "data: %s\n\n", data)
+		_, _ = fmt.Fprintf(w, "data: %s\n\n", data)
 		flusher.Flush()
 		return nil
 	})

--- a/services/api-gateway/internal/api/handler.go
+++ b/services/api-gateway/internal/api/handler.go
@@ -6,6 +6,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -30,6 +31,7 @@ func NewHandler(svc *domain.ApplyService) *Handler {
 // RegisterRoutes registers all HTTP routes on mux. Requires Go 1.22+ ServeMux.
 func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("POST /api/v1/apply", h.handleApply)
+	mux.HandleFunc("GET /api/v1/workflows/{id}/logs", h.handleWorkflowLogs)
 	mux.HandleFunc("GET /api/v1/workflows/{id}", h.handleGetWorkflow)
 	mux.HandleFunc("DELETE /api/v1/workflows/{id}", h.handleDeleteWorkflow)
 }
@@ -118,6 +120,47 @@ func (h *Handler) handleGetWorkflow(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+func (h *Handler) handleWorkflowLogs(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if id == "" {
+		writeError(w, http.StatusBadRequest, "run_id is required", "INVALID_ARGUMENT")
+		return
+	}
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		writeError(w, http.StatusInternalServerError, "streaming not supported", "INTERNAL")
+		return
+	}
+	started := false
+	err := h.svc.WatchWorkflowLogs(r.Context(), id, func(ev domain.WatchEvent) error {
+		if !started {
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.Header().Set("Cache-Control", "no-cache")
+			w.Header().Set("Connection", "keep-alive")
+			w.WriteHeader(http.StatusOK)
+			started = true
+		}
+		data, merr := json.Marshal(sseWatchEvent(ev))
+		if merr != nil {
+			return merr
+		}
+		fmt.Fprintf(w, "data: %s\n\n", data)
+		flusher.Flush()
+		return nil
+	})
+	if started {
+		return
+	}
+	switch {
+	case errors.Is(err, domain.ErrNotFound):
+		writeError(w, http.StatusNotFound, "workflow run not found", "NOT_FOUND")
+	case err != nil && !errors.Is(err, context.Canceled):
+		writeError(w, http.StatusInternalServerError, "internal error", "INTERNAL")
+	default:
+		w.WriteHeader(http.StatusOK)
+	}
+}
+
 func (h *Handler) handleDeleteWorkflow(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	if id == "" {
@@ -171,6 +214,28 @@ type workflowStatusResp struct {
 	WorkflowID   string `json:"workflow_id"`
 	Status       string `json:"status"`
 	CurrentState string `json:"current_state"`
+}
+
+type watchEventResp struct {
+	RunID     string `json:"run_id"`
+	EventType string `json:"event_type"`
+	FromState string `json:"from_state,omitempty"`
+	ToState   string `json:"to_state,omitempty"`
+	Status    string `json:"status"`
+	Timestamp string `json:"timestamp,omitempty"`
+	Payload   string `json:"payload,omitempty"`
+}
+
+func sseWatchEvent(ev domain.WatchEvent) watchEventResp {
+	return watchEventResp{
+		RunID:     ev.RunID,
+		EventType: ev.EventType,
+		FromState: ev.FromState,
+		ToState:   ev.ToState,
+		Status:    ev.Status,
+		Timestamp: ev.Timestamp,
+		Payload:   ev.Payload,
+	}
 }
 
 // ── helpers ───────────────────────────────────────────────────────────────

--- a/services/api-gateway/internal/api/handler_test.go
+++ b/services/api-gateway/internal/api/handler_test.go
@@ -3,6 +3,7 @@
 package api_test
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -27,11 +28,13 @@ func (s *stubCompiler) CompileWorkflow(_ context.Context, _ []byte, _ string, _ 
 }
 
 type stubEngine struct {
-	submitID  string
-	submitErr error
-	statusRun domain.WorkflowRunSummary
-	statusErr error
-	cancelErr error
+	submitID    string
+	submitErr   error
+	statusRun   domain.WorkflowRunSummary
+	statusErr   error
+	cancelErr   error
+	watchEvents []domain.WatchEvent
+	watchErr    error
 }
 
 func (s *stubEngine) SubmitWorkflow(_ context.Context, _ []byte, _ string) (string, error) {
@@ -44,6 +47,18 @@ func (s *stubEngine) GetWorkflowStatus(_ context.Context, _ string) (domain.Work
 
 func (s *stubEngine) CancelWorkflow(_ context.Context, _ string) error {
 	return s.cancelErr
+}
+
+func (s *stubEngine) WatchWorkflow(_ context.Context, _ string, send func(domain.WatchEvent) error) error {
+	if s.watchErr != nil {
+		return s.watchErr
+	}
+	for _, ev := range s.watchEvents {
+		if err := send(ev); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 type stubRegistry struct {
@@ -341,6 +356,64 @@ func TestHandler_DeleteWorkflow_NotFound_Returns404(t *testing.T) {
 
 	req, _ := http.NewRequest(http.MethodDelete, srv.URL+"/api/v1/workflows/run-missing", nil)
 	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("status: got %d, want 404", resp.StatusCode)
+	}
+}
+
+// ── GET /api/v1/workflows/{id}/logs ──────────────────────────────────────
+
+func TestHandler_WorkflowLogs_StreamsSSEEvents(t *testing.T) {
+	events := []domain.WatchEvent{
+		{RunID: "r1", EventType: "state.entered", ToState: "review", Status: "WORKFLOW_STATUS_RUNNING"},
+		{RunID: "r1", EventType: "workflow.completed", Status: "WORKFLOW_STATUS_COMPLETED"},
+	}
+	srv := newServer(&stubCompiler{}, &stubEngine{watchEvents: events})
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/v1/workflows/r1/logs")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status: got %d, want 200", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); ct != "text/event-stream" {
+		t.Errorf("Content-Type: got %q, want text/event-stream", ct)
+	}
+
+	var dataLines []string
+	scanner := bufio.NewScanner(resp.Body)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "data: ") {
+			dataLines = append(dataLines, strings.TrimPrefix(line, "data: "))
+		}
+	}
+	if len(dataLines) != 2 {
+		t.Fatalf("got %d data lines, want 2", len(dataLines))
+	}
+	var ev map[string]any
+	if err := json.Unmarshal([]byte(dataLines[1]), &ev); err != nil {
+		t.Fatalf("unmarshal last event: %v", err)
+	}
+	if ev["event_type"] != "workflow.completed" {
+		t.Errorf("last event_type: got %v, want workflow.completed", ev["event_type"])
+	}
+}
+
+func TestHandler_WorkflowLogs_NotFound_Returns404(t *testing.T) {
+	srv := newServer(&stubCompiler{}, &stubEngine{watchErr: domain.ErrNotFound})
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/v1/workflows/ghost/logs")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/services/api-gateway/internal/domain/apply.go
+++ b/services/api-gateway/internal/domain/apply.go
@@ -95,3 +95,12 @@ func (s *ApplyService) CancelWorkflow(ctx context.Context, runID string) error {
 	}
 	return nil
 }
+
+// WatchWorkflowLogs streams lifecycle events for runID, calling send for each event.
+// Returns when the stream closes, ctx is cancelled, or send returns an error.
+func (s *ApplyService) WatchWorkflowLogs(ctx context.Context, runID string, send func(WatchEvent) error) error {
+	if err := s.engine.WatchWorkflow(ctx, runID, send); err != nil {
+		return fmt.Errorf("api-gateway: %w", err)
+	}
+	return nil
+}

--- a/services/api-gateway/internal/domain/apply_test.go
+++ b/services/api-gateway/internal/domain/apply_test.go
@@ -22,11 +22,13 @@ func (s *stubCompiler) CompileWorkflow(_ context.Context, _ []byte, _ string, _ 
 
 // stubEngine is a test double for EnginePort.
 type stubEngine struct {
-	submitID  string
-	submitErr error
-	statusRun domain.WorkflowRunSummary
-	statusErr error
-	cancelErr error
+	submitID    string
+	submitErr   error
+	statusRun   domain.WorkflowRunSummary
+	statusErr   error
+	cancelErr   error
+	watchEvents []domain.WatchEvent
+	watchErr    error
 }
 
 func (s *stubEngine) SubmitWorkflow(_ context.Context, _ []byte, _ string) (string, error) {
@@ -39,6 +41,18 @@ func (s *stubEngine) GetWorkflowStatus(_ context.Context, _ string) (domain.Work
 
 func (s *stubEngine) CancelWorkflow(_ context.Context, _ string) error {
 	return s.cancelErr
+}
+
+func (s *stubEngine) WatchWorkflow(_ context.Context, _ string, send func(domain.WatchEvent) error) error {
+	if s.watchErr != nil {
+		return s.watchErr
+	}
+	for _, ev := range s.watchEvents {
+		if err := send(ev); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // stubRegistry is a test double for RegistryPort.
@@ -191,5 +205,39 @@ func TestApplyService_ApplyAgentDef_AlreadyExists(t *testing.T) {
 	})
 	if !errors.Is(err, domain.ErrAgentAlreadyExists) {
 		t.Errorf("expected ErrAgentAlreadyExists, got %v", err)
+	}
+}
+
+func TestApplyService_WatchWorkflowLogs_DeliversEvents(t *testing.T) {
+	events := []domain.WatchEvent{
+		{RunID: "r1", EventType: "state.entered", ToState: "review", Status: "WORKFLOW_STATUS_RUNNING"},
+		{RunID: "r1", EventType: "workflow.completed", Status: "WORKFLOW_STATUS_COMPLETED"},
+	}
+	svc := domain.NewApplyService(&stubCompiler{}, &stubEngine{watchEvents: events}, &stubRegistry{})
+
+	var got []domain.WatchEvent
+	err := svc.WatchWorkflowLogs(context.Background(), "r1", func(ev domain.WatchEvent) error {
+		got = append(got, ev)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d events, want 2", len(got))
+	}
+	if got[0].EventType != "state.entered" {
+		t.Errorf("event[0]: got %q, want state.entered", got[0].EventType)
+	}
+	if got[1].EventType != "workflow.completed" {
+		t.Errorf("event[1]: got %q, want workflow.completed", got[1].EventType)
+	}
+}
+
+func TestApplyService_WatchWorkflowLogs_NotFound(t *testing.T) {
+	svc := domain.NewApplyService(&stubCompiler{}, &stubEngine{watchErr: domain.ErrNotFound}, &stubRegistry{})
+	err := svc.WatchWorkflowLogs(context.Background(), "ghost", func(_ domain.WatchEvent) error { return nil })
+	if !errors.Is(err, domain.ErrNotFound) {
+		t.Fatalf("got %v, want ErrNotFound", err)
 	}
 }

--- a/services/api-gateway/internal/domain/ports.go
+++ b/services/api-gateway/internal/domain/ports.go
@@ -31,6 +31,17 @@ type WorkflowRunSummary struct {
 	CurrentState string
 }
 
+// WatchEvent is a single lifecycle event emitted by a streaming WatchWorkflow call.
+type WatchEvent struct {
+	RunID     string
+	EventType string
+	FromState string
+	ToState   string
+	Status    string
+	Timestamp string // RFC3339; empty when the engine omits it
+	Payload   string // JSON string or empty
+}
+
 // CompilerPort is the gateway's outbound dependency on WorkflowCompilerService.
 type CompilerPort interface {
 	CompileWorkflow(ctx context.Context, manifestYAML []byte, namespace string, dryRun bool) (CompileResult, error)
@@ -41,6 +52,9 @@ type EnginePort interface {
 	SubmitWorkflow(ctx context.Context, irBytes []byte, engineHint string) (string, error)
 	GetWorkflowStatus(ctx context.Context, runID string) (WorkflowRunSummary, error)
 	CancelWorkflow(ctx context.Context, runID string) error
+	// WatchWorkflow streams lifecycle events for runID, calling send for each.
+	// Returns when the stream closes, ctx is cancelled, or send returns an error.
+	WatchWorkflow(ctx context.Context, runID string, send func(WatchEvent) error) error
 }
 
 // AgentRegistration is the domain view of a successful RegisterAgent response.

--- a/services/api-gateway/internal/infrastructure/clients.go
+++ b/services/api-gateway/internal/infrastructure/clients.go
@@ -6,7 +6,10 @@ package infrastructure
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io"
+	"time"
 
 	zynaxv1 "github.com/zynax-io/zynax/protos/generated/go/zynax/v1"
 	"github.com/zynax-io/zynax/services/api-gateway/internal/domain"
@@ -105,6 +108,38 @@ func (c *GatewayClients) CancelWorkflow(ctx context.Context, runID string) error
 		return mapEngineGRPCError(err)
 	}
 	return nil
+}
+
+// WatchWorkflow implements domain.EnginePort. It bridges the gRPC server-stream
+// to the callback pattern, keeping gRPC types out of the domain layer.
+func (c *GatewayClients) WatchWorkflow(ctx context.Context, runID string, send func(domain.WatchEvent) error) error {
+	stream, err := c.engine.WatchWorkflow(ctx, &zynaxv1.WatchWorkflowRequest{RunId: runID})
+	if err != nil {
+		return mapEngineGRPCError(err)
+	}
+	for {
+		ev, err := stream.Recv()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+			return mapEngineGRPCError(err)
+		}
+		we := domain.WatchEvent{
+			RunID:     ev.GetRunId(),
+			EventType: ev.GetEventType(),
+			FromState: ev.GetFromState(),
+			ToState:   ev.GetToState(),
+			Status:    ev.GetStatus().String(),
+			Payload:   string(ev.GetPayload()),
+		}
+		if ts := ev.GetTimestamp(); ts != nil {
+			we.Timestamp = ts.AsTime().Format(time.RFC3339)
+		}
+		if err := send(we); err != nil {
+			return err
+		}
+	}
 }
 
 // RegisterAgent implements domain.RegistryPort.

--- a/services/api-gateway/tests/features/api_gateway.feature
+++ b/services/api-gateway/tests/features/api_gateway.feature
@@ -106,3 +106,18 @@ Feature: API Gateway
     When POST /api/v1/apply is called with a valid kind: AgentDef YAML body
     Then the HTTP status is 409
     And the response code is "ALREADY_EXISTS"
+
+  # ── GET /api/v1/workflows/{id}/logs (M4 step 4, issue #318) ─────────────
+
+  Scenario: GET /api/v1/workflows/{id}/logs streams SSE events and closes on terminal
+    Given a submitted workflow with run_id "log-run-001"
+    And the engine adapter streams a state-entered event and then a completed event
+    When GET /api/v1/workflows/log-run-001/logs is called
+    Then the HTTP status is 200
+    And the Content-Type is "text/event-stream"
+    And the response body contains 2 SSE data lines
+
+  Scenario: GET /api/v1/workflows/{id}/logs for unknown run_id returns 404
+    Given the engine adapter does not know about run_id "ghost-log-run"
+    When GET /api/v1/workflows/ghost-log-run/logs is called
+    Then the HTTP status is 404


### PR DESCRIPTION
## Summary

- Adds `GET /api/v1/workflows/{id}/logs` as a Server-Sent Events stream on the api-gateway; returns 404 before streaming starts if the run is unknown
- Extends `EnginePort` with `WatchWorkflow` (callback pattern) and `ApplyService` with `WatchWorkflowLogs`; bridges the gRPC server-stream in `GatewayClients`
- Adds `zynax logs <run-id> [--format text|json]` CLI command via `cmd/zynax/cmd/logs.go` and `Gateway.WatchWorkflowLogs` SSE client in `client/gateway.go`

## Test plan

- [x] BDD scenarios in `api_gateway.feature` (committed before implementation per ADR-016)
- [x] `domain` unit tests: `WatchWorkflowLogs` delivers events and surfaces `ErrNotFound`
- [x] `api` handler tests: streams SSE with correct `Content-Type`, returns 404 pre-stream
- [x] `client` tests: `WatchWorkflowLogs` parses SSE data lines, returns `ErrNotFound` on 404
- [x] `GOWORK=off go test ./...` — all packages green

Closes #318

Assisted-by: Claude/claude-sonnet-4-6