### PR TITLE
docs(adapters/http): align canvas, embed issue refs in O-steps (#380)

### DIFF
--- a/docs/spdd/380-http-adapter/canvas.md
+++ b/docs/spdd/380-http-adapter/canvas.md
@@ -9,7 +9,7 @@
 **Issue:** #380
 **Author:** Oscar Gómez Manresa
 **Date:** 2026-05-08
-**Status:** Draft
+**Status:** Aligned
 
 ---
 
@@ -165,21 +165,21 @@ agents/adapters/http/
 
 ## O — Operations
 
-This issue is a single `feat:` PR. Implementation is broken into logical commits within that PR.
+This issue (#380) is a single `feat:` PR. Implementation is broken into logical commits within that PR.
 
-1. **BDD feature file** — commit `protos/tests/features/http_adapter.feature` with adapter-specific scenarios: SSRF prevention (URL never from payload), static-header forwarding, 2xx→COMPLETED, 4xx/5xx→FAILED with `UPSTREAM_ERROR`, PROGRESS ticker fires for slow upstreams, `timeout_seconds` respected, `GetCapabilitySchema` returns route config schema, unknown capability returns `NOT_FOUND`, empty `capability_name` returns `INVALID_ARGUMENT`. CI must be green before any implementation code is committed.
+1. **BDD feature file** (#392) — commit `protos/tests/features/http_adapter.feature` with adapter-specific scenarios: SSRF prevention (URL never from payload), static-header forwarding, 2xx→COMPLETED, 4xx/5xx→FAILED with `UPSTREAM_ERROR`, PROGRESS ticker fires for slow upstreams, `timeout_seconds` respected, `GetCapabilitySchema` returns route config schema, unknown capability returns `NOT_FOUND`, empty `capability_name` returns `INVALID_ARGUMENT`. CI must be green before any implementation code is committed. ✓ Done
 
-2. **Module scaffold** — `go.mod` (Go 1.26.3, module path, `replace` directive for generated stubs), `go.work` updated with `use agents/adapters/http`, `cmd/http-adapter/main.go` skeleton (compile-only, no logic yet).
+2. **Module scaffold** (#391) — `go.mod` (Go 1.26.3, module path, `replace` directive for generated stubs), `go.work` updated with `use agents/adapters/http`, `cmd/http-adapter/main.go` skeleton (compile-only, no logic yet).
 
-3. **Config layer** — `internal/config/config.go`: `AdapterConfig` struct with YAML tags; `RouteConfig` struct; `Load(path string)` function validating required fields (`agent_id`, `endpoint`, `registry_endpoint`, at least one capability with non-empty `name`, `method`, `url`); unit tests.
+3. **Config layer** (#393) — `internal/config/config.go`: `AdapterConfig` struct with YAML tags; `RouteConfig` struct; `Load(path string)` function validating required fields (`agent_id`, `endpoint`, `registry_endpoint`, at least one capability with non-empty `name`, `method`, `url`); unit tests.
 
-4. **HTTP handler + router** — `internal/adapter/server.go`: `AgentServer` struct; `CapabilityRouter` (map built from `AdapterConfig`); `ExecuteCapability` implementation: validate inputs → lookup route → call `HTTPHandler` → stream events. `internal/adapter/handler.go`: `HTTPHandler.Execute(ctx, route, payload)`: build request with `http.NewRequestWithContext`; race HTTP call against `ProgressTicker`; map response → `TaskEvent`; sanitise error messages. `GetCapabilitySchema` from router. Unit tests with `httptest.Server`.
+4. **HTTP handler + router** (#394) — `internal/adapter/server.go`: `AgentServer` struct; `CapabilityRouter` (map built from `AdapterConfig`); `ExecuteCapability` implementation: validate inputs → lookup route → call `HTTPHandler` → stream events. `internal/adapter/handler.go`: `HTTPHandler.Execute(ctx, route, payload)`: build request with `http.NewRequestWithContext`; race HTTP call against `ProgressTicker`; map response → `TaskEvent`; sanitise error messages. `GetCapabilitySchema` from router. Unit tests with `httptest.Server`.
 
-5. **Registry client** — `internal/registry/client.go`: `RegisterAgent` with exponential backoff (2 s base, ×2, max 5 attempts); `DeregisterAgent`; both use `context.Context` from caller.
+5. **Registry client** (#395) — `internal/registry/client.go`: `RegisterAgent` with exponential backoff (2 s base, ×2, max 5 attempts); `DeregisterAgent`; both use `context.Context` from caller.
 
-6. **Bootstrap** — `cmd/http-adapter/main.go`: load config; build `CapabilityRouter`; dial registry; `RegisterAgent`; start gRPC server (health protocol); `signal.NotifyContext` for SIGTERM/SIGINT; `DeregisterAgent` + `GracefulStop` on shutdown.
+6. **Bootstrap** (#396) — `cmd/http-adapter/main.go`: load config; build `CapabilityRouter`; dial registry; `RegisterAgent`; start gRPC server (health protocol); `signal.NotifyContext` for SIGTERM/SIGINT; `DeregisterAgent` + `GracefulStop` on shutdown.
 
-7. **Dockerfile + docker-compose** — two-stage Alpine Dockerfile; `CGO_ENABLED=0 -trimpath`; `USER zynax`; `infra/docker/docker-compose.yml` `http-adapter` service block; `agent-def.yaml.example`.
+7. **Dockerfile + docker-compose** (#397) — two-stage Alpine Dockerfile; `CGO_ENABLED=0 -trimpath`; `USER zynax`; `infra/docker/docker-compose.yml` `http-adapter` service block; `agent-def.yaml.example`.
 
 ---
 


### PR DESCRIPTION
## Summary

- Sets `**Status:** Aligned` in `docs/spdd/380-http-adapter/canvas.md` — canvas is ready for implementation (ADR-019)
- Embeds child issue numbers (#391–#397) in every O-step so the canvas tracks the full implementation plan
- Step 1 (BDD feature file, #392) marked ✓ Done — already committed and merged in #390
- `/spdd-security-review` result: **PASS** — no Tier 2 content, no injection, all sections complete

## Issue references

- Closes related work under #380 (EPIC — http-adapter)
- Child stories: #391 #392 #393 #394 #395 #396 #397

## PR size

~9 lines changed (docs-only canvas update).

Signed-off-by: Oscar Gómez Manresa <ogomezmanresa@gmail.com>
Assisted-by: Claude/claude-sonnet-4-6