### PR TITLE
feat(zynax-ci): check ai-context command (#334 4/4)

### DIFF
--- a/cmd/zynax-ci/check/context.go
+++ b/cmd/zynax-ci/check/context.go
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package check implements advisory checks for the zynax-ci toolchain.
+package check
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// FileReport is the result for a single AI context file.
+type FileReport struct {
+	Path      string
+	Lines     int
+	Threshold int
+	Warn      bool
+}
+
+// ContextReport is the full report from an AI context check.
+type ContextReport struct {
+	Files      []FileReport
+	Total      int
+	TotalLimit int
+	Warnings   int
+}
+
+// thresholds mirrors the logic in tools/count-ai-context.sh.
+var (
+	thresholdClaude     = 200
+	thresholdRootAgents = 300
+	thresholdAISetup    = 150
+	thresholdDirAgents  = 150
+	thresholdTotal      = 2000
+)
+
+// Context scans repoRoot for CLAUDE.md, AGENTS.md files, and
+// docs/ai-assistant-setup.md, counting lines and comparing against
+// per-file thresholds. Always returns without error even when thresholds
+// are exceeded — this check is advisory only.
+func Context(repoRoot string) (ContextReport, error) {
+	var report ContextReport
+	report.TotalLimit = thresholdTotal
+
+	add := func(path string, threshold int) {
+		n, err := countLines(path)
+		if err != nil {
+			return // file absent — skip silently
+		}
+		warn := n > threshold
+		if warn {
+			report.Warnings++
+		}
+		report.Files = append(report.Files, FileReport{
+			Path:      relPath(repoRoot, path),
+			Lines:     n,
+			Threshold: threshold,
+			Warn:      warn,
+		})
+		report.Total += n
+	}
+
+	add(filepath.Join(repoRoot, "CLAUDE.md"), thresholdClaude)
+	add(filepath.Join(repoRoot, "AGENTS.md"), thresholdRootAgents)
+	add(filepath.Join(repoRoot, "docs", "ai-assistant-setup.md"), thresholdAISetup)
+
+	// Per-directory AGENTS.md files (all except root).
+	var subdirAgents []string
+	_ = filepath.WalkDir(repoRoot, func(path string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil
+		}
+		if d.Name() != "AGENTS.md" {
+			return nil
+		}
+		if path == filepath.Join(repoRoot, "AGENTS.md") {
+			return nil
+		}
+		subdirAgents = append(subdirAgents, path)
+		return nil
+	})
+	sort.Strings(subdirAgents)
+	for _, path := range subdirAgents {
+		add(path, thresholdDirAgents)
+	}
+
+	if report.Total > thresholdTotal {
+		report.Warnings++
+	}
+	return report, nil
+}
+
+// Print writes the report in the same table format as count-ai-context.sh.
+func (r ContextReport) Print(w *os.File) {
+	fmt.Fprintf(w, "| %-55s | %5s | %5s | %-6s |\n", "File", "Lines", "Limit", "Status")
+	fmt.Fprintln(w, "|----------------------------------------------------------|-------|-------|--------|")
+	for _, f := range r.Files {
+		status := "OK"
+		if f.Warn {
+			status = "WARN"
+		}
+		fmt.Fprintf(w, "| %-55s | %5d | %5d | %-6s |\n", f.Path, f.Lines, f.Threshold, status)
+	}
+	fmt.Fprintln(w, "|----------------------------------------------------------|-------|-------|--------|")
+	totalStatus := "OK"
+	if r.Total > r.TotalLimit {
+		totalStatus = "WARN"
+	}
+	fmt.Fprintf(w, "| %-55s | %5d | %5d | %-6s |\n", "TOTAL", r.Total, r.TotalLimit, totalStatus)
+	fmt.Fprintln(w, "")
+	if r.Warnings > 0 {
+		fmt.Fprintf(w, "WARNING: %d file(s) exceed their line threshold.\n", r.Warnings)
+		fmt.Fprintln(w, "Consider trimming AI context files — smaller budgets improve signal density.")
+	} else {
+		fmt.Fprintln(w, "All AI context files are within budget.")
+	}
+}
+
+func countLines(path string) (int, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return 0, err
+	}
+	defer f.Close()
+	s := bufio.NewScanner(f)
+	n := 0
+	for s.Scan() {
+		n++
+	}
+	return n, s.Err()
+}
+
+func relPath(base, path string) string {
+	rel, err := filepath.Rel(base, path)
+	if err != nil {
+		return path
+	}
+	return strings.TrimPrefix(rel, "./")
+}

