### PR TITLE
feat(zynax-ci): validate schema command (#334 1/4)

### DIFF
--- a/cmd/zynax-ci/cmd/validate_schema.go
+++ b/cmd/zynax-ci/cmd/validate_schema.go
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/zynax-io/zynax/cmd/zynax-ci/validate"
+)
+
+var schemaFormat string
+
+var validateSchemaCmd = &cobra.Command{
+	Use:   "schema <path>",
+	Short: "Validate JSON Schema files for well-formedness and $schema field",
+	Long: `Validate one JSON Schema file or all *.json files in a directory.
+
+Each file is checked for:
+  • Valid JSON syntax
+  • Presence of the required $schema field
+
+Exits 0 if all files pass, 1 on any failure.`,
+	Args: cobra.ExactArgs(1),
+	RunE: runValidateSchema,
+}
+
+func init() {
+	validateSchemaCmd.Flags().StringVar(&schemaFormat, "format", "text", "output format: text or json")
+	validateCmd.AddCommand(validateSchemaCmd)
+}
+
+func runValidateSchema(cmd *cobra.Command, args []string) error {
+	path := args[0]
+
+	results, err := validate.SchemaDir(path)
+	if err != nil {
+		// path may be a single file
+		errs, ferr := validate.Schema(path)
+		if ferr != nil {
+			return ferr
+		}
+		results = []validate.SchemaResult{{File: path, Errors: errs}}
+	}
+
+	if len(results) == 0 {
+		fmt.Fprintf(cmd.OutOrStdout(), "(no JSON schema files found under %s)\n", path)
+		return nil
+	}
+
+	failed := false
+	for _, r := range results {
+		if len(r.Errors) > 0 {
+			failed = true
+		}
+	}
+
+	if schemaFormat == "json" {
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(results)
+		if failed {
+			return fmt.Errorf("schema validation failed")
+		}
+		return nil
+	}
+
+	for _, r := range results {
+		if len(r.Errors) > 0 {
+			fmt.Fprintf(cmd.ErrOrStderr(), "FAIL %s:\n", r.File)
+			for _, e := range r.Errors {
+				fmt.Fprintf(cmd.ErrOrStderr(), "  ERROR  %s\n", e.Message)
+			}
+		} else {
+			fmt.Fprintf(cmd.OutOrStdout(), "  OK   %s\n", r.File)
+		}
+	}
+	if failed {
+		return fmt.Errorf("schema validation failed")
+	}
+	return nil
+}

--- a/cmd/zynax-ci/validate/canvas.go
+++ b/cmd/zynax-ci/validate/canvas.go
@@ -11,13 +11,17 @@ import (
 	"strings"
 )
 
-// ValidationError is a single hard failure from Canvas validation.
+// ValidationError is a single hard failure from validation.
 type ValidationError struct {
 	File    string `json:"file"`
+	Path    string `json:"path,omitempty"` // JSON Pointer to the failing element (optional)
 	Message string `json:"message"`
 }
 
 func (e ValidationError) Error() string {
+	if e.Path != "" {
+		return fmt.Sprintf("%s: at %s: %s", e.File, e.Path, e.Message)
+	}
 	return fmt.Sprintf("%s: %s", e.File, e.Message)
 }
 

--- a/cmd/zynax-ci/validate/helpers.go
+++ b/cmd/zynax-ci/validate/helpers.go
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package validate
+
+func single(file, path, msg string) []ValidationError {
+	return []ValidationError{{File: file, Path: path, Message: msg}}
+}

--- a/cmd/zynax-ci/validate/schema.go
+++ b/cmd/zynax-ci/validate/schema.go
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package validate
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// SchemaResult holds the outcome of validating a single JSON Schema file.
+type SchemaResult struct {
+	File   string            `json:"file"`
+	Errors []ValidationError `json:"errors,omitempty"`
+}
+
+// Schema validates a single JSON Schema file: well-formed JSON + $schema field present.
+func Schema(filePath string) ([]ValidationError, error) {
+	raw, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("validate schema: read %q: %w", filePath, err)
+	}
+
+	var doc map[string]interface{}
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		return single(filePath, "", "invalid JSON: "+err.Error()), nil
+	}
+	if _, ok := doc["$schema"]; !ok {
+		return single(filePath, "/$schema", "missing $schema field"), nil
+	}
+	return nil, nil
+}
+
+// SchemaDir walks dir for *.json files and validates each with Schema.
+func SchemaDir(dir string) ([]SchemaResult, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("validate schema: read dir %q: %w", dir, err)
+	}
+
+	var files []string
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasSuffix(e.Name(), ".json") {
+			files = append(files, filepath.Join(dir, e.Name()))
+		}
+	}
+	sort.Strings(files)
+
+	var results []SchemaResult
+	for _, path := range files {
+		errs, err := Schema(path)
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, SchemaResult{File: path, Errors: errs})
+	}
+	return results, nil
+}

