### PR TITLE
ci: add .dockerignore and auto-auth in pull-tools (#356)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: Apache-2.0
+# Docker build context filter — applies to all `docker build .` commands run
+# from the repo root (primarily `make build-tools` / Dockerfile.tools).
+#
+# Purpose: defence-in-depth. Dockerfile.tools only COPYs cmd/zynax-ci/, so
+# none of the excluded paths would reach the image anyway — but excluding them
+# prevents local secrets from being transmitted to the Docker daemon at all.
+
+# ── Credentials and secrets ───────────────────────────────────────────────────
+**/.env
+**/.env.*
+**/.env.local
+**/.env.*.local
+**/.netrc
+**/.pypirc
+**/.npmrc
+**/*.pem
+**/*.p12
+**/*.pfx
+**/id_rsa
+**/id_ed25519
+**/id_ecdsa
+**/*_key
+**/*_key.pem
+**/credentials
+**/secrets/
+**/canvas.private.md
+
+# ── Git and IDE metadata ──────────────────────────────────────────────────────
+.git/
+**/.gitkeep
+.idea/
+.vscode/
+**/*.swp
+**/*.swo
+
+# ── Build artefacts and caches ────────────────────────────────────────────────
+**/__pycache__/
+**/*.pyc
+**/*.pyo
+**/.pytest_cache/
+**/node_modules/
+**/.venv/
+**/*.out
+**/*.coverprofile
+**/domain-coverage.out
+**/.cache/
+
+# ── Large directories never needed by Dockerfile.tools ───────────────────────
+services/
+agents/
+protos/generated/
+docs/
+.github/
+infra/docker-compose/
+infra/helm/
+infra/k8s/

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,9 @@ build-tools: check-docker ## Build zynax-tools:local (golang:1.22-alpine + pytho
 	docker build -f infra/docker/Dockerfile.tools -t $(TOOLS_IMAGE) .
 	@echo "✅ Tools image: $(TOOLS_IMAGE)"
 
-pull-tools: check-docker ## Pull tools image from GHCR (faster than build-tools; needs docker login or public package)
+pull-tools: check-docker ## Pull tools image from GHCR (authenticates via `gh auth token`)
+	@echo "🔐 Authenticating to GHCR via gh..."
+	@gh auth token | docker login ghcr.io -u $$(gh api user --jq .login) --password-stdin 2>&1
 	docker pull $(GHCR_TOOLS)
 	@echo "✅ Pulled $(GHCR_TOOLS)"
 	@echo "   Run targets with: make TOOLS_IMAGE=$(GHCR_TOOLS) <target>"

--- a/tools/gitleaks-ai-context.toml
+++ b/tools/gitleaks-ai-context.toml
@@ -34,6 +34,8 @@ tags        = ["infrastructure"]
 [rules.allowlist]
 # 'local' as a standalone word or in NATS URLs is fine (dev environment docs)
 regexes     = ['''nats://localhost|nats://local\b|description.*[Ll]ocal''']
+# .dockerignore / .gitignore list glob patterns — never real hostnames
+paths       = ['''\.dockerignore$''', '''\.gitignore$''']
 
 [[rules]]
 id          = "private-ip-range"


### PR DESCRIPTION
## Summary

- **\`.dockerignore\`** (new file): prevents credentials, \`.env.*\`, private keys, \`.git/\`, IDE files, and large unused directories from being transmitted to the Docker daemon during \`make build-tools\`. Dockerfile.tools only COPYs \`cmd/zynax-ci/\` so none of these would reach the final image anyway — this is defence-in-depth.
- **\`Makefile pull-tools\`**: auto-authenticates to GHCR via \`gh auth token | docker login ghcr.io\` before pulling, so the target works with the private package without requiring a manual \`docker login\`.
- **\`tools/gitleaks-ai-context.toml\`**: add path-based allowlist for \`.dockerignore\` and \`.gitignore\` on the \`internal-hostname\` rule — glob patterns in these files (e.g. \`**/.env.local\`) were triggering false positives.

## Security audit summary

The final \`ghcr.io/zynax-io/zynax/tools\` image contains **only compiled binaries** (golangci-lint, buf, zynax-ci, etc.) and Python tool environments. No source code, no \`.env\` files, no credentials reach the final image because:
1. \`cmd/zynax-ci/\` source is COPYd into the \`go-tools\` build stage only
2. The final \`python:3.14-alpine\` stage only receives binaries via \`COPY --from=go-tools\`
3. \`infra/docker/.env.tools\` contains only telemetry flags (intentionally committed, no secrets)

The \`.dockerignore\` closes the theoretical gap where a local \`.env.local\` or private key on disk would be transmitted to the Docker daemon as build context.

## Test plan

- [x] All required CI checks pass: \`dco\` · \`security\` · \`test-unit\` · \`test-integration\` (runs [25434143125](https://github.com/zynax-io/zynax/actions/runs/25434143125), [25434143118](https://github.com/zynax-io/zynax/actions/runs/25434143118))
- [x] Secret scan (gitleaks) passes — false positive on \`**/.env.local\` fixed via path-based allowlist on \`internal-hostname\` rule
- [x] \`make build-tools\` works with \`.dockerignore\` — \`COPY cmd/zynax-ci/\` succeeded and \`zynax-ci\` binary built into final image (verified locally: layers #22–#34 all pass)
- [x] \`.dockerignore\` excludes sensitive patterns (credentials, \`.env.*\`, private keys, \`.git/\`, large unused dirs)
- [x] \`make pull-tools\` authenticates and pulls successfully — requires \`gh\` token with \`read:packages\` scope; GHCR package currently private (org policy blocks public visibility)

Closes #356

Assisted-by: Claude/claude-sonnet-4-6