### PR TITLE
feat(zynax-ci): remaining validators + check ai-context (#334)

### DIFF
--- a/cmd/zynax-ci/check/context.go
+++ b/cmd/zynax-ci/check/context.go
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package check implements advisory checks for the zynax-ci toolchain.
+package check
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// FileReport is the result for a single AI context file.
+type FileReport struct {
+	Path      string
+	Lines     int
+	Threshold int
+	Warn      bool
+}
+
+// ContextReport is the full report from an AI context check.
+type ContextReport struct {
+	Files      []FileReport
+	Total      int
+	TotalLimit int
+	Warnings   int
+}
+
+// thresholds mirrors the logic in tools/count-ai-context.sh.
+var (
+	thresholdClaude     = 200
+	thresholdRootAgents = 300
+	thresholdAISetup    = 150
+	thresholdDirAgents  = 150
+	thresholdTotal      = 2000
+)
+
+// Context scans repoRoot for CLAUDE.md, AGENTS.md files, and
+// docs/ai-assistant-setup.md, counting lines and comparing against
+// per-file thresholds. Always returns without error even when thresholds
+// are exceeded — this check is advisory only.
+func Context(repoRoot string) (ContextReport, error) {
+	var report ContextReport
+	report.TotalLimit = thresholdTotal
+
+	add := func(path string, threshold int) {
+		n, err := countLines(path)
+		if err != nil {
+			return // file absent — skip silently
+		}
+		warn := n > threshold
+		if warn {
+			report.Warnings++
+		}
+		report.Files = append(report.Files, FileReport{
+			Path:      relPath(repoRoot, path),
+			Lines:     n,
+			Threshold: threshold,
+			Warn:      warn,
+		})
+		report.Total += n
+	}
+
+	add(filepath.Join(repoRoot, "CLAUDE.md"), thresholdClaude)
+	add(filepath.Join(repoRoot, "AGENTS.md"), thresholdRootAgents)
+	add(filepath.Join(repoRoot, "docs", "ai-assistant-setup.md"), thresholdAISetup)
+
+	// Per-directory AGENTS.md files (all except root).
+	var subdirAgents []string
+	_ = filepath.WalkDir(repoRoot, func(path string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil
+		}
+		if d.Name() != "AGENTS.md" {
+			return nil
+		}
+		if path == filepath.Join(repoRoot, "AGENTS.md") {
+			return nil
+		}
+		subdirAgents = append(subdirAgents, path)
+		return nil
+	})
+	sort.Strings(subdirAgents)
+	for _, path := range subdirAgents {
+		add(path, thresholdDirAgents)
+	}
+
+	if report.Total > thresholdTotal {
+		report.Warnings++
+	}
+	return report, nil
+}
+
+// Print writes the report in the same table format as count-ai-context.sh.
+func (r ContextReport) Print(w *os.File) {
+	fmt.Fprintf(w, "| %-55s | %5s | %5s | %-6s |\n", "File", "Lines", "Limit", "Status")
+	fmt.Fprintln(w, "|----------------------------------------------------------|-------|-------|--------|")
+	for _, f := range r.Files {
+		status := "OK"
+		if f.Warn {
+			status = "WARN"
+		}
+		fmt.Fprintf(w, "| %-55s | %5d | %5d | %-6s |\n", f.Path, f.Lines, f.Threshold, status)
+	}
+	fmt.Fprintln(w, "|----------------------------------------------------------|-------|-------|--------|")
+	totalStatus := "OK"
+	if r.Total > r.TotalLimit {
+		totalStatus = "WARN"
+	}
+	fmt.Fprintf(w, "| %-55s | %5d | %5d | %-6s |\n", "TOTAL", r.Total, r.TotalLimit, totalStatus)
+	fmt.Fprintln(w, "")
+	if r.Warnings > 0 {
+		fmt.Fprintf(w, "WARNING: %d file(s) exceed their line threshold.\n", r.Warnings)
+		fmt.Fprintln(w, "Consider trimming AI context files — smaller budgets improve signal density.")
+	} else {
+		fmt.Fprintln(w, "All AI context files are within budget.")
+	}
+}
+
+func countLines(path string) (int, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return 0, err
+	}
+	defer f.Close()
+	s := bufio.NewScanner(f)
+	n := 0
+	for s.Scan() {
+		n++
+	}
+	return n, s.Err()
+}
+
+func relPath(base, path string) string {
+	rel, err := filepath.Rel(base, path)
+	if err != nil {
+		return path
+	}
+	return strings.TrimPrefix(rel, "./")
+}

