### PR TITLE
feat(cli): zynax validate manifest — local JSON schema validation (#332)

### DIFF
--- a/cmd/zynax/cmd/validate.go
+++ b/cmd/zynax/cmd/validate.go
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/zynax-io/zynax/cmd/zynax/validate"
+)
+
+var validateCmd = &cobra.Command{
+	Use:   "validate",
+	Short: "Validate manifests, Canvases, and JSON Schemas",
+}
+
+var (
+	validateSchemaDir string
+	validateFormat    string
+)
+
+var validateManifestCmd = &cobra.Command{
+	Use:   "manifest <file>",
+	Short: "Validate a YAML manifest against its JSON schema",
+	Long: `Validate <file> against the JSON Schema for its kind.
+
+The kind is read from the 'kind:' field in the YAML. The matching schema is
+loaded from <schema-dir>/<kind>.schema.json. Supported kinds: Workflow, AgentDef, Policy.
+
+Exits 0 on success, 1 on any validation error.`,
+	Args: cobra.ExactArgs(1),
+	RunE: runValidateManifest,
+}
+
+func init() {
+	validateManifestCmd.Flags().StringVar(&validateSchemaDir, "schema-dir", "spec/schemas",
+		"directory containing <kind>.schema.json files")
+	validateManifestCmd.Flags().StringVar(&validateFormat, "format", "text",
+		"output format: text or json")
+	validateCmd.AddCommand(validateManifestCmd)
+	rootCmd.AddCommand(validateCmd)
+}
+
+func runValidateManifest(cmd *cobra.Command, args []string) error {
+	file := args[0]
+	errs, err := validate.Manifest(file, validateSchemaDir)
+	if err != nil {
+		return err
+	}
+	if validateFormat == "json" {
+		return printValidateJSON(cmd, errs)
+	}
+	return printValidateText(cmd, file, errs)
+}
+
+func printValidateText(cmd *cobra.Command, file string, errs []validate.ValidationError) error {
+	if len(errs) == 0 {
+		fmt.Fprintf(cmd.OutOrStdout(), "ok: %s\n", file)
+		return nil
+	}
+	for _, e := range errs {
+		fmt.Fprintln(cmd.ErrOrStderr(), e.Error())
+	}
+	return fmt.Errorf("validation failed with %d error(s)", len(errs))
+}
+
+func printValidateJSON(cmd *cobra.Command, errs []validate.ValidationError) error {
+	if errs == nil {
+		errs = []validate.ValidationError{}
+	}
+	enc := json.NewEncoder(cmd.OutOrStdout())
+	enc.SetIndent("", "  ")
+	_ = enc.Encode(errs)
+	if len(errs) > 0 {
+		return fmt.Errorf("validation failed with %d error(s)", len(errs))
+	}
+	return nil
+}

