### PR TITLE
test: convert table-driven tests to t.Run subtests with named cases (#225)

### DIFF
--- a/services/engine-adapter/internal/domain/interpreter_test.go
+++ b/services/engine-adapter/internal/domain/interpreter_test.go
@@ -233,20 +233,23 @@ func (c *captureExecutor) DispatchCapability(ctx context.Context, in ActivityInp
 
 func TestWorkflowStatus_IsTerminal(t *testing.T) {
 	cases := []struct {
+		name string
 		s    WorkflowStatus
 		want bool
 	}{
-		{WorkflowStatusCompleted, true},
-		{WorkflowStatusFailed, true},
-		{WorkflowStatusCancelled, true},
-		{WorkflowStatusRunning, false},
-		{WorkflowStatusPending, false},
-		{WorkflowStatusUnspecified, false},
+		{"completed is terminal", WorkflowStatusCompleted, true},
+		{"failed is terminal", WorkflowStatusFailed, true},
+		{"cancelled is terminal", WorkflowStatusCancelled, true},
+		{"running is not terminal", WorkflowStatusRunning, false},
+		{"pending is not terminal", WorkflowStatusPending, false},
+		{"unspecified is not terminal", WorkflowStatusUnspecified, false},
 	}
 	for _, tc := range cases {
-		if got := tc.s.IsTerminal(); got != tc.want {
-			t.Errorf("IsTerminal(%v) = %v; want %v", tc.s, got, tc.want)
-		}
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.s.IsTerminal(); got != tc.want {
+				t.Errorf("IsTerminal(%v) = %v; want %v", tc.s, got, tc.want)
+			}
+		})
 	}
 }
 

--- a/services/engine-adapter/internal/infrastructure/temporal_test.go
+++ b/services/engine-adapter/internal/infrastructure/temporal_test.go
@@ -167,21 +167,24 @@ func TestTemporalEngine_GetStatus_Running(t *testing.T) {
 
 func TestTemporalEngine_GetStatus_AllMappings(t *testing.T) {
 	cases := []struct {
+		name string
 		in   enumspb.WorkflowExecutionStatus
 		want domain.WorkflowStatus
 	}{
-		{enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING, domain.WorkflowStatusRunning},
-		{enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED, domain.WorkflowStatusCompleted},
-		{enumspb.WORKFLOW_EXECUTION_STATUS_FAILED, domain.WorkflowStatusFailed},
-		{enumspb.WORKFLOW_EXECUTION_STATUS_TIMED_OUT, domain.WorkflowStatusFailed},
-		{enumspb.WORKFLOW_EXECUTION_STATUS_CANCELED, domain.WorkflowStatusCancelled},
-		{enumspb.WORKFLOW_EXECUTION_STATUS_TERMINATED, domain.WorkflowStatusCancelled},
+		{"running", enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING, domain.WorkflowStatusRunning},
+		{"completed", enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED, domain.WorkflowStatusCompleted},
+		{"failed", enumspb.WORKFLOW_EXECUTION_STATUS_FAILED, domain.WorkflowStatusFailed},
+		{"timed_out maps to failed", enumspb.WORKFLOW_EXECUTION_STATUS_TIMED_OUT, domain.WorkflowStatusFailed},
+		{"canceled", enumspb.WORKFLOW_EXECUTION_STATUS_CANCELED, domain.WorkflowStatusCancelled},
+		{"terminated maps to cancelled", enumspb.WORKFLOW_EXECUTION_STATUS_TERMINATED, domain.WorkflowStatusCancelled},
 	}
 	for _, tc := range cases {
-		got := temporalStatusToDomain(tc.in)
-		if got != tc.want {
-			t.Errorf("temporalStatusToDomain(%v) = %v; want %v", tc.in, got, tc.want)
-		}
+		t.Run(tc.name, func(t *testing.T) {
+			got := temporalStatusToDomain(tc.in)
+			if got != tc.want {
+				t.Errorf("temporalStatusToDomain(%v) = %v; want %v", tc.in, got, tc.want)
+			}
+		})
 	}
 }
 

--- a/services/workflow-compiler/internal/domain/ir/ir_test.go
+++ b/services/workflow-compiler/internal/domain/ir/ir_test.go
@@ -103,29 +103,32 @@ func TestToIR_StatesAreSortedByID(t *testing.T) {
 
 func TestToIR_StateTypes(t *testing.T) {
 	cases := []struct {
+		name       string
 		domainType domain.StateType
 		protoType  zynaxv1.StateType
 	}{
-		{domain.StateTypeNormal, zynaxv1.StateType_STATE_TYPE_NORMAL},
-		{domain.StateTypeTerminal, zynaxv1.StateType_STATE_TYPE_TERMINAL},
-		{domain.StateTypeHumanInTheLoop, zynaxv1.StateType_STATE_TYPE_HUMAN_IN_THE_LOOP},
+		{"normal state", domain.StateTypeNormal, zynaxv1.StateType_STATE_TYPE_NORMAL},
+		{"terminal state", domain.StateTypeTerminal, zynaxv1.StateType_STATE_TYPE_TERMINAL},
+		{"human-in-the-loop state", domain.StateTypeHumanInTheLoop, zynaxv1.StateType_STATE_TYPE_HUMAN_IN_THE_LOOP},
 	}
 	for _, tc := range cases {
-		g := &domain.WorkflowGraph{
-			Name:         "t",
-			Namespace:    "default",
-			InitialState: "s",
-			States: map[string]*domain.State{
-				"s": {ID: "s", Type: tc.domainType},
-			},
-		}
-		wfIR, err := ir.ToIR(g, "id", "v1", time.Time{})
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if wfIR.States[0].Type != tc.protoType {
-			t.Errorf("type %v: got %v, want %v", tc.domainType, wfIR.States[0].Type, tc.protoType)
-		}
+		t.Run(tc.name, func(t *testing.T) {
+			g := &domain.WorkflowGraph{
+				Name:         "t",
+				Namespace:    "default",
+				InitialState: "s",
+				States: map[string]*domain.State{
+					"s": {ID: "s", Type: tc.domainType},
+				},
+			}
+			wfIR, err := ir.ToIR(g, "id", "v1", time.Time{})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if wfIR.States[0].Type != tc.protoType {
+				t.Errorf("type %v: got %v, want %v", tc.domainType, wfIR.States[0].Type, tc.protoType)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

Three test functions iterated over a `cases` slice without `t.Run`, so failures reported only the parent function name with no indication of which case broke. This PR adds a `name string` field to each case struct and wraps the loop body in `t.Run(tc.name, ...)`.

**Files changed:**
- `services/engine-adapter/internal/domain/interpreter_test.go` — `TestWorkflowStatus_IsTerminal`
- `services/engine-adapter/internal/infrastructure/temporal_test.go` — `TestTemporalEngine_GetStatus_AllMappings`
- `services/workflow-compiler/internal/domain/ir/ir_test.go` — `TestToIR_StateTypes`

No production code changes. All other table-driven tests across the codebase already use `t.Run` (confirmed by audit).

## Test plan

- [x] `cd services/engine-adapter && GOWORK=off go test ./... -v` — all subtests named and passing
- [x] `cd services/workflow-compiler && GOWORK=off go test ./internal/domain/ir/... -v` — all subtests named and passing
- [x] `go test -v` output shows `TestToIR_StateTypes/normal_state`, `TestWorkflowStatus_IsTerminal/completed_is_terminal`, etc.
- [x] CI green (`make test`)

Closes #225.

Assisted-by: Claude/claude-sonnet-4-6