--- a/cmd/zynax-ci/check/context_test.go
+++ b/cmd/zynax-ci/check/context_test.go
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package check_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/zynax-io/zynax/cmd/zynax-ci/check"
+)
+
+func writeLines(t *testing.T, path string, n int) {
+	t.Helper()
+	var b strings.Builder
+	for i := 0; i < n; i++ {
+		b.WriteString("line\n")
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(b.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestContext_AllWithinBudget(t *testing.T) {
+	root := t.TempDir()
+	writeLines(t, filepath.Join(root, "CLAUDE.md"), 50)
+	writeLines(t, filepath.Join(root, "AGENTS.md"), 100)
+	writeLines(t, filepath.Join(root, "docs", "ai-assistant-setup.md"), 80)
+	writeLines(t, filepath.Join(root, "services", "AGENTS.md"), 60)
+
+	report, err := check.Context(root)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if report.Warnings != 0 {
+		t.Errorf("expected 0 warnings, got %d", report.Warnings)
+	}
+	if report.Total == 0 {
+		t.Error("expected non-zero total")
+	}
+}
+
+func TestContext_ExceedsThreshold(t *testing.T) {
+	root := t.TempDir()
+	// Write more than the CLAUDE.md threshold (200)
+	writeLines(t, filepath.Join(root, "CLAUDE.md"), 250)
+
+	report, err := check.Context(root)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if report.Warnings == 0 {
+		t.Error("expected at least 1 warning for oversized CLAUDE.md")
+	}
+	found := false
+	for _, f := range report.Files {
+		if strings.HasSuffix(f.Path, "CLAUDE.md") && f.Warn {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected CLAUDE.md to be flagged as WARN")
+	}
+}
+
+func TestContext_TotalExceedsLimit(t *testing.T) {
+	root := t.TempDir()
+	// Spread lines across many AGENTS.md files to breach the 2000-line total
+	for _, sub := range []string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n"} {
+		writeLines(t, filepath.Join(root, sub, "AGENTS.md"), 150)
+	}
+	writeLines(t, filepath.Join(root, "CLAUDE.md"), 180)
+	writeLines(t, filepath.Join(root, "AGENTS.md"), 290)
+
+	report, err := check.Context(root)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if report.Total <= 2000 {
+		t.Logf("total=%d — test may not be exercising total threshold, skipping", report.Total)
+		return
+	}
+	if report.Warnings == 0 {
+		t.Error("expected warnings when total exceeds 2000")
+	}
+}
+
+func TestContext_MissingFiles(t *testing.T) {
+	// Empty repo root — no AI context files at all
+	root := t.TempDir()
+	report, err := check.Context(root)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if report.Total != 0 {
+		t.Errorf("expected total=0 for empty root, got %d", report.Total)
+	}
+	if len(report.Files) != 0 {
+		t.Errorf("expected 0 file entries, got %d", len(report.Files))
+	}
+}
+
+func TestContext_RootAgentsMdNotCountedTwice(t *testing.T) {
+	root := t.TempDir()
+	writeLines(t, filepath.Join(root, "AGENTS.md"), 100)
+	writeLines(t, filepath.Join(root, "sub", "AGENTS.md"), 50)
+
+	report, err := check.Context(root)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Total should be 150, not 200 (root AGENTS.md should not appear twice)
+	if report.Total != 150 {
+		t.Errorf("expected total=150, got %d", report.Total)
+	}
+}

--- a/cmd/zynax-ci/cmd/check.go
+++ b/cmd/zynax-ci/cmd/check.go
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var checkCmd = &cobra.Command{
+	Use:   "check",
+	Short: "Advisory checks for the Zynax repository",
+}
+
+func init() {
+	rootCmd.AddCommand(checkCmd)
+}

--- a/cmd/zynax-ci/cmd/check_ai_context.go
+++ b/cmd/zynax-ci/cmd/check_ai_context.go
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/zynax-io/zynax/cmd/zynax-ci/check"
+)
+
+var aiContextRoot string
+
+var checkAIContextCmd = &cobra.Command{
+	Use:   "ai-context",
+	Short: "Report line counts for AI context files (advisory, always exits 0)",
+	Long: `Count lines in CLAUDE.md, AGENTS.md files, and docs/ai-assistant-setup.md.
+
+Thresholds:
+  CLAUDE.md                 200 lines
+  AGENTS.md (root)          300 lines
+  docs/ai-assistant-setup.md 150 lines
+  per-directory AGENTS.md   150 lines
+  TOTAL                    2000 lines
+
+Exceeding a threshold emits a WARN but never causes a non-zero exit code.
+This check is advisory only.`,
+	Args: cobra.NoArgs,
+	RunE: runCheckAIContext,
+}
+
+func init() {
+	checkAIContextCmd.Flags().StringVar(&aiContextRoot, "root", ".", "repository root directory")
+	checkCmd.AddCommand(checkAIContextCmd)
+}
+
+func runCheckAIContext(cmd *cobra.Command, args []string) error {
+	root := aiContextRoot
+	if root == "." {
+		var err error
+		root, err = os.Getwd()
+		if err != nil {
+			return fmt.Errorf("check ai-context: get working directory: %w", err)
+		}
+	}
+
+	report, err := check.Context(root)
+	if err != nil {
+		return err
+	}
+	report.Print(os.Stdout)
+	return nil // always exits 0
+}

--- a/cmd/zynax-ci/cmd/validate_agent_defs.go
+++ b/cmd/zynax-ci/cmd/validate_agent_defs.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	"github.com/zynax-io/zynax/cmd/zynax-ci/validate"
+)
+
+var agentDefsSchemaDir string
+var agentDefsFormat string
+
+var validateAgentDefsCmd = &cobra.Command{
+	Use:   "agent-defs <dir>",
+	Short: "Validate AgentDef YAML manifests against the JSON Schema",
+	Long: `Walk <dir> for *.yaml files, filter those with kind: AgentDef,
+and validate each against spec/schemas/agent-def.schema.json (or --schema-dir).
+
+Exits 0 if all manifests pass, 1 on any schema violation.`,
+	Args: cobra.ExactArgs(1),
+	RunE: runValidateAgentDefs,
+}
+
+func init() {
+	validateAgentDefsCmd.Flags().StringVar(&agentDefsSchemaDir, "schema-dir", "spec/schemas", "directory containing JSON Schema files")
+	validateAgentDefsCmd.Flags().StringVar(&agentDefsFormat, "format", "text", "output format: text or json")
+	validateCmd.AddCommand(validateAgentDefsCmd)
+}
+
+func runValidateAgentDefs(cmd *cobra.Command, args []string) error {
+	dir := args[0]
+	schemaPath := filepath.Join(agentDefsSchemaDir, "agent-def.schema.json")
+
+	results, err := validate.BatchManifests(dir, "AgentDef", schemaPath)
+	if err != nil {
+		return err
+	}
+
+	if len(results) == 0 {
+		fmt.Fprintf(cmd.OutOrStdout(), "(no AgentDef manifests found in %s)\n", dir)
+		return nil
+	}
+	return printManifestResults(cmd, results, agentDefsFormat)
+}

--- a/cmd/zynax-ci/cmd/validate_capabilities.go
+++ b/cmd/zynax-ci/cmd/validate_capabilities.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	"github.com/zynax-io/zynax/cmd/zynax-ci/validate"
+)
+
+var capabilitiesSchemaDir string
+var capabilitiesFormat string
+
+var validateCapabilitiesCmd = &cobra.Command{
+	Use:   "capabilities <dir>",
+	Short: "Validate capability declarations in AgentDef YAML files",
+	Long: `Walk <dir> for *.yaml files, extract capability declarations from
+AgentDef manifests (spec.capabilities or top-level capabilities), and validate
+each against spec/schemas/capability.schema.json (or --schema-dir).
+
+Exits 0 if all capabilities pass, 1 on any schema violation.`,
+	Args: cobra.ExactArgs(1),
+	RunE: runValidateCapabilities,
+}
+
+func init() {
+	validateCapabilitiesCmd.Flags().StringVar(&capabilitiesSchemaDir, "schema-dir", "spec/schemas", "directory containing JSON Schema files")
+	validateCapabilitiesCmd.Flags().StringVar(&capabilitiesFormat, "format", "text", "output format: text or json")
+	validateCmd.AddCommand(validateCapabilitiesCmd)
+}
+
+func runValidateCapabilities(cmd *cobra.Command, args []string) error {
+	dir := args[0]
+	schemaPath := filepath.Join(capabilitiesSchemaDir, "capability.schema.json")
+
+	results, err := validate.Capabilities(dir, schemaPath)
+	if err != nil {
+		return err
+	}
+
+	if len(results) == 0 {
+		fmt.Fprintf(cmd.OutOrStdout(), "(no capability declarations found in %s)\n", dir)
+		return nil
+	}
+
+	failed := false
+	for _, r := range results {
+		if len(r.Errors) > 0 {
+			failed = true
+		}
+	}
+
+	if capabilitiesFormat == "json" {
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(results)
+		if failed {
+			return fmt.Errorf("capability validation failed")
+		}
+		return nil
+	}
+
+	for _, r := range results {
+		if len(r.Errors) > 0 {
+			fmt.Fprintf(cmd.ErrOrStderr(), "FAIL %s capability %q:\n", r.File, r.Capability)
+			for _, e := range r.Errors {
+				if e.Path != "" {
+					fmt.Fprintf(cmd.ErrOrStderr(), "  %s: %s\n", e.Path, e.Message)
+				} else {
+					fmt.Fprintf(cmd.ErrOrStderr(), "  ERROR  %s\n", e.Message)
+				}
+			}
+		} else {
+			fmt.Fprintf(cmd.OutOrStdout(), "  OK   %s :: %s\n", r.File, r.Capability)
+		}
+	}
+	if failed {
+		return fmt.Errorf("capability validation failed")
+	}
+	return nil
+}

