### PR TITLE
feat(cli): zynax gitops watch sub-command (#320)

### DIFF
--- a/cmd/zynax/cmd/gitops.go
+++ b/cmd/zynax/cmd/gitops.go
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/spf13/cobra"
+	"github.com/zynax-io/zynax/cmd/zynax/gitops"
+)
+
+var gitopsCmd = &cobra.Command{
+	Use:   "gitops",
+	Short: "GitOps sub-commands",
+}
+
+var gitopsWatchCmd = &cobra.Command{
+	Use:   "watch <dir>",
+	Short: "Watch a directory for YAML changes and re-apply them",
+	Long: `Watch <dir> recursively for YAML manifest changes.
+
+On each change zynax computes a SHA-256 of the file content and calls
+zynax apply only when the content has changed since the last run.
+State is persisted to <dir>/.zynax-watch.state so restarts are idempotent.
+
+Press Ctrl+C to stop (exits 0).`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		dir := args[0]
+		info, err := os.Stat(dir)
+		if err != nil {
+			return fmt.Errorf("watch: %w", err)
+		}
+		if !info.IsDir() {
+			return fmt.Errorf("watch: %q is not a directory", dir)
+		}
+
+		gw := newGateway()
+		applyFn := func(ctx context.Context, _ string, content []byte) (string, error) {
+			runID, _, _, err := gw.Apply(ctx, content, "")
+			if err != nil {
+				return "", err
+			}
+			return runID, nil
+		}
+
+		ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+		defer stop()
+
+		slog.Info("gitops: starting", "dir", dir, "api_url", apiURL)
+		w := gitops.New(dir, applyFn)
+		if err := w.Run(ctx); err != nil {
+			return err
+		}
+		return nil
+	},
+}
+
+func init() {
+	gitopsCmd.AddCommand(gitopsWatchCmd)
+	rootCmd.AddCommand(gitopsCmd)
+}

