### PR TITLE
feat(zynax-ci): validate workflows/agent-defs/policies (#334 2/4)

### DIFF
--- a/cmd/zynax-ci/cmd/validate_agent_defs.go
+++ b/cmd/zynax-ci/cmd/validate_agent_defs.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	"github.com/zynax-io/zynax/cmd/zynax-ci/validate"
+)
+
+var agentDefsSchemaDir string
+var agentDefsFormat string
+
+var validateAgentDefsCmd = &cobra.Command{
+	Use:   "agent-defs <dir>",
+	Short: "Validate AgentDef YAML manifests against the JSON Schema",
+	Long: `Walk <dir> for *.yaml files, filter those with kind: AgentDef,
+and validate each against spec/schemas/agent-def.schema.json (or --schema-dir).
+
+Exits 0 if all manifests pass, 1 on any schema violation.`,
+	Args: cobra.ExactArgs(1),
+	RunE: runValidateAgentDefs,
+}
+
+func init() {
+	validateAgentDefsCmd.Flags().StringVar(&agentDefsSchemaDir, "schema-dir", "spec/schemas", "directory containing JSON Schema files")
+	validateAgentDefsCmd.Flags().StringVar(&agentDefsFormat, "format", "text", "output format: text or json")
+	validateCmd.AddCommand(validateAgentDefsCmd)
+}
+
+func runValidateAgentDefs(cmd *cobra.Command, args []string) error {
+	dir := args[0]
+	schemaPath := filepath.Join(agentDefsSchemaDir, "agent-def.schema.json")
+
+	results, err := validate.BatchManifests(dir, "AgentDef", schemaPath)
+	if err != nil {
+		return err
+	}
+
+	if len(results) == 0 {
+		fmt.Fprintf(cmd.OutOrStdout(), "(no AgentDef manifests found in %s)\n", dir)
+		return nil
+	}
+	return printManifestResults(cmd, results, agentDefsFormat)
+}

--- a/cmd/zynax-ci/cmd/validate_policies.go
+++ b/cmd/zynax-ci/cmd/validate_policies.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	"github.com/zynax-io/zynax/cmd/zynax-ci/validate"
+)
+
+var policiesSchemaDir string
+var policiesFormat string
+
+var validatePoliciesCmd = &cobra.Command{
+	Use:   "policies <dir>",
+	Short: "Validate Policy YAML manifests against the JSON Schema",
+	Long: `Walk <dir> for *.yaml files, filter those with kind: Policy,
+and validate each against spec/schemas/policy.schema.json (or --schema-dir).
+
+Exits 0 if all manifests pass, 1 on any schema violation.`,
+	Args: cobra.ExactArgs(1),
+	RunE: runValidatePolicies,
+}
+
+func init() {
+	validatePoliciesCmd.Flags().StringVar(&policiesSchemaDir, "schema-dir", "spec/schemas", "directory containing JSON Schema files")
+	validatePoliciesCmd.Flags().StringVar(&policiesFormat, "format", "text", "output format: text or json")
+	validateCmd.AddCommand(validatePoliciesCmd)
+}
+
+func runValidatePolicies(cmd *cobra.Command, args []string) error {
+	dir := args[0]
+	schemaPath := filepath.Join(policiesSchemaDir, "policy.schema.json")
+
+	results, err := validate.BatchManifests(dir, "Policy", schemaPath)
+	if err != nil {
+		return err
+	}
+
+	if len(results) == 0 {
+		fmt.Fprintf(cmd.OutOrStdout(), "(no Policy manifests found in %s)\n", dir)
+		return nil
+	}
+	return printManifestResults(cmd, results, policiesFormat)
+}