--- a/cmd/zynax-ci/cmd/validate_policies.go
+++ b/cmd/zynax-ci/cmd/validate_policies.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	"github.com/zynax-io/zynax/cmd/zynax-ci/validate"
+)
+
+var policiesSchemaDir string
+var policiesFormat string
+
+var validatePoliciesCmd = &cobra.Command{
+	Use:   "policies <dir>",
+	Short: "Validate Policy YAML manifests against the JSON Schema",
+	Long: `Walk <dir> for *.yaml files, filter those with kind: Policy,
+and validate each against spec/schemas/policy.schema.json (or --schema-dir).
+
+Exits 0 if all manifests pass, 1 on any schema violation.`,
+	Args: cobra.ExactArgs(1),
+	RunE: runValidatePolicies,
+}
+
+func init() {
+	validatePoliciesCmd.Flags().StringVar(&policiesSchemaDir, "schema-dir", "spec/schemas", "directory containing JSON Schema files")
+	validatePoliciesCmd.Flags().StringVar(&policiesFormat, "format", "text", "output format: text or json")
+	validateCmd.AddCommand(validatePoliciesCmd)
+}
+
+func runValidatePolicies(cmd *cobra.Command, args []string) error {
+	dir := args[0]
+	schemaPath := filepath.Join(policiesSchemaDir, "policy.schema.json")
+
+	results, err := validate.BatchManifests(dir, "Policy", schemaPath)
+	if err != nil {
+		return err
+	}
+
+	if len(results) == 0 {
+		fmt.Fprintf(cmd.OutOrStdout(), "(no Policy manifests found in %s)\n", dir)
+		return nil
+	}
+	return printManifestResults(cmd, results, policiesFormat)
+}

