### PR TITLE
feat(zynax-ci): module scaffold + validate canvas (#333)

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -309,7 +309,7 @@ jobs:
 # Rules (ADR-019):
 #   - feat: PRs must include at least one docs/spdd/**/canvas.md in the diff
 #     OR have an existing canvas.md anywhere under docs/spdd/.
-#   - Any canvas touched by this PR is validated with tools/validate_canvas.py.
+#   - Any canvas touched by this PR is validated with zynax-ci validate canvas.
 #   - Draft status emits a warning but does not fail (Aligned is enforced by
 #     /spdd-generate at code-generation time, not at PR open time).
   canvas-freshness:
@@ -365,10 +365,14 @@ jobs:
             find docs/spdd -name "canvas.md"
           fi
 
-      - name: Set up Python for canvas validation
-        uses: actions/setup-python@v5
+      - name: Set up Go for zynax-ci
+        uses: actions/setup-go@v5
         with:
-          python-version: "3.12"
+          go-version: "1.25"
+          cache-dependency-path: cmd/zynax-ci/go.sum
+
+      - name: Build zynax-ci
+        run: cd cmd/zynax-ci && GOWORK=off go build -o /usr/local/bin/zynax-ci .
 
       - name: Validate touched canvases
         env:
@@ -389,12 +393,12 @@ jobs:
             for canvas in $canvas_in_pr; do
               dir=$(dirname "$canvas")
               echo "Validating $canvas ..."
-              python tools/validate_canvas.py "$dir" || failed=1
+              zynax-ci validate canvas "$dir" || failed=1
             done
             exit $failed
           else
             echo "No canvas in this PR diff — running validate-canvas on all existing canvases..."
-            python tools/validate_canvas.py docs/spdd/
+            zynax-ci validate canvas docs/spdd/
           fi
 
 # ── Secret Scan (gitleaks) ────────────────────────────────────────────────────

--- a/cmd/zynax-ci/AGENTS.md
+++ b/cmd/zynax-ci/AGENTS.md
@@ -1,0 +1,76 @@
+# AGENTS.md — cmd/zynax-ci/
+
+The `zynax-ci` CLI is a **standalone Go module** (`github.com/zynax-io/zynax/cmd/zynax-ci`).
+It is the CI and developer toolchain for Zynax — it replaces all Python validation scripts
+in `tools/` and `count-ai-context.sh`. It has no dependency on the `zynax` operational CLI,
+the api-gateway, or any platform services.
+
+---
+
+## Module Rules
+
+- This module is **not** in `go.work`. Always use `GOWORK=off` for every `go` command here.
+- Depends only on `github.com/spf13/cobra` and the standard library.
+- No gRPC, no HTTP client, no platform service imports.
+
+## Layout
+
+```
+cmd/zynax-ci/
+  main.go                  entry point — calls cmd.Execute()
+  go.mod / go.sum          standalone module (GOWORK=off)
+  AGENTS.md                this file
+  cmd/
+    root.go                root command, Version variable
+    validate.go            validate parent command
+    validate_canvas.go     zynax-ci validate canvas <path>
+    validate_schema.go     zynax-ci validate schema <file>         [step 9]
+    validate_workflows.go  zynax-ci validate workflows <dir>       [step 9]
+    validate_agent_defs.go zynax-ci validate agent-defs <dir>      [step 9]
+    validate_capabilities.go                                        [step 9]
+    validate_policies.go                                            [step 9]
+    check_ai_context.go    zynax-ci check ai-context               [step 9]
+  validate/
+    canvas.go              Canvas validator (full port of tools/validate_canvas.py)
+    canvas_test.go
+    schema.go              [step 9]
+    manifest.go            [step 9]
+    capabilities.go        [step 9]
+  check/
+    context.go             [step 9]
+```
+
+## Hard Constraints
+
+- **No platform service imports** — no gRPC, no api-gateway client, no cross-service types.
+- **No `os.Exit` outside `cmd.Execute()`** — return errors up to Cobra.
+- **No `panic`** — return errors; never crash.
+- **GOWORK=off** for all `go` commands inside this directory.
+- **Exit codes:** 0 = all valid · 1 = validation errors found.
+- Warnings (e.g., Draft status) are printed but do not cause exit 1.
+
+## Build & Install
+
+```bash
+# Build:
+cd cmd/zynax-ci && GOWORK=off go build -o zynax-ci .
+
+# Install to ~/bin:
+cd cmd/zynax-ci && GOWORK=off go build -o ~/bin/zynax-ci .
+
+# Or via Makefile (step 10):
+make install-ci-tools
+```
+
+## Testing
+
+```bash
+cd cmd/zynax-ci && GOWORK=off go test ./... -race -timeout 60s
+```
+
+## Adding a New Sub-Command
+
+1. Add `cmd/zynax-ci/cmd/<name>.go` with a `var <name>Cmd = &cobra.Command{...}`.
+2. Register it in `init()` under the correct parent: `validateCmd.AddCommand(...)` or `rootCmd.AddCommand(...)`.
+3. Add any new validation logic to `validate/<name>.go` or `check/<name>.go`.
+4. Add tests alongside the logic file.

--- a/cmd/zynax-ci/cmd/root.go
+++ b/cmd/zynax-ci/cmd/root.go
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// Version is set at build time via -ldflags "-X ...cmd.Version=v0.3.0".
+var Version = "dev"
+
+var rootCmd = &cobra.Command{
+	Use:          "zynax-ci",
+	Short:        "zynax-ci — CI and developer toolchain for Zynax",
+	Version:      Version,
+	SilenceUsage: true,
+}
+
+// Execute runs the root command.
+func Execute() {
+	if err := rootCmd.Execute(); err != nil {
+		os.Exit(1)
+	}
+}

--- a/cmd/zynax-ci/cmd/validate.go
+++ b/cmd/zynax-ci/cmd/validate.go
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import "github.com/spf13/cobra"
+
+var validateCmd = &cobra.Command{
+	Use:   "validate",
+	Short: "Validate CI and documentation artifacts",
+}
+
+func init() {
+	rootCmd.AddCommand(validateCmd)
+}

--- a/cmd/zynax-ci/cmd/validate_canvas.go
+++ b/cmd/zynax-ci/cmd/validate_canvas.go
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	"github.com/zynax-io/zynax/cmd/zynax-ci/validate"
+)
+
+var canvasFormat string
+
+var validateCanvasCmd = &cobra.Command{
+	Use:   "canvas <path>",
+	Short: "Validate REASONS Canvas files for structural completeness",
+	Long: `Walk <path> recursively and validate every canvas.md file found.
+
+Checks per canvas:
+  • Seven REASONS sections (R, E, A, S-structure, O, N, S-safeguards)
+  • Header fields: **Issue:**, **Author:**, **Date:**, **Status:**
+  • Status value one of: Draft, Aligned, Implemented, Synced
+  • Context Security checklist marker present
+
+Status: Draft emits a warning but does not fail.
+Exits 0 if all canvas files pass, 1 on any structural error.`,
+	Args: cobra.ExactArgs(1),
+	RunE: runValidateCanvas,
+}
+
+func init() {
+	validateCanvasCmd.Flags().StringVar(&canvasFormat, "format", "text", "output format: text or json")
+	validateCmd.AddCommand(validateCanvasCmd)
+}
+
+type canvasResult struct {
+	File     string                     `json:"file"`
+	Errors   []validate.ValidationError `json:"errors,omitempty"`
+	Warnings []validate.ValidationWarning `json:"warnings,omitempty"`
+}
+
+func runValidateCanvas(cmd *cobra.Command, args []string) error {
+	root := args[0]
+
+	canvases, err := findCanvases(root)
+	if err != nil {
+		return err
+	}
+	if len(canvases) == 0 {
+		fmt.Fprintf(cmd.OutOrStdout(), "(no canvas.md files found under %s)\n", root)
+		return nil
+	}
+
+	var results []canvasResult
+	failed := false
+
+	for _, path := range canvases {
+		errs, warns, valErr := validate.Canvas(path)
+		if valErr != nil {
+			return valErr
+		}
+		if len(errs) > 0 {
+			failed = true
+		}
+		results = append(results, canvasResult{File: path, Errors: errs, Warnings: warns})
+	}
+
+	if canvasFormat == "json" {
+		return printCanvasJSON(cmd, results, failed)
+	}
+	return printCanvasText(cmd, results, failed)
+}
+
+func printCanvasText(cmd *cobra.Command, results []canvasResult, failed bool) error {
+	for _, r := range results {
+		if len(r.Errors) > 0 {
+			fmt.Fprintf(cmd.ErrOrStderr(), "FAIL %s:\n", r.File)
+			for _, e := range r.Errors {
+				fmt.Fprintf(cmd.ErrOrStderr(), "  ERROR  %s\n", e.Message)
+			}
+			for _, w := range r.Warnings {
+				fmt.Fprintf(cmd.ErrOrStderr(), "  WARN   %s\n", w.Message)
+			}
+		} else if len(r.Warnings) > 0 {
+			fmt.Fprintf(cmd.OutOrStdout(), "  WARN %s:\n", r.File)
+			for _, w := range r.Warnings {
+				fmt.Fprintf(cmd.OutOrStdout(), "         %s\n", w.Message)
+			}
+		} else {
+			fmt.Fprintf(cmd.OutOrStdout(), "  OK   %s\n", r.File)
+		}
+	}
+	if failed {
+		return fmt.Errorf("canvas validation failed")
+	}
+	return nil
+}
+
+func printCanvasJSON(cmd *cobra.Command, results []canvasResult, failed bool) error {
+	enc := json.NewEncoder(cmd.OutOrStdout())
+	enc.SetIndent("", "  ")
+	_ = enc.Encode(results)
+	if failed {
+		return fmt.Errorf("canvas validation failed")
+	}
+	return nil
+}
+
+func findCanvases(root string) ([]string, error) {
+	info, err := os.Stat(root)
+	if err != nil {
+		return nil, fmt.Errorf("validate canvas: %w", err)
+	}
+	if !info.IsDir() {
+		return []string{root}, nil
+	}
+	var paths []string
+	err = filepath.WalkDir(root, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if !d.IsDir() && d.Name() == "canvas.md" {
+			paths = append(paths, path)
+		}
+		return nil
+	})
+	return paths, err
+}

