### PR TITLE
chore: add pre-commit hooks — gofmt, golangci-lint, ruff, mypy, gitleaks (#247)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+# Zynax — pre-commit hook configuration
+#
+# Activate once per clone: make bootstrap  (runs `pre-commit install`)
+# Run manually on all files: pre-commit run --all-files
+# Bypass for a single commit: git commit --no-verify  (add a PR comment explaining why)
+#
+# Managed hooks (gitleaks, ruff): pre-commit auto-downloads these — no manual install.
+# System hooks (gofmt, golangci-lint, mypy): require local Go/Python toolchain.
+#   golangci-lint: make install-ci-tools  (builds to ~/bin/golangci-lint)
+#   mypy:          uv tool install mypy
+
+default_stages: [pre-commit]
+
+repos:
+  # ── Secret scanning — managed by pre-commit, no manual install required ──────
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.21.2
+    hooks:
+      - id: gitleaks
+        args: [--config, tools/gitleaks-ai-context.toml]
+
+  # ── Python lint + format — managed by pre-commit, no manual install required ─
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.11.8
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+
+  # ── Go + Python type-check — require local toolchain (language: system) ───────
+  - repo: local
+    hooks:
+      - id: gofmt
+        name: gofmt
+        entry: gofmt -l -w
+        language: system
+        files: \.go$
+        exclude: ^protos/generated/
+
+      - id: golangci-lint
+        name: golangci-lint
+        entry: tools/golangci-lint-precommit.sh
+        language: system
+        files: \.go$
+        exclude: ^protos/generated/
+        pass_filenames: false
+
+      - id: mypy
+        name: mypy
+        entry: mypy --strict --config-file tools/mypy.ini agents/sdk/src
+        language: system
+        files: ^agents/sdk/src/.*\.py$
+        pass_filenames: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,11 +49,12 @@ Read this document before opening your first PR.
 
 | Tool | Version | Install |
 |------|---------|---------|
-| Go | ≥ 1.22 | [go.dev](https://go.dev) |
+| Go | ≥ 1.26 | [go.dev](https://go.dev) |
 | Python | ≥ 3.12 | `uv python install 3.12` |
 | uv | latest | `curl -LsSf https://astral.sh/uv/install.sh \| sh` |
 | Docker | ≥ 24 | [docker.com](https://docker.com) |
 | buf | 1.28+ | `brew install bufbuild/buf/buf` |
+| pre-commit | latest | `pip install pre-commit` or `brew install pre-commit` |
 | make | any | pre-installed on macOS/Linux |
 
 ### Setup
@@ -61,7 +62,15 @@ Read this document before opening your first PR.
 ```bash
 git clone https://github.com/zynax-io/zynax.git
 cd zynax
-make bootstrap        # Install all tools + pre-commit hooks (includes commitlint + DCO)
+make bootstrap        # Builds tools Docker image + runs `pre-commit install`
+```
+
+`make bootstrap` wires the pre-commit hooks into `.git/hooks/` so they fire
+automatically on every `git commit`. **You must run this once per clone.**
+If `pre-commit` is not yet installed, `make bootstrap` prints a warning —
+install it first, then re-run `make bootstrap`.
+
+```bash
 make dev-up           # Start local stack: PostgreSQL, Redis, NATS, all services
 make dev-ps           # Verify everything is healthy
 ```
@@ -80,7 +89,7 @@ The `zynax` CLI is a standalone module under `cmd/zynax/`. To test it against th
 running platform:
 
 ```bash
-# 1. Install the CLI (requires Go 1.25 locally, or download from GitHub Releases)
+# 1. Install the CLI (requires Go 1.26 locally, or download from GitHub Releases)
 make install-cli            # builds cmd/zynax and installs to ~/bin/zynax
 
 # 2. Start the local stack
@@ -102,6 +111,38 @@ CLI unit tests (no running stack needed):
 ```bash
 cd cmd/zynax && GOWORK=off go test ./... -race -timeout 60s
 ```
+
+### Pre-commit hooks
+
+The hooks are declared in `.pre-commit-config.yaml`. They do **nothing** until you
+activate them once per clone — `make bootstrap` does this automatically.
+
+**Activate manually** (if you didn't run `make bootstrap`):
+
+```bash
+pip install pre-commit   # or: brew install pre-commit
+pre-commit install       # wires hooks into .git/hooks/pre-commit
+```
+
+After that, on every `git commit` the following checks run automatically:
+
+| Hook | What it checks | Needs locally |
+|------|---------------|---------------|
+| `gofmt` | Go formatting (formats in-place) | Go toolchain |
+| `golangci-lint` | Go static analysis (`tools/golangci-lint.yml`) | `golangci-lint` binary |
+| `ruff` | Python lint + formatting | `ruff` (`uv tool install ruff`) |
+| `mypy` | Python type-checking (`agents/sdk/src/`) | `mypy` (`uv tool install mypy`) |
+| `gitleaks` | Secret / credential scan | `gitleaks` binary |
+
+Run all hooks manually at any time: `pre-commit run --all-files`
+
+> **Note:** The same checks run in CI via `make lint` (Docker-based), so a missing
+> local tool means your commit goes through but CI will catch it. Install the tools
+> for a faster feedback loop — you'll see failures in seconds, not minutes.
+
+**Bypassing hooks:** Use `git commit --no-verify` only for legitimate reasons (e.g. a
+work-in-progress checkpoint on a branch). Add a PR comment explaining why — reviewers
+will ask if you don't.
 
 ### Linting
 

--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,13 @@ help:
 		| awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 .PHONY: bootstrap check-docker build-tools
-bootstrap: check-docker build-tools ## ★ Run once after clone
-	@echo "✅ Done. make dev-up → start stack, make lint → lint all"
+bootstrap: check-docker build-tools ## ★ Run once after clone — builds tools image and installs pre-commit hooks
+	@if command -v pre-commit >/dev/null 2>&1; then \
+	  pre-commit install && echo "✅ pre-commit hooks installed"; \
+	else \
+	  echo "⚠️  pre-commit not found — skipping hook install (pip install pre-commit)"; \
+	fi
+	@echo "✅ Done. make lint → lint all, make test → full test suite"
 
 check-docker:
 	@docker info >/dev/null 2>&1 || (echo "❌ Docker not running" && exit 1)

--- a/README.md
+++ b/README.md
@@ -279,10 +279,16 @@ Port map while the stack is running:
 **Prerequisites:** Docker Desktop only (Go, Python, buf are not needed locally).
 
 ```bash
-make bootstrap   # one-time: build the zynax-tools Docker image
+# Prerequisites: Docker, Go 1.26+, pip install pre-commit
+make bootstrap   # one-time per clone: builds tools image + installs pre-commit hooks
 make lint        # proto + Go + Python lint
 make test        # full suite (unit + BDD + coverage gate)
 ```
+
+> **Pre-commit hooks** — `make bootstrap` wires `gofmt`, `golangci-lint`, `ruff`,
+> `mypy`, and `gitleaks` to run automatically on every `git commit`. You must run
+> `make bootstrap` once per clone to activate them.
+> See [CONTRIBUTING.md §Pre-commit hooks](CONTRIBUTING.md#pre-commit-hooks) for details.
 
 ### Key make commands
 

--- a/cmd/zynax-ci/cmd/validate_canvas.go
+++ b/cmd/zynax-ci/cmd/validate_canvas.go
@@ -37,8 +37,8 @@ func init() {
 }
 
 type canvasResult struct {
-	File     string                     `json:"file"`
-	Errors   []validate.ValidationError `json:"errors,omitempty"`
+	File     string                       `json:"file"`
+	Errors   []validate.ValidationError   `json:"errors,omitempty"`
 	Warnings []validate.ValidationWarning `json:"warnings,omitempty"`
 }
 

--- a/cmd/zynax-ci/validate/capabilities_test.go
+++ b/cmd/zynax-ci/validate/capabilities_test.go
@@ -15,9 +15,9 @@ import (
 func writeCapabilitySchema(t *testing.T, dir string) string {
 	t.Helper()
 	schema := map[string]interface{}{
-		"$schema": "https://json-schema.org/draft/2020-12/schema",
-		"$id":     "https://test.zynax.io/capability",
-		"type":    "object",
+		"$schema":  "https://json-schema.org/draft/2020-12/schema",
+		"$id":      "https://test.zynax.io/capability",
+		"type":     "object",
 		"required": []string{"name"},
 		"properties": map[string]interface{}{
 			"name":        map[string]interface{}{"type": "string"},

--- a/cmd/zynax-ci/validate/manifest_test.go
+++ b/cmd/zynax-ci/validate/manifest_test.go
@@ -16,9 +16,9 @@ import (
 func writeMinimalWorkflowSchema(t *testing.T, dir string) string {
 	t.Helper()
 	schema := map[string]interface{}{
-		"$schema": "https://json-schema.org/draft/2020-12/schema",
-		"$id":     "https://test.zynax.io/workflow",
-		"type":    "object",
+		"$schema":  "https://json-schema.org/draft/2020-12/schema",
+		"$id":      "https://test.zynax.io/workflow",
+		"type":     "object",
 		"required": []string{"kind", "apiVersion", "metadata"},
 		"properties": map[string]interface{}{
 			"kind":       map[string]interface{}{"type": "string", "const": "Workflow"},

--- a/protos/tests/agent_registry_service/steps_test.go
+++ b/protos/tests/agent_registry_service/steps_test.go
@@ -164,15 +164,15 @@ func matchesLabelSelector(labels map[string]string, selector string) bool {
 // ─── Test context ─────────────────────────────────────────────────────────────
 
 type testCtx struct {
-	client          zynaxv1.AgentRegistryServiceClient
-	stub            *registryStub
-	pendingAgent    *zynaxv1.AgentDef
-	lastRegResp     *zynaxv1.RegisterAgentResponse
-	lastAgent       *zynaxv1.AgentDef
-	listResp        *zynaxv1.ListAgentsResponse
-	findResp        *zynaxv1.FindByCapabilityResponse
-	grpcErr         error
-	lastLabels      map[string]string
+	client       zynaxv1.AgentRegistryServiceClient
+	stub         *registryStub
+	pendingAgent *zynaxv1.AgentDef
+	lastRegResp  *zynaxv1.RegisterAgentResponse
+	lastAgent    *zynaxv1.AgentDef
+	listResp     *zynaxv1.ListAgentsResponse
+	findResp     *zynaxv1.FindByCapabilityResponse
+	grpcErr      error
+	lastLabels   map[string]string
 }
 
 func newTestCtx() *testCtx {
@@ -261,11 +261,11 @@ func TestFeatures(t *testing.T) {
 			sc.Step(`^the AgentDef has labels \{"([^"]+)": "([^"]+)"(?:, "([^"]+)": "([^"]+)")?\}$`, func(ctx context.Context, k1, v1, k2, v2 string) (context.Context, error) {
 				if tc.pendingAgent == nil {
 					tc.pendingAgent = &zynaxv1.AgentDef{
-						AgentId:  "agent-temp",
-						Name:     "agent-temp",
-						Endpoint: "localhost:50051",
+						AgentId:      "agent-temp",
+						Name:         "agent-temp",
+						Endpoint:     "localhost:50051",
 						Capabilities: []*zynaxv1.CapabilityDef{{Name: "cap"}},
-						Labels:   make(map[string]string),
+						Labels:       make(map[string]string),
 					}
 				}
 				tc.pendingAgent.Labels[k1] = v1

--- a/protos/tests/event_bus_service/steps_test.go
+++ b/protos/tests/event_bus_service/steps_test.go
@@ -207,16 +207,16 @@ func (s *busStub) Unsubscribe(_ context.Context, req *zynaxv1.UnsubscribeRequest
 // ─── Test context ─────────────────────────────────────────────────────────────
 
 type busCtx struct {
-	client       zynaxv1.EventBusServiceClient
-	stub         *busStub
-	publishResp  *zynaxv1.PublishResponse
-	grpcErr      error
+	client      zynaxv1.EventBusServiceClient
+	stub        *busStub
+	publishResp *zynaxv1.PublishResponse
+	grpcErr     error
 	// Track subscriber state for streaming scenarios
 	subEvents    map[string][]*zynaxv1.CloudEvent // subID -> received events
 	subStreams   map[string]grpc.ServerStreamingClient[zynaxv1.SubscribeResponse]
 	subCtxCancel map[string]context.CancelFunc
 	// For initial metadata check
-	initialResp  *zynaxv1.SubscribeResponse
+	initialResp *zynaxv1.SubscribeResponse
 	// Pending invalid request
 	pendingSubReq   *zynaxv1.SubscribeRequest
 	pendingUnsubReq *zynaxv1.UnsubscribeRequest
@@ -230,11 +230,11 @@ type godogBKey struct{}
 
 func makeCloudEvent(evtType, workflowID string) *zynaxv1.CloudEvent {
 	return &zynaxv1.CloudEvent{
-		Id:         fmt.Sprintf("evt-%d", time.Now().UnixNano()),
-		Source:     "/zynax/test",
+		Id:          fmt.Sprintf("evt-%d", time.Now().UnixNano()),
+		Source:      "/zynax/test",
 		Specversion: "1.0",
-		Type:       evtType,
-		WorkflowId: workflowID,
+		Type:        evtType,
+		WorkflowId:  workflowID,
 	}
 }
 

--- a/protos/tests/memory_service/steps_test.go
+++ b/protos/tests/memory_service/steps_test.go
@@ -41,7 +41,7 @@ type memStub struct {
 	zynaxv1.UnimplementedMemoryServiceServer
 	mu      sync.Mutex
 	kv      map[string]map[string]*kvEntry // wfID -> key -> entry
-	vectors map[string][]*vectorEntry       // wfID -> entries
+	vectors map[string][]*vectorEntry      // wfID -> entries
 	nextVec int
 }
 

--- a/protos/tests/stub_generation/steps_test.go
+++ b/protos/tests/stub_generation/steps_test.go
@@ -388,10 +388,10 @@ func (s *stubSuite) noStaleGeneratedFilesRemainFromThePreviousRun() error {
 
 // ─── CI freshness gate ────────────────────────────────────────────────────────
 
-func (s *stubSuite) aPullRequestThatModifiesAProtoFile() error       { return nil }
-func (s *stubSuite) makeGenerateProtosWasNOTRunBeforeCommitting() error { return nil }
+func (s *stubSuite) aPullRequestThatModifiesAProtoFile() error            { return nil }
+func (s *stubSuite) makeGenerateProtosWasNOTRunBeforeCommitting() error   { return nil }
 func (s *stubSuite) makeGenerateProtosWasRunAndStubsWereCommitted() error { return nil }
-func (s *stubSuite) aPullRequestThatDoesNotModifyAnyProtoFiles() error { return nil }
+func (s *stubSuite) aPullRequestThatDoesNotModifyAnyProtoFiles() error    { return nil }
 
 func (s *stubSuite) theProtoStubsFreshCICheckRuns() error {
 	return s.ciReferencesProtoFreshnessGate()

--- a/protos/tests/task_broker_service/steps_test.go
+++ b/protos/tests/task_broker_service/steps_test.go
@@ -25,8 +25,8 @@ import (
 
 type brokerStub struct {
 	zynaxv1.UnimplementedTaskBrokerServiceServer
-	mu         sync.Mutex
-	tasks      map[string]*zynaxv1.WorkflowTask
+	mu    sync.Mutex
+	tasks map[string]*zynaxv1.WorkflowTask
 	// capabilities[cap] = agentID
 	capabilities map[string]string
 	// lastDispatchAgent records which agent a task was dispatched to

--- a/protos/tests/workflow_compiler_service/steps_test.go
+++ b/protos/tests/workflow_compiler_service/steps_test.go
@@ -31,8 +31,8 @@ type stateSpec struct {
 }
 
 type workflowManifest struct {
-	ApiVersion string      `yaml:"apiVersion"`
-	Kind       string      `yaml:"kind"`
+	ApiVersion string `yaml:"apiVersion"`
+	Kind       string `yaml:"kind"`
 	Metadata   struct {
 		Name      string `yaml:"name"`
 		Namespace string `yaml:"namespace"`
@@ -135,8 +135,8 @@ func (s *compilerStub) ValidateManifest(_ context.Context, req *zynaxv1.Validate
 	}
 
 	return &zynaxv1.ValidateManifestResponse{
-		Valid:   len(errs) == 0,
-		Errors:  errs,
+		Valid:  len(errs) == 0,
+		Errors: errs,
 	}, nil
 }
 
@@ -282,16 +282,16 @@ states:
 // ─── Test context ────────────────────────────────────────────────────────────
 
 type compilerCtx struct {
-	client          zynaxv1.WorkflowCompilerServiceClient
-	stub            *compilerStub
-	compileReq      *zynaxv1.CompileWorkflowRequest
-	validateReq     *zynaxv1.ValidateManifestRequest
-	getReq          *zynaxv1.GetCompiledWorkflowRequest
-	compileResp     *zynaxv1.CompileWorkflowResponse
-	validateResp    *zynaxv1.ValidateManifestResponse
-	getResp         *zynaxv1.GetCompiledWorkflowResponse
-	grpcErr         error
-	lastWorkflowID  string
+	client         zynaxv1.WorkflowCompilerServiceClient
+	stub           *compilerStub
+	compileReq     *zynaxv1.CompileWorkflowRequest
+	validateReq    *zynaxv1.ValidateManifestRequest
+	getReq         *zynaxv1.GetCompiledWorkflowRequest
+	compileResp    *zynaxv1.CompileWorkflowResponse
+	validateResp   *zynaxv1.ValidateManifestResponse
+	getResp        *zynaxv1.GetCompiledWorkflowResponse
+	grpcErr        error
+	lastWorkflowID string
 }
 
 type godogCKey struct{}
@@ -757,13 +757,13 @@ states:
 			}
 
 			codeByName := map[string]zynaxv1.CompilationErrorCode{
-				"ORPHAN_STATE":          zynaxv1.CompilationErrorCode_COMPILATION_ERROR_CODE_ORPHAN_STATE,
-				"DUPLICATE_STATE_NAME":  zynaxv1.CompilationErrorCode_COMPILATION_ERROR_CODE_DUPLICATE_STATE_NAME,
-				"NO_TERMINAL_STATE":     zynaxv1.CompilationErrorCode_COMPILATION_ERROR_CODE_NO_TERMINAL_STATE,
-				"NO_INITIAL_STATE":      zynaxv1.CompilationErrorCode_COMPILATION_ERROR_CODE_NO_INITIAL_STATE,
+				"ORPHAN_STATE":            zynaxv1.CompilationErrorCode_COMPILATION_ERROR_CODE_ORPHAN_STATE,
+				"DUPLICATE_STATE_NAME":    zynaxv1.CompilationErrorCode_COMPILATION_ERROR_CODE_DUPLICATE_STATE_NAME,
+				"NO_TERMINAL_STATE":       zynaxv1.CompilationErrorCode_COMPILATION_ERROR_CODE_NO_TERMINAL_STATE,
+				"NO_INITIAL_STATE":        zynaxv1.CompilationErrorCode_COMPILATION_ERROR_CODE_NO_INITIAL_STATE,
 				"MULTIPLE_INITIAL_STATES": zynaxv1.CompilationErrorCode_COMPILATION_ERROR_CODE_MULTIPLE_INITIAL_STATES,
 				"UNKNOWN_STATE_REFERENCE": zynaxv1.CompilationErrorCode_COMPILATION_ERROR_CODE_UNKNOWN_STATE_REFERENCE,
-				"YAML_PARSE_ERROR":      zynaxv1.CompilationErrorCode_COMPILATION_ERROR_CODE_YAML_PARSE_ERROR,
+				"YAML_PARSE_ERROR":        zynaxv1.CompilationErrorCode_COMPILATION_ERROR_CODE_YAML_PARSE_ERROR,
 			}
 
 			sc.Step(`^the response contains a CompilationError with code (\w+)$`, func(codeName string) error {

--- a/tools/mypy.ini
+++ b/tools/mypy.ini
@@ -52,5 +52,5 @@ ignore_missing_imports = true
 ignore_missing_imports = true
 
 # Generated proto stubs — not strict
-[mypy-zynax.*_pb2*]
+[mypy-zynax.v1.*]
 ignore_errors = true


### PR DESCRIPTION
## Summary

- Add \`.pre-commit-config.yaml\` with 5 hooks: \`gofmt\`, \`golangci-lint\`, \`ruff\`, \`mypy\`, \`gitleaks\`
- \`gitleaks\` and \`ruff\` use managed repos (auto-downloaded by pre-commit, no manual install)
- \`gofmt\`, \`golangci-lint\`, \`mypy\` use \`language: system\` — require local toolchain
- \`golangci-lint\` uses \`tools/golangci-lint-precommit.sh\` wrapper — runs per-module with \`GOWORK=off\` to handle the multi-module workspace correctly
- \`make bootstrap\` now runs \`pre-commit install\` (gracefully skips if \`pre-commit\` not installed)
- Fix \`tools/mypy.ini\`: \`[mypy-zynax.*_pb2*]\` → \`[mypy-zynax.v1.*]\` (mypy ≥1.10 requires \`*\` as a standalone component, not within a name)
- Fix mypy hook entry: add explicit \`agents/sdk/src\` target so hook doesn't error with "Missing target module" when no Python files are staged
- \`CONTRIBUTING.md\`: added pre-commit hooks table with managed vs system distinction, \`--no-verify\` bypass policy, fixed stale Go 1.25 → 1.26 reference
- Apply \`gofmt\` formatting fixes surfaced on first run across 9 files

## Test plan

- [x] \`.pre-commit-config.yaml\` at repo root with all 5 hooks
- [x] \`make bootstrap\` wires \`pre-commit install\` (with graceful skip if not installed)
- [x] \`pre-commit run --all-files\` passes locally — all 6 checks green (gitleaks, ruff, ruff-format, gofmt, golangci-lint, mypy)
- [x] mypy hook fixed: \`tools/mypy.ini\` bad pattern replaced, explicit target added to hook entry
- [x] gofmt formatting fixes committed (9 files had minor style drift)
- [x] \`--no-verify\` bypass policy documented in \`CONTRIBUTING.md\`
- [ ] CI green end-to-end (\`make lint\` + \`make test\` via CI)

Closes #247.

Assisted-by: Claude/claude-sonnet-4-6