### PR TITLE
ci(security): add inline explanations to all gosec suppressions (#237)

### DIFF
--- a/cmd/zynax/client/gateway.go
+++ b/cmd/zynax/client/gateway.go
@@ -47,7 +47,7 @@ func New(baseURL string, insecure bool) *Gateway {
 	tr := http.DefaultTransport
 	if insecure {
 		tr = &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // G402: intentional for --insecure local-dev flag; never used in production
 		}
 	}
 	return &Gateway{

--- a/services/engine-adapter/internal/api/handler.go
+++ b/services/engine-adapter/internal/api/handler.go
@@ -97,7 +97,7 @@ func runToProto(r *domain.WorkflowRun) *zynaxv1.WorkflowRun {
 		RunId:              r.RunID,
 		WorkflowId:         r.WorkflowID,
 		Namespace:          r.Namespace,
-		Status:             zynaxv1.WorkflowStatus(r.Status), //nolint:gosec
+		Status:             zynaxv1.WorkflowStatus(r.Status), //nolint:gosec // G115: domain status is a small positive int enum; conversion is safe
 		CurrentState:       r.CurrentState,
 		Engine:             r.Engine,
 		Labels:             r.Labels,
@@ -114,7 +114,7 @@ func eventToProto(ev *domain.WorkflowEvent) *zynaxv1.WorkflowEvent {
 		EventType: ev.EventType,
 		FromState: ev.FromState,
 		ToState:   ev.ToState,
-		Status:    zynaxv1.WorkflowStatus(ev.Status), //nolint:gosec
+		Status:    zynaxv1.WorkflowStatus(ev.Status), //nolint:gosec // G115: domain status is a small positive int enum; conversion is safe
 		Payload:   ev.Payload,
 		Timestamp: timestamppb.New(ev.Timestamp),
 	}


### PR DESCRIPTION
## Summary

`gosec` was already enabled in `tools/golangci-lint.yml`. This PR completes issue #237 by adding inline explanations to the three bare `//nolint:gosec` annotations that were missing a reason:

| File | Rule | Reason |
|------|------|--------|
| `services/engine-adapter/internal/api/handler.go` (×2) | G115 | Domain status is a small positive int enum; proto conversion is safe |
| `cmd/zynax/client/gateway.go` | G402 | `InsecureSkipVerify` is intentional for `--insecure` local-dev flag; never used in production |

`make lint` was already green before and after this change.

## Test plan

- [x] `gosec` is enabled in `tools/golangci-lint.yml`
- [x] All `//nolint:gosec` suppressions have an inline explanation (`G115` / `G402`)
- [x] `go vet ./...` clean in `cmd/zynax` and `services/engine-adapter` (verified locally)
- [x] `make lint` passes in CI

Closes #237.

Assisted-by: Claude/claude-sonnet-4-6