--- a/cmd/zynax-ci/go.mod
+++ b/cmd/zynax-ci/go.mod
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+module github.com/zynax-io/zynax/cmd/zynax-ci
+
+go 1.25.0
+
+require github.com/spf13/cobra v1.9.1
+
+require (
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.6 // indirect
+)

--- a/cmd/zynax-ci/go.sum
+++ b/cmd/zynax-ci/go.sum
@@ -1,0 +1,10 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=
+github.com/spf13/cobra v1.9.1/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wxYW0=
+github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
+github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/cmd/zynax-ci/main.go
+++ b/cmd/zynax-ci/main.go
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import "github.com/zynax-io/zynax/cmd/zynax-ci/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/cmd/zynax-ci/validate/canvas.go
+++ b/cmd/zynax-ci/validate/canvas.go
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package validate
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// ValidationError is a single hard failure from Canvas validation.
+type ValidationError struct {
+	File    string `json:"file"`
+	Message string `json:"message"`
+}
+
+func (e ValidationError) Error() string {
+	return fmt.Sprintf("%s: %s", e.File, e.Message)
+}
+
+// ValidationWarning is an advisory finding that does not fail validation.
+type ValidationWarning struct {
+	File    string `json:"file"`
+	Message string `json:"message"`
+}
+
+var validStatuses = map[string]bool{
+	"Draft": true, "Aligned": true, "Implemented": true, "Synced": true,
+}
+
+type sectionCheck struct {
+	prefix   string
+	name     string
+	minCount int
+}
+
+// canvasSections mirrors the seven REASONS headings.
+// The two "## S —" entries enforce both Structure (≥1) and Safeguards (≥2).
+var canvasSections = []sectionCheck{
+	{"## R —", "R — Requirements", 1},
+	{"## E —", "E — Entities", 1},
+	{"## A —", "A — Approach", 1},
+	{"## S —", "S — Structure", 1},
+	{"## O —", "O — Operations", 1},
+	{"## N —", "N — Norms", 1},
+	{"## S —", "Safeguards (second ## S — section)", 2},
+}
+
+var requiredFields = []string{"**Issue:**", "**Author:**", "**Date:**", "**Status:**"}
+
+const securityMarker = "Context Security"
+
+var statusRe = regexp.MustCompile(`\*\*Status:\*\*\s*(\w+)`)
+
+// Canvas validates a single canvas.md file for full structural completeness.
+//
+// Checks (full parity with tools/validate_canvas.py):
+//   - Seven REASONS sections present
+//   - **Issue:**, **Author:**, **Date:**, **Status:** header fields present
+//   - Status value is one of Draft, Aligned, Implemented, Synced
+//   - Context Security checklist marker present
+//   - canvas.private.md not committed alongside canvas.md
+//
+// Returns errors (hard failures), warnings (advisory), and any I/O error.
+func Canvas(filePath string) ([]ValidationError, []ValidationWarning, error) {
+	f, err := os.Open(filePath)
+	if err != nil {
+		return nil, nil, fmt.Errorf("validate: read %q: %w", filePath, err)
+	}
+	defer f.Close()
+
+	var lines []string
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+	}
+	if err = scanner.Err(); err != nil {
+		return nil, nil, fmt.Errorf("validate: scan %q: %w", filePath, err)
+	}
+
+	text := strings.Join(lines, "\n")
+	var errs []ValidationError
+	var warns []ValidationWarning
+
+	checkHeaderFields(filePath, text, &errs)
+	checkStatus(filePath, text, &errs, &warns)
+	checkSections(filePath, lines, &errs)
+	checkSecurityMarker(filePath, text, &errs)
+	checkNoPrivateFile(filePath, &errs)
+
+	return errs, warns, nil
+}
+
+func checkHeaderFields(filePath, text string, errs *[]ValidationError) {
+	for _, field := range requiredFields {
+		if !strings.Contains(text, field) {
+			*errs = append(*errs, ValidationError{File: filePath, Message: "missing header field: " + field})
+		}
+	}
+}
+
+func checkStatus(filePath, text string, errs *[]ValidationError, warns *[]ValidationWarning) {
+	m := statusRe.FindStringSubmatch(text)
+	if m == nil {
+		return
+	}
+	status := m[1]
+	if !validStatuses[status] {
+		*errs = append(*errs, ValidationError{
+			File:    filePath,
+			Message: fmt.Sprintf("invalid Status %q — must be one of: Aligned, Draft, Implemented, Synced", status),
+		})
+		return
+	}
+	if status == "Draft" {
+		*warns = append(*warns, ValidationWarning{
+			File:    filePath,
+			Message: "Canvas is Draft — must reach Aligned before /spdd-generate runs",
+		})
+	}
+}
+
+func checkSections(filePath string, lines []string, errs *[]ValidationError) {
+	counts := make(map[string]int)
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		for _, sec := range canvasSections {
+			if strings.HasPrefix(trimmed, sec.prefix) {
+				counts[sec.prefix]++
+				break
+			}
+		}
+	}
+	for _, sec := range canvasSections {
+		if counts[sec.prefix] < sec.minCount {
+			*errs = append(*errs, ValidationError{
+				File:    filePath,
+				Message: "missing section: " + sec.name,
+			})
+		}
+	}
+}
+
+func checkSecurityMarker(filePath, text string, errs *[]ValidationError) {
+	if !strings.Contains(text, securityMarker) {
+		*errs = append(*errs, ValidationError{
+			File:    filePath,
+			Message: "missing Context Security checklist in Safeguards section",
+		})
+	}
+}
+
+func checkNoPrivateFile(filePath string, errs *[]ValidationError) {
+	privatePath := filepath.Join(filepath.Dir(filePath), "canvas.private.md")
+	if _, err := os.Stat(privatePath); err == nil {
+		*errs = append(*errs, ValidationError{
+			File:    filePath,
+			Message: fmt.Sprintf("canvas.private.md found at %s — must be gitignored, never committed", privatePath),
+		})
+	}
+}

