### PR TITLE
docs: clarify pre-commit hook install method in CONTRIBUTING.md (#247)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,19 +145,25 @@ pre-commit install       # wires hooks into .git/hooks/pre-commit
 
 After that, on every `git commit` the following checks run automatically:
 
-| Hook | What it checks | Needs locally |
-|------|---------------|---------------|
-| `gofmt` | Go formatting (formats in-place) | Go toolchain |
-| `golangci-lint` | Go static analysis (`tools/golangci-lint.yml`) | `golangci-lint` binary |
-| `ruff` | Python lint + formatting | `ruff` (`uv tool install ruff`) |
-| `mypy` | Python type-checking (`agents/sdk/src/`) | `mypy` (`uv tool install mypy`) |
-| `gitleaks` | Secret / credential scan | `gitleaks` binary |
+| Hook | What it checks | How it's installed |
+|------|---------------|-------------------|
+| `gitleaks` | Secret / credential scan | **Auto** — pre-commit manages it |
+| `ruff` | Python lint + formatting | **Auto** — pre-commit manages it |
+| `gofmt` | Go formatting (formats in-place) | Needs Go toolchain locally |
+| `golangci-lint` | Go static analysis per module (`tools/golangci-lint-precommit.sh`) | Needs `golangci-lint` (`make install-ci-tools`) |
+| `mypy` | Python type-checking (`agents/sdk/src/`) | Needs `mypy` (`uv tool install mypy`) |
+
+`gitleaks` and `ruff` are **managed hooks** — pre-commit downloads and caches them
+automatically on first run; no manual install needed.
+
+`gofmt`, `golangci-lint`, and `mypy` use `language: system` — if the binary is not
+in your `PATH` the hook will fail and block the commit. Install them as part of the
+normal dev setup (`make install-ci-tools` handles golangci-lint and zynax-ci).
+
+> The same checks run in CI via `make lint` (Docker-based). If you're missing a
+> local tool, use `git commit --no-verify` and note it in the PR — CI will catch it.
 
 Run all hooks manually at any time: `pre-commit run --all-files`
-
-> **Note:** The same checks run in CI via `make lint` (Docker-based), so a missing
-> local tool means your commit goes through but CI will catch it. Install the tools
-> for a faster feedback loop — you'll see failures in seconds, not minutes.
 
 **Bypassing hooks:** Use `git commit --no-verify` only for legitimate reasons (e.g. a
 work-in-progress checkpoint on a branch). Add a PR comment explaining why — reviewers


### PR DESCRIPTION
## Summary

- Splits the pre-commit hook table into **managed** (auto-downloaded) vs **`language: system`** (needs local binary) so contributors know immediately which tools they must install.
- Corrects the `golangci-lint` config file reference from the old `tools/golangci-lint.yml` to the actual wrapper script `tools/golangci-lint-precommit.sh` (committed in #369 / `fe845da`).
- Rewrites the note under the table: recommends `git commit --no-verify` + PR comment rather than implying the commit silently passes CI when a local tool is missing.
- `gitleaks` and `ruff` have `language: python` / `language: golang` in `.pre-commit-config.yaml` — pre-commit manages their download automatically. `gofmt`, `golangci-lint`, and `mypy` have `language: system` — they need the binary in `PATH`.

## Test plan

- [ ] `make lint` passes (docs-only change — no code)
- [ ] CI: `actionlint`, `conventional-commit`, `gitleaks-scan` pass
- [ ] PR size: `CONTRIBUTING.md` is not excluded, but change is 17 lines net → `size/S`

Signed-off-by: Oscar Gómez Manresa <ogomezmanresa@gmail.com>
Assisted-by: Claude/claude-sonnet-4-6