--- a/cmd/zynax/go.mod
+++ b/cmd/zynax/go.mod
@@ -8,6 +8,8 @@ require github.com/spf13/cobra v1.9.1
 require (
 	github.com/fsnotify/fsnotify v1.10.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
 	golang.org/x/sys v0.13.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/cmd/zynax/go.sum
+++ b/cmd/zynax/go.sum
@@ -4,6 +4,8 @@ github.com/fsnotify/fsnotify v1.10.1/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxv
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 h1:lZUw3E0/J3roVtGQ+SCrUrg3ON6NgVqpn3+iol9aGu4=
+github.com/santhosh-tekuri/jsonschema/v5 v5.3.1/go.mod h1:uToXkOrWAZ6/Oc07xWQrPOhJotwFIyu2bBVN41fcDUY=
 github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=
 github.com/spf13/cobra v1.9.1/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wxYW0=
 github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
@@ -11,4 +13,5 @@ github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 golang.org/x/sys v0.13.0 h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=
 golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/cmd/zynax/validate/manifest.go
+++ b/cmd/zynax/validate/manifest.go
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package validate provides local validation for Zynax manifests,
+// REASONS Canvases, and JSON Schema documents.
+package validate
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/santhosh-tekuri/jsonschema/v5"
+	"gopkg.in/yaml.v3"
+)
+
+// ValidationError is a single schema validation failure.
+type ValidationError struct {
+	File    string `json:"file"`
+	Path    string `json:"path,omitempty"` // JSON Pointer to the failing element
+	Message string `json:"message"`
+}
+
+func (e ValidationError) Error() string {
+	if e.Path != "" {
+		return fmt.Sprintf("%s: at %s: %s", e.File, e.Path, e.Message)
+	}
+	return fmt.Sprintf("%s: %s", e.File, e.Message)
+}
+
+// Manifest validates the YAML manifest at filePath against the JSON Schema
+// for its kind. schemaDir is the directory containing <kind>.schema.json
+// files (default: "spec/schemas" relative to CWD).
+//
+// Returns (nil, nil) on success; ([errors…], nil) on schema violations;
+// (nil, err) on I/O or structural failures.
+func Manifest(filePath, schemaDir string) ([]ValidationError, error) {
+	raw, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("validate: read %q: %w", filePath, err)
+	}
+
+	var doc interface{}
+	if err := yaml.Unmarshal(raw, &doc); err != nil {
+		return single(filePath, "", "YAML parse error: "+err.Error()), nil
+	}
+
+	m, ok := doc.(map[string]interface{})
+	if !ok {
+		return single(filePath, "", "manifest must be a YAML mapping"), nil
+	}
+
+	kind, _ := m["kind"].(string)
+	if kind == "" {
+		return single(filePath, "/kind", "missing or empty 'kind' field"), nil
+	}
+
+	schemaFile, err := kindToSchemaFile(kind)
+	if err != nil {
+		return single(filePath, "/kind", err.Error()), nil
+	}
+
+	absSchema, err := filepath.Abs(filepath.Join(schemaDir, schemaFile))
+	if err != nil {
+		return nil, fmt.Errorf("validate: resolve schema path: %w", err)
+	}
+
+	sch, err := compileSchema(absSchema)
+	if err != nil {
+		return nil, fmt.Errorf("validate: compile schema %q: %w", absSchema, err)
+	}
+
+	jsonBytes, err := json.Marshal(normalise(doc))
+	if err != nil {
+		return nil, fmt.Errorf("validate: marshal to JSON: %w", err)
+	}
+
+	var instance interface{}
+	if err := json.Unmarshal(jsonBytes, &instance); err != nil {
+		return nil, fmt.Errorf("validate: unmarshal JSON: %w", err)
+	}
+
+	if err := sch.Validate(instance); err != nil {
+		var ve *jsonschema.ValidationError
+		if errors.As(err, &ve) {
+			return flattenErrors(filePath, ve), nil
+		}
+		return nil, fmt.Errorf("validate: %w", err)
+	}
+	return nil, nil
+}
+
+// compileSchema compiles a JSON Schema from an absolute file path.
+func compileSchema(absPath string) (*jsonschema.Schema, error) {
+	c := jsonschema.NewCompiler()
+	c.Draft = jsonschema.Draft2020
+	return c.Compile("file://" + absPath)
+}
+
+// flattenErrors collects leaf validation errors from the error tree.
+func flattenErrors(file string, ve *jsonschema.ValidationError) []ValidationError {
+	if len(ve.Causes) == 0 {
+		return single(file, ve.InstanceLocation, ve.Message)
+	}
+	var out []ValidationError
+	for _, c := range ve.Causes {
+		out = append(out, flattenErrors(file, c)...)
+	}
+	return out
+}
+
+// normalise converts map[interface{}]interface{} (yaml.v3 edge case) to
+// map[string]interface{} so json.Marshal succeeds on all valid YAML.
+func normalise(v interface{}) interface{} {
+	switch val := v.(type) {
+	case map[string]interface{}:
+		out := make(map[string]interface{}, len(val))
+		for k, v2 := range val {
+			out[k] = normalise(v2)
+		}
+		return out
+	case map[interface{}]interface{}:
+		out := make(map[string]interface{}, len(val))
+		for k, v2 := range val {
+			out[fmt.Sprintf("%v", k)] = normalise(v2)
+		}
+		return out
+	case []interface{}:
+		out := make([]interface{}, len(val))
+		for i, v2 := range val {
+			out[i] = normalise(v2)
+		}
+		return out
+	default:
+		return val
+	}
+}
+
+// kindToSchemaFile maps a manifest kind to its JSON Schema filename.
+func kindToSchemaFile(kind string) (string, error) {
+	switch kind {
+	case "Workflow":
+		return "workflow.schema.json", nil
+	case "AgentDef":
+		return "agent-def.schema.json", nil
+	case "Policy":
+		return "policy.schema.json", nil
+	default:
+		return "", fmt.Errorf("no JSON schema for kind %q — supported: Workflow, AgentDef, Policy", kind)
+	}
+}
+
+func single(file, path, msg string) []ValidationError {
+	return []ValidationError{{File: file, Path: path, Message: msg}}
+}