--- a/cmd/zynax-ci/cmd/validate_schema.go
+++ b/cmd/zynax-ci/cmd/validate_schema.go
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/zynax-io/zynax/cmd/zynax-ci/validate"
+)
+
+var schemaFormat string
+
+var validateSchemaCmd = &cobra.Command{
+	Use:   "schema <path>",
+	Short: "Validate JSON Schema files for well-formedness and $schema field",
+	Long: `Validate one JSON Schema file or all *.json files in a directory.
+
+Each file is checked for:
+  • Valid JSON syntax
+  • Presence of the required $schema field
+
+Exits 0 if all files pass, 1 on any failure.`,
+	Args: cobra.ExactArgs(1),
+	RunE: runValidateSchema,
+}
+
+func init() {
+	validateSchemaCmd.Flags().StringVar(&schemaFormat, "format", "text", "output format: text or json")
+	validateCmd.AddCommand(validateSchemaCmd)
+}
+
+func runValidateSchema(cmd *cobra.Command, args []string) error {
+	path := args[0]
+
+	results, err := validate.SchemaDir(path)
+	if err != nil {
+		// path may be a single file
+		errs, ferr := validate.Schema(path)
+		if ferr != nil {
+			return ferr
+		}
+		results = []validate.SchemaResult{{File: path, Errors: errs}}
+	}
+
+	if len(results) == 0 {
+		fmt.Fprintf(cmd.OutOrStdout(), "(no JSON schema files found under %s)\n", path)
+		return nil
+	}
+
+	failed := false
+	for _, r := range results {
+		if len(r.Errors) > 0 {
+			failed = true
+		}
+	}
+
+	if schemaFormat == "json" {
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(results)
+		if failed {
+			return fmt.Errorf("schema validation failed")
+		}
+		return nil
+	}
+
+	for _, r := range results {
+		if len(r.Errors) > 0 {
+			fmt.Fprintf(cmd.ErrOrStderr(), "FAIL %s:\n", r.File)
+			for _, e := range r.Errors {
+				fmt.Fprintf(cmd.ErrOrStderr(), "  ERROR  %s\n", e.Message)
+			}
+		} else {
+			fmt.Fprintf(cmd.OutOrStdout(), "  OK   %s\n", r.File)
+		}
+	}
+	if failed {
+		return fmt.Errorf("schema validation failed")
+	}
+	return nil
+}

--- a/cmd/zynax-ci/cmd/validate_workflows.go
+++ b/cmd/zynax-ci/cmd/validate_workflows.go
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	"github.com/zynax-io/zynax/cmd/zynax-ci/validate"
+)
+
+var workflowsSchemaDir string
+var workflowsFormat string
+
+var validateWorkflowsCmd = &cobra.Command{
+	Use:   "workflows <dir>",
+	Short: "Validate Workflow YAML manifests against the JSON Schema",
+	Long: `Walk <dir> for *.yaml files, filter those with kind: Workflow,
+and validate each against spec/schemas/workflow.schema.json (or --schema-dir).
+
+Exits 0 if all manifests pass, 1 on any schema violation.`,
+	Args: cobra.ExactArgs(1),
+	RunE: runValidateWorkflows,
+}
+
+func init() {
+	validateWorkflowsCmd.Flags().StringVar(&workflowsSchemaDir, "schema-dir", "spec/schemas", "directory containing JSON Schema files")
+	validateWorkflowsCmd.Flags().StringVar(&workflowsFormat, "format", "text", "output format: text or json")
+	validateCmd.AddCommand(validateWorkflowsCmd)
+}
+
+func runValidateWorkflows(cmd *cobra.Command, args []string) error {
+	dir := args[0]
+	schemaPath := filepath.Join(workflowsSchemaDir, "workflow.schema.json")
+
+	results, err := validate.BatchManifests(dir, "Workflow", schemaPath)
+	if err != nil {
+		return err
+	}
+
+	if len(results) == 0 {
+		fmt.Fprintf(cmd.OutOrStdout(), "(no Workflow manifests found in %s)\n", dir)
+		return nil
+	}
+	return printManifestResults(cmd, results, workflowsFormat)
+}
+
+func printManifestResults(cmd *cobra.Command, results []validate.ManifestResult, format string) error {
+	failed := false
+	for _, r := range results {
+		if len(r.Errors) > 0 {
+			failed = true
+		}
+	}
+
+	if format == "json" {
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(results)
+		if failed {
+			return fmt.Errorf("manifest validation failed")
+		}
+		return nil
+	}
+
+	for _, r := range results {
+		if len(r.Errors) > 0 {
+			fmt.Fprintf(cmd.ErrOrStderr(), "FAIL %s:\n", r.File)
+			for _, e := range r.Errors {
+				if e.Path != "" {
+					fmt.Fprintf(cmd.ErrOrStderr(), "  %s: %s\n", e.Path, e.Message)
+				} else {
+					fmt.Fprintf(cmd.ErrOrStderr(), "  ERROR  %s\n", e.Message)
+				}
+			}
+		} else {
+			fmt.Fprintf(cmd.OutOrStdout(), "  OK   %s\n", r.File)
+		}
+	}
+	if failed {
+		return fmt.Errorf("manifest validation failed")
+	}
+	return nil
+}

--- a/cmd/zynax-ci/go.mod
+++ b/cmd/zynax-ci/go.mod
@@ -3,7 +3,11 @@ module github.com/zynax-io/zynax/cmd/zynax-ci
 
 go 1.25.0
 
-require github.com/spf13/cobra v1.9.1
+require (
+	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
+	github.com/spf13/cobra v1.9.1
+	gopkg.in/yaml.v3 v3.0.1
+)
 
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/cmd/zynax-ci/go.sum
+++ b/cmd/zynax-ci/go.sum
@@ -2,9 +2,13 @@ github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6N
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 h1:lZUw3E0/J3roVtGQ+SCrUrg3ON6NgVqpn3+iol9aGu4=
+github.com/santhosh-tekuri/jsonschema/v5 v5.3.1/go.mod h1:uToXkOrWAZ6/Oc07xWQrPOhJotwFIyu2bBVN41fcDUY=
 github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=
 github.com/spf13/cobra v1.9.1/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wxYW0=
 github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
 github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/cmd/zynax-ci/validate/canvas.go
