### PR TITLE
feat(zynax-ci): validate capabilities command (#334 3/4)

### DIFF
--- a/cmd/zynax-ci/cmd/validate_capabilities.go
+++ b/cmd/zynax-ci/cmd/validate_capabilities.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	"github.com/zynax-io/zynax/cmd/zynax-ci/validate"
+)
+
+var capabilitiesSchemaDir string
+var capabilitiesFormat string
+
+var validateCapabilitiesCmd = &cobra.Command{
+	Use:   "capabilities <dir>",
+	Short: "Validate capability declarations in AgentDef YAML files",
+	Long: `Walk <dir> for *.yaml files, extract capability declarations from
+AgentDef manifests (spec.capabilities or top-level capabilities), and validate
+each against spec/schemas/capability.schema.json (or --schema-dir).
+
+Exits 0 if all capabilities pass, 1 on any schema violation.`,
+	Args: cobra.ExactArgs(1),
+	RunE: runValidateCapabilities,
+}
+
+func init() {
+	validateCapabilitiesCmd.Flags().StringVar(&capabilitiesSchemaDir, "schema-dir", "spec/schemas", "directory containing JSON Schema files")
+	validateCapabilitiesCmd.Flags().StringVar(&capabilitiesFormat, "format", "text", "output format: text or json")
+	validateCmd.AddCommand(validateCapabilitiesCmd)
+}
+
+func runValidateCapabilities(cmd *cobra.Command, args []string) error {
+	dir := args[0]
+	schemaPath := filepath.Join(capabilitiesSchemaDir, "capability.schema.json")
+
+	results, err := validate.Capabilities(dir, schemaPath)
+	if err != nil {
+		return err
+	}
+
+	if len(results) == 0 {
+		fmt.Fprintf(cmd.OutOrStdout(), "(no capability declarations found in %s)\n", dir)
+		return nil
+	}
+
+	failed := false
+	for _, r := range results {
+		if len(r.Errors) > 0 {
+			failed = true
+		}
+	}
+
+	if capabilitiesFormat == "json" {
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(results)
+		if failed {
+			return fmt.Errorf("capability validation failed")
+		}
+		return nil
+	}
+
+	for _, r := range results {
+		if len(r.Errors) > 0 {
+			fmt.Fprintf(cmd.ErrOrStderr(), "FAIL %s capability %q:\n", r.File, r.Capability)
+			for _, e := range r.Errors {
+				if e.Path != "" {
+					fmt.Fprintf(cmd.ErrOrStderr(), "  %s: %s\n", e.Path, e.Message)
+				} else {
+					fmt.Fprintf(cmd.ErrOrStderr(), "  ERROR  %s\n", e.Message)
+				}
+			}
+		} else {
+			fmt.Fprintf(cmd.OutOrStdout(), "  OK   %s :: %s\n", r.File, r.Capability)
+		}
+	}
+	if failed {
+		return fmt.Errorf("capability validation failed")
+	}
+	return nil
+}

--- a/cmd/zynax-ci/validate/capabilities.go
+++ b/cmd/zynax-ci/validate/capabilities.go
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package validate
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/santhosh-tekuri/jsonschema/v5"
+	"gopkg.in/yaml.v3"
+)
+
+// CapabilityResult holds the outcome of validating a single capability entry.
+type CapabilityResult struct {
+	File       string            `json:"file"`
+	Capability string            `json:"capability"`
+	Errors     []ValidationError `json:"errors,omitempty"`
+}
+
+// Capabilities walks dir for *.yaml files, extracts capability declarations
+// from AgentDef manifests, and validates each against the schema at schemaPath.
+// Both spec.capabilities and top-level capabilities arrays are supported.
+func Capabilities(dir, schemaPath string) ([]CapabilityResult, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("validate capabilities: read dir %q: %w", dir, err)
+	}
+
+	absSchema, err := filepath.Abs(schemaPath)
+	if err != nil {
+		return nil, fmt.Errorf("validate capabilities: resolve schema: %w", err)
+	}
+	sch, err := compileSchema(absSchema)
+	if err != nil {
+		return nil, fmt.Errorf("validate capabilities: compile schema %q: %w", absSchema, err)
+	}
+
+	var files []string
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasSuffix(e.Name(), ".yaml") {
+			files = append(files, filepath.Join(dir, e.Name()))
+		}
+	}
+	sort.Strings(files)
+
+	var results []CapabilityResult
+	for _, path := range files {
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("validate capabilities: read %q: %w", path, err)
+		}
+
+		var doc interface{}
+		if err := yaml.Unmarshal(raw, &doc); err != nil {
+			continue // not a valid YAML doc — skip
+		}
+
+		m, ok := normaliseMap(doc)
+		if !ok {
+			continue
+		}
+
+		caps := extractCapabilities(m)
+		for _, cap := range caps {
+			name, _ := cap["name"].(string)
+			if name == "" {
+				name = "?"
+			}
+
+			jsonBytes, err := json.Marshal(cap)
+			if err != nil {
+				return nil, fmt.Errorf("validate capabilities: marshal capability in %q: %w", path, err)
+			}
+			var instance interface{}
+			if err := json.Unmarshal(jsonBytes, &instance); err != nil {
+				return nil, fmt.Errorf("validate capabilities: unmarshal capability in %q: %w", path, err)
+			}
+
+			if valErr := sch.Validate(instance); valErr != nil {
+				var ve *jsonschema.ValidationError
+				if errors.As(valErr, &ve) {
+					results = append(results, CapabilityResult{
+						File:       path,
+						Capability: name,
+						Errors:     flattenManifestErrors(path, ve),
+					})
+					continue
+				}
+				return nil, fmt.Errorf("validate capabilities: %w", valErr)
+			}
+			results = append(results, CapabilityResult{File: path, Capability: name})
+		}
+	}
+	return results, nil
+}
+
+// extractCapabilities pulls capabilities from spec.capabilities or top-level capabilities.
+func extractCapabilities(m map[string]interface{}) []map[string]interface{} {
+	var raw []interface{}
+	if spec, ok := m["spec"].(map[string]interface{}); ok {
+		if caps, ok := spec["capabilities"].([]interface{}); ok {
+			raw = caps
+		}
+	}
+	if raw == nil {
+		if caps, ok := m["capabilities"].([]interface{}); ok {
+			raw = caps
+		}
+	}
+
+	var out []map[string]interface{}
+	for _, item := range raw {
+		if cap, ok := item.(map[string]interface{}); ok {
+			out = append(out, cap)
+		}
+	}
+	return out
+}

