### PR TITLE
chore: refresh M5 adapter library canvas and milestone docs (#377)

### DIFF
--- a/agents/adapters/AGENTS.md
+++ b/agents/adapters/AGENTS.md
@@ -3,7 +3,8 @@
 > Adapter-First Integration. No SDK Required.
 > ADR-013: any system becomes a capability by implementing `AgentService` gRPC.
 > Inherits all rules from root `AGENTS.md` and `agents/AGENTS.md`.
-> Full implementation patterns: `docs/patterns/python-agent-guide.md`.
+> Full implementation patterns: `docs/patterns/python-agent-guide.md` (Python adapters)
+> and `docs/patterns/go-service-patterns.md` (Go adapters).
 
 ---
 
@@ -15,11 +16,11 @@
 ```
 External System      Adapter             Zynax capability
 ─────────────────    ──────────────      ─────────────────
-Bedrock API     →    llm/              → summarize
-GitHub API      →    git/              → open_mr, request_review
-Jenkins/CI      →    ci/               → run_tests, deploy
-HTTP REST API   →    http/             → call_payments_api
-LangGraph app   →    langgraph/        → research_topic
+REST API        →    http/    (Go)     → call_payments_api
+GitHub API      →    git/     (Go)     → open_pr, request_review
+Jenkins/CI      →    ci/      (Go)     → trigger_workflow, get_run_status
+Bedrock/OpenAI  →    llm/     (Python) → chat_completion
+LangGraph app   →    langgraph/ (Py)   → research_topic
 ```
 
 ---
@@ -28,31 +29,97 @@ LangGraph app   →    langgraph/        → research_topic
 
 ```
 agents/adapters/
-├── http/          ← Wraps any REST API (config-only, M5)
-├── llm/           ← Bedrock, Ollama, OpenAI (M5)
-├── git/           ← GitHub/GitLab (M5)
-├── ci/            ← Jenkins, GitHub Actions (M5)
-└── langgraph/     ← LangGraph app as capability (M5)
+├── http/          ← Wraps any REST API (config-only) — Go, #380
+├── git/           ← GitHub/GitLab operations          — Go, #381
+├── ci/            ← GitHub Actions / Jenkins triggers  — Go, #382
+├── llm/           ← Bedrock, Ollama, OpenAI            — Python, #383
+└── langgraph/     ← LangGraph app as capability        — Python, #384
 ```
 
-All adapters are M5+ unless otherwise noted. BDD `.feature` file before implementation.
+All adapters are M5 deliverables. Parent epic: #377. Canvas: `docs/spdd/377-adapter-library/canvas.md`.
+BDD `.feature` file required before any implementation (ADR-016).
+Individual REASONS Canvas required before any implementation (ADR-019).
+
+---
+
+## Language Strategy
+
+| Adapter | Language | Reason |
+|---------|----------|--------|
+| `http/` | **Go** | Stateless REST proxy — no ML deps. Single binary, small image. |
+| `git/` | **Go** | GitHub/GitLab API calls over HTTP — same profile as http. |
+| `ci/` | **Go** | CI API calls (GitHub Actions, Jenkins REST) — same profile. |
+| `llm/` | **Python** | OpenAI / Anthropic / Bedrock SDKs are Python-native. ML ecosystem. |
+| `langgraph/` | **Python** | LangGraph is a Python framework — adapter must import graph code. |
+
+**Rule:** Default to Go for any adapter that is a stateless HTTP/gRPC proxy. Only choose Python
+when the wrapped system's primary SDK or framework is Python-native (AI/ML exclusively).
 
 ---
 
 ## The Two Adapter Interfaces
 
 **Zynax-facing:** Implement `ExecuteCapability` gRPC (stream of `TaskEvent`).
-Register capabilities in an `AgentDef` YAML on startup.
+Register capabilities in an `AgentDef` YAML on startup via `AgentRegistryService.RegisterAgent`.
+Deregister via `AgentRegistryService.DeregisterAgent` on graceful shutdown.
 
 **System-facing:** Whatever protocol the wrapped system speaks (REST, gRPC, CLI).
 The adapter translates between the two sides.
 
 ---
 
+## Go Adapter Module Layout
+
+```
+agents/adapters/<name>/
+├── go.mod                   module github.com/zynax-io/zynax/agents/adapters/<name>
+├── cmd/<name>-adapter/
+│   └── main.go              gRPC server bootstrap + graceful shutdown
+├── internal/
+│   ├── adapter.go           CapabilityRouter + system-facing CapabilityHandler
+│   └── config.go            AdapterConfig YAML parsing
+├── Dockerfile               two-stage Alpine (golang:*-alpine → alpine:*)
+└── agent-def.yaml.example   operator documentation
+```
+
+All Go adapter modules are added to `go.work` with `use agents/adapters/<name>`.
+
+## Python Adapter Module Layout
+
+```
+agents/adapters/<name>/
+├── pyproject.toml           uv-managed; grpcio, protobuf, pydantic-settings in deps
+├── src/<name>_adapter/
+│   ├── server.py            gRPC server; ExecuteCapability; GetCapabilitySchema
+│   ├── router.py            CapabilityRouter
+│   ├── config.py            AdapterConfig + provider-specific config
+│   └── ...                  provider modules, graph loader, etc.
+├── Dockerfile               two-stage Python image (python:3.12-slim)
+└── agent-def.yaml.example
+```
+
+---
+
 ## Rules
 
-- Adapters are stateless — no adapter-local state that survives restart.
-- Register capabilities from `AgentDef` YAML, not hardcoded in Python.
-- Capability names must be `snake_case` and match the registry entry.
-- Emit at least one `TaskEvent.progress()` for tasks > 2 seconds.
-- Always emit exactly one `TaskEvent.result()` or `TaskEvent.error()` as the final event.
+- Adapters are **stateless** — no adapter-local state that survives restart.
+- Capabilities declared in `AgentDef` YAML, not hardcoded in source.
+- Capability names must be `snake_case`, 1–64 characters, matching the registry entry exactly.
+- Emit at least one `TASK_EVENT_TYPE_PROGRESS` event for tasks >2 seconds.
+- Always emit exactly one `TASK_EVENT_TYPE_COMPLETED` or `TASK_EVENT_TYPE_FAILED` as the final event.
+- Never emit events after the terminal event.
+- Echo `task_id` on every `TaskEvent`. Populate `timestamp` on every event.
+- Honour `timeout_seconds` — emit `TASK_EVENT_TYPE_FAILED` with code `"TIMEOUT"` on breach.
+- `CapabilityError.message` is human-readable and sanitised — no raw API responses, no stack traces, no credential values.
+- Never import `agents/sdk/` — adapters implement `AgentService` directly via generated stubs (ADR-013).
+- Never call Zynax platform services via HTTP (Python adapters) — gRPC stubs only.
+- Go adapters: `GOWORK=off` for all `go test` and `go build` (ADR-017). `CGO_ENABLED=0`, `-trimpath`.
+- Python adapters: `asyncio` throughout; no blocking calls on the event loop.
+
+---
+
+## SSRF Prevention (http-adapter)
+
+The http-adapter maps capability names to HTTP routes via static config only. No URL fields are
+accepted in `input_payload` — all HTTP endpoints are declared in `AgentDef` YAML at startup.
+This is a hard requirement enforced by the Canvas Safeguards (ADR-019).

--- a/docs/spdd/377-adapter-library/canvas.md
+++ b/docs/spdd/377-adapter-library/canvas.md
@@ -28,8 +28,8 @@
 
 - **Definition of done — observable outcomes:**
   - `zynax apply agent-def.yaml` registers an http-adapter instance; a workflow step calls the declared capability; the task broker receives a `TASK_EVENT_TYPE_COMPLETED` `TaskEvent` with the proxied HTTP response payload.
-  - A workflow step calls `open_pr` via the git-adapter; a PR appears in the target Git repository.
-  - A workflow step calls `trigger_workflow` via the ci-adapter; a GitHub Actions run is dispatched; its status streams as `TASK_EVENT_TYPE_PROGRESS` events until completion.
+  - A workflow step calls `open_pr` via the git-adapter; a PR appears in the target Git repository with the correct title, body, and head branch.
+  - A workflow step calls `trigger_workflow` via the ci-adapter; a GitHub Actions run is dispatched; its status streams as `TASK_EVENT_TYPE_PROGRESS` events until terminal state.
   - A workflow step calls `chat_completion` via the llm-adapter; token chunks arrive as `TASK_EVENT_TYPE_PROGRESS` events; the full response arrives as `TASK_EVENT_TYPE_COMPLETED`.
   - A workflow step calls the mapped capability via the langgraph-adapter; per-node progress events stream to the task broker; the final graph output arrives as `TASK_EVENT_TYPE_COMPLETED`.
   - All five adapters: `make test` green · `make lint` clean · `make security` clean.
@@ -41,24 +41,28 @@
 
 ### Existing entities consumed (contracts unchanged in M5)
 
-- **`AgentService`** (`protos/zynax/v1/agent.proto`) — the two-RPC contract every adapter implements: `ExecuteCapability` (server-streaming) and `GetCapabilitySchema`. No proto changes in M5.
+- **`AgentService`** (`protos/zynax/v1/agent.proto`) — the two-RPC contract every adapter implements: `ExecuteCapability` (server-streaming `TaskEvent`) and `GetCapabilitySchema`. Contract invariants: exactly one terminal event per stream; `task_id` echoed on every event; `timeout_seconds` honoured; no events after terminal. No proto changes in M5.
 - **`AgentRegistryService`** (`protos/zynax/v1/agent_registry.proto`) — adapters call `RegisterAgent` on startup with their `AgentDef`; `DeregisterAgent` on graceful shutdown. No proto changes in M5.
 - **`AgentDef`** (proto message) — declares `agent_id`, `name`, `description`, `endpoint` (`host:port`), and a list of `CapabilityDef`. Adapters build this from their YAML config at startup.
 - **`CapabilityDef`** (proto message) — `name` (snake_case, 1–64 chars), `description`, `input_schema` (JSON Schema bytes), `output_schema` (JSON Schema bytes). Declared in the AgentDef YAML; never hardcoded in source.
 - **`ExecuteCapabilityRequest`** (proto message) — `request_id` (UUID v4), `capability_name`, `task_id`, `workflow_id`, `input_payload` (JSON bytes), `timeout_seconds`. Sent by the task broker to trigger a capability.
 - **`TaskEvent`** (proto message) — `task_id`, `event_type` (PROGRESS / COMPLETED / FAILED), `payload` (JSON bytes), `timestamp`, `error` (`CapabilityError`). Adapters stream these back to the task broker.
-- **`CapabilityError`** (proto message) — `code` (well-known string: `"TIMEOUT"`, `"INVALID_INPUT"`, `"UPSTREAM_ERROR"`, `"RESOURCE_EXHAUSTED"`, `"INTERNAL"`), `message` (human-readable, sanitised — no raw API responses or stack traces).
+- **`CapabilityError`** (proto message) — `code` (well-known string: `"TIMEOUT"`, `"INVALID_INPUT"`, `"UPSTREAM_ERROR"`, `"RESOURCE_EXHAUSTED"`, `"INTERNAL"`), `message` (human-readable, sanitised — no raw API responses, no stack traces, no credential values).
 
 ### New entities (introduced by M5)
 
 - **`AdapterConfig`** — YAML struct parsed at startup from the `AgentDef` YAML file on disk. Common fields: `agent_id`, `name`, `endpoint`, `capabilities[]`. Adapter-specific subsections carry system-facing config (route maps, provider selection, auth env-var references). Never contains credential values — only env-var name references.
-- **`CapabilityRouter`** — dispatches `ExecuteCapabilityRequest.capability_name` to the registered `CapabilityHandler`. One per adapter process; initialised from `AdapterConfig` at startup.
+- **`CapabilityRouter`** — dispatches `ExecuteCapabilityRequest.capability_name` to the registered `CapabilityHandler`. One per adapter process; initialised from `AdapterConfig` at startup; immutable thereafter.
 - **`CapabilityHandler`** (interface/protocol) — one implementation per declared capability. Translates a single `ExecuteCapabilityRequest` into the system-facing protocol call and yields `TaskEvent` values. Stateless between invocations.
-- **`RouteConfig`** (http-adapter) — maps one capability name to an HTTP method, URL, and static request headers. URL is static config only; no user-controlled fields in `input_payload` (SSRF prevention).
-- **`GitConfig`** (git-adapter) — auth mode (`pat` / `github-app`); token sourced from the env-var name declared in `AdapterConfig`. Target org and repo declared per capability.
-- **`CIConfig`** (ci-adapter) — provider flag (`github-actions` / `jenkins-stub`); token from env-var reference; org/repo/workflow-id per capability.
-- **`ProviderConfig`** (llm-adapter) — provider (`openai` / `bedrock` / `ollama`); model name from env-var reference; Ollama endpoint; max-tokens ceiling from config.
-- **`GraphMount`** (langgraph-adapter) — maps one capability name to a Python module path and graph entry node; loaded at adapter startup, not per-request.
+- **`RouteConfig`** (http-adapter) — maps one capability name to an HTTP method, URL (static config only — no user-controlled fields), and optional static request headers. URL is never derived from `input_payload` (SSRF prevention).
+- **`GitConfig`** (git-adapter) — auth mode (`pat` / `github-app`); token sourced from the env-var name declared in `AdapterConfig` at startup (never from `input_payload`). Target org and repo declared per capability. GitLab: config flag only (stub).
+- **`CIConfig`** (ci-adapter) — provider flag (`github-actions` / `jenkins-stub`); token from env-var reference; org/repo/workflow-id per capability. Includes poll interval and max-poll configuration.
+- **`PollLoop`** (ci-adapter) — exponential backoff polling (2 s → 4 s → 8 s → max 30 s) for run status; honours `timeout_seconds` via `context.Context` deadline; emits `TASK_EVENT_TYPE_PROGRESS` per cycle.
+- **`ProviderConfig`** (llm-adapter) — provider (`openai` / `bedrock` / `ollama`); model name from env-var reference; Ollama base URL from config; max-tokens ceiling from config.
+- **`ChatCompletionHandler`** (llm-adapter) — async coroutine; token chunks → `TASK_EVENT_TYPE_PROGRESS` events; terminal `TASK_EVENT_TYPE_COMPLETED` with full response payload. Provider routing: `openai.AsyncOpenAI` for OpenAI; `aiobotocore` for Bedrock; `httpx.AsyncClient` for Ollama REST.
+- **`GraphMount`** (langgraph-adapter) — maps one capability name to a Python module path and graph entry node; imported and compiled at adapter startup, not per-request.
+- **`GraphLoader`** (langgraph-adapter) — imports the graph module from `GraphMount.graph_module`, retrieves the `StateGraph` object, and calls `graph.compile()`. Fails fast at startup if any graph fails to load.
+- **`LangGraphHandler`** (langgraph-adapter) — async coroutine; calls `compiled_graph.astream(input_state)`, yielding one `TASK_EVENT_TYPE_PROGRESS` per `(node_name, state_update)` tuple; terminal `TASK_EVENT_TYPE_COMPLETED` with final graph state as JSON.
 
 ### Entity relationships
 
@@ -92,22 +96,24 @@ On graceful shutdown:
 
 - Implement five standalone adapter services — each is an independently deployable gRPC server with its own module (`go.mod` or `pyproject.toml`), Dockerfile, and docker-compose entry.
 - Use **Go** for `http/`, `git/`, `ci/` adapters — stateless HTTP proxy pattern with no ML library dependency. Single-binary deployment, smaller images, faster cold start.
-- Use **Python 3.12** for `llm/` and `langgraph/` adapters — the ML ecosystem (openai, boto3, langgraph) is Python-native. Forcing Go here gains nothing and loses the ecosystem.
+- Use **Python 3.12** for `llm/` and `langgraph/` adapters — the ML ecosystem (openai, aiobotocore, langgraph) is Python-native. Forcing Go here gains nothing and loses the ecosystem.
 - All adapters are **config-driven**: capabilities are declared in an `AgentDef` YAML file; the adapter reads this at startup and never hardcodes capability names or system endpoints in source.
 - BDD `.feature` file committed to `protos/tests/features/` before any implementation code per adapter (ADR-016).
 - Individual REASONS Canvas committed in `docs/spdd/` before implementation per adapter PR (ADR-019).
 - Each adapter registers with `AgentRegistryService.RegisterAgent` on startup and calls `DeregisterAgent` on graceful shutdown.
 - Go adapters: standalone `go.mod` per adapter module; added to `go.work` with `use` directive.
 - Python adapters: standalone `pyproject.toml` with `uv`; two-stage Docker image.
+- The http-adapter (step 1) establishes the Go scaffold; git/ci adapters reuse it structurally.
+- The llm-adapter (step 4) establishes the Python scaffold; langgraph-adapter reuses it structurally.
 
 ### What we WILL NOT do
 
 - Import `agents/sdk/` in any adapter (ADR-013 — adapter-first, no SDK required).
 - Store execution state between `ExecuteCapabilityRequest` invocations (stateless per ADR-013).
-- Accept user-controlled URLs in `input_payload` for the http-adapter (SSRF prevention).
+- Accept user-controlled URLs in `input_payload` for the http-adapter (SSRF prevention — all routes are static config).
 - Implement webhook ingestion (inbound events to Zynax — out of M5 scope).
 - Deploy to Kubernetes — Docker Compose only in M5 (Kubernetes is M6).
-- Use LangGraph as a Zynax workflow engine — the langgraph-adapter wraps LangGraph as a capability, not as an engine (LangGraph engine is M6+, separate ADR required).
+- Use LangGraph as a Zynax workflow engine — the langgraph-adapter wraps LangGraph as a **capability**, not as an engine. LangGraph as an engine replacement for Temporal is M6+, requires a new ADR (ADR-015 governs this boundary).
 - Write any adapter in two languages or mix languages within one adapter.
 - Extend any proto contract in M5 — all adapter contracts are already finalised in `protos/zynax/v1/`.
 
@@ -116,6 +122,7 @@ On graceful shutdown:
 - **ADR-001** — gRPC-only for all Zynax platform calls. No REST callbacks from adapters to platform.
 - **ADR-009** — Go for stateless proxies; Python only where ML ecosystem is the explicit justification.
 - **ADR-013** — Adapter-first: no SDK required. SDK is never imported in an adapter.
+- **ADR-015** — Pluggable workflow engines. LangGraph-adapter wraps LangGraph as a capability (not an engine); crossing to "LangGraph as engine" requires a new ADR.
 - **ADR-016** — BDD `.feature` file committed and CI-green before any implementation code.
 - **ADR-019** — REASONS Canvas committed before any implementation code for each `feat:` PR.
 
@@ -135,30 +142,30 @@ agents/adapters/
 │   │   ├── adapter.go           CapabilityRouter + HTTP proxy CapabilityHandler
 │   │   └── config.go            AdapterConfig YAML parsing + RouteConfig
 │   ├── Dockerfile               two-stage Alpine (golang:*-alpine → alpine:*)
-│   └── agent-def.yaml.example   documented example for operators
+│   └── agent-def.yaml.example   operator documentation
 │
 ├── git/                         ← feat(adapters/git) #381  — Go module
-│   └── (same layout as http/)   go-github client; GitConfig
+│   └── (same layout as http/)   go-github client; GitConfig; open_pr/request_review/get_diff
 │
 ├── ci/                          ← feat(adapters/ci) #382  — Go module
-│   └── (same layout as http/)   GitHub Actions REST API; CIConfig; poll loop
+│   └── (same layout as http/)   GitHub Actions REST API; CIConfig; PollLoop; trigger_workflow/get_run_status
 │
 ├── llm/                         ← feat(adapters/llm) #383  — Python module
-│   ├── pyproject.toml
+│   ├── pyproject.toml           openai, aiobotocore, httpx as deps; uv
 │   ├── src/llm_adapter/
 │   │   ├── server.py            gRPC server; ExecuteCapability; GetCapabilitySchema
 │   │   ├── router.py            CapabilityRouter
 │   │   ├── providers/           openai.py · bedrock.py · ollama.py
 │   │   └── config.py            AdapterConfig + ProviderConfig
-│   ├── Dockerfile               two-stage Python image (python:3.12-slim → python:3.12-slim)
+│   ├── Dockerfile               two-stage Python image (python:3.12-slim)
 │   └── agent-def.yaml.example
 │
 └── langgraph/                   ← feat(adapters/langgraph) #384  — Python module
-    ├── pyproject.toml
+    ├── pyproject.toml           langgraph as dep; uv
     ├── src/langgraph_adapter/
     │   ├── server.py            gRPC server
     │   ├── router.py            CapabilityRouter
-    │   ├── graph_loader.py      GraphMount loading; module import at startup
+    │   ├── graph_loader.py      GraphLoader — imports and compiles graphs at startup
     │   └── config.py            AdapterConfig + GraphMount
     ├── Dockerfile
     └── agent-def.yaml.example
@@ -184,15 +191,15 @@ agents/adapters/
 Each step is a separate `feat:` PR with its own REASONS Canvas and BDD feature file committed before implementation.
 Steps 1–3 (Go track) and steps 4–5 (Python track) are independent and can proceed in parallel.
 
-1. **feat(adapters/http) #380** — Go module scaffold (`go.mod`, `main.go`, `internal/adapter.go`, `internal/config.go`); `AdapterConfig` YAML parsing; `CapabilityRouter`; HTTP proxy `CapabilityHandler` (static route map, no user-controlled URLs); `ExecuteCapability` streaming loop (PROGRESS for >2 s, COMPLETED/FAILED terminal); `GetCapabilitySchema` returning schema from config; graceful shutdown with `DeregisterAgent`; two-stage Alpine Dockerfile; docker-compose entry. BDD: `http_adapter.feature`. Establishes the Go adapter scaffold reused by steps 2 and 3.
+1. **feat(adapters/http) #380** — Go module scaffold (`go.mod`, `main.go` with graceful shutdown, `internal/adapter.go` with `CapabilityRouter` + HTTP proxy `CapabilityHandler`, `internal/config.go` with `AdapterConfig`/`RouteConfig` YAML parsing); `ExecuteCapability` streaming loop (ticker PROGRESS for >2 s, COMPLETED/FAILED terminal); `input_payload` JSON Schema validation before execution (INVALID_INPUT on failure); `GetCapabilitySchema` returning schema from config; SSRF prevention (all URLs static config, never from payload); `DeregisterAgent` on shutdown; two-stage Alpine Dockerfile; docker-compose entry. BDD: `http_adapter.feature`. Establishes the Go adapter scaffold reused by steps 2 and 3.
 
-2. **feat(adapters/git) #381** — Go module (same layout as http-adapter); `go-github` client; `GitConfig` (auth mode, env-var token ref); capabilities: `open_pr`, `request_review`, `get_diff`; PROGRESS events on long-running PR operations; graceful shutdown; Dockerfile; docker-compose entry. BDD: `git_adapter.feature`.
+2. **feat(adapters/git) #381** — Go module (same layout as http-adapter); `go-github` client with PAT/App auth from env-var ref (never from payload); `GitConfig`; capabilities: `open_pr` (create PR, validate branch exists before API call), `request_review` (request reviewers, poll for confirmation with PROGRESS), `get_diff` (fetch unified diff, truncate at 4 MB with `truncated: true` flag); rate-limit awareness (`RESOURCE_EXHAUSTED` on 429/403); GitLab config flag (stub only). BDD: `git_adapter.feature`.
 
-3. **feat(adapters/ci) #382** — Go module; GitHub Actions REST API; `CIConfig` (provider flag, env-var token ref); capabilities: `trigger_workflow` (dispatch `workflow_dispatch`), `get_run_status` (poll loop with PROGRESS events per cycle); TIMEOUT enforcement; Jenkins config flag (stub, no implementation); Dockerfile; docker-compose entry. BDD: `ci_adapter.feature`.
+3. **feat(adapters/ci) #382** — Go module; GitHub Actions REST API; `CIConfig`; capabilities: `trigger_workflow` (dispatch `workflow_dispatch`, poll up to 10 s for run ID to appear), `get_run_status` (`PollLoop` with exponential backoff 2 s→30 s, PROGRESS per cycle with run URL and status, TIMEOUT enforcement via ctx deadline); Jenkins config flag (stub only, returns `INTERNAL` with "not implemented" message). BDD: `ci_adapter.feature`.
 
-4. **feat(adapters/llm) #383** — Python module; `AdapterConfig` + `ProviderConfig` (`openai`/`bedrock`/`ollama`); `chat_completion` capability; async token streaming as PROGRESS events; COMPLETED with full response; sanitised CapabilityError codes; TIMEOUT via `asyncio`; `bandit`+`pip-audit`+`mypy --strict` clean; Dockerfile; docker-compose entry. BDD: `llm_adapter.feature`. Establishes the Python adapter scaffold reused by step 5.
+4. **feat(adapters/llm) #383** — Python module; `AdapterConfig` + `ProviderConfig` parsed at startup; `chat_completion` capability; provider routing: `openai.AsyncOpenAI` for OpenAI, `aiobotocore` for Bedrock (required — boto3 sync is forbidden on the event loop), `httpx.AsyncClient` for Ollama REST; async token streaming → PROGRESS events; COMPLETED with full response; `asyncio.wait_for` for TIMEOUT enforcement; `pydantic.SecretStr` for key fields (never log, never include in CapabilityError); `bandit`+`pip-audit`+`mypy --strict` clean; `[[tool.mypy.overrides]] ignore_missing_imports = true` for untyped provider SDKs. BDD: `llm_adapter.feature`. Establishes the Python adapter scaffold reused by step 5.
 
-5. **feat(adapters/langgraph) #384** — Python module; `GraphMount` config; graph module loader at startup; capability-name-to-entry-node dispatch; async graph execution with PROGRESS event per node completion; COMPLETED with final graph output; TIMEOUT via `asyncio`; sanitised CapabilityError; `bandit`+`pip-audit`+`mypy --strict` clean; Dockerfile; docker-compose entry. BDD: `langgraph_adapter.feature`.
+5. **feat(adapters/langgraph) #384** — Python module; `GraphMount` config; `GraphLoader` imports and compiles LangGraph graphs at adapter startup (fail-fast if any graph fails to import); `LangGraphHandler` calls `compiled_graph.astream(input_state)` async; one PROGRESS event per `(node_name, state_update)` tuple; ticker PROGRESS if no node fires within 2 s; final graph state serialised with `json.dumps(..., default=str)` fallback; `asyncio.wait_for` for TIMEOUT; graph exceptions mapped to typed `CapabilityError` codes; ADR-015 scope enforced (LangGraph as capability, not engine — documented in Canvas and code comments). BDD: `langgraph_adapter.feature`.
 
 ---
 
@@ -208,13 +215,14 @@ Pulled from root `AGENTS.md` §Hard Constraints, `agents/AGENTS.md` §Rules, `ag
 - Individual REASONS Canvas at `docs/spdd/<issue>-<slug>/canvas.md` committed **before** implementation for each `feat:` adapter PR (ADR-019).
 - Adapters are **stateless** — no adapter-local state that survives a process restart.
 - Capability names: `snake_case`, 1–64 characters, matching the `AgentDef` YAML declaration exactly.
-- At least one `TASK_EVENT_TYPE_PROGRESS` event emitted for tasks running >2 seconds.
+- At least one `TASK_EVENT_TYPE_PROGRESS` event emitted for tasks running >2 seconds (ticker-based if no natural progress checkpoint exists).
 - Exactly one terminal event (`TASK_EVENT_TYPE_COMPLETED` or `TASK_EVENT_TYPE_FAILED`) per stream. No events after the terminal.
 - `timeout_seconds` honoured: emit `TASK_EVENT_TYPE_FAILED` with code `"TIMEOUT"` on breach.
 - `task_id` echoed in every `TaskEvent`. `timestamp` populated on every `TaskEvent`.
 - `CapabilityError.message` is human-readable and sanitised — no raw API response bodies, no stack traces, no credential values.
 - Health probe endpoint exposed (gRPC health protocol).
 - Structured logs to stdout only (no file sinks). Never log credential values or `SecretStr` fields.
+- `input_payload` validated against the capability's declared `input_schema` before execution; return `INVALID_INPUT` on validation failure.
 
 ### Go adapters (http, git, ci)
 
@@ -233,11 +241,12 @@ Pulled from root `AGENTS.md` §Hard Constraints, `agents/AGENTS.md` §Rules, `ag
 - Two-stage Python Dockerfile. Final image runs as unprivileged user.
 - Platform calls via gRPC stubs only — never HTTP (root `AGENTS.md` §Hard Constraints).
 - Never import `agents/sdk/` in an adapter. Adapters are self-contained.
-- Python functions ≤ 20 lines. `mypy --strict` clean. `ruff` clean (including `ruff D` Google docstring convention).
+- Python functions ≤ 20 lines. `mypy --strict` clean (with `ignore_missing_imports` overrides for untyped provider SDKs). `ruff` clean (including `ruff D` Google docstring convention).
 - `bandit` + `pip-audit` clean in CI.
-- LLM model name from config or env-var reference — never hardcoded in source.
+- Credential values (`SecretStr`) never logged, never included in `CapabilityError.message`.
 - All I/O resources closed in `finally` blocks or `async with` context managers.
-- `asyncio` throughout; no blocking calls on the event loop.
+- `asyncio` throughout; no blocking calls on the event loop. Bedrock: `aiobotocore` (not `boto3`). Ollama: `httpx.AsyncClient`.
+- `asyncio.wait_for` for timeout enforcement; catch `asyncio.TimeoutError` → emit FAILED with `"TIMEOUT"`.
 
 ---
 
@@ -256,8 +265,9 @@ Pulled from root `AGENTS.md` §Hard Constraints, `agents/AGENTS.md` §Rules, `ag
 - **Never** import `agents/sdk/` in an adapter — adapters implement `AgentService` directly via generated proto stubs (ADR-013).
 - **Never** hardcode capability names in source — capabilities are always declared in the `AgentDef` YAML and read at startup.
 - **Never** emit a `TaskEvent` after the terminal event (`TASK_EVENT_TYPE_COMPLETED` or `TASK_EVENT_TYPE_FAILED`).
-- **Never** allow user-controlled URL fields in `input_payload` for the http-adapter — all HTTP routes are static config (SSRF prevention).
-- **Never** log or include credential values (tokens, API keys, passwords) in `TaskEvent` payloads, `CapabilityError.message`, or structured log fields.
+- **Never** allow user-controlled URL fields in `input_payload` for the http-adapter — all HTTP routes are static config in `RouteConfig` (SSRF prevention; this is a hard security requirement, not a style choice).
+- **Never** source credentials (PAT, API keys, tokens, model names) from `input_payload` — credentials are sourced from named environment variables declared in `AdapterConfig`; the value is never passed through user-controlled fields.
+- **Never** log or include credential values in `TaskEvent` payloads, `CapabilityError.message`, or structured log fields. Python: use `pydantic.SecretStr` for credential fields.
 - **Never** use Go `panic` in adapter code — return errors via gRPC status codes and `CapabilityError` (root `AGENTS.md` §Hard Constraints).
 - **Never** discard `error` return values in Go adapters (`_ = f()` is forbidden).
 - **Never** call Zynax platform services via HTTP in Python adapters — gRPC stubs only (root `AGENTS.md` §Hard Constraints).
@@ -265,3 +275,6 @@ Pulled from root `AGENTS.md` §Hard Constraints, `agents/AGENTS.md` §Rules, `ag
 - **Never** store execution state across `ExecuteCapabilityRequest` invocations — adapters are stateless (ADR-013).
 - **Never** extend proto contracts in M5 — all adapter contracts are finalised in `protos/zynax/v1/`.
 - **Never** deploy adapters to Kubernetes in M5 — Docker Compose scope only; K8s is M6.
+- **Never** use LangGraph as a Zynax workflow engine in M5 — the langgraph-adapter wraps LangGraph as a capability only (ADR-015; the engine boundary is a one-way door requiring a new ADR).
+- **Never** call blocking I/O on the Python `asyncio` event loop — Bedrock via `aiobotocore`, Ollama via `httpx.AsyncClient`, all other I/O via `async with` or `await`.
+- **Never** skip `input_payload` JSON Schema validation — validate before any system-facing call and return `INVALID_INPUT` on failure.

--- a/state/current-milestone.md
+++ b/state/current-milestone.md
@@ -20,31 +20,64 @@
 
 ## M5 — Progress
 
-Goal: Production-ready code quality across all Go services and Python SDK, plus
-security supply-chain gates (SBOM, SLSA). Sets the foundation for M6 Helm deployment.
+Goal: Deliver the Adapter Library (#377) — five production-ready adapter services
+(http, git, ci, llm, langgraph) that turn any external system into a Zynax capability.
+Accompanied by code quality, security supply-chain gates, and documentation that bring
+the whole platform to production readiness. Sets the foundation for M6 Helm deployment.
 
-- [ ] refactor(workflow-compiler): naming, zero-value structs, functional options audit (#222)
-- [ ] refactor: context.Context propagation into domain layer across all Go services (#223)
-- [ ] refactor: error chain consistency — %w wrapping, typed sentinels, errors.Is/As (#224)
-- [ ] docs(agents): Google-style docstrings on all public symbols in agents/sdk (#228)
-- [ ] refactor(agents): strip explanatory comments — self-documenting names (#229)
+Epic: [#377 — M5 Adapter Library](https://github.com/zynax-io/zynax/issues/377)
+Canvas: `docs/spdd/377-adapter-library/canvas.md` (Status: Draft — PR #385)
+
+### Track 1 — Adapter Library (the main M5 deliverable)
+
+Each adapter requires a REASONS Canvas + BDD feature file before implementation.
+
+- [ ] feat(adapters/http): REST capability proxy adapter (#380, step 1) — Go
+- [ ] feat(adapters/git): GitHub/GitLab operations adapter (#381, step 2) — Go
+- [ ] feat(adapters/ci): CI pipeline trigger adapter (#382, step 3) — Go
+- [ ] feat(adapters/llm): LLM provider capability adapter (#383, step 4) — Python
+- [ ] feat(adapters/langgraph): LangGraph capability adapter (#384, step 5) — Python
+
+### Track 2 — Go Code Quality
+
+- [ ] refactor(workflow-compiler): naming, zero-value structs, functional options (#222)
+- [ ] refactor: context.Context propagation — parent (#223)
+  - [ ] refactor(workflow-compiler): thread ctx from gRPC boundary (#373, step 1)
+  - [ ] docs(services): ctx-first mandate + Temporal exemption in AGENTS.md (#374, step 2)
+- [ ] refactor: error chain consistency — %w, typed sentinels, errors.Is/As (#224)
+
+### Track 2 — Python SDK Quality
+
+- [ ] ci(agents): enable ruff Google-style docstring enforcement (#375) ← unblocked
+- [ ] feat(agents): SDK core modules — runtime, context, capability, server, platform, observability ← needs new issue
+- [ ] docs(agents): Google-style docstrings on all public SDK symbols (#228 / #376) ← blocked on SDK impl
+- [ ] refactor(agents): strip explanatory comments (#229) ← blocked on #376
+
+### Track 2 — Supply-Chain Security
+
+- [ ] ci: consolidate tools image publish to single workflow (#358) ← do first
+- [ ] ci: SBOM generation with syft (#235) ← after #358
+- [ ] ci: SLSA provenance — sign artifacts with cosign (#239) ← after #235
+
+### Track 2 — Architecture & Docs
+
 - [ ] docs: architecture fitness functions — document all CI gates (#232)
-- [ ] ci: SBOM generation with syft — publish as release artifact (#235)
-- [ ] ci: SLSA provenance — sign released artifacts with sigstore/cosign (#239)
 - [ ] docs: AI-output review checklist (#248)
-- [ ] ci: publish tools image to public GHCR registry securely (#358)
 
 ---
 
 ## Active PRs
 
-None.
+| PR | Title | Status |
+|----|-------|--------|
+| [#385](https://github.com/zynax-io/zynax/pull/385) | docs: REASONS Canvas for M5 Adapter Library (#377) | Open — pending merge |
 
 ---
 
 ## Known Blockers
 
-None.
+- **#376 (docstrings) and #229 (strip comments)** are blocked until a `feat(agents):` issue is created and merged for the SDK core module implementation.
+- **#239 (cosign)** depends on #358 (stable GHCR path) and #235 (SBOM).
 
 ---
 


### PR DESCRIPTION
## Summary

- Refreshes `docs/spdd/377-adapter-library/canvas.md` with full `/spdd-analysis` findings for all five M5 adapters (#380–384) and all Track 2 issues. New canvas entities: `PollLoop` (ci-adapter exponential backoff), `ChatCompletionHandler` (llm-adapter with aiobotocore for Bedrock, httpx for Ollama), `GraphLoader`/`LangGraphHandler` (langgraph-adapter with ADR-015 scope boundary documented in Operations and Safeguards). Adds concrete per-adapter Operations steps, asyncio-specific Norms, SSRF and blocking-I/O Safeguards.
- Updates `state/current-milestone.md` with Track 1 (adapters #380–384) / Track 2 (Go quality, Python SDK, supply-chain, docs) structure, active PR #385 table, and known blockers.
- Updates `agents/adapters/AGENTS.md` with language strategy table (Go for http/git/ci, Python for llm/langgraph), Go and Python module layout scaffolds, SSRF prevention section, and full adapter directory with issue numbers.

## Test plan

- [ ] CI: `canvas-freshness` validates updated canvas (structural check via `zynax-ci validate canvas`)
- [ ] CI: `actionlint`, `conventional-commit`, `gitleaks-scan` pass (docs/state/AGENTS.md only — no code)
- [ ] PR size: all changed files (`docs/`, `state/`, `AGENTS.md`) are excluded from line count — expected `size/S`

Signed-off-by: Oscar Gómez Manresa <ogomezmanresa@gmail.com>
Assisted-by: Claude/claude-sonnet-4-6