### PR TITLE
feat(adapters/http): bootstrap — gRPC server wiring (#396)

### DIFF
--- a/agents/adapters/http/cmd/http-adapter/main.go
+++ b/agents/adapters/http/cmd/http-adapter/main.go
@@ -1,27 +1,27 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Package main is the entry point for the http-adapter gRPC service.
-// Business logic lives in internal/; full bootstrap is wired in step #396.
+// Config path from ADAPTER_CONFIG env var; registry endpoint from config.
 package main
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
+	"net"
 	"os"
 	"os/signal"
 	"syscall"
 
+	"github.com/zynax-io/zynax/agents/adapters/http/internal/adapter"
+	"github.com/zynax-io/zynax/agents/adapters/http/internal/config"
+	"github.com/zynax-io/zynax/agents/adapters/http/internal/registry"
 	zynaxv1 "github.com/zynax-io/zynax/protos/generated/go/zynax/v1"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/health"
+	"google.golang.org/grpc/health/grpc_health_v1"
 )
-
-// compile-time check: agentServer satisfies AgentServiceServer.
-// Replaced by internal/adapter.AgentServer in step #396.
-var _ zynaxv1.AgentServiceServer = (*agentServer)(nil)
-
-type agentServer struct {
-	zynaxv1.UnimplementedAgentServiceServer
-}
 
 func main() {
 	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stdout, nil)))
@@ -32,13 +32,60 @@ func main() {
 }
 
 func run() error {
+	cfgPath := os.Getenv("ADAPTER_CONFIG")
+	if cfgPath == "" {
+		return fmt.Errorf("ADAPTER_CONFIG env var is required")
+	}
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		return err
+	}
+	slog.Info("config loaded", "agent_id", cfg.AgentID, "endpoint", cfg.Endpoint)
+
+	regConn, err := grpc.NewClient(cfg.RegistryEndpoint,
+		grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return fmt.Errorf("registry dial %s: %w", cfg.RegistryEndpoint, err)
+	}
+	defer regConn.Close()
+	regClient := zynaxv1.NewAgentRegistryServiceClient(regConn)
+
+	lis, err := net.Listen("tcp", cfg.Endpoint)
+	if err != nil {
+		return fmt.Errorf("listen %s: %w", cfg.Endpoint, err)
+	}
+
+	grpcSrv := grpc.NewServer()
+	zynaxv1.RegisterAgentServiceServer(grpcSrv, adapter.NewAgentServer(cfg))
+	healthSrv := health.NewServer()
+	grpc_health_v1.RegisterHealthServer(grpcSrv, healthSrv)
+
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 	defer stop()
 
-	srv := grpc.NewServer()
-	zynaxv1.RegisterAgentServiceServer(srv, &agentServer{})
-	<-ctx.Done()
-	srv.GracefulStop()
+	def := registry.BuildAgentDef(cfg)
+	if err := registry.RegisterAgent(ctx, regClient, def); err != nil {
+		return fmt.Errorf("register: %w", err)
+	}
+	healthSrv.SetServingStatus("", grpc_health_v1.HealthCheckResponse_SERVING)
+	slog.Info("http-adapter serving", "endpoint", cfg.Endpoint)
+
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- grpcSrv.Serve(lis) }()
+
+	select {
+	case <-ctx.Done():
+		slog.Info("shutdown signal received")
+	case err := <-serveErr:
+		return fmt.Errorf("grpc serve: %w", err)
+	}
+
+	healthSrv.SetServingStatus("", grpc_health_v1.HealthCheckResponse_NOT_SERVING)
+	deregCtx := context.Background()
+	if err := registry.DeregisterAgent(deregCtx, regClient, cfg.AgentID); err != nil {
+		slog.Warn("deregister failed", "err", err)
+	}
+	grpcSrv.GracefulStop()
 	slog.Info("http-adapter stopped")
 	return nil
 }

--- a/agents/adapters/http/cmd/http-adapter/main_test.go
+++ b/agents/adapters/http/cmd/http-adapter/main_test.go
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+func TestRun_MissingEnvVar(t *testing.T) {
+	t.Setenv("ADAPTER_CONFIG", "")
+	if err := run(); err == nil {
+		t.Fatal("expected error when ADAPTER_CONFIG is unset")
+	}
+}
+
+func TestRun_MissingFile(t *testing.T) {
+	t.Setenv("ADAPTER_CONFIG", "/nonexistent/path/adapter.yaml")
+	if err := run(); err == nil {
+		t.Fatal("expected error for missing config file")
+	}
+}
+
+func TestRun_InvalidConfig(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "adapter-*.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _ = f.WriteString("{{invalid yaml")
+	f.Close()
+	t.Setenv("ADAPTER_CONFIG", f.Name())
+	if err := run(); err == nil {
+		t.Fatal("expected error for invalid config")
+	}
+}
+
+func TestRun_MissingRequiredFields(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "adapter-*.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// valid YAML but missing agent_id
+	_, _ = f.WriteString("endpoint: \"0.0.0.0:8080\"\nregistry_endpoint: \"localhost:9090\"\ncapabilities:\n  - name: x\n    method: POST\n    url: http://x\n")
+	f.Close()
+	t.Setenv("ADAPTER_CONFIG", f.Name())
+	if err := run(); err == nil {
+		t.Fatal("expected error for config missing agent_id")
+	}
+}


### PR DESCRIPTION
**Parent epic:** [#380 HTTP Adapter](https://github.com/zynax-io/zynax/issues/380) · [#377 Adapter Library](https://github.com/zynax-io/zynax/issues/377)
**Canvas step:** O6 — [docs/spdd/380-http-adapter/canvas.md](https://github.com/zynax-io/zynax/blob/main/docs/spdd/380-http-adapter/canvas.md)

---

## Story

As a **platform**, I want the http-adapter bootstrap to wire config, registry registration, gRPC server, and graceful shutdown in the correct order so that the adapter never serves traffic before it is registered and always deregisters before exiting.

---

## Implemented

1. Config: `ADAPTER_CONFIG` env var → `config.Load` → fast-fail on missing/invalid
2. Registry dial: `grpc.NewClient` to `cfg.RegistryEndpoint`
3. gRPC server: `adapter.NewAgentServer` registered + gRPC health protocol
4. Startup: `registry.RegisterAgent` with retry → `SetServingStatus(SERVING)` → begin accepting traffic
5. Signal handling: `signal.NotifyContext(SIGTERM, SIGINT)`
6. Graceful shutdown: `SetServingStatus(NOT_SERVING)` → `registry.DeregisterAgent` → `grpcSrv.GracefulStop()`

No credential values or payload content logged at any level.

---

## Acceptance Criteria (verified)

- [x] Missing `ADAPTER_CONFIG` → non-zero exit (fast-fail before network)
- [x] Missing config file, invalid YAML, missing required field → errors
- [x] `GOWORK=off go test ./... -race -short` — all 4 packages pass

---

Closes #396 · Part of #380 · Parent epic #377

Assisted-by: Claude/claude-sonnet-4-6