### PR TITLE
chore(agents): pin SDK dev dependencies to exact minor versions (#230)

### DIFF
--- a/agents/sdk/pyproject.toml
+++ b/agents/sdk/pyproject.toml
@@ -50,12 +50,12 @@ addopts     = "-v --tb=short"
 
 [dependency-groups]
 dev = [
-    "pytest>=8.2.0",
-    "pytest-bdd>=7.2.0",
-    "pytest-asyncio>=0.23.0",
-    "pytest-cov>=5.0.0",
-    "ruff>=0.4.0",
-    "mypy>=1.10.0",
-    "bandit>=1.7.0",
-    "pip-audit>=2.7.0",
+    "pytest==9.0.*",
+    "pytest-bdd==8.1.*",
+    "pytest-asyncio==1.3.*",
+    "pytest-cov==7.1.*",
+    "ruff==0.15.*",
+    "mypy==1.20.*",
+    "bandit==1.9.*",
+    "pip-audit==2.10.*",
 ]


### PR DESCRIPTION
## User Story

**As a** Python agent contributor,
**I want** dev dependencies pinned to exact minor versions (`==X.Y.*`),
**so that** local environments and CI always install the same package set, and version drift is caught at lock-regeneration time rather than silently at test execution.

## Context

The SDK `pyproject.toml` used lower-bound constraints (`>=X.Y.Z`) for all dev dependencies, allowing uv to silently upgrade to any future major version. This makes builds non-reproducible across machines and over time. Pinning to `==X.Y.*` keeps patch-level flexibility (automatic security patches) while preventing unintended minor/major upgrades.

`requires-python = ">=3.12"` was already correct. No `agents/examples/` have a `pyproject.toml` yet.

## What Changed

`agents/sdk/pyproject.toml` — eight dev deps tightened from lower-bound to exact minor:

| Package | Before | After | Resolved version |
|---------|--------|-------|-----------------|
| pytest | `>=8.2.0` | `==9.0.*` | 9.0.3 |
| pytest-bdd | `>=7.2.0` | `==8.1.*` | 8.1.0 |
| pytest-asyncio | `>=0.23.0` | `==1.3.*` | 1.3.0 |
| pytest-cov | `>=5.0.0` | `==7.1.*` | 7.1.0 |
| ruff | `>=0.4.0` | `==0.15.*` | 0.15.12 |
| mypy | `>=1.10.0` | `==1.20.*` | 1.20.2 |
| bandit | `>=1.7.0` | `==1.9.*` | 1.9.4 |
| pip-audit | `>=2.7.0` | `==2.10.*` | 2.10.0 |

`uv.lock` is **unchanged** — the already-resolved versions all satisfy the new narrower constraints, so the resolver produces an identical lock.

## Acceptance Criteria

- [x] All `pyproject.toml` files have `requires-python = ">=3.12"` (was already correct)
- [x] All dev dependencies pinned to `==X.Y.*` (exact minor version)
- [x] `uv lock` produces an identical lock file (no version changes needed)
- [x] `uv sync --frozen` installs cleanly
- [x] All 40 SDK tests pass with pinned deps

## Test Plan

- [x] `uv lock` run inside Docker tools image — resolves to 70 packages, identical `uv.lock` (no diff)
- [x] `uv sync --frozen` inside Docker — installs cleanly, no conflicts
- [x] `uv run pytest tests/ -v` inside Docker — **40 passed in 0.20s**
- [x] CI `lint-python` green — passed (11s)
- [x] CI `test-unit` green — passed (1m36s), includes SDK pytest-bdd suite
- [x] CI `security` green — passed (51s), bandit + pip-audit with pinned versions
- [x] CI `test-integration` green — passed (17s)

Closes #230.

Assisted-by: Claude/claude-sonnet-4-6