### PR TITLE
ci(zynax-ci): migrate Makefile and CI workflows to use zynax-ci (#335)

### DIFF
--- a/.github/workflows/ai-context-budget.yml
+++ b/.github/workflows/ai-context-budget.yml
@@ -24,11 +24,17 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version: "1.25"
+          cache: true
+          cache-dependency-path: cmd/zynax-ci/go.sum
+
       - name: Count AI context lines
         id: count
         run: |
-          chmod +x tools/count-ai-context.sh
-          OUTPUT=$(sh tools/count-ai-context.sh)
+          (cd cmd/zynax-ci && GOWORK=off go build -o /tmp/zynax-ci .)
+          OUTPUT=$(/tmp/zynax-ci check ai-context)
           echo "$OUTPUT"
           {
             echo "## AI Context Budget"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
             if echo "$f" | grep -qE '^(protos/|spec/|CLAUDE\.md|AGENTS\.md|.*/AGENTS\.md|docs/ai-assistant-setup\.md|\.ai/|\.claude/)'; then
               proto=true
             fi
-            if echo "$f" | grep -qE '^(services/|protos/)'; then
+            if echo "$f" | grep -qE '^(services/|protos/|cmd/)'; then
               go=true
             fi
             if echo "$f" | grep -qE '^agents/'; then
@@ -306,9 +306,18 @@ jobs:
           asyncapi validate spec/asyncapi/zynax-events.yaml
           echo "✅ AsyncAPI spec is valid"
 
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        if: steps.spec-detect.outputs.has_spec == '1'
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+          cache-dependency-path: cmd/zynax-ci/go.sum
+
       - name: Validate JSON Schemas are well-formed
         if: steps.spec-detect.outputs.has_spec == '1'
-        run: python3 tools/validate_json_schemas.py spec/schemas/
+        run: |
+          (cd cmd/zynax-ci && GOWORK=off go build -o /tmp/zynax-ci .)
+          /tmp/zynax-ci validate schema spec/schemas/
 
 # ── Lint: Go services ─────────────────────────────────────────────────────────
 # Runs: golangci-lint on all Go platform services.

--- a/.github/workflows/tools-image.yml
+++ b/.github/workflows/tools-image.yml
@@ -58,7 +58,7 @@ jobs:
           IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
           SHA_TAG="${IMAGE}:main-${{ github.sha }}"
 
-          if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+          if echo "${{ github.ref }}" | grep -q '^refs/tags/v'; then
             VERSION_TAG="${IMAGE}:${{ github.ref_name }}"
             echo "tags=${IMAGE}:latest,${VERSION_TAG},${SHA_TAG}" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/tools-image.yml
+++ b/.github/workflows/tools-image.yml
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: Apache-2.0
+# Zynax — Developer Tools Image
+#
+# Builds infra/docker/Dockerfile.tools and pushes to GHCR on every merge
+# to main that touches the tools image or zynax-ci source. Also triggered
+# on version tags so pinned image digests are available for production use.
+#
+# Image: ghcr.io/zynax-io/zynax/tools
+# Tags:  :latest  (always points to the newest main build)
+#        :main-<sha>  (immutable per-commit tag)
+#        :v*.*.*  (on version tag pushes)
+#
+# Usage in local Makefile (after GHCR publish):
+#   TOOLS_IMAGE := ghcr.io/zynax-io/zynax/tools:latest
+# Usage in Dockerfiles:
+#   FROM ghcr.io/zynax-io/zynax/tools:latest AS ci-tools
+
+name: tools-image
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'infra/docker/Dockerfile.tools'
+      - 'cmd/zynax-ci/**'
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: zynax-io/zynax/tools
+
+jobs:
+  build-push:
+    name: Build and push tools image
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Compute image tags
+        id: tags
+        run: |
+          IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
+          SHA_TAG="${IMAGE}:main-${{ github.sha }}"
+
+          if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+            VERSION_TAG="${IMAGE}:${{ github.ref_name }}"
+            echo "tags=${IMAGE}:latest,${VERSION_TAG},${SHA_TAG}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tags=${IMAGE}:latest,${SHA_TAG}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: infra/docker/Dockerfile.tools
+          push: true
+          tags: ${{ steps.tags.outputs.tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          labels: |
+            org.opencontainers.image.source=https://github.com/zynax-io/zynax
+            org.opencontainers.image.revision=${{ github.sha }}

--- a/.github/workflows/zynax-ci-release.yml
+++ b/.github/workflows/zynax-ci-release.yml
@@ -1,0 +1,105 @@
+# SPDX-License-Identifier: Apache-2.0
+# Zynax — zynax-ci binary release
+#
+# Triggered on version tags (v*.*.*). Builds static binaries for
+# linux/amd64, darwin/amd64, and darwin/arm64, then creates a
+# GitHub Release with all three as downloadable assets.
+
+name: zynax-ci release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to build (e.g. v0.3.0)'
+        required: true
+
+permissions:
+  contents: write
+
+env:
+  GO_VERSION: "1.25"
+
+jobs:
+  build:
+    name: Build ${{ matrix.goos }}/${{ matrix.goarch }}
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        include:
+          - goos: linux
+            goarch: amd64
+            suffix: linux-amd64
+          - goos: darwin
+            goarch: amd64
+            suffix: darwin-amd64
+          - goos: darwin
+            goarch: arm64
+            suffix: darwin-arm64
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+          cache-dependency-path: cmd/zynax-ci/go.sum
+
+      - name: Build zynax-ci binary
+        working-directory: cmd/zynax-ci
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+          CGO_ENABLED: "0"
+        run: |
+          GOWORK=off go build -trimpath \
+            -ldflags "-s -w -X github.com/zynax-io/zynax/cmd/zynax-ci/cmd.Version=${GITHUB_REF_NAME}" \
+            -o zynax-ci-${{ matrix.suffix }} .
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: zynax-ci-${{ matrix.suffix }}
+          path: cmd/zynax-ci/zynax-ci-${{ matrix.suffix }}
+          retention-days: 1
+
+  release:
+    name: Create GitHub Release
+    runs-on: ubuntu-24.04
+    needs: [build]
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist/
+          merge-multiple: true
+
+      - name: Create release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name || inputs.tag }}
+          name: zynax-ci ${{ github.ref_name || inputs.tag }}
+          body: |
+            ## zynax-ci ${{ github.ref_name || inputs.tag }}
+
+            Standalone CI and developer toolchain for Zynax.
+
+            ### Installation
+
+            ```bash
+            # Linux (amd64)
+            curl -fsSL https://github.com/zynax-io/zynax/releases/download/${{ github.ref_name || inputs.tag }}/zynax-ci-linux-amd64 \
+              -o ~/bin/zynax-ci && chmod +x ~/bin/zynax-ci
+
+            # macOS (Apple Silicon)
+            curl -fsSL https://github.com/zynax-io/zynax/releases/download/${{ github.ref_name || inputs.tag }}/zynax-ci-darwin-arm64 \
+              -o ~/bin/zynax-ci && chmod +x ~/bin/zynax-ci
+            ```
+
+            Or build from source: `cd cmd/zynax-ci && GOWORK=off go build -o ~/bin/zynax-ci .`
+          files: dist/zynax-ci-*
+          generate_release_notes: true

--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,10 @@ install-cli: ## Build and install zynax CLI to ~/bin/zynax (requires Go 1.25)
 	cd cmd/zynax && GOWORK=off go build -trimpath -o ~/bin/zynax .
 	@echo "✅ zynax installed → ~/bin/zynax  (ensure ~/bin is on your PATH)"
 
+install-ci-tools: ## Build and install zynax-ci toolchain to ~/bin/zynax-ci (requires Go 1.25)
+	cd cmd/zynax-ci && GOWORK=off go build -trimpath -o ~/bin/zynax-ci .
+	@echo "✅ zynax-ci installed → ~/bin/zynax-ci  (ensure ~/bin is on your PATH)"
+
 # ── Lint ───────────────────────────────────────────────────────────────────
 .PHONY: lint lint-go lint-agents lint-go-svc lint-agent lint-fix
 lint: lint-protos lint-go lint-agents ## Lint everything (proto + Go + Python)
@@ -229,53 +233,24 @@ clean-all: clean dev-down clean-tools ## ⚠ Remove everything
 
 validate-spec: validate-asyncapi validate-capability-schemas validate-workflow-schema validate-agent-def-schema validate-policy-schema ## Validate all specs (AsyncAPI + capability schemas + workflow + agent-def + policy manifests)
 
-validate-canvas: ## Validate REASONS Canvas files under docs/spdd/ (SPDD — ADR-019)
-	docker run --rm \
-		-v "$(PWD)":/workspace \
-		-w /workspace \
-		python:3.12-alpine sh -c " \
-			python tools/validate_canvas.py docs/spdd/ \
-		"
+validate-canvas: build-tools ## Validate REASONS Canvas files under docs/spdd/ (SPDD — ADR-019)
+	$(TOOLS_RUN) zynax-ci validate canvas docs/spdd/
 	@echo "✅ Canvas validation passed"
 
-validate-capability-schemas: ## Validate capability declarations in spec/ against capability.schema.json
-	docker run --rm \
-		-v "$(PWD)":/workspace \
-		-w /workspace \
-		python:3.12-alpine sh -c " \
-			pip install --quiet jsonschema pyyaml && \
-			python tools/validate_capabilities.py spec/schemas/capability.schema.json spec/workflows/examples/ \
-		"
+validate-capability-schemas: build-tools ## Validate capability declarations in spec/ against capability.schema.json
+	$(TOOLS_RUN) zynax-ci validate capabilities spec/workflows/examples/ --schema-dir spec/schemas
 	@echo "✅ Capability schemas valid"
 
-validate-workflow-schema: ## Validate Workflow manifests in spec/workflows/examples/ against workflow.schema.json
-	docker run --rm \
-		-v "$(PWD)":/workspace \
-		-w /workspace \
-		python:3.12-alpine sh -c " \
-			pip install --quiet jsonschema pyyaml && \
-			python tools/validate_workflows.py spec/schemas/workflow.schema.json spec/workflows/examples/ \
-		"
+validate-workflow-schema: build-tools ## Validate Workflow manifests in spec/workflows/examples/ against workflow.schema.json
+	$(TOOLS_RUN) zynax-ci validate workflows spec/workflows/examples/ --schema-dir spec/schemas
 	@echo "✅ Workflow schemas valid"
 
-validate-agent-def-schema: ## Validate AgentDef manifests in spec/workflows/examples/ against agent-def.schema.json
-	docker run --rm \
-		-v "$(PWD)":/workspace \
-		-w /workspace \
-		python:3.12-alpine sh -c " \
-			pip install --quiet jsonschema pyyaml && \
-			python tools/validate_agent_defs.py spec/schemas/agent-def.schema.json spec/workflows/examples/ \
-		"
+validate-agent-def-schema: build-tools ## Validate AgentDef manifests in spec/workflows/examples/ against agent-def.schema.json
+	$(TOOLS_RUN) zynax-ci validate agent-defs spec/workflows/examples/ --schema-dir spec/schemas
 	@echo "✅ AgentDef schemas valid"
 
-validate-policy-schema: ## Validate Policy manifests in spec/workflows/examples/ against policy.schema.json
-	docker run --rm \
-		-v "$(PWD)":/workspace \
-		-w /workspace \
-		python:3.12-alpine sh -c " \
-			pip install --quiet jsonschema pyyaml && \
-			python tools/validate_policies.py spec/schemas/policy.schema.json spec/workflows/examples/ \
-		"
+validate-policy-schema: build-tools ## Validate Policy manifests in spec/workflows/examples/ against policy.schema.json
+	$(TOOLS_RUN) zynax-ci validate policies spec/workflows/examples/ --schema-dir spec/schemas
 	@echo "✅ Policy schemas valid"
 
 validate-asyncapi: ## Validate spec/asyncapi/zynax-events.yaml via AsyncAPI CLI (Docker)

--- a/infra/docker/Dockerfile.tools
+++ b/infra/docker/Dockerfile.tools
@@ -71,6 +71,10 @@ RUN curl -fsSL \
       -o /usr/local/bin/buf \
     && chmod +x /usr/local/bin/buf
 
+# zynax-ci — CI and developer toolchain (validation + AI context checker)
+COPY cmd/zynax-ci/ /src/zynax-ci/
+RUN cd /src/zynax-ci && GOWORK=off go build -trimpath -o /usr/local/bin/zynax-ci .
+
 # ── Stage 2: Final image (python:3.12-alpine) ───────────────────────────────
 FROM python:3.14-alpine AS tools
 
@@ -88,6 +92,7 @@ COPY --from=go-tools /go/bin/protoc-gen-go-grpc  /usr/local/bin/
 COPY --from=go-tools /go/bin/godog               /usr/local/bin/
 COPY --from=go-tools /go/bin/mockery             /usr/local/bin/
 COPY --from=go-tools /go/bin/migrate             /usr/local/bin/
+COPY --from=go-tools /usr/local/bin/zynax-ci     /usr/local/bin/
 
 # ── uv — Python package manager ──────────────────────────────────────────
 # renovate: datasource=github-releases depName=astral-sh/uv


### PR DESCRIPTION
## Summary

- Replace all 5 \`docker run python:3.12-alpine\` validation Makefile targets with \`\$(TOOLS_RUN) zynax-ci validate …\` (steps 8–9 of canvas #331)
- Embed \`zynax-ci\` binary in \`Dockerfile.tools\` so the tools image ships it for local use
- \`ci.yml\`: add \`cmd/\` to Go path detection so \`lint-go\` runs on \`cmd/zynax-ci\` PRs; replace \`python3 tools/validate_json_schemas.py\` with \`zynax-ci validate schema\` (built from source)
- \`ai-context-budget.yml\`: replace \`count-ai-context.sh\` with \`zynax-ci check ai-context\`
- New: \`zynax-ci-release.yml\` — multi-platform binaries (linux-amd64, darwin-amd64, darwin-arm64) published as GitHub Release assets on \`v*.*.*\` tags
- New: \`tools-image.yml\` — builds and pushes \`ghcr.io/zynax-io/zynax/tools\` to GHCR on every merge to \`main\` that touches \`Dockerfile.tools\` or \`cmd/zynax-ci/**\`

## Canvas reference

Canvas: [docs/spdd/314-yaml-system-cli/canvas.md](docs/spdd/314-yaml-system-cli/canvas.md)
Step: O-10 — CI: update Makefile and workflows to use \`zynax-ci\`
Epic: #314 · Issue: #335

## Test plan

- [x] All required CI checks pass: \`dco\` · \`security\` · \`test-unit\` · \`test-integration\` (runs [25432298136](https://github.com/zynax-io/zynax/actions/runs/25432298136), [25432414641](https://github.com/zynax-io/zynax/actions/runs/25432414641))
- [x] \`tools-image.yml\` and \`zynax-ci-release.yml\` syntactically valid — GitHub Actions workflow lint passed
- [x] \`zynax-ci\` binary builds from source in \`cmd/zynax-ci\` — verified locally (\`GOWORK=off go build\` + unit tests green)
- [ ] \`lint-proto\` JSON schema step uses \`zynax-ci\` — will fire on next PR touching \`spec/\` (skips correctly here: no spec/proto files changed)
- [ ] \`lint-go\` triggered by \`cmd/\` path — will fire on next PR touching \`cmd/zynax-ci\` Go source (skips correctly here: no Go source changed)
- [ ] \`Dockerfile.tools\` builds cleanly with \`zynax-ci\` binary — exercised by \`tools-image.yml\` after merge to \`main\`
- [ ] Makefile \`zynax-ci validate\` targets work end-to-end via \`\$(TOOLS_RUN)\` — exercised after \`make build-tools\`

Closes #335

Assisted-by: Claude/claude-sonnet-4-6