+++ b/cmd/zynax-ci/validate/canvas.go
@@ -11,13 +11,17 @@ import (
 	"strings"
 )
 
-// ValidationError is a single hard failure from Canvas validation.
+// ValidationError is a single hard failure from validation.
 type ValidationError struct {
 	File    string `json:"file"`
+	Path    string `json:"path,omitempty"` // JSON Pointer to the failing element (optional)
 	Message string `json:"message"`
 }
 
 func (e ValidationError) Error() string {
+	if e.Path != "" {
+		return fmt.Sprintf("%s: at %s: %s", e.File, e.Path, e.Message)
+	}
 	return fmt.Sprintf("%s: %s", e.File, e.Message)
 }
 

--- a/cmd/zynax-ci/validate/capabilities.go
+++ b/cmd/zynax-ci/validate/capabilities.go
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package validate
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/santhosh-tekuri/jsonschema/v5"
+	"gopkg.in/yaml.v3"
+)
+
+// CapabilityResult holds the outcome of validating a single capability entry.
+type CapabilityResult struct {
+	File       string            `json:"file"`
+	Capability string            `json:"capability"`
+	Errors     []ValidationError `json:"errors,omitempty"`
+}
+
+// Capabilities walks dir for *.yaml files, extracts capability declarations
+// from AgentDef manifests, and validates each against the schema at schemaPath.
+// Both spec.capabilities and top-level capabilities arrays are supported.
+func Capabilities(dir, schemaPath string) ([]CapabilityResult, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("validate capabilities: read dir %q: %w", dir, err)
+	}
+
+	absSchema, err := filepath.Abs(schemaPath)
+	if err != nil {
+		return nil, fmt.Errorf("validate capabilities: resolve schema: %w", err)
+	}
+	sch, err := compileSchema(absSchema)
+	if err != nil {
+		return nil, fmt.Errorf("validate capabilities: compile schema %q: %w", absSchema, err)
+	}
+
+	var files []string
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasSuffix(e.Name(), ".yaml") {
+			files = append(files, filepath.Join(dir, e.Name()))
+		}
+	}
+	sort.Strings(files)
+
+	var results []CapabilityResult
+	for _, path := range files {
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("validate capabilities: read %q: %w", path, err)
+		}
+
+		var doc interface{}
+		if err := yaml.Unmarshal(raw, &doc); err != nil {
+			continue // not a valid YAML doc — skip
+		}
+
+		m, ok := normaliseMap(doc)
+		if !ok {
+			continue
+		}
+
+		caps := extractCapabilities(m)
+		for _, cap := range caps {
+			name, _ := cap["name"].(string)
+			if name == "" {
+				name = "?"
+			}
+
+			jsonBytes, err := json.Marshal(cap)
+			if err != nil {
+				return nil, fmt.Errorf("validate capabilities: marshal capability in %q: %w", path, err)
+			}
+			var instance interface{}
+			if err := json.Unmarshal(jsonBytes, &instance); err != nil {
+				return nil, fmt.Errorf("validate capabilities: unmarshal capability in %q: %w", path, err)
+			}
+
+			if valErr := sch.Validate(instance); valErr != nil {
+				var ve *jsonschema.ValidationError
+				if errors.As(valErr, &ve) {
+					results = append(results, CapabilityResult{
+						File:       path,
+						Capability: name,
+						Errors:     flattenManifestErrors(path, ve),
+					})
+					continue
+				}
+				return nil, fmt.Errorf("validate capabilities: %w", valErr)
+			}
+			results = append(results, CapabilityResult{File: path, Capability: name})
+		}
+	}
+	return results, nil
+}
+
+// extractCapabilities pulls capabilities from spec.capabilities or top-level capabilities.
+func extractCapabilities(m map[string]interface{}) []map[string]interface{} {
+	var raw []interface{}
+	if spec, ok := m["spec"].(map[string]interface{}); ok {
+		if caps, ok := spec["capabilities"].([]interface{}); ok {
+			raw = caps
+		}
+	}
+	if raw == nil {
+		if caps, ok := m["capabilities"].([]interface{}); ok {
+			raw = caps
+		}
+	}
+
+	var out []map[string]interface{}
+	for _, item := range raw {
+		if cap, ok := item.(map[string]interface{}); ok {
+			out = append(out, cap)
+		}
+	}
+	return out
+}

