### PR TITLE
feat(cli): zynax validate canvas — REASONS Canvas structural checker (#333)

### DIFF
--- a/cmd/zynax/cmd/validate.go
+++ b/cmd/zynax/cmd/validate.go
@@ -33,13 +33,41 @@ Exits 0 on success, 1 on any validation error.`,
 	RunE: runValidateManifest,
 }
 
+var validateCanvasCmd = &cobra.Command{
+	Use:   "canvas <file>",
+	Short: "Validate a REASONS Canvas for structural completeness",
+	Long: `Validate <file> for all seven REASONS section headers and a **Status:** field.
+
+Required sections: R — Requirements, E — Entities, A — Approach, S — Structure,
+O — Operations, N — Norms, S — Safeguards (two S sections required).
+
+Exits 0 if all sections present, 1 if any are missing.`,
+	Args: cobra.ExactArgs(1),
+	RunE: runValidateCanvas,
+}
+
 func init() {
 	validateManifestCmd.Flags().StringVar(&validateSchemaDir, "schema-dir", "spec/schemas",
 		"directory containing <kind>.schema.json files")
 	validateManifestCmd.Flags().StringVar(&validateFormat, "format", "text",
 		"output format: text or json")
+	validateCanvasCmd.Flags().StringVar(&validateFormat, "format", "text",
+		"output format: text or json")
 	validateCmd.AddCommand(validateManifestCmd)
+	validateCmd.AddCommand(validateCanvasCmd)
 	rootCmd.AddCommand(validateCmd)
+}
+
+func runValidateCanvas(cmd *cobra.Command, args []string) error {
+	file := args[0]
+	errs, err := validate.Canvas(file)
+	if err != nil {
+		return err
+	}
+	if validateFormat == "json" {
+		return printValidateJSON(cmd, errs)
+	}
+	return printValidateText(cmd, file, errs)
 }
 
 func runValidateManifest(cmd *cobra.Command, args []string) error {

--- a/cmd/zynax/validate/canvas.go
+++ b/cmd/zynax/validate/canvas.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package validate
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// sectionCheck is a single structural requirement for a REASONS Canvas.
+type sectionCheck struct {
+	prefix   string // Markdown heading prefix to detect (e.g. "## R —")
+	name     string // human-readable label for error messages
+	minCount int    // minimum required occurrences
+}
+
+// canvasSections lists all 7 required REASONS sections plus the second S.
+// The two "## S —" entries enforce both Structure (≥1) and Safeguards (≥2).
+var canvasSections = []sectionCheck{
+	{"## R —", "R — Requirements", 1},
+	{"## E —", "E — Entities", 1},
+	{"## A —", "A — Approach", 1},
+	{"## S —", "S — Structure", 1},
+	{"## O —", "O — Operations", 1},
+	{"## N —", "N — Norms", 1},
+	{"## S —", "S — Safeguards (second S —)", 2},
+}
+
+const statusMarker = "**Status:**"
+
+// Canvas validates that a Markdown file contains all seven REASONS section
+// headers and a **Status:** field. Reports each missing element by name.
+//
+// Returns (nil, nil) on success; ([errors…], nil) on structural failures;
+// (nil, err) on I/O errors.
+func Canvas(filePath string) ([]ValidationError, error) {
+	counts, hasStatus, err := scanCanvasFile(filePath)
+	if err != nil {
+		return nil, err
+	}
+	return buildCanvasErrors(filePath, counts, hasStatus), nil
+}
+
+// scanCanvasFile reads the Markdown file and counts section header occurrences.
+func scanCanvasFile(filePath string) (counts map[string]int, hasStatus bool, err error) {
+	f, err := os.Open(filePath)
+	if err != nil {
+		return nil, false, fmt.Errorf("validate: read %q: %w", filePath, err)
+	}
+	defer f.Close()
+
+	counts = make(map[string]int)
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.Contains(line, statusMarker) {
+			hasStatus = true
+		}
+		trimmed := strings.TrimSpace(line)
+		for _, sec := range canvasSections {
+			if strings.HasPrefix(trimmed, sec.prefix) {
+				counts[sec.prefix]++
+				break
+			}
+		}
+	}
+	return counts, hasStatus, scanner.Err()
+}
+
+// buildCanvasErrors compares observed counts against requirements.
+func buildCanvasErrors(filePath string, counts map[string]int, hasStatus bool) []ValidationError {
+	var errs []ValidationError
+	for _, sec := range canvasSections {
+		if counts[sec.prefix] < sec.minCount {
+			errs = append(errs, ValidationError{
+				File:    filePath,
+				Message: "missing section: " + sec.name,
+			})
+		}
+	}
+	if !hasStatus {
+		errs = append(errs, ValidationError{
+			File:    filePath,
+			Message: "missing **Status:** field",
+		})
+	}
+	return errs
+}

--- a/cmd/zynax/validate/canvas_test.go
+++ b/cmd/zynax/validate/canvas_test.go
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package validate_test
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/zynax-io/zynax/cmd/zynax/validate"
+)
+
+// fullCanvas is a minimal but structurally complete REASONS Canvas.
+const fullCanvas = `# REASONS Canvas — Test
+
+**Status:** Aligned
+
+## R — Requirements
+content
+
+## E — Entities
+content
+
+## A — Approach
+content
+
+## S — Structure
+content
+
+## O — Operations
+content
+
+## N — Norms
+content
+
+## S — Safeguards
+content
+`
+
+func TestCanvas_ValidCanvas(t *testing.T) {
+	f := writeTempMD(t, fullCanvas)
+	errs, err := validate.Canvas(f)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(errs) != 0 {
+		for _, e := range errs {
+			t.Errorf("unexpected error: %s", e)
+		}
+	}
+}
+
+func TestCanvas_RealCanvas(t *testing.T) {
+	_, file, _, _ := runtime.Caller(0)
+	canvas := filepath.Join(filepath.Dir(file), "../../../docs/spdd/314-yaml-system-cli/canvas.md")
+	errs, err := validate.Canvas(canvas)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(errs) != 0 {
+		for _, e := range errs {
+			t.Errorf("real canvas failed: %s", e)
+		}
+	}
+}
+
+func TestCanvas_MissingStatus(t *testing.T) {
+	content := strings.ReplaceAll(fullCanvas, "**Status:** Aligned\n", "")
+	f := writeTempMD(t, content)
+	errs, err := validate.Canvas(f)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertContainsMessage(t, errs, "**Status:**")
+}
+
+func TestCanvas_MissingRSection(t *testing.T) {
+	content := strings.ReplaceAll(fullCanvas, "## R — Requirements\n", "")
+	f := writeTempMD(t, content)
+	errs, err := validate.Canvas(f)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertContainsMessage(t, errs, "R — Requirements")
+}
+
+func TestCanvas_MissingSecondS(t *testing.T) {
+	// Remove the Safeguards S section (second ## S —).
+	// The first ## S — (Structure) remains, so count == 1.
+	content := strings.ReplaceAll(fullCanvas, "## S — Safeguards\n", "")
+	f := writeTempMD(t, content)
+	errs, err := validate.Canvas(f)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertContainsMessage(t, errs, "Safeguards")
+}
+
+func TestCanvas_BothSMissing(t *testing.T) {
+	content := strings.ReplaceAll(fullCanvas, "## S — Structure\n", "")
+	content = strings.ReplaceAll(content, "## S — Safeguards\n", "")
+	f := writeTempMD(t, content)
+	errs, err := validate.Canvas(f)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Both Structure and Safeguards should be reported.
+	assertContainsMessage(t, errs, "S — Structure")
+	assertContainsMessage(t, errs, "Safeguards")
+}
+
+func TestCanvas_MultipleMissing(t *testing.T) {
+	content := strings.ReplaceAll(fullCanvas, "## N — Norms\n", "")
+	content = strings.ReplaceAll(content, "## O — Operations\n", "")
+	f := writeTempMD(t, content)
+	errs, err := validate.Canvas(f)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertContainsMessage(t, errs, "N — Norms")
+	assertContainsMessage(t, errs, "O — Operations")
+}
+
+func TestCanvas_FileNotFound(t *testing.T) {
+	_, err := validate.Canvas("/nonexistent/canvas.md")
+	if err == nil {
+		t.Fatal("expected error for missing file, got nil")
+	}
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+func writeTempMD(t *testing.T, content string) string {
+	t.Helper()
+	f := filepath.Join(t.TempDir(), "canvas.md")
+	if err := os.WriteFile(f, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return f
+}
+
+func assertContainsMessage(t *testing.T, errs []validate.ValidationError, substr string) {
+	t.Helper()
+	for _, e := range errs {
+		if strings.Contains(e.Message, substr) {
+			return
+		}
+	}
+	t.Errorf("expected an error containing %q; got: %v", substr, errs)
+}


### PR DESCRIPTION
## Summary

- Adds \`zynax validate canvas <file>\` sub-command (closes #333)
- Checks all seven REASONS section headers: R, E, A, S (Structure), O, N, S (Safeguards)
- The dual-S rule requires \`## S —\` to appear at least twice
- Checks for \`**Status:**\` field presence
- Reports each missing element by name; exits 0 on success, 1 on any failure
- \`--format json\` for machine-readable output

## Test plan

- [ ] Unit tests pass: \`cd cmd/zynax && GOWORK=off go test ./validate/... -race\`
- [ ] Build compiles cleanly: \`cd cmd/zynax && GOWORK=off go build ./...\`
- [ ] \`zynax validate canvas --help\` shows usage
- [ ] \`zynax validate canvas docs/spdd/314-yaml-system-cli/canvas.md\` exits 0
- [ ] Partial canvas (missing sections) exits 1 and names each missing section
- [ ] \`--format json\` outputs valid JSON array

Assisted-by: Claude/claude-sonnet-4-6