### PR TITLE
docs: M4 Canvas prompt-update — add zynax validate steps (#331–#336)

### DIFF
--- a/docs/spdd/314-yaml-system-cli/canvas.md
+++ b/docs/spdd/314-yaml-system-cli/canvas.md
@@ -16,8 +16,8 @@
 ## R — Requirements
 
 - **Problem:** M3 delivers a working Temporal execution engine, but there is no user-facing entry point. A developer cannot run `zynax apply workflow.yaml` — the `api-gateway` service has only stub BDD scenarios and no Go implementation, and no CLI binary exists. The three-layer architecture is complete internally but inaccessible from outside the platform.
-- **Missing capability:** (1) The `api-gateway` has no HTTP handlers, no kind-routing logic, and no gRPC client wiring to the compiler, engine-adapter, or registry. (2) There is no `zynax` CLI binary. (3) There is no local Docker Compose stack for end-to-end development without Kubernetes. (4) `kind: AgentDef` manifests cannot be submitted to the registry via the public API.
-- **M4 adds:** A fully implemented `api-gateway` with a `/api/v1/apply` endpoint that routes YAML manifests by `kind`, a `zynax` CLI with `apply`, `get`, `delete`, `status`, and `logs` commands, a local Docker Compose runner, and a `zynax gitops watch` sub-command.
+- **Missing capability:** (1) The `api-gateway` has no HTTP handlers, no kind-routing logic, and no gRPC client wiring to the compiler, engine-adapter, or registry. (2) There is no `zynax` CLI binary. (3) There is no local Docker Compose stack for end-to-end development without Kubernetes. (4) `kind: AgentDef` manifests cannot be submitted to the registry via the public API. (5) Manifest JSON schema validation, REASONS Canvas structural checking, and JSON Schema meta-validation all run as Python-only scripts in `tools/`, creating a Python runtime dependency in CI and preventing distribution as part of the `zynax` binary.
+- **M4 adds:** A fully implemented `api-gateway` with a `/api/v1/apply` endpoint that routes YAML manifests by `kind`, a `zynax` CLI with `apply`, `get`, `delete`, `status`, `logs`, and `validate` commands, a local Docker Compose runner, a `zynax gitops watch` sub-command, and a Go-native replacement for all Python validation scripts in `tools/`.
 - **Definition of done — observable outcomes:**
   - `zynax apply workflow.yaml` compiles + submits a workflow and prints a `run_id`.
   - `zynax apply --dry-run workflow.yaml` returns compiler errors with line numbers and exits non-zero.
@@ -26,6 +26,10 @@
   - `POST /api/v1/apply` with `kind: AgentDef` registers an agent and returns `agent_id`.
   - `make run-local` starts all services; `zynax apply spec/workflows/examples/code-review.yaml` succeeds end-to-end against the local stack.
   - `zynax gitops watch <dir>` re-applies changed YAML files automatically.
+  - `zynax validate manifest <file>` validates a YAML manifest against its JSON schema; exits non-zero with line-annotated errors on failure.
+  - `zynax validate canvas <file>` confirms all 7 REASONS section headers and a `**Status:**` field are present; exits non-zero on any missing section.
+  - `zynax validate schema <file>` validates a JSON Schema document against the JSON Schema 2020-12 meta-schema; exits non-zero if invalid.
+  - `make validate-spec` and `make validate-canvas` invoke `zynax validate` instead of `python3 tools/*.py`; Python validation scripts removed from `tools/`.
   - All BDD scenarios in `services/api-gateway/tests/features/` pass; `make test` green; `make lint` clean.
 
 ---
@@ -51,6 +55,10 @@
 - **`zynax` CLI binary** (`cmd/zynax/`) — standalone Go module. Cobra CLI with sub-commands: `apply`, `get workflow`, `delete workflow`, `status workflow`, `logs workflow`, `gitops watch`. Reads `ZYNAX_API_URL` from env (default: `http://localhost:8080`). `--insecure` flag for local dev.
 - **`GitOpsWatcher`** (`cmd/zynax/gitops/`) — `zynax gitops watch <dir>` sub-command; uses `fsnotify` to watch a directory for YAML changes; tracks content hashes in `.zynax-watch.state`; calls `POST /api/v1/apply` on create/modify.
 - **`DockerComposeStack`** (`infra/docker-compose/`) — `docker-compose.yml` starting all services + Temporal + NATS on the `70xx` port range. `make run-local` / `make stop-local` targets.
+- **`ValidateCmd`** (`cmd/zynax/cmd/validate.go`) — `zynax validate` parent Cobra command with three sub-commands: `manifest`, `canvas`, `schema`. Exits 0 on success, 1 on any validation error. `--format json` flag for machine-readable output.
+- **`ManifestValidator`** (`cmd/zynax/validate/manifest.go`) — reads the `kind:` field from a YAML file, loads the matching JSON Schema from `spec/schemas/<kind>.json`, validates using a Go JSON Schema library. Returns structured `ValidationError` values with file path and line number.
+- **`CanvasValidator`** (`cmd/zynax/validate/canvas.go`) — parses a Markdown file; asserts all seven REASONS section headers (`R —`, `E —`, `A —`, `S —`, `O —`, `N —`, second `S —`) and a `**Status:**` field are present. Reports each missing section by name.
+- **`SchemaValidator`** (`cmd/zynax/validate/schema.go`) — validates a JSON Schema document against the JSON Schema 2020-12 meta-schema using an established Go library. Exits 0 if valid, 1 with diagnostics if not.
 
 ### Entity relationships
 
@@ -81,6 +89,7 @@ zynax CLI  ──── POST /api/v1/apply ────────────�
 - Return all compiler `CompilationError` structs (including `line_number`) in the HTTP response body as structured JSON, never swallowed (ADR-016 — error visibility).
 - Implement the `zynax` CLI as a separate Go module (`cmd/zynax/go.mod`) so it can be released as a standalone binary without pulling in service internals (ADR-008 — no cross-service internal imports).
 - Use `fsnotify` for the GitOps watcher — no polling loop; content-hash tracked in `.zynax-watch.state` for idempotent restarts.
+- Replace Python validation scripts in `tools/` (`validate_canvas.py`, `validate_manifest.py`, and related) with Go implementations inside `cmd/zynax/validate/`. This removes the Python runtime dependency from all CI validation paths and makes the validators distributable as part of the `zynax` binary.
 - Write BDD `.feature` file for `/api/v1/apply` scenarios **before** any Go implementation (ADR-016 — contracts before code).
 - Provide `make run-local` Docker Compose stack as a first-class development target. All services use the same Docker images built by `make build`.
 - Forward `engine_hint` from the CLI `--engine` flag to `SubmitWorkflowRequest.engine_hint` — never hardcode an engine name in the gateway or CLI (ADR-015).
@@ -94,6 +103,7 @@ zynax CLI  ──── POST /api/v1/apply ────────────�
 - Implement `zynax delete` as a hard-delete. It calls `CancelWorkflow` — Temporal owns the execution record.
 - Implement multi-tenant auth beyond the token check already covered by the existing BDD scenarios. Auth hardening is M6.
 - Implement `kind: Policy` apply or `kind: RoutingRule` apply (ADR-011 §Manifest Kinds are defined but M4 scope is Workflow + AgentDef only).
+- Re-implement a full JSON Schema or AsyncAPI specification validator from scratch — `zynax validate schema` and `zynax validate manifest` delegate to established Go JSON Schema libraries for spec compliance; we only add the CLI wrapper and `kind:`-to-schema resolution logic.
 
 **Governing ADRs:** ADR-001 (gRPC inter-service), ADR-008 (no shared databases / no cross-service imports), ADR-009 (Go for services), ADR-011 (declarative YAML control plane), ADR-012 (WorkflowIR as engine-agnostic IR), ADR-013 (adapter-first, no SDK required), ADR-014 (event-driven state machine), ADR-015 (pluggable engines), ADR-016 (layered testing — .feature before code), ADR-017 (GOWORK=off), ADR-019 (SPDD — Canvas before code)
 
@@ -130,12 +140,20 @@ cmd/zynax/                               ← new standalone Go module
 │   ├── delete.go                        ← zynax delete workflow <id>
 │   ├── status.go                        ← zynax status workflow <id>
 │   ├── logs.go                          ← zynax logs workflow <id>
+│   ├── validate.go                      ← zynax validate (parent + sub-command dispatch)
 │   └── gitops/
 │       └── watch.go                     ← zynax gitops watch <dir>
 ├── client/
 │   └── gateway.go                       ← HTTP client for api-gateway REST
+├── validate/
+│   ├── manifest.go                      ← JSON schema validation against spec/schemas/
+│   ├── canvas.go                        ← REASONS Canvas section structural checker
+│   └── schema.go                        ← JSON Schema 2020-12 meta-validator
 ├── go.mod
 └── go.sum
+
+tools/                                   ← Python validation scripts deleted in step 11
+                                           (validate_canvas.py, validate_manifest.py, etc.)
 
 infra/docker-compose/
 ├── docker-compose.yml                   ← all services + Temporal + NATS (70xx ports)
@@ -169,6 +187,16 @@ Each step is a single PR, independently verifiable. Steps must be executed in or
 5. **Local Docker Compose runner** ([#319](https://github.com/zynax-io/zynax/issues/319)) — `infra/docker-compose/docker-compose.yml` for all services + Temporal + NATS on 70xx ports. `make run-local` / `make stop-local` targets. `docs/local-dev.md` quickstart (≤ 100 lines). Verify: `make run-local` starts all services; all `/healthz` probes pass; `zynax apply spec/workflows/examples/code-review.yaml` succeeds end-to-end.
 
 6. **`zynax gitops watch`** ([#320](https://github.com/zynax-io/zynax/issues/320)) — Add `gitops watch <dir>` sub-command using `fsnotify`. Content-hash tracking in `.zynax-watch.state`. Re-applies on create/modify; skips unchanged files on restart. `Ctrl+C` exits 0. Verify: unit tests for hash-tracking; integration smoke: modify a YAML file → confirm re-apply triggered.
+
+7. **`zynax validate manifest` — local JSON schema validation** ([#332](https://github.com/zynax-io/zynax/issues/332)) — Add `cmd/zynax/cmd/validate.go` (parent Cobra command) and `cmd/zynax/validate/manifest.go`. Reads the `kind:` field from the target YAML, resolves `spec/schemas/<kind>.json`, validates using a Go JSON Schema library. Structured output: one error per line with file path and line number; `--format json` for machine-readable. Exits 0 on valid, 1 on errors. Verify: `GOWORK=off go test ./... -race` green; `zynax validate manifest spec/workflows/examples/code-review.yaml` exits 0.
+
+8. **`zynax validate canvas` — REASONS Canvas structural checker** ([#333](https://github.com/zynax-io/zynax/issues/333)) — Add `cmd/zynax/validate/canvas.go`. Parses a Markdown file; asserts all seven REASONS section headers (`R —`, `E —`, `A —`, `S —`, `O —`, `N —`, second `S —`) and a `**Status:**` line are present. Reports each missing section by name. Exits 0 if all present, 1 if any missing. Verify: `GOWORK=off go test ./...` green; `zynax validate canvas docs/spdd/314-yaml-system-cli/canvas.md` exits 0.
+
+9. **`zynax validate schema` — JSON schema meta-validator** ([#334](https://github.com/zynax-io/zynax/issues/334)) — Add `cmd/zynax/validate/schema.go`. Validates a JSON Schema document against the JSON Schema 2020-12 meta-schema using an established Go library. Exits 0 if valid, 1 with diagnostics if invalid. Verify: `GOWORK=off go test ./...` green; `zynax validate schema spec/schemas/workflow.json` exits 0.
+
+10. **CI: update Makefile and workflows to use `zynax validate`** ([#335](https://github.com/zynax-io/zynax/issues/335)) — Replace all `python3 tools/validate_*.py` invocations in `Makefile` and `.github/workflows/` with `zynax validate manifest`, `zynax validate canvas`, `zynax validate schema`. Ensure the `zynax` binary is built before any validate CI step. Verify: `make validate-spec` and `make validate-canvas` pass with no Python invocations; CI green end-to-end.
+
+11. **Remove Python validation scripts from `tools/`** ([#336](https://github.com/zynax-io/zynax/issues/336)) — Delete `tools/validate_canvas.py`, `tools/validate_manifest.py`, and any other Python-only validation scripts whose function is now covered by `zynax validate`. Update `tools/README.md` to reflect the change. Verify: `tools/` contains no Python validation scripts; `make validate-spec` and `make validate-canvas` still green after deletion; `make lint` clean.
 
 ---
 
@@ -209,7 +237,7 @@ Cross-cutting standards pulled from root `AGENTS.md`, `services/AGENTS.md`, and 
 - **Never** import domain types across services. `ApplyResult`, `KindRouter`, etc. are internal to `services/api-gateway/internal/`. The CLI communicates with the gateway via HTTP REST only (ADR-008).
 - **Never** hardcode an engine name (`"temporal"`) in `api-gateway` or the CLI. The `--engine` flag passes `engine_hint` to `SubmitWorkflowRequest`; the engine adapter selects the backend (ADR-015).
 - **Never** add new proto fields or new gRPC methods in M4. All M4 use cases are served by existing contracts. A proto change requires a separate proto review PR.
-- **Never** open a `feat:` PR without first verifying this Canvas is status `Aligned` (ADR-019). The human reviewer must change `Draft` → `Aligned` before any Step 2–6 code lands.
+- **Never** open a `feat:` PR without first verifying this Canvas is status `Aligned` (ADR-019). The human reviewer must change `Draft` → `Aligned` before any Step 2–11 code lands.
 - **Never** deploy agent containers from `kind: AgentDef apply`. Registration in the agent registry is the only M4 action — container scheduling is M6 (Kubernetes + Helm).
 - **Never** merge a PR where `make lint` or `make test` is red. All BDD scenarios in `api_gateway.feature` must pass before Step 1 is declared done.
 - **Never** route an unknown `kind:` value to any downstream service. The `KindRouter` allowlist (`{Workflow, AgentDef}`) must return `ErrUnknownKind` for any other value; the HTTP handler maps this to `400 Bad Request`.


### PR DESCRIPTION
## What changed

The M4 REASONS Canvas (`docs/spdd/314-yaml-system-cli/canvas.md`) has been updated via `/spdd-prompt-update` to incorporate **epic #331** and its five child step issues, which were added to the M4 milestone after the Canvas was originally aligned.

## Why

Epic #331 introduces `zynax validate` — a Go-native replacement for the Python validation scripts in `tools/`. These five new Operations steps were assigned to the M4 GitHub milestone but were not reflected in the Canvas, which would have caused `/spdd-generate` to refuse to generate code for them (status `Aligned` required, and the Canvas must describe the step).

## Sections updated

| Section | Change |
|---------|--------|
| **R** | Added missing-capability (5): Python-only scripts block binary distribution. Added four new DoD bullets for `zynax validate manifest/canvas/schema` and Makefile migration. |
| **E** | Added `ValidateCmd`, `ManifestValidator`, `CanvasValidator`, `SchemaValidator` with package paths and responsibilities. |
| **A** | Added "We will": replace Python scripts with Go in `cmd/zynax/validate/`. Added "We will NOT": no from-scratch JSON Schema spec implementation. |
| **S** | Added `cmd/validate.go` and `validate/` package to the structure tree. Added `tools/` deletion note for step 11. |
| **O** | Added steps 7–11 linked 1:1 to issues #332–#336 with verify criteria. |
| **S (Safeguards)** | Corrected stale "Step 2–6" reference to "Step 2–11". |

## Process followed

1. `/spdd-prompt-update docs/spdd/314-yaml-system-cli/canvas.md` — updated all six affected sections, reset status to `Draft`
2. `/spdd-security-review` — **PASS**: no Tier 2 content, no injection, no authority violations
3. Status set to `Aligned` after human review

## New Operations steps

| Step | Issue | Work |
|------|-------|------|
| 7 | #332 | `zynax validate manifest` — JSON schema validation |
| 8 | #333 | `zynax validate canvas` — REASONS Canvas structural checker |
| 9 | #334 | `zynax validate schema` — JSON Schema meta-validator |
| 10 | #335 | CI: swap Makefile + workflows to `zynax validate` |
| 11 | #336 | Chore: delete `tools/*.py` validation scripts |

Closes #314 (partial — canvas now covers full M4 scope)

Assisted-by: Claude/claude-sonnet-4-6