--- a/cmd/zynax-ci/cmd/validate_workflows.go
+++ b/cmd/zynax-ci/cmd/validate_workflows.go
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	"github.com/zynax-io/zynax/cmd/zynax-ci/validate"
+)
+
+var workflowsSchemaDir string
+var workflowsFormat string
+
+var validateWorkflowsCmd = &cobra.Command{
+	Use:   "workflows <dir>",
+	Short: "Validate Workflow YAML manifests against the JSON Schema",
+	Long: `Walk <dir> for *.yaml files, filter those with kind: Workflow,
+and validate each against spec/schemas/workflow.schema.json (or --schema-dir).
+
+Exits 0 if all manifests pass, 1 on any schema violation.`,
+	Args: cobra.ExactArgs(1),
+	RunE: runValidateWorkflows,
+}
+
+func init() {
+	validateWorkflowsCmd.Flags().StringVar(&workflowsSchemaDir, "schema-dir", "spec/schemas", "directory containing JSON Schema files")
+	validateWorkflowsCmd.Flags().StringVar(&workflowsFormat, "format", "text", "output format: text or json")
+	validateCmd.AddCommand(validateWorkflowsCmd)
+}
+
+func runValidateWorkflows(cmd *cobra.Command, args []string) error {
+	dir := args[0]
+	schemaPath := filepath.Join(workflowsSchemaDir, "workflow.schema.json")
+
+	results, err := validate.BatchManifests(dir, "Workflow", schemaPath)
+	if err != nil {
+		return err
+	}
+
+	if len(results) == 0 {
+		fmt.Fprintf(cmd.OutOrStdout(), "(no Workflow manifests found in %s)\n", dir)
+		return nil
+	}
+	return printManifestResults(cmd, results, workflowsFormat)
+}
+
+func printManifestResults(cmd *cobra.Command, results []validate.ManifestResult, format string) error {
+	failed := false
+	for _, r := range results {
+		if len(r.Errors) > 0 {
+			failed = true
+		}
+	}
+
+	if format == "json" {
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(results)
+		if failed {
+			return fmt.Errorf("manifest validation failed")
+		}
+		return nil
+	}
+
+	for _, r := range results {
+		if len(r.Errors) > 0 {
+			fmt.Fprintf(cmd.ErrOrStderr(), "FAIL %s:\n", r.File)
+			for _, e := range r.Errors {
+				if e.Path != "" {
+					fmt.Fprintf(cmd.ErrOrStderr(), "  %s: %s\n", e.Path, e.Message)
+				} else {
+					fmt.Fprintf(cmd.ErrOrStderr(), "  ERROR  %s\n", e.Message)
+				}
+			}
+		} else {
+			fmt.Fprintf(cmd.OutOrStdout(), "  OK   %s\n", r.File)
+		}
+	}
+	if failed {
+		return fmt.Errorf("manifest validation failed")
+	}
+	return nil
+}

--- a/cmd/zynax-ci/go.mod
+++ b/cmd/zynax-ci/go.mod
@@ -3,7 +3,11 @@ module github.com/zynax-io/zynax/cmd/zynax-ci
 
 go 1.25.0
 
-require github.com/spf13/cobra v1.9.1
+require (
+	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
+	github.com/spf13/cobra v1.9.1
+	gopkg.in/yaml.v3 v3.0.1
+)
 
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/cmd/zynax-ci/go.sum
+++ b/cmd/zynax-ci/go.sum
@@ -2,9 +2,13 @@ github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6N
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 h1:lZUw3E0/J3roVtGQ+SCrUrg3ON6NgVqpn3+iol9aGu4=
+github.com/santhosh-tekuri/jsonschema/v5 v5.3.1/go.mod h1:uToXkOrWAZ6/Oc07xWQrPOhJotwFIyu2bBVN41fcDUY=
 github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=
 github.com/spf13/cobra v1.9.1/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wxYW0=
 github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
 github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/cmd/zynax-ci/validate/manifest.go