--- a/cmd/zynax/gitops/watcher.go
+++ b/cmd/zynax/gitops/watcher.go
@@ -1,0 +1,203 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package gitops implements the zynax gitops watch sub-command.
+// It watches a directory for YAML manifest changes and re-applies them
+// to the api-gateway when their content changes.
+package gitops
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+const stateFile = ".zynax-watch.state"
+
+// ApplyFunc is called when a YAML file should be re-applied.
+// It receives the file path and its content, and returns the run_id or agent_id.
+type ApplyFunc func(ctx context.Context, path string, content []byte) (string, error)
+
+// Watcher watches a directory tree for YAML changes and calls apply on each changed file.
+type Watcher struct {
+	dir   string
+	apply ApplyFunc
+	state map[string]string // path → sha256 hex
+}
+
+// New creates a Watcher for dir, using apply to submit changed manifests.
+func New(dir string, apply ApplyFunc) *Watcher {
+	return &Watcher{
+		dir:   dir,
+		apply: apply,
+		state: make(map[string]string),
+	}
+}
+
+// RunSync loads state and applies any changed YAML files once, then returns.
+// It is used in unit tests and by Run before entering the fsnotify loop.
+func (w *Watcher) RunSync(ctx context.Context) error {
+	if err := w.loadState(); err != nil {
+		return fmt.Errorf("gitops: load state: %w", err)
+	}
+	if err := w.syncAll(ctx); err != nil {
+		return err
+	}
+	return w.saveState()
+}
+
+// Run starts the watch loop. It blocks until ctx is cancelled (Ctrl+C → exit 0).
+func (w *Watcher) Run(ctx context.Context) error {
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return fmt.Errorf("gitops: create watcher: %w", err)
+	}
+	defer watcher.Close()
+
+	if err := w.addDirs(watcher); err != nil {
+		return err
+	}
+
+	// Apply any changed files that accumulated since last run.
+	if err := w.RunSync(ctx); err != nil {
+		return err
+	}
+
+	slog.Info("gitops: watching", "dir", w.dir, "state_file", stateFile)
+
+	for {
+		select {
+		case <-ctx.Done():
+			_ = w.saveState()
+			return nil
+
+		case event, ok := <-watcher.Events:
+			if !ok {
+				return nil
+			}
+			if !isYAML(event.Name) {
+				continue
+			}
+			if event.Has(fsnotify.Create) || event.Has(fsnotify.Write) {
+				w.applyFile(ctx, event.Name)
+			}
+			if event.Has(fsnotify.Remove) || event.Has(fsnotify.Rename) {
+				delete(w.state, event.Name)
+				_ = w.saveState()
+			}
+
+		case err, ok := <-watcher.Errors:
+			if !ok {
+				return nil
+			}
+			slog.Warn("gitops: watcher error", "err", err)
+		}
+	}
+}
+
+// applyFile hashes the file and calls apply only if the content changed.
+func (w *Watcher) applyFile(ctx context.Context, path string) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		slog.Warn("gitops: read file", "path", path, "err", err)
+		return
+	}
+
+	hash := hashContent(content)
+	if w.state[path] == hash {
+		slog.Debug("gitops: unchanged, skipping", "path", path)
+		return
+	}
+
+	start := time.Now()
+	id, err := w.apply(ctx, path, content)
+	if err != nil {
+		slog.Error("gitops: apply failed", "path", path, "err", err)
+		return
+	}
+
+	w.state[path] = hash
+	_ = w.saveState()
+	slog.Info("gitops: applied", "path", path, "id", id, "elapsed_ms", time.Since(start).Milliseconds())
+}
+
+// syncAll applies all YAML files in the watched directory that have changed
+// since the last run (compares against the persisted state file).
+func (w *Watcher) syncAll(ctx context.Context) error {
+	return filepath.WalkDir(w.dir, func(path string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() || !isYAML(path) {
+			return err
+		}
+		w.applyFile(ctx, path)
+		return nil
+	})
+}
+
+// addDirs registers the target directory and all subdirectories with the watcher.
+func (w *Watcher) addDirs(fw *fsnotify.Watcher) error {
+	return filepath.WalkDir(w.dir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if err := fw.Add(path); err != nil {
+				return fmt.Errorf("gitops: watch dir %q: %w", path, err)
+			}
+		}
+		return nil
+	})
+}
+
+// ── State persistence ─────────────────────────────────────────────────────
+
+func (w *Watcher) loadState() error {
+	statePath := filepath.Join(w.dir, stateFile)
+	f, err := os.Open(statePath)
+	if os.IsNotExist(err) {
+		return nil // first run — no state yet
+	}
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	return json.NewDecoder(f).Decode(&w.state)
+}
+
+func (w *Watcher) saveState() error {
+	statePath := filepath.Join(w.dir, stateFile)
+	f, err := os.CreateTemp(filepath.Dir(statePath), ".zynax-watch-tmp-")
+	if err != nil {
+		return err
+	}
+	tmpName := f.Name()
+	if err := json.NewEncoder(f).Encode(w.state); err != nil {
+		f.Close()
+		_ = os.Remove(tmpName)
+		return err
+	}
+	f.Close()
+	return os.Rename(tmpName, statePath)
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+func isYAML(path string) bool {
+	ext := strings.ToLower(filepath.Ext(path))
+	return ext == ".yaml" || ext == ".yml"
+}
+
+// hashContent returns a stable hex-encoded SHA-256 of content.
+func hashContent(content []byte) string {
+	h := sha256.New()
+	_, _ = io.WriteString(h, string(content))
+	return hex.EncodeToString(h.Sum(nil))
+}

--- a/cmd/zynax/gitops/watcher_test.go
+++ b/cmd/zynax/gitops/watcher_test.go
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package gitops_test
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/zynax-io/zynax/cmd/zynax/gitops"
+)
+
+// ── hashContent (via state round-trip) ────────────────────────────────────
+
+func TestWatcher_SkipsUnchangedFiles(t *testing.T) {
+	dir := t.TempDir()
+	content := []byte("kind: Workflow\n")
+	yamlPath := filepath.Join(dir, "wf.yaml")
+	if err := os.WriteFile(yamlPath, content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	calls := 0
+	applyFn := func(_ context.Context, _ string, _ []byte) (string, error) {
+		calls++
+		return "wf-test", nil
+	}
+
+	w := gitops.New(dir, applyFn)
+
+	// First sync — file is new → should apply.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := runSync(w, ctx); err != nil {
+		t.Fatal(err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected 1 apply call on first sync, got %d", calls)
+	}
+
+	// Second sync — file unchanged → should skip.
+	ctx2, cancel2 := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel2()
+	w2 := gitops.New(dir, applyFn) // new watcher reads persisted state
+	if err := runSync(w2, ctx2); err != nil {
+		t.Fatal(err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected 1 total apply calls after second sync (no change), got %d", calls)
+	}
+}
+
+func TestWatcher_ReappliesChangedFiles(t *testing.T) {
+	dir := t.TempDir()
+	yamlPath := filepath.Join(dir, "wf.yaml")
+	if err := os.WriteFile(yamlPath, []byte("kind: Workflow\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	calls := 0
+	applyFn := func(_ context.Context, _ string, _ []byte) (string, error) {
+		calls++
+		return "wf-test", nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	w := gitops.New(dir, applyFn)
+	if err := runSync(w, ctx); err != nil {
+		t.Fatal(err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected 1 apply on first sync, got %d", calls)
+	}
+
+	// Modify the file.
+	if err := os.WriteFile(yamlPath, []byte("kind: Workflow\nmetadata:\n  name: updated\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx2, cancel2 := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel2()
+	w2 := gitops.New(dir, applyFn)
+	if err := runSync(w2, ctx2); err != nil {
+		t.Fatal(err)
+	}
+	if calls != 2 {
+		t.Fatalf("expected 2 total apply calls after file change, got %d", calls)
+	}
+}
+
+func TestWatcher_IgnoresNonYAML(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("# docs\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "config.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	calls := 0
+	applyFn := func(_ context.Context, _ string, _ []byte) (string, error) {
+		calls++
+		return "wf-test", nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	w := gitops.New(dir, applyFn)
+	if err := runSync(w, ctx); err != nil {
+		t.Fatal(err)
+	}
+	if calls != 0 {
+		t.Fatalf("expected 0 apply calls for non-YAML files, got %d", calls)
+	}
+}
+
+func TestWatcher_StatePersisted(t *testing.T) {
+	dir := t.TempDir()
+	yamlPath := filepath.Join(dir, "wf.yaml")
+	if err := os.WriteFile(yamlPath, []byte("kind: Workflow\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	applyFn := func(_ context.Context, _ string, _ []byte) (string, error) {
+		return "wf-state-test", nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	gitops.New(dir, applyFn)
+	w := gitops.New(dir, applyFn)
+	if err := runSync(w, ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	// State file should exist and contain the YAML path.
+	stateData, err := os.ReadFile(filepath.Join(dir, ".zynax-watch.state"))
+	if err != nil {
+		t.Fatalf("state file not created: %v", err)
+	}
+	var state map[string]string
+	if err := json.Unmarshal(stateData, &state); err != nil {
+		t.Fatalf("state file not valid JSON: %v", err)
+	}
+	if _, ok := state[yamlPath]; !ok {
+		t.Errorf("expected %q in state, got keys: %v", yamlPath, state)
+	}
+}
+
+// runSync cancels ctx immediately after the initial sync completes to avoid
+// blocking on the fsnotify loop in unit tests.
+func runSync(w *gitops.Watcher, ctx context.Context) error {
+	syncCtx, syncCancel := context.WithCancel(ctx)
+	defer syncCancel()
+	return w.RunSync(syncCtx)
+}

--- a/cmd/zynax/go.mod
+++ b/cmd/zynax/go.mod
@@ -6,6 +6,8 @@ go 1.25.0
 require github.com/spf13/cobra v1.9.1
 
 require (
+	github.com/fsnotify/fsnotify v1.10.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
+	golang.org/x/sys v0.13.0 // indirect
 )

--- a/cmd/zynax/go.sum
+++ b/cmd/zynax/go.sum
@@ -1,4 +1,6 @@
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx59Ho=
+github.com/fsnotify/fsnotify v1.10.1/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
@@ -6,5 +8,7 @@ github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=
 github.com/spf13/cobra v1.9.1/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wxYW0=
 github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
 github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+golang.org/x/sys v0.13.0 h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=
+golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/spec/workflows/examples/ci-pipeline.yaml
+++ b/spec/workflows/examples/ci-pipeline.yaml
@@ -80,9 +80,9 @@ spec:
             environment: "staging"
           timeout: 20m
       on:
-        - event: integration_tests.passed
+        - event: integration.passed
           goto: done
-        - event: integration_tests.failed
+        - event: integration.failed
           goto: rollback
 
     rollback:

--- a/spec/workflows/examples/research-task.yaml
+++ b/spec/workflows/examples/research-task.yaml
@@ -48,7 +48,7 @@ spec:
         - event: search.completed
           goto: summarize
 
-        - event: search.no_results
+        - event: search.noresults
           goto: abandon
           set:
             context.abandon_reason: "No results found for topic"


### PR DESCRIPTION
## Summary

- Adds \`zynax gitops watch <dir>\` sub-command (closes #320)
- \`gitops.Watcher\` uses \`fsnotify\` to monitor a directory tree recursively
- Content-hash tracking (SHA-256) in \`<dir>/.zynax-watch.state\` — unchanged files are skipped on restart
- Atomic state persistence via \`os.Rename(tmpfile)\` — crash-safe
- \`Ctrl+C\` → graceful shutdown, exit 0
- Exported \`RunSync()\` method enables unit testing without the fsnotify event loop
- Fixes invalid \`event_type\` names in \`ci-pipeline.yaml\` and \`research-task.yaml\` (underscores not allowed within segments — same class of bug already fixed in \`code-review.yaml\`)

## Test plan

- [x] **Unit tests pass:** \`cd cmd/zynax && GOWORK=off go test ./gitops/... -race\`

  ```
  === RUN   TestWatcher_SkipsUnchangedFiles
  --- PASS: TestWatcher_SkipsUnchangedFiles (0.00s)
  === RUN   TestWatcher_ReappliesChangedFiles
  --- PASS: TestWatcher_ReappliesChangedFiles (0.00s)
  === RUN   TestWatcher_IgnoresNonYAML
  --- PASS: TestWatcher_IgnoresNonYAML (0.00s)
  === RUN   TestWatcher_StatePersisted
  --- PASS: TestWatcher_StatePersisted (0.00s)
  ok    github.com/zynax-io/zynax/cmd/zynax/gitops  1.008s
  ```

- [x] **Build compiles cleanly:** \`cd cmd/zynax && GOWORK=off go build ./...\` — no output, exit 0

- [x] **\`zynax gitops watch --help\` shows usage:**

  ```
  Watch <dir> recursively for YAML manifest changes.

  On each change zynax computes a SHA-256 of the file content and calls
  zynax apply only when the content has changed since the last run.
  State is persisted to <dir>/.zynax-watch.state so restarts are idempotent.

  Press Ctrl+C to stop (exits 0).

  Usage:
    zynax gitops watch <dir> [flags]

  Flags:
    -h, --help   help for watch

  Global Flags:
        --api-url string   api-gateway base URL ($ZYNAX_API_URL) (default "http://localhost:8080")
        --insecure         skip TLS certificate verification
  ```

- [x] **\`make run-local\` → \`zynax gitops watch\` → file change → re-apply triggered:**

  Initial sync (first run):
  ```
  INFO gitops: starting dir=…/spec/workflows/examples/ api_url=http://localhost:7080
  INFO gitops: applied path=…/code-review.yaml id=wf-b9db07dc5a7c0826 elapsed_ms=17
  INFO gitops: watching dir=…/spec/workflows/examples/ state_file=.zynax-watch.state
  ```

  After editing \`code-review.yaml\` (renamed workflow to \`code-review-workflow-v2\`):
  ```
  INFO gitops: applied path=…/code-review.yaml id=wf-120dbe009bf7917c elapsed_ms=5
  ```
  New \`run_id\` confirms the file was detected and re-applied.

- [x] **Restart without modifying files → idempotent (zero apply calls for unchanged file):**

  Watcher killed and restarted with no file changes — \`code-review.yaml\` absent from log, hash matched persisted state, skipped as expected.

- [x] **\`ci-pipeline.yaml\` dry-run passes after fix:**

  ```
  zynax apply --dry-run spec/workflows/examples/ci-pipeline.yaml
  ok (dry-run: no errors)
  ```
  Fixed: \`integration_tests.passed\` → \`integration.passed\`, \`integration_tests.failed\` → \`integration.failed\`

- [x] **\`research-task.yaml\` dry-run passes after fix:**

  ```
  zynax apply --dry-run spec/workflows/examples/research-task.yaml
  ok (dry-run: no errors)
  ```
  Fixed: \`search.no_results\` → \`search.noresults\`

> Note: \`agent-def-example.yaml\` (HTTP 500) and \`policy-example.yaml\` (HTTP 400 UNSUPPORTED_KIND) are not regressions — \`agent-registry\` is an M5 service not yet deployed, and \`Policy\` enforcement is scoped to M6. Both are explicitly documented in the Docker Compose comments.

Assisted-by: Claude/claude-sonnet-4-6