--- a/cmd/zynax-ci/check/context_test.go
+++ b/cmd/zynax-ci/check/context_test.go
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package check_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/zynax-io/zynax/cmd/zynax-ci/check"
+)
+
+func writeLines(t *testing.T, path string, n int) {
+	t.Helper()
+	var b strings.Builder
+	for i := 0; i < n; i++ {
+		b.WriteString("line\n")
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(b.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestContext_AllWithinBudget(t *testing.T) {
+	root := t.TempDir()
+	writeLines(t, filepath.Join(root, "CLAUDE.md"), 50)
+	writeLines(t, filepath.Join(root, "AGENTS.md"), 100)
+	writeLines(t, filepath.Join(root, "docs", "ai-assistant-setup.md"), 80)
+	writeLines(t, filepath.Join(root, "services", "AGENTS.md"), 60)
+
+	report, err := check.Context(root)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if report.Warnings != 0 {
+		t.Errorf("expected 0 warnings, got %d", report.Warnings)
+	}
+	if report.Total == 0 {
+		t.Error("expected non-zero total")
+	}
+}
+
+func TestContext_ExceedsThreshold(t *testing.T) {
+	root := t.TempDir()
+	// Write more than the CLAUDE.md threshold (200)
+	writeLines(t, filepath.Join(root, "CLAUDE.md"), 250)
+
+	report, err := check.Context(root)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if report.Warnings == 0 {
+		t.Error("expected at least 1 warning for oversized CLAUDE.md")
+	}
+	found := false
+	for _, f := range report.Files {
+		if strings.HasSuffix(f.Path, "CLAUDE.md") && f.Warn {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected CLAUDE.md to be flagged as WARN")
+	}
+}
+
+func TestContext_TotalExceedsLimit(t *testing.T) {
+	root := t.TempDir()
+	// Spread lines across many AGENTS.md files to breach the 2000-line total
+	for _, sub := range []string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n"} {
+		writeLines(t, filepath.Join(root, sub, "AGENTS.md"), 150)
+	}
+	writeLines(t, filepath.Join(root, "CLAUDE.md"), 180)
+	writeLines(t, filepath.Join(root, "AGENTS.md"), 290)
+
+	report, err := check.Context(root)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if report.Total <= 2000 {
+		t.Logf("total=%d — test may not be exercising total threshold, skipping", report.Total)
+		return
+	}
+	if report.Warnings == 0 {
+		t.Error("expected warnings when total exceeds 2000")
+	}
+}
+
+func TestContext_MissingFiles(t *testing.T) {
+	// Empty repo root — no AI context files at all
+	root := t.TempDir()
+	report, err := check.Context(root)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if report.Total != 0 {
+		t.Errorf("expected total=0 for empty root, got %d", report.Total)
+	}
+	if len(report.Files) != 0 {
+		t.Errorf("expected 0 file entries, got %d", len(report.Files))
+	}
+}
+
+func TestContext_RootAgentsMdNotCountedTwice(t *testing.T) {
+	root := t.TempDir()
+	writeLines(t, filepath.Join(root, "AGENTS.md"), 100)
+	writeLines(t, filepath.Join(root, "sub", "AGENTS.md"), 50)
+
+	report, err := check.Context(root)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Total should be 150, not 200 (root AGENTS.md should not appear twice)
+	if report.Total != 150 {
+		t.Errorf("expected total=150, got %d", report.Total)
+	}
+}

--- a/cmd/zynax-ci/cmd/check.go
+++ b/cmd/zynax-ci/cmd/check.go
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var checkCmd = &cobra.Command{
+	Use:   "check",
+	Short: "Advisory checks for the Zynax repository",
+}
+
+func init() {
+	rootCmd.AddCommand(checkCmd)
+}

--- a/cmd/zynax-ci/cmd/check_ai_context.go
+++ b/cmd/zynax-ci/cmd/check_ai_context.go
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/zynax-io/zynax/cmd/zynax-ci/check"
+)
+
+var aiContextRoot string
+
+var checkAIContextCmd = &cobra.Command{
+	Use:   "ai-context",
+	Short: "Report line counts for AI context files (advisory, always exits 0)",
+	Long: `Count lines in CLAUDE.md, AGENTS.md files, and docs/ai-assistant-setup.md.
+
+Thresholds:
+  CLAUDE.md                 200 lines
+  AGENTS.md (root)          300 lines
+  docs/ai-assistant-setup.md 150 lines
+  per-directory AGENTS.md   150 lines
+  TOTAL                    2000 lines
+
+Exceeding a threshold emits a WARN but never causes a non-zero exit code.
+This check is advisory only.`,
+	Args: cobra.NoArgs,
+	RunE: runCheckAIContext,
+}
+
+func init() {
+	checkAIContextCmd.Flags().StringVar(&aiContextRoot, "root", ".", "repository root directory")
+	checkCmd.AddCommand(checkAIContextCmd)
+}
+
+func runCheckAIContext(cmd *cobra.Command, args []string) error {
+	root := aiContextRoot
+	if root == "." {
+		var err error
+		root, err = os.Getwd()
+		if err != nil {
+			return fmt.Errorf("check ai-context: get working directory: %w", err)
+		}
+	}
+
+	report, err := check.Context(root)
+	if err != nil {
+		return err
+	}
+	report.Print(os.Stdout)
+	return nil // always exits 0
+}


### PR DESCRIPTION
## Summary

Ports `tools/count-ai-context.sh` to Go as `zynax-ci check ai-context`.

- Adds `check/context.go`: `Context(repoRoot)` — counts lines in `CLAUDE.md`, root `AGENTS.md`, `docs/ai-assistant-setup.md`, and all per-directory `AGENTS.md` files; compares against per-file thresholds; never returns an error (advisory only, always exits 0)
- Adds `cmd/check.go`: `zynax-ci check` parent command
- Adds `cmd/check_ai_context.go`: `zynax-ci check ai-context [--root <dir>]`

Thresholds mirror the shell script: `CLAUDE.md`=200, root `AGENTS.md`=300, `ai-assistant-setup.md`=150, per-dir `AGENTS.md`=150, `TOTAL`=2000.

**Lines changed:** 332 additions (ideal range)

## Test plan

- [x] `GOWORK=off go test ./... -race` — passes
- [x] `zynax-ci check ai-context` — all files within budget (current total: 1757)

## PR chain

Stacked on #349. Base will change to `main` once #349 merges. This PR closes #334 when merged.
1. #347 — `validate schema`
2. #348 — `validate workflows|agent-defs|policies`
3. #349 — `validate capabilities`
4. **This PR** — `check ai-context` — Closes #334

Epic: #331.

Assisted-by: Claude/claude-sonnet-4-6