+++ b/cmd/zynax-ci/validate/manifest.go
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package validate
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/santhosh-tekuri/jsonschema/v5"
+	"gopkg.in/yaml.v3"
+)
+
+// ManifestResult holds the outcome of validating a single manifest file.
+type ManifestResult struct {
+	File   string            `json:"file"`
+	Errors []ValidationError `json:"errors,omitempty"`
+}
+
+// BatchManifests walks dir for *.yaml files, filters by kind, and validates each
+// against the JSON Schema at schemaPath. Returns one result per matching file.
+func BatchManifests(dir, kind, schemaPath string) ([]ManifestResult, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("validate manifests: read dir %q: %w", dir, err)
+	}
+
+	absSchema, err := filepath.Abs(schemaPath)
+	if err != nil {
+		return nil, fmt.Errorf("validate manifests: resolve schema path: %w", err)
+	}
+	sch, err := compileSchema(absSchema)
+	if err != nil {
+		return nil, fmt.Errorf("validate manifests: compile schema %q: %w", absSchema, err)
+	}
+
+	var files []string
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasSuffix(e.Name(), ".yaml") {
+			files = append(files, filepath.Join(dir, e.Name()))
+		}
+	}
+	sort.Strings(files)
+
+	var results []ManifestResult
+	for _, path := range files {
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("validate manifests: read %q: %w", path, err)
+		}
+
+		var doc interface{}
+		if err := yaml.Unmarshal(raw, &doc); err != nil {
+			results = append(results, ManifestResult{
+				File:   path,
+				Errors: single(path, "", "YAML parse error: "+err.Error()),
+			})
+			continue
+		}
+
+		m, ok := normaliseMap(doc)
+		if !ok {
+			continue // not a mapping — skip silently (not a manifest)
+		}
+		if docKind, _ := m["kind"].(string); docKind != kind {
+			continue // wrong kind — skip
+		}
+
+		jsonBytes, err := json.Marshal(normalise(doc))
+		if err != nil {
+			return nil, fmt.Errorf("validate manifests: marshal %q: %w", path, err)
+		}
+
+		var instance interface{}
+		if err := json.Unmarshal(jsonBytes, &instance); err != nil {
+			return nil, fmt.Errorf("validate manifests: unmarshal %q: %w", path, err)
+		}
+
+		if valErr := sch.Validate(instance); valErr != nil {
+			var ve *jsonschema.ValidationError
+			if errors.As(valErr, &ve) {
+				results = append(results, ManifestResult{File: path, Errors: flattenManifestErrors(path, ve)})
+				continue
+			}
+			return nil, fmt.Errorf("validate manifests: %w", valErr)
+		}
+		results = append(results, ManifestResult{File: path})
+	}
+	return results, nil
+}
+
+func compileSchema(absPath string) (*jsonschema.Schema, error) {
+	c := jsonschema.NewCompiler()
+	c.Draft = jsonschema.Draft2020
+	return c.Compile("file://" + absPath)
+}
+
+func flattenManifestErrors(file string, ve *jsonschema.ValidationError) []ValidationError {
+	if len(ve.Causes) == 0 {
+		return single(file, ve.InstanceLocation, ve.Message)
+	}
+	var out []ValidationError
+	for _, c := range ve.Causes {
+		out = append(out, flattenManifestErrors(file, c)...)
+	}
+	return out
+}
+
+// normalise converts map[interface{}]interface{} produced by yaml.v3 edge
+// cases to map[string]interface{} so json.Marshal succeeds on all valid YAML.
+func normalise(v interface{}) interface{} {
+	switch val := v.(type) {
+	case map[string]interface{}:
+		out := make(map[string]interface{}, len(val))
+		for k, v2 := range val {
+			out[k] = normalise(v2)
+		}
+		return out
+	case map[interface{}]interface{}:
+		out := make(map[string]interface{}, len(val))
+		for k, v2 := range val {
+			out[fmt.Sprintf("%v", k)] = normalise(v2)
+		}
+		return out
+	case []interface{}:
+		out := make([]interface{}, len(val))
+		for i, v2 := range val {
+			out[i] = normalise(v2)
+		}
+		return out
+	default:
+		return val
+	}
+}
+
+func normaliseMap(v interface{}) (map[string]interface{}, bool) {
+	n := normalise(v)
+	m, ok := n.(map[string]interface{})
+	return m, ok
+}