--- a/cmd/zynax-ci/validate/capabilities_test.go
+++ b/cmd/zynax-ci/validate/capabilities_test.go
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package validate_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/zynax-io/zynax/cmd/zynax-ci/validate"
+)
+
+// writeCapabilitySchema writes a minimal capability schema to dir and returns its path.
+func writeCapabilitySchema(t *testing.T, dir string) string {
+	t.Helper()
+	schema := map[string]interface{}{
+		"$schema": "https://json-schema.org/draft/2020-12/schema",
+		"$id":     "https://test.zynax.io/capability",
+		"type":    "object",
+		"required": []string{"name"},
+		"properties": map[string]interface{}{
+			"name":        map[string]interface{}{"type": "string"},
+			"description": map[string]interface{}{"type": "string"},
+		},
+	}
+	b, _ := json.Marshal(schema)
+	path := filepath.Join(dir, "capability.schema.json")
+	if err := os.WriteFile(path, b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestCapabilities_ValidSpecCapabilities(t *testing.T) {
+	dir := t.TempDir()
+	schema := writeCapabilitySchema(t, dir)
+	writeYAML(t, dir, "agent.yaml", `
+kind: AgentDef
+spec:
+  capabilities:
+    - name: summarize
+      description: Summarise text
+`)
+	results, err := validate.Capabilities(dir, schema)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 capability result, got %d", len(results))
+	}
+	if len(results[0].Errors) != 0 {
+		t.Errorf("expected no errors, got %v", results[0].Errors)
+	}
+	if results[0].Capability != "summarize" {
+		t.Errorf("expected capability name 'summarize', got %q", results[0].Capability)
+	}
+}
+
+func TestCapabilities_TopLevelCapabilities(t *testing.T) {
+	dir := t.TempDir()
+	schema := writeCapabilitySchema(t, dir)
+	writeYAML(t, dir, "agent.yaml", `
+capabilities:
+  - name: legacy-cap
+`)
+	results, err := validate.Capabilities(dir, schema)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if len(results[0].Errors) != 0 {
+		t.Errorf("expected no errors, got %v", results[0].Errors)
+	}
+}
+
+func TestCapabilities_MissingRequiredField(t *testing.T) {
+	dir := t.TempDir()
+	schema := writeCapabilitySchema(t, dir)
+	writeYAML(t, dir, "agent.yaml", `
+spec:
+  capabilities:
+    - description: no name field here
+`)
+	results, err := validate.Capabilities(dir, schema)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if len(results[0].Errors) == 0 {
+		t.Error("expected schema error for missing 'name' field")
+	}
+}
+
+func TestCapabilities_NoCapabilities(t *testing.T) {
+	dir := t.TempDir()
+	schema := writeCapabilitySchema(t, dir)
+	// A YAML file with no capability fields at all
+	writeYAML(t, dir, "workflow.yaml", `
+kind: Workflow
+spec:
+  states: []
+`)
+	results, err := validate.Capabilities(dir, schema)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("expected 0 results for file with no capabilities, got %d", len(results))
+	}
+}
+
+func TestCapabilities_EmptyDir(t *testing.T) {
+	dir := t.TempDir()
+	schema := writeCapabilitySchema(t, dir)
+	results, err := validate.Capabilities(dir, schema)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("expected 0 results in empty dir, got %d", len(results))
+	}
+}

--- a/cmd/zynax-ci/validate/helpers.go
+++ b/cmd/zynax-ci/validate/helpers.go
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package validate
+
+func single(file, path, msg string) []ValidationError {
+	return []ValidationError{{File: file, Path: path, Message: msg}}
+}

--- a/cmd/zynax-ci/validate/manifest.go
+++ b/cmd/zynax-ci/validate/manifest.go
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package validate
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/santhosh-tekuri/jsonschema/v5"
+	"gopkg.in/yaml.v3"
+)
+
+// ManifestResult holds the outcome of validating a single manifest file.
+type ManifestResult struct {
+	File   string            `json:"file"`
+	Errors []ValidationError `json:"errors,omitempty"`
+}
+
+// BatchManifests walks dir for *.yaml files, filters by kind, and validates each
+// against the JSON Schema at schemaPath. Returns one result per matching file.
+func BatchManifests(dir, kind, schemaPath string) ([]ManifestResult, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("validate manifests: read dir %q: %w", dir, err)
+	}
+
+	absSchema, err := filepath.Abs(schemaPath)
+	if err != nil {
+		return nil, fmt.Errorf("validate manifests: resolve schema path: %w", err)
+	}
+	sch, err := compileSchema(absSchema)
+	if err != nil {
+		return nil, fmt.Errorf("validate manifests: compile schema %q: %w", absSchema, err)
+	}
+
+	var files []string
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasSuffix(e.Name(), ".yaml") {
+			files = append(files, filepath.Join(dir, e.Name()))
+		}
+	}
+	sort.Strings(files)
+
+	var results []ManifestResult
+	for _, path := range files {
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("validate manifests: read %q: %w", path, err)
+		}
+
+		var doc interface{}
+		if err := yaml.Unmarshal(raw, &doc); err != nil {
+			results = append(results, ManifestResult{
+				File:   path,
+				Errors: single(path, "", "YAML parse error: "+err.Error()),
+			})
+			continue
+		}
+
+		m, ok := normaliseMap(doc)
+		if !ok {
+			continue // not a mapping — skip silently (not a manifest)
+		}
+		if docKind, _ := m["kind"].(string); docKind != kind {
+			continue // wrong kind — skip
+		}
+
+		jsonBytes, err := json.Marshal(normalise(doc))
+		if err != nil {
+			return nil, fmt.Errorf("validate manifests: marshal %q: %w", path, err)
+		}
+
+		var instance interface{}
+		if err := json.Unmarshal(jsonBytes, &instance); err != nil {
+			return nil, fmt.Errorf("validate manifests: unmarshal %q: %w", path, err)
+		}
+
+		if valErr := sch.Validate(instance); valErr != nil {
+			var ve *jsonschema.ValidationError
+			if errors.As(valErr, &ve) {
+				results = append(results, ManifestResult{File: path, Errors: flattenManifestErrors(path, ve)})
+				continue
+			}
+			return nil, fmt.Errorf("validate manifests: %w", valErr)
+		}
+		results = append(results, ManifestResult{File: path})
+	}
+	return results, nil
+}
+
+func compileSchema(absPath string) (*jsonschema.Schema, error) {
+	c := jsonschema.NewCompiler()
+	c.Draft = jsonschema.Draft2020
+	return c.Compile("file://" + absPath)
+}
+
+func flattenManifestErrors(file string, ve *jsonschema.ValidationError) []ValidationError {
+	if len(ve.Causes) == 0 {
+		return single(file, ve.InstanceLocation, ve.Message)
+	}
+	var out []ValidationError
+	for _, c := range ve.Causes {
+		out = append(out, flattenManifestErrors(file, c)...)
+	}
+	return out
+}
+
+// normalise converts map[interface{}]interface{} produced by yaml.v3 edge
+// cases to map[string]interface{} so json.Marshal succeeds on all valid YAML.
+func normalise(v interface{}) interface{} {
+	switch val := v.(type) {
+	case map[string]interface{}:
+		out := make(map[string]interface{}, len(val))
+		for k, v2 := range val {
+			out[k] = normalise(v2)
+		}
+		return out
+	case map[interface{}]interface{}:
+		out := make(map[string]interface{}, len(val))
+		for k, v2 := range val {
+			out[fmt.Sprintf("%v", k)] = normalise(v2)
+		}
+		return out
+	case []interface{}:
+		out := make([]interface{}, len(val))
+		for i, v2 := range val {
+			out[i] = normalise(v2)
+		}
+		return out
+	default:
+		return val
+	}
+}
+
+func normaliseMap(v interface{}) (map[string]interface{}, bool) {
+	n := normalise(v)
+	m, ok := n.(map[string]interface{})
+	return m, ok
+}

