### PR TITLE
ci: fix concurrent workflow cancellation blocking required checks (#351)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,8 @@ on:
     branches: [main]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.sha }}
+  cancel-in-progress: false
 
 permissions:
   contents: read

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -28,8 +28,8 @@ on:
     branches: [main]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.sha }}
+  cancel-in-progress: false
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

- Adds \`\${{ github.sha }}\` to the concurrency group key in both \`ci.yml\` and \`pr-checks.yml\`
- Sets \`cancel-in-progress: false\` on both workflows

## Root cause

A push to a PR branch fires a \`synchronize\` event. Retargeting the PR base (via \`gh api ... --field base=main\`) fires a second \`synchronize\` event. Both events hit the same concurrency group (\`workflow-ref\`) so the second run cancels the first.

Branch protection evaluates the **highest run ID** as the most recent result per required check name. When the higher-ID run is CANCELLED, the check shows CANCELLED and the PR is blocked — even though an earlier run passed.

## Fix

Including \`github.sha\` in the group key means a base-retarget produces a new merge SHA and lands in a **different group**, leaving the original run undisturbed. \`cancel-in-progress: false\` is an additional guard: even if two events share the same SHA, neither cancels the other.

## Test plan

- [x] Push a commit to a PR, then immediately retarget the PR base — verify no CANCELLED checks
      → runs 25431605900 (PR Checks) and 25431605954 (CI) both completed SUCCESS/SKIPPED; no CANCELLED jobs
- [x] CI passes on this PR without manual reruns
      → all 16 checks green; \`mergeStateStatus: CLEAN\` with no \`gh run rerun\` needed

Closes #351. M4 milestone — CI tooling.

Assisted-by: Claude/claude-sonnet-4-6