--- a/cmd/zynax-ci/validate/canvas_test.go
+++ b/cmd/zynax-ci/validate/canvas_test.go
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package validate_test
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/zynax-io/zynax/cmd/zynax-ci/validate"
+)
+
+// fullCanvas is a minimal but structurally complete REASONS Canvas.
+const fullCanvas = `# REASONS Canvas — Test
+
+**Issue:** #1
+**Author:** Test Author
+**Date:** 2026-01-01
+**Status:** Aligned
+
+---
+
+## R — Requirements
+content
+
+## E — Entities
+content
+
+## A — Approach
+content
+
+## S — Structure
+content
+
+## O — Operations
+content
+
+## N — Norms
+content
+
+## S — Safeguards
+
+### Context Security
+- [x] No Tier 2 content
+`
+
+func TestCanvas_ValidAligned(t *testing.T) {
+	f := writeTempCanvas(t, fullCanvas)
+	errs, warns, err := validate.Canvas(f)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(errs) != 0 {
+		t.Errorf("expected no errors, got: %v", errs)
+	}
+	if len(warns) != 0 {
+		t.Errorf("expected no warnings, got: %v", warns)
+	}
+}
+
+func TestCanvas_DraftStatus_IsWarning(t *testing.T) {
+	content := strings.ReplaceAll(fullCanvas, "**Status:** Aligned", "**Status:** Draft")
+	f := writeTempCanvas(t, content)
+	errs, warns, err := validate.Canvas(f)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(errs) != 0 {
+		t.Errorf("expected no errors for Draft status, got: %v", errs)
+	}
+	if len(warns) == 0 {
+		t.Error("expected a warning for Draft status, got none")
+	}
+}
+
+func TestCanvas_InvalidStatus(t *testing.T) {
+	content := strings.ReplaceAll(fullCanvas, "**Status:** Aligned", "**Status:** InProgress")
+	f := writeTempCanvas(t, content)
+	errs, _, err := validate.Canvas(f)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertContainsMessage(t, errs, "invalid Status")
+}
+
+func TestCanvas_MissingIssueField(t *testing.T) {
+	content := strings.ReplaceAll(fullCanvas, "**Issue:** #1\n", "")
+	f := writeTempCanvas(t, content)
+	errs, _, err := validate.Canvas(f)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertContainsMessage(t, errs, "**Issue:**")
+}
+
+func TestCanvas_MissingAuthorField(t *testing.T) {
+	content := strings.ReplaceAll(fullCanvas, "**Author:** Test Author\n", "")
+	f := writeTempCanvas(t, content)
+	errs, _, err := validate.Canvas(f)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertContainsMessage(t, errs, "**Author:**")
+}
+
+func TestCanvas_MissingRSection(t *testing.T) {
+	content := strings.ReplaceAll(fullCanvas, "## R — Requirements\n", "")
+	f := writeTempCanvas(t, content)
+	errs, _, err := validate.Canvas(f)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertContainsMessage(t, errs, "R — Requirements")
+}
+
+func TestCanvas_MissingSecondS(t *testing.T) {
+	content := strings.ReplaceAll(fullCanvas, "## S — Safeguards\n", "")
+	f := writeTempCanvas(t, content)
+	errs, _, err := validate.Canvas(f)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertContainsMessage(t, errs, "Safeguards")
+}
+
+func TestCanvas_BothSMissing(t *testing.T) {
+	content := strings.ReplaceAll(fullCanvas, "## S — Structure\n", "")
+	content = strings.ReplaceAll(content, "## S — Safeguards\n", "")
+	f := writeTempCanvas(t, content)
+	errs, _, err := validate.Canvas(f)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertContainsMessage(t, errs, "S — Structure")
+	assertContainsMessage(t, errs, "Safeguards")
+}
+
+func TestCanvas_MissingContextSecurity(t *testing.T) {
+	content := strings.ReplaceAll(fullCanvas, "Context Security", "No-Security-Marker")
+	f := writeTempCanvas(t, content)
+	errs, _, err := validate.Canvas(f)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertContainsMessage(t, errs, "Context Security")
+}
+
+func TestCanvas_PrivateFilePresent(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "canvas.md")
+	if err := os.WriteFile(f, []byte(fullCanvas), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	private := filepath.Join(dir, "canvas.private.md")
+	if err := os.WriteFile(private, []byte("secret"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	errs, _, err := validate.Canvas(f)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertContainsMessage(t, errs, "canvas.private.md")
+}
+
+func TestCanvas_MultipleMissing(t *testing.T) {
+	content := strings.ReplaceAll(fullCanvas, "## N — Norms\n", "")
+	content = strings.ReplaceAll(content, "## O — Operations\n", "")
+	f := writeTempCanvas(t, content)
+	errs, _, err := validate.Canvas(f)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertContainsMessage(t, errs, "N — Norms")
+	assertContainsMessage(t, errs, "O — Operations")
+}
+
+func TestCanvas_FileNotFound(t *testing.T) {
+	_, _, err := validate.Canvas("/nonexistent/canvas.md")
+	if err == nil {
+		t.Fatal("expected error for missing file, got nil")
+	}
+}
+
+func TestCanvas_RealCanvas(t *testing.T) {
+	_, file, _, _ := runtime.Caller(0)
+	canvas := filepath.Join(filepath.Dir(file), "../../../docs/spdd/314-yaml-system-cli/canvas.md")
+	errs, _, err := validate.Canvas(canvas)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(errs) != 0 {
+		for _, e := range errs {
+			t.Errorf("real canvas failed: %s", e)
+		}
+	}
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+func writeTempCanvas(t *testing.T, content string) string {
+	t.Helper()
+	f := filepath.Join(t.TempDir(), "canvas.md")
+	if err := os.WriteFile(f, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return f
+}
+
+func assertContainsMessage(t *testing.T, errs []validate.ValidationError, substr string) {
+	t.Helper()
+	for _, e := range errs {
+		if strings.Contains(e.Message, substr) {
+			return
+		}
+	}
+	t.Errorf("expected an error containing %q; got: %v", substr, errs)
+}


### PR DESCRIPTION
Closes #333

## Summary

- Creates `cmd/zynax-ci/` as a new standalone Go module (separate from `cmd/zynax/`)
- Implements `zynax-ci validate canvas <path>` — full Go port of `tools/validate_canvas.py`
- Replaces Python setup in the `canvas-freshness` CI gate with `zynax-ci validate canvas`

## What is validated per canvas.md

| Check | Failure mode |
|-------|-------------|
| Seven REASONS sections (R, E, A, S×2, O, N) | Missing section → error |
| `**Issue:**` / `**Author:**` / `**Date:**` / `**Status:**` | Missing field → error |
| Status value: Draft / Aligned / Implemented / Synced | Invalid value → error |
| `Context Security` checklist marker | Absent → error |
| `canvas.private.md` not committed | Present → error |
| Status = Draft | Warning only (does not fail) |

## Test plan

- [x] `GOWORK=off go test ./... -race` — 13/13 pass
- [x] `TestCanvas_RealCanvas` — validates `docs/spdd/314-yaml-system-cli/canvas.md` ✅
- [x] `zynax-ci validate canvas docs/spdd/` — both live canvases exit 0
- [x] `GOWORK=off go build ./...` — clean build
- [x] `pr-checks.yml` canvas-freshness: Python removed, zynax-ci build + validate wired in

## Structure (Step 8 scope only)

```
cmd/zynax-ci/
├── main.go
├── AGENTS.md
├── go.mod / go.sum
├── cmd/
│   ├── root.go
│   ├── validate.go
│   └── validate_canvas.go
└── validate/
    ├── canvas.go
    └── canvas_test.go
```

Remaining `zynax-ci` commands (validate schema/workflows/agent-defs/capabilities/policies, check ai-context) are Step 9 (#334).

Signed-off-by: Oscar Gómez Manresa <ogomezmanresa@gmail.com>
Assisted-by: Claude/claude-sonnet-4-6