--- a/cmd/zynax-ci/validate/manifest_test.go
+++ b/cmd/zynax-ci/validate/manifest_test.go
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package validate_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/zynax-io/zynax/cmd/zynax-ci/validate"
+)
+
+// minimalSchema returns a minimal Draft 2020-12 JSON Schema that requires
+// kind, apiVersion, and metadata fields — good enough to exercise the validator.
+func writeMinimalWorkflowSchema(t *testing.T, dir string) string {
+	t.Helper()
+	schema := map[string]interface{}{
+		"$schema": "https://json-schema.org/draft/2020-12/schema",
+		"$id":     "https://test.zynax.io/workflow",
+		"type":    "object",
+		"required": []string{"kind", "apiVersion", "metadata"},
+		"properties": map[string]interface{}{
+			"kind":       map[string]interface{}{"type": "string", "const": "Workflow"},
+			"apiVersion": map[string]interface{}{"type": "string"},
+			"metadata":   map[string]interface{}{"type": "object"},
+		},
+	}
+	b, _ := json.Marshal(schema)
+	path := filepath.Join(dir, "workflow.schema.json")
+	if err := os.WriteFile(path, b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func writeYAML(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestBatchManifests_ValidWorkflow(t *testing.T) {
+	dir := t.TempDir()
+	schema := writeMinimalWorkflowSchema(t, dir)
+	writeYAML(t, dir, "wf.yaml", `
+kind: Workflow
+apiVersion: zynax.io/v1
+metadata:
+  name: test-wf
+`)
+	results, err := validate.BatchManifests(dir, "Workflow", schema)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if len(results[0].Errors) != 0 {
+		t.Errorf("expected no errors, got %v", results[0].Errors)
+	}
+}
+
+func TestBatchManifests_InvalidWorkflow(t *testing.T) {
+	dir := t.TempDir()
+	schema := writeMinimalWorkflowSchema(t, dir)
+	writeYAML(t, dir, "bad.yaml", `
+kind: Workflow
+apiVersion: zynax.io/v1
+`)
+	// metadata is required but missing
+	results, err := validate.BatchManifests(dir, "Workflow", schema)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if len(results[0].Errors) == 0 {
+		t.Error("expected schema errors for missing metadata field")
+	}
+}
+
+func TestBatchManifests_FiltersByKind(t *testing.T) {
+	dir := t.TempDir()
+	schema := writeMinimalWorkflowSchema(t, dir)
+	// This file is AgentDef — should be skipped when validating Workflow kind
+	writeYAML(t, dir, "agent.yaml", `
+kind: AgentDef
+apiVersion: zynax.io/v1
+metadata:
+  name: my-agent
+`)
+	results, err := validate.BatchManifests(dir, "Workflow", schema)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("expected 0 results (AgentDef should be filtered), got %d", len(results))
+	}
+}
+
+func TestBatchManifests_EmptyDir(t *testing.T) {
+	dir := t.TempDir()
+	schema := writeMinimalWorkflowSchema(t, dir)
+	results, err := validate.BatchManifests(dir, "Workflow", schema)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("expected 0 results in empty dir, got %d", len(results))
+	}
+}
+
+func TestBatchManifests_InvalidYAML(t *testing.T) {
+	dir := t.TempDir()
+	schema := writeMinimalWorkflowSchema(t, dir)
+	writeYAML(t, dir, "bad.yaml", "kind: Workflow\n  bad_indent: {")
+	results, err := validate.BatchManifests(dir, "Workflow", schema)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Invalid YAML with kind Workflow cannot be parsed — returns error entry
+	if len(results) != 1 || len(results[0].Errors) == 0 {
+		t.Errorf("expected error result for invalid YAML, got %v", results)
+	}
+}

--- a/cmd/zynax-ci/validate/schema.go
+++ b/cmd/zynax-ci/validate/schema.go
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package validate
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// SchemaResult holds the outcome of validating a single JSON Schema file.
+type SchemaResult struct {
+	File   string            `json:"file"`
+	Errors []ValidationError `json:"errors,omitempty"`
+}
+
+// Schema validates a single JSON Schema file: well-formed JSON + $schema field present.
+func Schema(filePath string) ([]ValidationError, error) {
+	raw, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("validate schema: read %q: %w", filePath, err)
+	}
+
+	var doc map[string]interface{}
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		return single(filePath, "", "invalid JSON: "+err.Error()), nil
+	}
+	if _, ok := doc["$schema"]; !ok {
+		return single(filePath, "/$schema", "missing $schema field"), nil
+	}
+	return nil, nil
+}
+
+// SchemaDir walks dir for *.json files and validates each with Schema.
+func SchemaDir(dir string) ([]SchemaResult, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("validate schema: read dir %q: %w", dir, err)
+	}
+
+	var files []string
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasSuffix(e.Name(), ".json") {
+			files = append(files, filepath.Join(dir, e.Name()))
+		}
+	}
+	sort.Strings(files)
+
+	var results []SchemaResult
+	for _, path := range files {
+		errs, err := Schema(path)
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, SchemaResult{File: path, Errors: errs})
+	}
+	return results, nil
+}

