### PR TITLE
ci: add pull-tools, ensure-tools and document GHCR artifacts (#354)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -207,7 +207,7 @@ Observed mistakes in AI-assisted contributions — check before writing code.
 | Competitive analysis and Kestra/Temporal/LangGraph positioning | `docs/architecture/competitive-analysis-2026.md` |
 | Dependency version policy, security scanning, upgrade cadence | `docs/engineering/dependency-strategy.md` |
 | Renovate bot CI failure fix procedure (go.sum, go directive) | `docs/engineering/renovate-fix-sop.md` |
-| AI context line counts and budget thresholds (advisory, non-blocking) | `tools/count-ai-context.sh` |
+| AI context line counts and budget thresholds (advisory, non-blocking) | `zynax-ci check ai-context` |
 | `zynax` CLI (standalone Go module, M4) — apply/get/delete/status/logs via api-gateway HTTP | `cmd/zynax/AGENTS.md` |
 | Per-layer rules | `services/AGENTS.md` · `agents/AGENTS.md` · `protos/AGENTS.md` · `spec/AGENTS.md` · `infra/AGENTS.md` |
 

--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,10 @@ GO_SERVICES   := agent-registry task-broker memory-service event-bus api-gateway
 AGENTS        := summarizer researcher calculator
 COMPOSE       := docker compose -f infra/docker/docker-compose.yml
 COMPOSE_TOOLS := docker compose -f infra/docker/docker-compose.tools.yml
-TOOLS_IMAGE   := zynax-tools:local
+# Override to skip the local build: make TOOLS_IMAGE=ghcr.io/zynax-io/zynax/tools:latest <target>
+TOOLS_IMAGE   ?= zynax-tools:local
 REGISTRY      := ghcr.io/zynax-io
+GHCR_TOOLS    := ghcr.io/zynax-io/zynax/tools:latest
 TOOLS_RUN     := docker run --rm -v "$(PWD)":/workspace -w /workspace --env-file infra/docker/.env.tools $(TOOLS_IMAGE)
 
 .PHONY: help
@@ -29,6 +31,20 @@ check-docker:
 build-tools: check-docker ## Build zynax-tools:local (golang:1.22-alpine + python:3.12-alpine + all CI tools)
 	docker build -f infra/docker/Dockerfile.tools -t $(TOOLS_IMAGE) .
 	@echo "✅ Tools image: $(TOOLS_IMAGE)"
+
+pull-tools: check-docker ## Pull tools image from GHCR (faster than build-tools; needs docker login or public package)
+	docker pull $(GHCR_TOOLS)
+	@echo "✅ Pulled $(GHCR_TOOLS)"
+	@echo "   Run targets with: make TOOLS_IMAGE=$(GHCR_TOOLS) <target>"
+
+# Internal: build local image only when TOOLS_IMAGE is the local default.
+# Targets that use this as a prereq skip the Docker build when the caller
+# overrides TOOLS_IMAGE (e.g. TOOLS_IMAGE=ghcr.io/zynax-io/zynax/tools:latest).
+.PHONY: ensure-tools
+ensure-tools: check-docker
+ifeq ($(TOOLS_IMAGE),zynax-tools:local)
+	$(MAKE) build-tools
+endif
 
 # ── Local environment ──────────────────────────────────────────────────────
 .PHONY: dev-up dev-down dev-logs dev-ps dev-reset dev-restart
@@ -76,25 +92,25 @@ install-ci-tools: ## Build and install zynax-ci toolchain to ~/bin/zynax-ci (req
 .PHONY: lint lint-go lint-agents lint-go-svc lint-agent lint-fix
 lint: lint-protos lint-go lint-agents ## Lint everything (proto + Go + Python)
 
-lint-go: build-tools ## Lint all Go platform services with golangci-lint
+lint-go: ensure-tools ## Lint all Go platform services with golangci-lint
 	@for svc in $(GO_SERVICES); do \
 		echo "🔍 $$svc"; \
 		$(TOOLS_RUN) sh -c "cd services/$$svc && golangci-lint run ./... --config ../../tools/golangci-lint.yml"; \
 	done && echo "✅ Go lint passed"
 
-lint-go-svc: build-tools ## Lint one Go service: make lint-go-svc SVC=agent-registry
+lint-go-svc: ensure-tools ## Lint one Go service: make lint-go-svc SVC=agent-registry
 	$(TOOLS_RUN) sh -c "cd services/$(SVC) && golangci-lint run ./... --config ../../tools/golangci-lint.yml"
 
-lint-agents: build-tools ## Lint SDK + all Python agents (ruff + mypy)
+lint-agents: ensure-tools ## Lint SDK + all Python agents (ruff + mypy)
 	$(TOOLS_RUN) sh -c "cd agents/sdk && uv run ruff check src/ && uv run mypy src/ --strict"
 	@for a in $(AGENTS); do [ -f "agents/examples/$$a/pyproject.toml" ] && \
 		$(TOOLS_RUN) sh -c "cd agents/examples/$$a && uv run ruff check src/ tests/ && uv run mypy src/ --strict" || true; done
 	@echo "✅ Python lint passed"
 
-lint-agent: build-tools ## Lint one agent: make lint-agent AGENT=summarizer
+lint-agent: ensure-tools ## Lint one agent: make lint-agent AGENT=summarizer
 	$(TOOLS_RUN) sh -c "cd agents/examples/$(AGENT) && uv run ruff check src/ tests/ && uv run mypy src/ --strict"
 
-lint-fix: build-tools ## Auto-fix Python agent lint errors
+lint-fix: ensure-tools ## Auto-fix Python agent lint errors
 	@for a in $(AGENTS); do [ -f "agents/examples/$$a/pyproject.toml" ] && \
 		$(TOOLS_RUN) sh -c "cd agents/examples/$$a && uv run ruff check --fix src/ tests/ && uv run ruff format src/ tests/" || true; done
 
@@ -103,7 +119,7 @@ lint-fix: build-tools ## Auto-fix Python agent lint errors
 test: validate-spec test-unit test-bdd test-coverage ## ★ Full local test suite — mirrors CI (spec + Go + Python + BDD + coverage gate)
 test-unit: test-unit-go test-unit-agents ## All unit tests (Go + Python)
 
-test-unit-go: build-tools ## Go unit tests for all services
+test-unit-go: ensure-tools ## Go unit tests for all services
 	@for svc in $(GO_SERVICES); do \
 		if [ -f "services/$$svc/go.mod" ]; then \
 			echo "🧪 $$svc"; \
@@ -111,10 +127,10 @@ test-unit-go: build-tools ## Go unit tests for all services
 		fi; \
 	done && echo "✅ Go tests passed"
 
-test-unit-svc: build-tools ## Go tests for one service: make test-unit-svc SVC=workflow-compiler
+test-unit-svc: ensure-tools ## Go tests for one service: make test-unit-svc SVC=workflow-compiler
 	$(TOOLS_RUN) sh -c "cd services/$(SVC) && GOWORK=off go test ./... -v -timeout 60s"
 
-test-coverage: build-tools ## Domain coverage gate — ≥90% on internal/domain/ for every Go service
+test-coverage: ensure-tools ## Domain coverage gate — ≥90% on internal/domain/ for every Go service
 	@failed=false; \
 	for svc in $(GO_SERVICES); do \
 		if [ -f "services/$$svc/go.mod" ] && [ -d "services/$$svc/internal/domain" ]; then \
@@ -130,17 +146,17 @@ test-coverage: build-tools ## Domain coverage gate — ≥90% on internal/domain
 	done; \
 	$$failed && exit 1 || echo "✅ Domain coverage gate passed (all services ≥90%%)"
 
-test-bdd: build-tools ## Godog BDD contract tests for all protos/tests/ packages
+test-bdd: ensure-tools ## Godog BDD contract tests for all protos/tests/ packages
 	$(TOOLS_RUN) sh -c "cd protos/tests && GOWORK=off go test ./... -v -timeout 120s"
 	@echo "✅ BDD contract tests passed"
 
-test-unit-agents: build-tools ## pytest-bdd for SDK + all Python agents
+test-unit-agents: ensure-tools ## pytest-bdd for SDK + all Python agents
 	$(TOOLS_RUN) sh -c "cd agents/sdk && uv run pytest tests/ --cov=src --cov-fail-under=90 -v"
 	@for a in $(AGENTS); do [ -f "agents/examples/$$a/pyproject.toml" ] && \
 		$(TOOLS_RUN) sh -c "cd agents/examples/$$a && uv run pytest tests/ --cov=src --cov-fail-under=90 -v" || true; done
 	@echo "✅ Python tests passed"
 
-test-unit-agent: build-tools ## pytest for one agent: make test-unit-agent AGENT=summarizer
+test-unit-agent: ensure-tools ## pytest for one agent: make test-unit-agent AGENT=summarizer
 	$(TOOLS_RUN) sh -c "cd agents/examples/$(AGENT) && uv run pytest tests/ -v"
 
 test-integration: check-docker ## Integration tests against NATS JetStream and Redis backing services
@@ -163,11 +179,11 @@ test-integration: check-docker ## Integration tests against NATS JetStream and R
 
 # ── Proto generation + lint ────────────────────────────────────────────────
 .PHONY: generate-protos lint-protos
-generate-protos: build-tools ## Generate Go + Python stubs from .proto files
+generate-protos: ensure-tools ## Generate Go + Python stubs from .proto files
 	$(TOOLS_RUN) sh -c "cd protos && buf generate --template buf.gen.yaml"
 	@echo "✅ Stubs in protos/generated/go/ and protos/generated/python/ — commit them"
 
-lint-protos: build-tools ## buf lint + format check on all proto files
+lint-protos: ensure-tools ## buf lint + format check on all proto files
 	$(TOOLS_RUN) sh -c "cd protos && buf lint && buf format --diff --exit-code"
 	@echo "✅ Proto lint passed"
 
@@ -183,15 +199,15 @@ scan-image: ## Scan one service container image for CVEs: make scan-image SVC=ag
 gitleaks: ## Scan local repo for secrets (requires gitleaks installed: brew install gitleaks)
 	gitleaks detect --source . --config tools/gitleaks-ai-context.toml --verbose
 
-security-go: build-tools ## govulncheck on all Go services
+security-go: ensure-tools ## govulncheck on all Go services
 	@for svc in $(GO_SERVICES); do $(TOOLS_RUN) sh -c "cd services/$$svc && govulncheck ./..."; done
 
-security-agents: build-tools ## bandit + pip-audit on SDK + all agents
+security-agents: ensure-tools ## bandit + pip-audit on SDK + all agents
 	@$(TOOLS_RUN) sh -c "cd agents/sdk && uv run bandit -r src/ -ll && uv run pip-audit"
 	@for a in $(AGENTS); do [ -f "agents/examples/$$a/pyproject.toml" ] && \
 		$(TOOLS_RUN) sh -c "cd agents/examples/$$a && uv run bandit -r src/ -ll && uv run pip-audit" || true; done
 
-audit: build-tools ## Dependency vulnerability audit (govulncheck + pip-audit); exits 1 on any finding
+audit: ensure-tools ## Dependency vulnerability audit (govulncheck + pip-audit); exits 1 on any finding
 	@failed=false; \
 	for svc in $(GO_SERVICES); do \
 		if [ -f "services/$$svc/go.mod" ]; then \
@@ -233,23 +249,23 @@ clean-all: clean dev-down clean-tools ## ⚠ Remove everything
 
 validate-spec: validate-asyncapi validate-capability-schemas validate-workflow-schema validate-agent-def-schema validate-policy-schema ## Validate all specs (AsyncAPI + capability schemas + workflow + agent-def + policy manifests)
 
-validate-canvas: build-tools ## Validate REASONS Canvas files under docs/spdd/ (SPDD — ADR-019)
+validate-canvas: ensure-tools ## Validate REASONS Canvas files under docs/spdd/ (SPDD — ADR-019)
 	$(TOOLS_RUN) zynax-ci validate canvas docs/spdd/
 	@echo "✅ Canvas validation passed"
 
-validate-capability-schemas: build-tools ## Validate capability declarations in spec/ against capability.schema.json
+validate-capability-schemas: ensure-tools ## Validate capability declarations in spec/ against capability.schema.json
 	$(TOOLS_RUN) zynax-ci validate capabilities spec/workflows/examples/ --schema-dir spec/schemas
 	@echo "✅ Capability schemas valid"
 
-validate-workflow-schema: build-tools ## Validate Workflow manifests in spec/workflows/examples/ against workflow.schema.json
+validate-workflow-schema: ensure-tools ## Validate Workflow manifests in spec/workflows/examples/ against workflow.schema.json
 	$(TOOLS_RUN) zynax-ci validate workflows spec/workflows/examples/ --schema-dir spec/schemas
 	@echo "✅ Workflow schemas valid"
 
-validate-agent-def-schema: build-tools ## Validate AgentDef manifests in spec/workflows/examples/ against agent-def.schema.json
+validate-agent-def-schema: ensure-tools ## Validate AgentDef manifests in spec/workflows/examples/ against agent-def.schema.json
 	$(TOOLS_RUN) zynax-ci validate agent-defs spec/workflows/examples/ --schema-dir spec/schemas
 	@echo "✅ AgentDef schemas valid"
 
-validate-policy-schema: build-tools ## Validate Policy manifests in spec/workflows/examples/ against policy.schema.json
+validate-policy-schema: ensure-tools ## Validate Policy manifests in spec/workflows/examples/ against policy.schema.json
 	$(TOOLS_RUN) zynax-ci validate policies spec/workflows/examples/ --schema-dir spec/schemas
 	@echo "✅ Policy schemas valid"
 
@@ -261,7 +277,7 @@ validate-asyncapi: ## Validate spec/asyncapi/zynax-events.yaml via AsyncAPI CLI 
 		validate /spec/asyncapi/zynax-events.yaml
 	@echo "✅ AsyncAPI spec valid"
 
-dry-run: build-tools ## Dry-run a workflow: make dry-run FILE=spec/workflows/examples/code-review.yaml
+dry-run: ensure-tools ## Dry-run a workflow: make dry-run FILE=spec/workflows/examples/code-review.yaml
 	@test -n "$(FILE)" || (echo "Usage: make dry-run FILE=<path>" && exit 1)
 	$(TOOLS_RUN) sh -c "keel apply --dry-run $(FILE)"
 

--- a/README.md
+++ b/README.md
@@ -80,47 +80,82 @@ zynax logs wf-236c478f00eb68ce
 
 ---
 
-## Install the zynax CLI
+## Published Artifacts
 
-Download a pre-built binary from the [latest GitHub Release](https://github.com/zynax-io/zynax/releases/latest):
+Zynax publishes three kinds of artifacts on every release and on every merge to `main`.
 
-**macOS (Apple Silicon):**
+### zynax CLI — user-facing binary
+
+Download from the [latest GitHub Release](https://github.com/zynax-io/zynax/releases/latest):
+
+| Platform | Command |
+|----------|---------|
+| macOS (Apple Silicon) | `curl -fsSL https://github.com/zynax-io/zynax/releases/latest/download/zynax_darwin_arm64.tar.gz \| tar xz && sudo mv zynax /usr/local/bin/` |
+| macOS (Intel) | `curl -fsSL https://github.com/zynax-io/zynax/releases/latest/download/zynax_darwin_amd64.tar.gz \| tar xz && sudo mv zynax /usr/local/bin/` |
+| Linux (amd64) | `curl -fsSL https://github.com/zynax-io/zynax/releases/latest/download/zynax_linux_amd64.tar.gz \| tar xz && sudo mv zynax /usr/local/bin/` |
+| Linux (arm64) | `curl -fsSL https://github.com/zynax-io/zynax/releases/latest/download/zynax_linux_arm64.tar.gz \| tar xz && sudo mv zynax /usr/local/bin/` |
+
+**From source** (requires Go 1.25+): `cd cmd/zynax && GOWORK=off go build -o ~/bin/zynax .`
+**Makefile shortcut:** `make install-cli`
+
+Verify: `zynax --version`
+
+---
+
+### zynax-ci — CI and developer toolchain
+
+`zynax-ci` is a standalone Go binary that replaces all Python validation scripts. It contains:
+`validate canvas`, `validate schema`, `validate workflows`, `validate agent-defs`,
+`validate capabilities`, `validate policies`, and `check ai-context`.
+
+Download from the [latest GitHub Release](https://github.com/zynax-io/zynax/releases/latest):
+
 ```bash
-curl -L https://github.com/zynax-io/zynax/releases/latest/download/zynax_darwin_arm64.tar.gz | tar xz
-sudo mv zynax /usr/local/bin/
+# Linux (amd64)
+curl -fsSL https://github.com/zynax-io/zynax/releases/latest/download/zynax-ci-linux-amd64 \
+  -o ~/bin/zynax-ci && chmod +x ~/bin/zynax-ci
+
+# macOS (Apple Silicon)
+curl -fsSL https://github.com/zynax-io/zynax/releases/latest/download/zynax-ci-darwin-arm64 \
+  -o ~/bin/zynax-ci && chmod +x ~/bin/zynax-ci
+
+# macOS (Intel)
+curl -fsSL https://github.com/zynax-io/zynax/releases/latest/download/zynax-ci-darwin-amd64 \
+  -o ~/bin/zynax-ci && chmod +x ~/bin/zynax-ci
 ```
 
-**macOS (Intel):**
+**From source** (requires Go 1.25+): `cd cmd/zynax-ci && GOWORK=off go build -o ~/bin/zynax-ci .`
+**Makefile shortcut:** `make install-ci-tools`
+
+---
+
+### Developer tools Docker image
+
+`ghcr.io/zynax-io/zynax/tools` is the canonical developer tools image. It ships:
+`golangci-lint`, `buf`, `govulncheck`, `godog`, `mockery`, `migrate`,
+`grpc_health_probe`, `protoc-gen-go`, `protoc-gen-go-grpc`, `uv`,
+`ruff`, `mypy`, `bandit`, `pip-audit`, `pytest`, and **`zynax-ci`**.
+
+The image is rebuilt and pushed to GHCR on every merge to `main` that changes
+`infra/docker/Dockerfile.tools` or `cmd/zynax-ci/**` (via
+[`.github/workflows/tools-image.yml`](.github/workflows/tools-image.yml)).
+
+**Pull the image** (alternative to `make build-tools`):
 ```bash
-curl -L https://github.com/zynax-io/zynax/releases/latest/download/zynax_darwin_amd64.tar.gz | tar xz
-sudo mv zynax /usr/local/bin/
+docker pull ghcr.io/zynax-io/zynax/tools:latest
 ```
 
-**Linux (amd64):**
+**Use with make targets** (skips the local build step):
 ```bash
-curl -L https://github.com/zynax-io/zynax/releases/latest/download/zynax_linux_amd64.tar.gz | tar xz
-sudo mv zynax /usr/local/bin/
+make TOOLS_IMAGE=ghcr.io/zynax-io/zynax/tools:latest lint
+make TOOLS_IMAGE=ghcr.io/zynax-io/zynax/tools:latest test
+make TOOLS_IMAGE=ghcr.io/zynax-io/zynax/tools:latest validate-spec
 ```
 
-**Linux (arm64):**
+Or set it once in your shell:
 ```bash
-curl -L https://github.com/zynax-io/zynax/releases/latest/download/zynax_linux_arm64.tar.gz | tar xz
-sudo mv zynax /usr/local/bin/
-```
-
-**Windows (amd64):** download `zynax_windows_amd64.zip` from the release page and add the extracted `zynax.exe` to your `PATH`.
-
-**From source** (requires Go 1.25+):
-```bash
-git clone https://github.com/zynax-io/zynax.git
-cd zynax/cmd/zynax
-GOWORK=off go build -o zynax .
-sudo mv zynax /usr/local/bin/
-```
-
-Verify:
-```bash
-zynax --version
+export TOOLS_IMAGE=ghcr.io/zynax-io/zynax/tools:latest
+make lint test validate-spec
 ```
 
 ---
@@ -259,9 +294,13 @@ make test        # full suite (unit + BDD + coverage gate)
 | `make lint` | Proto + Go + Python lint |
 | `make audit` | Dependency vulnerability audit — govulncheck (Go) + pip-audit (Python); exits 1 on any finding |
 | `make security` | Full security scan — adds bandit SAST to the audit checks |
-| `make validate-spec` | Validate all YAML manifests against JSON schemas |
+| `make validate-spec` | Validate all YAML manifests against JSON schemas (via `zynax-ci`) |
+| `make validate-canvas` | Validate REASONS Canvas files under `docs/spdd/` (via `zynax-ci`) |
 | `make generate-protos` | Regenerate Go + Python stubs from `.proto` files |
-| `make build-tools` | Build the `zynax-tools:local` Docker image (run once after clone) |
+| `make build-tools` | Build the `zynax-tools:local` Docker image from source (one-time after clone) |
+| `make pull-tools` | Pull `ghcr.io/zynax-io/zynax/tools:latest` from GHCR (faster than building) |
+| `make install-cli` | Build and install `zynax` CLI to `~/bin/zynax` |
+| `make install-ci-tools` | Build and install `zynax-ci` toolchain to `~/bin/zynax-ci` |
 
 ---
 
@@ -315,7 +354,7 @@ AI assistants working in this repo load context in layers. Smaller budgets = hig
 | `services/*/AGENTS.md` | Per-service rules (layout, tests, service-specific mistakes) | 150 lines each |
 | `agents/*/AGENTS.md` | Per-adapter rules (Python patterns, gRPC stub usage) | 150 lines each |
 
-Total budget: **2000 lines** across all files. The [AI Context Budget](https://github.com/zynax-io/zynax/actions/workflows/ai-context-budget.yml) workflow reports current totals on every relevant PR (advisory, non-blocking). Counted by [tools/count-ai-context.sh](tools/count-ai-context.sh).
+Total budget: **2000 lines** across all files. The [AI Context Budget](https://github.com/zynax-io/zynax/actions/workflows/ai-context-budget.yml) workflow reports current totals on every relevant PR (advisory, non-blocking). Counted by `zynax-ci check ai-context`.
 
 ---
 
@@ -332,6 +371,7 @@ services/            Go platform services
   memory-service/    KV + vector context store (M4+)
   event-bus/         NATS JetStream async pub/sub (M4+)
 cmd/zynax/           zynax CLI — apply, get, delete, status (M4 — in progress)
+cmd/zynax-ci/        zynax-ci CI toolchain — validate canvas/schema/manifests, check ai-context
 agents/              Python execution adapters + zynax-sdk
 protos/              gRPC contracts (Go + Python stubs generated)
 protos/tests/        BDD contract test suites (godog)

--- a/cmd/zynax-ci/AGENTS.md
+++ b/cmd/zynax-ci/AGENTS.md
@@ -1,9 +1,13 @@
 # AGENTS.md — cmd/zynax-ci/
 
 The `zynax-ci` CLI is a **standalone Go module** (`github.com/zynax-io/zynax/cmd/zynax-ci`).
-It is the CI and developer toolchain for Zynax — it replaces all Python validation scripts
-in `tools/` and `count-ai-context.sh`. It has no dependency on the `zynax` operational CLI,
-the api-gateway, or any platform services.
+It is the CI and developer toolchain for Zynax. It has no dependency on the `zynax` operational
+CLI, the api-gateway, or any platform services.
+
+Pre-built binaries are published to GitHub Releases on `v*.*.*` tags (see
+`.github/workflows/zynax-ci-release.yml`). The binary is also shipped inside the
+`ghcr.io/zynax-io/zynax/tools` Docker image, rebuilt on every main merge that
+changes `cmd/zynax-ci/**` or `infra/docker/Dockerfile.tools`.
 
 ---
 
@@ -24,20 +28,21 @@ cmd/zynax-ci/
     root.go                root command, Version variable
     validate.go            validate parent command
     validate_canvas.go     zynax-ci validate canvas <path>
-    validate_schema.go     zynax-ci validate schema <file>         [step 9]
-    validate_workflows.go  zynax-ci validate workflows <dir>       [step 9]
-    validate_agent_defs.go zynax-ci validate agent-defs <dir>      [step 9]
-    validate_capabilities.go                                        [step 9]
-    validate_policies.go                                            [step 9]
-    check_ai_context.go    zynax-ci check ai-context               [step 9]
+    validate_schema.go     zynax-ci validate schema <file>
+    validate_workflows.go  zynax-ci validate workflows <dir>
+    validate_agent_defs.go zynax-ci validate agent-defs <dir>
+    validate_capabilities.go  zynax-ci validate capabilities <dir>
+    validate_policies.go   zynax-ci validate policies <dir>
+    check_ai_context.go    zynax-ci check ai-context
   validate/
-    canvas.go              Canvas validator (full port of tools/validate_canvas.py)
+    canvas.go              Canvas validator (seven REASONS sections, header fields, Status)
     canvas_test.go
-    schema.go              [step 9]
-    manifest.go            [step 9]
-    capabilities.go        [step 9]
+    schema.go              JSON Schema well-formedness validator
+    manifest.go            Batch YAML manifest validator (Workflow/AgentDef/Policy)
+    capabilities.go        Capability declaration validator
+    helpers.go             Shared ValidationError helpers
   check/
-    context.go             [step 9]
+    context.go             AI context line-count reporter (advisory, always exits 0)
 ```
 
 ## Hard Constraints


### PR DESCRIPTION
## Summary

- **Makefile**: \`TOOLS_IMAGE\` is now overridable (\`?=\`); add \`ensure-tools\` prereq that skips the Docker build when using a remote image; add \`pull-tools\` to fetch from GHCR in one command
- **README**: Expand into a full \"Published Artifacts\" section covering zynax CLI, zynax-ci toolchain, and the GHCR developer tools image with copy-paste install/usage snippets; update make commands table; fix stale count-ai-context.sh reference
- **AGENTS.md / cmd/zynax-ci/AGENTS.md**: Update tool pointer and remove completed \`[step N]\` placeholders

### Using the GHCR tools image

\`\`\`bash
# One-time pull (replaces make build-tools)
make pull-tools

# All make targets respect TOOLS_IMAGE override
make TOOLS_IMAGE=ghcr.io/zynax-io/zynax/tools:latest lint
make TOOLS_IMAGE=ghcr.io/zynax-io/zynax/tools:latest test

# Or set once in your shell
export TOOLS_IMAGE=ghcr.io/zynax-io/zynax/tools:latest
make lint test validate-spec
\`\`\`

## Test plan

- [x] All required CI checks pass: \`dco\` · \`lint-go\` · \`lint-proto\` · \`test-unit\` · \`test-integration\` · \`security\` (runs [25432984562](https://github.com/zynax-io/zynax/actions/runs/25432984562), [25433106899](https://github.com/zynax-io/zynax/actions/runs/25433106899))
- [x] \`lint-proto\` exercised \`zynax-ci validate schema\` end-to-end — JSON Schemas step passed via \`zynax-ci\` binary built from source (run [25432984562](https://github.com/zynax-io/zynax/actions/runs/25432984562) job 74603711438)
- [x] \`lint-go\` passed — \`cmd/\` path detection triggered correctly
- [x] \`tools-image.yml\` ran twice and completed successfully — image pushed with tags \`latest\` and \`main-<sha>\` (runs [25432661254](https://github.com/zynax-io/zynax/actions/runs/25432661254), [25433138296](https://github.com/zynax-io/zynax/actions/runs/25433138296))
- [x] \`make TOOLS_IMAGE=ghcr.io/zynax-io/zynax/tools:latest validate-canvas\` skips \`build-tools\` — \`ensure-tools\` no-op confirmed by Makefile logic
- [ ] \`make pull-tools\` — **blocked: GHCR package is private** (new packages in orgs are private by default). Manual step required: go to [https://github.com/orgs/zynax-io/packages/container/zynax%2Ftools/settings](https://github.com/orgs/zynax-io/packages/container/zynax%2Ftools/settings) → Change visibility → Public. Once public, \`docker pull ghcr.io/zynax-io/zynax/tools:latest\` will work unauthenticated.

Closes #354

Assisted-by: Claude/claude-sonnet-4-6