--- a/cmd/zynax-ci/validate/schema_test.go
+++ b/cmd/zynax-ci/validate/schema_test.go
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package validate_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/zynax-io/zynax/cmd/zynax-ci/validate"
+)
+
+func writeJSON(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestSchema_ValidFile(t *testing.T) {
+	dir := t.TempDir()
+	path := writeJSON(t, dir, "good.json", `{
+		"$schema": "https://json-schema.org/draft/2020-12/schema",
+		"type": "object"
+	}`)
+	errs, err := validate.Schema(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(errs) != 0 {
+		t.Errorf("expected no errors, got %v", errs)
+	}
+}
+
+func TestSchema_MissingSchemaField(t *testing.T) {
+	dir := t.TempDir()
+	path := writeJSON(t, dir, "no-schema.json", `{"type": "object"}`)
+	errs, err := validate.Schema(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(errs) == 0 {
+		t.Error("expected error for missing $schema field")
+	}
+}
+
+func TestSchema_InvalidJSON(t *testing.T) {
+	dir := t.TempDir()
+	path := writeJSON(t, dir, "bad.json", `{not json}`)
+	errs, err := validate.Schema(path)
+	if err != nil {
+		t.Fatalf("unexpected I/O error: %v", err)
+	}
+	if len(errs) == 0 {
+		t.Error("expected error for invalid JSON")
+	}
+}
+
+func TestSchema_FileNotFound(t *testing.T) {
+	_, err := validate.Schema("/nonexistent/path/schema.json")
+	if err == nil {
+		t.Error("expected error for nonexistent file")
+	}
+}
+
+func TestSchemaDir_ValidDir(t *testing.T) {
+	dir := t.TempDir()
+	writeJSON(t, dir, "a.json", `{"$schema":"https://json-schema.org/draft/2020-12/schema"}`)
+	writeJSON(t, dir, "b.json", `{"$schema":"https://json-schema.org/draft/2020-12/schema"}`)
+	results, err := validate.SchemaDir(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+	for _, r := range results {
+		if len(r.Errors) != 0 {
+			t.Errorf("unexpected errors for %s: %v", r.File, r.Errors)
+		}
+	}
+}
+
+func TestSchemaDir_OneFailingFile(t *testing.T) {
+	dir := t.TempDir()
+	writeJSON(t, dir, "good.json", `{"$schema":"https://json-schema.org/draft/2020-12/schema"}`)
+	writeJSON(t, dir, "bad.json", `{"type":"object"}`)
+	results, err := validate.SchemaDir(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+	failCount := 0
+	for _, r := range results {
+		if len(r.Errors) > 0 {
+			failCount++
+		}
+	}
+	if failCount != 1 {
+		t.Errorf("expected 1 failing file, got %d", failCount)
+	}
+}
+
+func TestSchemaDir_EmptyDir(t *testing.T) {
+	dir := t.TempDir()
+	results, err := validate.SchemaDir(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("expected 0 results in empty dir, got %d", len(results))
+	}
+}


### PR DESCRIPTION
## Summary

Ports `tools/validate_json_schemas.py` to Go as `zynax-ci validate schema <path>`.

- Adds `Path` field to `ValidationError` (non-breaking; canvas errors leave it empty)
- Adds `validate/helpers.go` with shared `single()` error constructor
- Adds `validate/schema.go`: `Schema(file)` + `SchemaDir(dir)` — checks well-formed JSON and `$schema` field presence
- Adds `cmd/validate_schema.go`: `zynax-ci validate schema <path>` with `--format text|json`

**Lines changed:** 273 additions (ideal range)
**No new deps** — uses stdlib only.

## Test plan

- [x] `GOWORK=off go test ./... -race` — passes
- [x] `zynax-ci validate schema spec/schemas/` — all 5 schemas OK

## PR chain

This is part of a 4-PR chain for issue #334 (Canvas #331 step 9):
1. **This PR** — `validate schema`
2. Stacked: `feat/issue-334b-validate-manifests` — `validate workflows|agent-defs|policies`
3. Stacked: `feat/issue-334c-validate-capabilities` — `validate capabilities`
4. Stacked: `feat/issue-334d-check-ai-context` — `check ai-context`

Supersedes #346 (too large — 1402 lines).

Part of #334. Epic: #331.

Assisted-by: Claude/claude-sonnet-4-6