--- a/cmd/zynax/validate/manifest_test.go
+++ b/cmd/zynax/validate/manifest_test.go
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package validate_test
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/zynax-io/zynax/cmd/zynax/validate"
+)
+
+// repoSchemaDir resolves spec/schemas/ relative to this source file,
+// so tests work regardless of the CWD they are invoked from.
+func repoSchemaDir() string {
+	_, file, _, _ := runtime.Caller(0)
+	// file = cmd/zynax/validate/manifest_test.go (absolute)
+	// three levels up reaches the repo root
+	return filepath.Join(filepath.Dir(file), "../../../spec/schemas")
+}
+
+func TestManifest_ValidWorkflow(t *testing.T) {
+	_, file, _, _ := runtime.Caller(0)
+	fixture := filepath.Join(filepath.Dir(file), "../../../spec/workflows/examples/code-review.yaml")
+
+	errs, err := validate.Manifest(fixture, repoSchemaDir())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(errs) != 0 {
+		for _, e := range errs {
+			t.Errorf("unexpected validation error: %s", e)
+		}
+	}
+}
+
+func TestManifest_ValidAgentDef(t *testing.T) {
+	_, file, _, _ := runtime.Caller(0)
+	fixture := filepath.Join(filepath.Dir(file), "../../../spec/workflows/examples/agent-def-example.yaml")
+
+	errs, err := validate.Manifest(fixture, repoSchemaDir())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(errs) != 0 {
+		for _, e := range errs {
+			t.Errorf("unexpected validation error: %s", e)
+		}
+	}
+}
+
+func TestManifest_MissingRequiredField(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "bad.yaml")
+	// Missing 'spec' — required by the Workflow schema.
+	if err := os.WriteFile(f, []byte("kind: Workflow\napiVersion: zynax.io/v1\nmetadata:\n  name: x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	errs, err := validate.Manifest(f, repoSchemaDir())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(errs) == 0 {
+		t.Fatal("expected validation errors for missing 'spec', got none")
+	}
+}
+
+func TestManifest_UnknownKind(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "unknown.yaml")
+	if err := os.WriteFile(f, []byte("kind: Unknown\napiVersion: zynax.io/v1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	errs, err := validate.Manifest(f, repoSchemaDir())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(errs) == 0 {
+		t.Fatal("expected error for unknown kind, got none")
+	}
+	if errs[0].Path != "/kind" {
+		t.Errorf("expected error path '/kind', got %q", errs[0].Path)
+	}
+}
+
+func TestManifest_MissingKind(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "nokind.yaml")
+	if err := os.WriteFile(f, []byte("apiVersion: zynax.io/v1\nmetadata:\n  name: x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	errs, err := validate.Manifest(f, repoSchemaDir())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(errs) == 0 {
+		t.Fatal("expected error for missing kind, got none")
+	}
+}
+
+func TestManifest_InvalidYAML(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "broken.yaml")
+	if err := os.WriteFile(f, []byte(":\t invalid yaml {{{"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	errs, err := validate.Manifest(f, repoSchemaDir())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(errs) == 0 {
+		t.Fatal("expected error for invalid YAML, got none")
+	}
+}
+
+func TestManifest_FileNotFound(t *testing.T) {
+	_, err := validate.Manifest("/nonexistent/path/manifest.yaml", repoSchemaDir())
+	if err == nil {
+		t.Fatal("expected error for missing file, got nil")
+	}
+}


### PR DESCRIPTION
## Summary

- Adds \`zynax validate manifest <file>\` sub-command (closes #332)
- Reads the \`kind:\` field from the YAML manifest
- Resolves \`spec/schemas/<kind>.schema.json\` (Workflow, AgentDef, Policy)
- Validates using \`santhosh-tekuri/jsonschema/v5\` (JSON Schema 2020-12)
- Exits 0 on success, 1 on any violation; structured errors with JSON Pointer paths
- \`--format json\` for machine-readable output
- \`--schema-dir\` flag (default: \`spec/schemas\` relative to CWD)
- Sets up the \`zynax validate\` parent Cobra command for Steps 8–9 (canvas, schema)

## Test plan

- [x] **Unit tests pass:** \`cd cmd/zynax && GOWORK=off go test ./validate/... -race\`

  ```
  === RUN   TestManifest_ValidWorkflow
  --- PASS: TestManifest_ValidWorkflow (0.01s)
  === RUN   TestManifest_ValidAgentDef
  --- PASS: TestManifest_ValidAgentDef (0.01s)
  === RUN   TestManifest_MissingRequiredField
  --- PASS: TestManifest_MissingRequiredField (0.00s)
  === RUN   TestManifest_UnknownKind
  --- PASS: TestManifest_UnknownKind (0.00s)
  === RUN   TestManifest_MissingKind
  --- PASS: TestManifest_MissingKind (0.00s)
  === RUN   TestManifest_InvalidYAML
  --- PASS: TestManifest_InvalidYAML (0.00s)
  === RUN   TestManifest_FileNotFound
  --- PASS: TestManifest_FileNotFound (0.00s)
  PASS
  ok    github.com/zynax-io/zynax/cmd/zynax/validate
  ```

- [x] **Build compiles cleanly:** \`cd cmd/zynax && GOWORK=off go build ./...\` — no output, exit 0

- [x] **\`zynax validate manifest --help\` shows usage:**

  ```
  Validate <file> against the JSON Schema for its kind.

  The kind is read from the 'kind:' field in the YAML. The matching schema is
  loaded from <schema-dir>/<kind>.schema.json. Supported kinds: Workflow, AgentDef, Policy.

  Exits 0 on success, 1 on any validation error.

  Usage:
    zynax validate manifest <file> [flags]

  Flags:
        --format string       output format: text or json (default "text")
    -h, --help                help for manifest
        --schema-dir string   directory containing <kind>.schema.json files (default "spec/schemas")

  Global Flags:
        --api-url string   api-gateway base URL ($ZYNAX_API_URL) (default "http://localhost:8080")
        --insecure         skip TLS certificate verification
  ```

- [x] **\`zynax validate manifest spec/workflows/examples/code-review.yaml\` exits 0:**

  ```
  ok: spec/workflows/examples/code-review.yaml
  exit: 0
  ```

- [x] **\`zynax validate manifest spec/workflows/examples/agent-def-example.yaml\` exits 0:**

  ```
  ok: spec/workflows/examples/agent-def-example.yaml
  exit: 0
  ```

- [x] **Manifest missing required field exits 1 with structured error:**

  Input: YAML with \`kind: Workflow\` but no \`spec\` block.
  ```
  /tmp/bad.yaml: missing properties: 'spec'
  Error: validation failed with 1 error(s)
  exit: 1
  ```

- [x] **\`--format json\` outputs valid JSON array of errors:**

  ```json
  [
    {
      "file": "/tmp/bad.yaml",
      "message": "missing properties: 'spec'"
    }
  ]
  Error: validation failed with 1 error(s)
  exit: 1
  ```

Assisted-by: Claude/claude-sonnet-4-6