### PR TITLE
fix: bump Go toolchain to 1.26.3 (3 stdlib vulns)

### DIFF
--- a/cmd/zynax-ci/go.mod
+++ b/cmd/zynax-ci/go.mod
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 module github.com/zynax-io/zynax/cmd/zynax-ci
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1

--- a/cmd/zynax/go.mod
+++ b/cmd/zynax/go.mod
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 module github.com/zynax-io/zynax/cmd/zynax
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/fsnotify/fsnotify v1.10.1

--- a/go.work
+++ b/go.work
@@ -2,7 +2,7 @@
 // Zynax — Go workspace
 // All platform services (Go). Agents/adapters are Python (separate pyproject.toml).
 
-go 1.26.2
+go 1.26.3
 
 use (
 	./protos/generated/go

--- a/infra/docker/Dockerfile.tools
+++ b/infra/docker/Dockerfile.tools
@@ -25,9 +25,9 @@
 
 # ── Stage 1: Go binaries ────────────────────────────────────────────────────
 # GO_VERSION is the single source of truth for the Go toolchain.
-# Override at build time: docker build --build-arg GO_VERSION=1.26.2 ...
+# Override at build time: docker build --build-arg GO_VERSION=1.26.3 ...
 # Default must match go.work `go` directive.
-ARG GO_VERSION=1.26.2
+ARG GO_VERSION=1.26.3
 FROM golang:${GO_VERSION}-alpine AS go-tools
 
 RUN apk add --no-cache git curl

--- a/protos/generated/go/go.mod
+++ b/protos/generated/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/zynax-io/zynax/protos/generated/go
 
-go 1.26.2
+go 1.26.3
 
 require (
 	google.golang.org/grpc v1.80.0

--- a/protos/tests/go.mod
+++ b/protos/tests/go.mod
@@ -1,6 +1,6 @@
 module github.com/zynax-io/zynax/protos/tests
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/cucumber/godog v0.14.1

--- a/services/api-gateway/go.mod
+++ b/services/api-gateway/go.mod
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 module github.com/zynax-io/zynax/services/api-gateway
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/kelseyhightower/envconfig v1.4.0

--- a/services/engine-adapter/go.mod
+++ b/services/engine-adapter/go.mod
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 module github.com/zynax-io/zynax/services/engine-adapter
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/zynax-io/zynax/protos/generated/go v0.0.0

--- a/services/workflow-compiler/go.mod
+++ b/services/workflow-compiler/go.mod
@@ -1,6 +1,6 @@
 module github.com/zynax-io/zynax/services/workflow-compiler
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/kelseyhightower/envconfig v1.4.0


### PR DESCRIPTION
## Summary

Bumps the Go toolchain from 1.26.2 → 1.26.3 across all modules to fix three Go standard library vulnerabilities detected by `govulncheck` in CI:

| ID | Description | Severity |
|----|-------------|----------|
| GO-2026-4982 | Bypass of meta content URL escaping causes XSS in `html/template` | High |
| GO-2026-4980 | Escaper bypass leads to XSS in `html/template` | High |
| GO-2026-4971 | Panic in `Dial`/`LookupPort` when handling NUL byte on Windows in `net` | Medium |

All three are fixed in go1.26.3 (stdlib-only — no third-party dependency changes).

**Files updated** (9): `go.work`, `services/{api-gateway,engine-adapter,workflow-compiler}/go.mod`, `protos/{tests,generated/go}/go.mod`, `cmd/{zynax,zynax-ci}/go.mod`, `infra/docker/Dockerfile.tools` (ARG + comment).

## Test plan

- [x] CI: `govulncheck (all Go services)` passes — no stdlib vulnerabilities at go1.26.3
- [x] CI: `Go service unit tests` passes — no behaviour change, stdlib patch only
- [x] CI: `lint-go` passes — `go 1.26.3` directive is valid

Signed-off-by: Oscar Gómez Manresa <ogomezmanresa@gmail.com>
Assisted-by: Claude/claude-sonnet-4-6