### PR TITLE
chore: close M1–M4 GitHub milestones and mark M4 complete in docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ any layer.
 | M1 — Contracts Foundation | **Complete** | v0.1.0 | [Engineering Review](docs/milestones/M1-engineering-review.md) · [Release Notes](docs/milestones/M1-release-notes.md) |
 | M2 — Workflow IR | **Complete** | v0.1.0 | [Epic #101](https://github.com/zynax-io/zynax/issues/101) |
 | M3 — Temporal Execution | **Complete** | v0.2.0 | [Epic #214](https://github.com/zynax-io/zynax/issues/214) · [Canvas](docs/spdd/214-temporal-execution/canvas.md) |
-| M4 — YAML System + CLI | **In Progress** | v0.3.0 | [Epic #314](https://github.com/zynax-io/zynax/issues/314) · [Canvas](docs/spdd/314-yaml-system-cli/canvas.md) |
+| M4 — YAML System + CLI | **Complete** | v0.3.0 | [Epic #314](https://github.com/zynax-io/zynax/issues/314) · [Canvas](docs/spdd/314-yaml-system-cli/canvas.md) |
 
 M1 delivered: 8 gRPC contracts, AsyncAPI spec, JSON schemas, Go + Python generated stubs,
 140+ BDD scenarios across all services, 5 CI gates. All work tracked in Epic #1 (closed).
@@ -25,9 +25,9 @@ M3 delivered: `WorkflowEngine` interface + `TemporalEngine`, `IRInterpreterWorkf
 `DispatchCapabilityActivity`, CEL guards, CloudEvents, all 5 `EngineAdapterService` gRPC methods.
 Step issues #301–#305. [Epic #214](https://github.com/zynax-io/zynax/issues/214).
 
-M4 in progress: api-gateway REST (`/api/v1/apply`, `/api/v1/workflows/{id}`) (#315–#316 done),
-`zynax` CLI (#317, PR open), logs/#318, Docker Compose/#319, GitOps/#320.
-[Epic #314](https://github.com/zynax-io/zynax/issues/314) · [Canvas](docs/spdd/314-yaml-system-cli/canvas.md).
+M4 delivered: api-gateway REST (`/api/v1/apply`, `/api/v1/workflows/{id}`), `zynax` CLI
+(apply/get/delete/status/logs), Docker Compose local runner, GitOps watch.
+Step issues #315–#320. [Epic #314](https://github.com/zynax-io/zynax/issues/314) · [Canvas](docs/spdd/314-yaml-system-cli/canvas.md).
 
 ## Key pointers
 
@@ -152,12 +152,10 @@ Full guide: `docs/patterns/spdd-guide.md` · Template: `docs/spdd/CANVAS_TEMPLAT
 | **M1** (Complete) | Proto contracts, AsyncAPI spec, generated stubs, BDD scenarios, CI gates | Service implementations, DB schemas, runtime |
 | **M2** (Complete) | WorkflowIR structured fields in `workflow_compiler.proto`, `WorkflowCompilerService` skeleton (in-memory), JSON Schema for WorkflowIR | Temporal integration, persistence, CLI |
 | **M3** (Complete) | Temporal-backed `EngineAdapterService` — `WorkflowEngine` interface, `IRInterpreterWorkflow`, `DispatchCapabilityActivity`, `TemporalEngine`, gRPC wiring | Other engine adapters, K8s deployment |
-| **M4** (In Progress) | api-gateway REST layer, `zynax` CLI, `kind: AgentDef` routing, Docker Compose runner, GitOps watch | Observability, production hardening |
+| **M4** (Complete) | api-gateway REST layer, `zynax` CLI, `kind: AgentDef` routing, Docker Compose runner, GitOps watch | Observability, production hardening |
 | **M5+** | Adapter library (http, llm, git, ci adapters), additional engine backends | — |
 
-For M4: Canvas at `docs/spdd/314-yaml-system-cli/canvas.md` (status: Aligned).
-Active issues: #315 (done), #316, #317 (done), #318, #319, #320.
-CLI validation tools migration: #331 epic, steps #332–#336.
+M4 complete. Active milestone: M5 (Adapter Library). See open issues labelled `milestone: M5`.
 
 ## Common AI Anti-Patterns
 

--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ make test        # full suite (unit + BDD + coverage gate)
 | **M1 — Contracts Foundation** | **Complete** | v0.1.0 | [Engineering Review](docs/milestones/M1-engineering-review.md) · [Release Notes](docs/milestones/M1-release-notes.md) |
 | **M2 — Workflow IR** | **Complete** | v0.1.0 | [Epic #101](https://github.com/zynax-io/zynax/issues/101) |
 | **M3 — Temporal Execution** | **Complete** | v0.2.0 | [Epic #214](https://github.com/zynax-io/zynax/issues/214) · [Canvas](docs/spdd/214-temporal-execution/canvas.md) |
-| **M4 — YAML System + CLI** | **In Progress** | v0.3.0 | [Epic #314](https://github.com/zynax-io/zynax/issues/314) · [Canvas](docs/spdd/314-yaml-system-cli/canvas.md) |
+| **M4 — YAML System + CLI** | **Complete** | v0.3.0 | [Epic #314](https://github.com/zynax-io/zynax/issues/314) · [Canvas](docs/spdd/314-yaml-system-cli/canvas.md) |
 
 **M1** delivered the contracts-only foundation: 8 gRPC services defined as protobuf contracts,
 AsyncAPI spec covering 11 event channels, generated Go + Python stubs, 140+ BDD contract
@@ -339,7 +339,7 @@ lifecycle publishing (`zynax.workflow.state.entered/exited/completed/failed`), a
 `EngineAdapterService` gRPC methods (`Submit`, `Signal`, `Cancel`, `GetWorkflowStatus`,
 `WatchWorkflow`) wired end-to-end.
 
-**M4 (in progress)** is delivering the YAML system and CLI: api-gateway HTTP REST layer
+**M4** delivered the YAML system and CLI: api-gateway HTTP REST layer
 (`POST /api/v1/apply`, `GET /api/v1/workflows/{id}`, `DELETE /api/v1/workflows/{id}`),
 `kind: AgentDef` routing via `AgentRegistryService`, the `zynax` CLI (`apply`, `get`,
 `delete`, `status`, `logs`), local Docker Compose runner (`make run-local`),
@@ -371,12 +371,12 @@ spec/                Workflow YAML manifests and JSON schemas (Workflow, AgentDe
 services/            Go platform services
   workflow-compiler/ YAML → WorkflowIR compiler (M2 — complete)
   engine-adapter/    Temporal execution engine bridge (M3 — complete)
-  api-gateway/       HTTP REST entry point: /api/v1/apply + /api/v1/workflows (M4 — in progress)
+  api-gateway/       HTTP REST entry point: /api/v1/apply + /api/v1/workflows (M4 — complete)
   agent-registry/    Capability catalogue service (M4+)
   task-broker/       Capability routing service (M4+)
   memory-service/    KV + vector context store (M4+)
   event-bus/         NATS JetStream async pub/sub (M4+)
-cmd/zynax/           zynax CLI — apply, get, delete, status (M4 — in progress)
+cmd/zynax/           zynax CLI — apply, get, delete, status (M4 — complete)
 cmd/zynax-ci/        zynax-ci CI toolchain — validate canvas/schema/manifests, check ai-context
 agents/              Python execution adapters + zynax-sdk
 protos/              gRPC contracts (Go + Python stubs generated)


### PR DESCRIPTION
## User Story

**As a** contributor browsing the GitHub milestone board or reading CLAUDE.md,
**I want** completed milestones to be closed and status labels to be accurate,
**so that** M5 is clearly the active milestone and completed work is visibly done.

## What Changed

**GitHub milestones** — closed via API (all had 0 open issues):
- M1 — Contracts Foundation → closed
- M2 — Workflow IR → closed
- M3 — Temporal Execution → closed
- M4 — YAML System + CLI → closed (all step issues #315–#320 and epic #331 merged)

**\`CLAUDE.md\`**:
- M4 status: `In Progress` → `Complete`
- M4 delivery summary updated from "in progress" to past tense
- Per-Milestone Scope table: M4 `(In Progress)` → `(Complete)`
- Stale M4 active-issue list replaced with single line pointing to M5

**\`README.md\`**:
- Milestone table: M4 `In Progress` → `Complete`
- Delivery paragraph: "M4 (in progress) is delivering" → "M4 delivered"
- Repo tree: two `M4 — in progress` labels → `M4 — complete`

## Acceptance Criteria

- [x] M1 milestone closed on GitHub
- [x] M2 milestone closed on GitHub
- [x] M3 and M4 milestones closed on GitHub (also 0 open issues)
- [x] CLAUDE.md milestone table marks M4 as Complete
- [x] README.md milestone table marks M4 as Complete

## Test Plan

- [x] GitHub API confirmed all four milestones transitioned to `closed` state
- [x] CLAUDE.md and README.md diffs reviewed — no broken links, no stale references
- [x] CI green

Closes #267.

Assisted-by: Claude/claude-sonnet-4-6