--- a/cmd/zynax-ci/validate/schema_test.go
+++ b/cmd/zynax-ci/validate/schema_test.go
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package validate_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/zynax-io/zynax/cmd/zynax-ci/validate"
+)
+
+func writeJSON(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestSchema_ValidFile(t *testing.T) {
+	dir := t.TempDir()
+	path := writeJSON(t, dir, "good.json", `{
+		"$schema": "https://json-schema.org/draft/2020-12/schema",
+		"type": "object"
+	}`)
+	errs, err := validate.Schema(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(errs) != 0 {
+		t.Errorf("expected no errors, got %v", errs)
+	}
+}
+
+func TestSchema_MissingSchemaField(t *testing.T) {
+	dir := t.TempDir()
+	path := writeJSON(t, dir, "no-schema.json", `{"type": "object"}`)
+	errs, err := validate.Schema(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(errs) == 0 {
+		t.Error("expected error for missing $schema field")
+	}
+}
+
+func TestSchema_InvalidJSON(t *testing.T) {
+	dir := t.TempDir()
+	path := writeJSON(t, dir, "bad.json", `{not json}`)
+	errs, err := validate.Schema(path)
+	if err != nil {
+		t.Fatalf("unexpected I/O error: %v", err)
+	}
+	if len(errs) == 0 {
+		t.Error("expected error for invalid JSON")
+	}
+}
+
+func TestSchema_FileNotFound(t *testing.T) {
+	_, err := validate.Schema("/nonexistent/path/schema.json")
+	if err == nil {
+		t.Error("expected error for nonexistent file")
+	}
+}
+
+func TestSchemaDir_ValidDir(t *testing.T) {
+	dir := t.TempDir()
+	writeJSON(t, dir, "a.json", `{"$schema":"https://json-schema.org/draft/2020-12/schema"}`)
+	writeJSON(t, dir, "b.json", `{"$schema":"https://json-schema.org/draft/2020-12/schema"}`)
+	results, err := validate.SchemaDir(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+	for _, r := range results {
+		if len(r.Errors) != 0 {
+			t.Errorf("unexpected errors for %s: %v", r.File, r.Errors)
+		}
+	}
+}
+
+func TestSchemaDir_OneFailingFile(t *testing.T) {
+	dir := t.TempDir()
+	writeJSON(t, dir, "good.json", `{"$schema":"https://json-schema.org/draft/2020-12/schema"}`)
+	writeJSON(t, dir, "bad.json", `{"type":"object"}`)
+	results, err := validate.SchemaDir(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+	failCount := 0
+	for _, r := range results {
+		if len(r.Errors) > 0 {
+			failCount++
+		}
+	}
+	if failCount != 1 {
+		t.Errorf("expected 1 failing file, got %d", failCount)
+	}
+}
+
+func TestSchemaDir_EmptyDir(t *testing.T) {
+	dir := t.TempDir()
+	results, err := validate.SchemaDir(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("expected 0 results in empty dir, got %d", len(results))
+	}
+}


### PR DESCRIPTION
## Summary

- Ports five Python validator scripts and one shell script to Go inside `cmd/zynax-ci`
- Adds `validate workflows|agent-defs|policies|capabilities|schema` sub-commands
- Adds `check ai-context` command (advisory, always exits 0)
- Adds `gopkg.in/yaml.v3` and `santhosh-tekuri/jsonschema/v5` to `cmd/zynax-ci/go.mod`
- Adds `Path` field to `ValidationError` (non-breaking; canvas errors leave it empty)

## Commands added

| Command | Replaces |
|---------|---------|
| `zynax-ci validate workflows <dir>` | `tools/validate_workflows.py` |
| `zynax-ci validate agent-defs <dir>` | `tools/validate_agent_defs.py` |
| `zynax-ci validate policies <dir>` | `tools/validate_policies.py` |
| `zynax-ci validate capabilities <dir>` | `tools/validate_capabilities.py` |
| `zynax-ci validate schema <path>` | `tools/validate_json_schemas.py` |
| `zynax-ci check ai-context` | `tools/count-ai-context.sh` |

## Test plan

- [x] `GOWORK=off go test ./... -race -timeout 60s` — all packages pass
- [x] `zynax-ci validate schema spec/schemas/` — 5 OK
- [x] `zynax-ci validate workflows spec/workflows/examples/` — 3 OK
- [x] `zynax-ci validate agent-defs spec/workflows/examples/` — 1 OK
- [x] `zynax-ci validate policies spec/workflows/examples/` — 1 OK
- [x] `zynax-ci validate capabilities spec/workflows/examples/` — 3 OK
- [x] `zynax-ci check ai-context` — all files within budget

Closes #334

Assisted-by: Claude/claude-sonnet-4-6