--- a/cmd/zynax-ci/validate/capabilities_test.go
+++ b/cmd/zynax-ci/validate/capabilities_test.go
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package validate_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/zynax-io/zynax/cmd/zynax-ci/validate"
+)
+
+// writeCapabilitySchema writes a minimal capability schema to dir and returns its path.
+func writeCapabilitySchema(t *testing.T, dir string) string {
+	t.Helper()
+	schema := map[string]interface{}{
+		"$schema": "https://json-schema.org/draft/2020-12/schema",
+		"$id":     "https://test.zynax.io/capability",
+		"type":    "object",
+		"required": []string{"name"},
+		"properties": map[string]interface{}{
+			"name":        map[string]interface{}{"type": "string"},
+			"description": map[string]interface{}{"type": "string"},
+		},
+	}
+	b, _ := json.Marshal(schema)
+	path := filepath.Join(dir, "capability.schema.json")
+	if err := os.WriteFile(path, b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestCapabilities_ValidSpecCapabilities(t *testing.T) {
+	dir := t.TempDir()
+	schema := writeCapabilitySchema(t, dir)
+	writeYAML(t, dir, "agent.yaml", `
+kind: AgentDef
+spec:
+  capabilities:
+    - name: summarize
+      description: Summarise text
+`)
+	results, err := validate.Capabilities(dir, schema)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 capability result, got %d", len(results))
+	}
+	if len(results[0].Errors) != 0 {
+		t.Errorf("expected no errors, got %v", results[0].Errors)
+	}
+	if results[0].Capability != "summarize" {
+		t.Errorf("expected capability name 'summarize', got %q", results[0].Capability)
+	}
+}
+
+func TestCapabilities_TopLevelCapabilities(t *testing.T) {
+	dir := t.TempDir()
+	schema := writeCapabilitySchema(t, dir)
+	writeYAML(t, dir, "agent.yaml", `
+capabilities:
+  - name: legacy-cap
+`)
+	results, err := validate.Capabilities(dir, schema)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if len(results[0].Errors) != 0 {
+		t.Errorf("expected no errors, got %v", results[0].Errors)
+	}
+}
+
+func TestCapabilities_MissingRequiredField(t *testing.T) {
+	dir := t.TempDir()
+	schema := writeCapabilitySchema(t, dir)
+	writeYAML(t, dir, "agent.yaml", `
+spec:
+  capabilities:
+    - description: no name field here
+`)
+	results, err := validate.Capabilities(dir, schema)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if len(results[0].Errors) == 0 {
+		t.Error("expected schema error for missing 'name' field")
+	}
+}
+
+func TestCapabilities_NoCapabilities(t *testing.T) {
+	dir := t.TempDir()
+	schema := writeCapabilitySchema(t, dir)
+	// A YAML file with no capability fields at all
+	writeYAML(t, dir, "workflow.yaml", `
+kind: Workflow
+spec:
+  states: []
+`)
+	results, err := validate.Capabilities(dir, schema)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("expected 0 results for file with no capabilities, got %d", len(results))
+	}
+}
+
+func TestCapabilities_EmptyDir(t *testing.T) {
+	dir := t.TempDir()
+	schema := writeCapabilitySchema(t, dir)
+	results, err := validate.Capabilities(dir, schema)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("expected 0 results in empty dir, got %d", len(results))
+	}
+}


### PR DESCRIPTION
## Summary

Ports `tools/validate_capabilities.py` to Go as `zynax-ci validate capabilities <dir>`.

- Adds `validate/capabilities.go`: `Capabilities(dir, schemaPath)` — walks `*.yaml`, extracts `spec.capabilities` and top-level `capabilities` arrays from AgentDef manifests, validates each item against `capability.schema.json`
- Adds `cmd/validate_capabilities.go`: `zynax-ci validate capabilities <dir> [--schema-dir spec/schemas]`
- Supports both `spec.capabilities` (current schema) and top-level `capabilities` (legacy)

**Lines changed:** 334 additions (ideal range)

## Test plan

- [x] `GOWORK=off go test ./... -race` — passes
- [x] `zynax-ci validate capabilities spec/workflows/examples/` — 3 capabilities OK

## PR chain

Stacked on #348. Base will change to `main` once #348 merges.
1. #347 — `validate schema`
2. #348 — `validate workflows|agent-defs|policies`
3. **This PR** — `validate capabilities`
4. Stacked: `feat/issue-334d-check-ai-context` — `check ai-context`

Part of #334. Epic: #331.

Assisted-by: Claude/claude-sonnet-4-6