--- a/cmd/zynax-ci/validate/manifest_test.go
+++ b/cmd/zynax-ci/validate/manifest_test.go
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package validate_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/zynax-io/zynax/cmd/zynax-ci/validate"
+)
+
+// minimalSchema returns a minimal Draft 2020-12 JSON Schema that requires
+// kind, apiVersion, and metadata fields — good enough to exercise the validator.
+func writeMinimalWorkflowSchema(t *testing.T, dir string) string {
+	t.Helper()
+	schema := map[string]interface{}{
+		"$schema": "https://json-schema.org/draft/2020-12/schema",
+		"$id":     "https://test.zynax.io/workflow",
+		"type":    "object",
+		"required": []string{"kind", "apiVersion", "metadata"},
+		"properties": map[string]interface{}{
+			"kind":       map[string]interface{}{"type": "string", "const": "Workflow"},
+			"apiVersion": map[string]interface{}{"type": "string"},
+			"metadata":   map[string]interface{}{"type": "object"},
+		},
+	}
+	b, _ := json.Marshal(schema)
+	path := filepath.Join(dir, "workflow.schema.json")
+	if err := os.WriteFile(path, b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func writeYAML(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestBatchManifests_ValidWorkflow(t *testing.T) {
+	dir := t.TempDir()
+	schema := writeMinimalWorkflowSchema(t, dir)
+	writeYAML(t, dir, "wf.yaml", `
+kind: Workflow
+apiVersion: zynax.io/v1
+metadata:
+  name: test-wf
+`)
+	results, err := validate.BatchManifests(dir, "Workflow", schema)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if len(results[0].Errors) != 0 {
+		t.Errorf("expected no errors, got %v", results[0].Errors)
+	}
+}
+
+func TestBatchManifests_InvalidWorkflow(t *testing.T) {
+	dir := t.TempDir()
+	schema := writeMinimalWorkflowSchema(t, dir)
+	writeYAML(t, dir, "bad.yaml", `
+kind: Workflow
+apiVersion: zynax.io/v1
+`)
+	// metadata is required but missing
+	results, err := validate.BatchManifests(dir, "Workflow", schema)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if len(results[0].Errors) == 0 {
+		t.Error("expected schema errors for missing metadata field")
+	}
+}
+
+func TestBatchManifests_FiltersByKind(t *testing.T) {
+	dir := t.TempDir()
+	schema := writeMinimalWorkflowSchema(t, dir)
+	// This file is AgentDef — should be skipped when validating Workflow kind
+	writeYAML(t, dir, "agent.yaml", `
+kind: AgentDef
+apiVersion: zynax.io/v1
+metadata:
+  name: my-agent
+`)
+	results, err := validate.BatchManifests(dir, "Workflow", schema)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("expected 0 results (AgentDef should be filtered), got %d", len(results))
+	}
+}
+
+func TestBatchManifests_EmptyDir(t *testing.T) {
+	dir := t.TempDir()
+	schema := writeMinimalWorkflowSchema(t, dir)
+	results, err := validate.BatchManifests(dir, "Workflow", schema)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("expected 0 results in empty dir, got %d", len(results))
+	}
+}
+
+func TestBatchManifests_InvalidYAML(t *testing.T) {
+	dir := t.TempDir()
+	schema := writeMinimalWorkflowSchema(t, dir)
+	writeYAML(t, dir, "bad.yaml", "kind: Workflow\n  bad_indent: {")
+	results, err := validate.BatchManifests(dir, "Workflow", schema)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Invalid YAML with kind Workflow cannot be parsed — returns error entry
+	if len(results) != 1 || len(results[0].Errors) == 0 {
+		t.Errorf("expected error result for invalid YAML, got %v", results)
+	}
+}


### PR DESCRIPTION
## Summary

Ports `tools/validate_workflows.py`, `validate_agent_defs.py`, `validate_policies.py` to Go.

- Adds `gopkg.in/yaml.v3` and `santhosh-tekuri/jsonschema/v5` to `cmd/zynax-ci/go.mod`
- Adds `validate/manifest.go`: `BatchManifests(dir, kind, schemaPath)` — walks `*.yaml`, filters by `kind` field, validates each against the JSON Schema
- Adds `cmd/validate_workflows.go`, `cmd/validate_agent_defs.go`, `cmd/validate_policies.go`: `zynax-ci validate workflows|agent-defs|policies <dir> [--schema-dir spec/schemas]`

**Lines changed:** 463 additions (go.mod/go.sum account for ~29; justified by core batch logic + 3 related manifest-type commands sharing the same `BatchManifests` implementation)

## Test plan

- [x] `GOWORK=off go test ./... -race` — passes
- [x] `zynax-ci validate workflows spec/workflows/examples/` — 3 OK
- [x] `zynax-ci validate agent-defs spec/workflows/examples/` — 1 OK
- [x] `zynax-ci validate policies spec/workflows/examples/` — 1 OK

## PR chain

Stacked on #347. Base will change to `main` once #347 merges.
1. #347 — `validate schema`
2. **This PR** — `validate workflows|agent-defs|policies`
3. Stacked: `feat/issue-334c-validate-capabilities` — `validate capabilities`
4. Stacked: `feat/issue-334d-check-ai-context` — `check ai-context`

Part of #334. Epic: #331.

Assisted-by: Claude/claude-sonnet-4-6