### PR TITLE
feat(adapters/http): Dockerfile, docker-compose, operator example (#397)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -55,3 +55,9 @@ docs/
 infra/docker-compose/
 infra/helm/
 infra/k8s/
+
+# ── Adapter build allowlist (negations for agents/adapters/*/Dockerfile) ──────
+# Adapter Dockerfiles are built from repo root and need their module source
+# plus the generated proto stubs to resolve the workspace replace directive.
+!agents/adapters/http/
+!protos/generated/go/

--- a/agents/adapters/http/Dockerfile
+++ b/agents/adapters/http/Dockerfile
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0
+# Build context: repo root  (docker build -f agents/adapters/http/Dockerfile .)
+FROM golang:1.26.3-alpine AS builder
+
+WORKDIR /workspace
+
+COPY protos/generated/go/go.mod protos/generated/go/go.sum ./protos/generated/go/
+COPY agents/adapters/http/go.mod agents/adapters/http/go.sum ./agents/adapters/http/
+RUN cd agents/adapters/http && GOWORK=off go mod download
+
+COPY protos/generated/go/ ./protos/generated/go/
+COPY agents/adapters/http/ ./agents/adapters/http/
+RUN cd agents/adapters/http && CGO_ENABLED=0 GOWORK=off \
+    go build -trimpath -o /http-adapter ./cmd/http-adapter/
+
+FROM alpine:3.21
+
+RUN apk add --no-cache ca-certificates \
+    && addgroup -S zynax && adduser -S zynax -G zynax
+
+COPY --from=builder /http-adapter /http-adapter
+
+USER zynax
+
+ENTRYPOINT ["/http-adapter"]

--- a/agents/adapters/http/agent-def.yaml.example
+++ b/agents/adapters/http/agent-def.yaml.example
@@ -1,0 +1,86 @@
+# SPDX-License-Identifier: Apache-2.0
+# http-adapter — AdapterConfig example
+#
+# Copy this file to agent-def.yaml, fill in your values, and point the
+# adapter at it via:  ADAPTER_CONFIG=/path/to/agent-def.yaml
+#
+# Credentials are NEVER placed inline — use env-var name references in
+# headers (the adapter resolves the value at startup from the process env).
+# This is the SSRF safeguard: all HTTP endpoints are static config only;
+# no URL fields are accepted from input_payload at runtime.
+
+# Unique identifier for this adapter instance in the Zynax registry.
+agent_id: http-adapter-payments
+
+# Human-readable name surfaced in operator dashboards.
+name: Payments HTTP Adapter
+
+# Optional description for the registry UI.
+description: Wraps the internal payments REST API as a Zynax capability.
+
+# gRPC address this adapter listens on (host:port).
+# Must match the endpoint registered with AgentRegistryService.
+endpoint: "0.0.0.0:9090"
+
+# gRPC address of the AgentRegistryService.
+registry_endpoint: "agent-registry:9091"
+
+# capabilities — one entry per Zynax capability exposed by this adapter.
+# Each entry maps a capability name to a static HTTP route.
+capabilities:
+  - name: create_payment          # snake_case, 1–64 chars; must match workflow step name
+    description: "Creates a new payment transaction via the payments API."
+    method: POST
+    url: "https://api.example.com/v1/transactions"
+
+    # Static headers. Values beginning with '$' are env-var name references:
+    # the adapter reads os.Getenv("PAYMENTS_API_KEY") at startup.
+    # Never put credential values here — only env-var names.
+    headers:
+      Authorization: "$PAYMENTS_API_KEY"
+      Accept: "application/json"
+
+    # Per-route timeout override (seconds). 0 means use the request's
+    # timeout_seconds field from ExecuteCapabilityRequest.
+    timeout_seconds: 30
+
+    # JSON Schema (draft-07) for input_payload validation.
+    # The adapter validates every incoming request before calling upstream.
+    # Omit or leave empty to skip validation.
+    input_schema_json: |
+      {
+        "type": "object",
+        "required": ["amount", "currency", "recipient"],
+        "properties": {
+          "amount":    { "type": "number",  "minimum": 0.01 },
+          "currency":  { "type": "string",  "pattern": "^[A-Z]{3}$" },
+          "recipient": { "type": "string",  "minLength": 1 }
+        },
+        "additionalProperties": false
+      }
+
+    # JSON Schema for the COMPLETED event payload returned to the caller.
+    output_schema_json: |
+      {
+        "type": "object",
+        "properties": {
+          "transaction_id": { "type": "string" },
+          "status":         { "type": "string" }
+        }
+      }
+
+  - name: get_payment_status
+    description: "Returns the current status of an existing payment transaction."
+    method: GET
+    url: "https://api.example.com/v1/transactions"
+    headers:
+      Authorization: "$PAYMENTS_API_KEY"
+    timeout_seconds: 10
+    input_schema_json: |
+      {
+        "type": "object",
+        "required": ["transaction_id"],
+        "properties": {
+          "transaction_id": { "type": "string" }
+        }
+      }

--- a/infra/docker/docker-compose.yml
+++ b/infra/docker/docker-compose.yml
@@ -3,12 +3,13 @@
 #
 # Profiles:
 #   testing  — backing stores only (NATS JetStream + Redis); used by make test-integration
-#   dev      — (future) full local stack
+#   dev      — full local stack (platform services + adapters)
 #
 # Usage:
 #   make test-integration                           # starts testing profile, runs tests, stops
 #   docker compose --profile testing up -d          # manual start
 #   docker compose --profile testing down           # manual stop
+#   docker compose --profile dev up -d              # start full dev stack
 
 services:
   nats:
@@ -39,6 +40,22 @@ services:
       timeout: 3s
       retries: 10
       start_period: 3s
+
+  http-adapter:
+    profiles: [dev]
+    build:
+      context: ../..
+      dockerfile: agents/adapters/http/Dockerfile
+    environment:
+      ADAPTER_CONFIG: /etc/http-adapter/agent-def.yaml
+    volumes:
+      - type: bind
+        source: ../../agents/adapters/http/agent-def.yaml.example
+        target: /etc/http-adapter/agent-def.yaml
+        read_only: true
+    depends_on:
+      - agent-registry
+    restart: on-failure
 
 volumes:
   nats-data:


### PR DESCRIPTION
**Parent epic:** [#380 HTTP Adapter](https://github.com/zynax-io/zynax/issues/380) · [#377 Adapter Library](https://github.com/zynax-io/zynax/issues/377)
**Canvas step:** O7 — [docs/spdd/380-http-adapter/canvas.md](https://github.com/zynax-io/zynax/blob/main/docs/spdd/380-http-adapter/canvas.md)

---

## Story

As a **developer running `make run-local`**, I want the http-adapter containerised with a multi-stage Dockerfile and wired into Docker Compose, so that a full local end-to-end test includes a live http-adapter with a documented operator configuration example.

---

## Implemented

- `Dockerfile`: two-stage Alpine build (`golang:1.26.3-alpine` → `alpine:3.21`); build context is repo root; `CGO_ENABLED=0 GOWORK=off -trimpath`; final stage runs as unprivileged `zynax` user
- `.dockerignore`: negation allowlist (`!agents/adapters/http/`, `!protos/generated/go/`)
- `docker-compose.yml`: `http-adapter` service under the `dev` profile; bind-mounts `agent-def.yaml.example` as the adapter config; `depends_on: agent-registry`
- `agent-def.yaml.example`: fully annotated operator reference covering all `AdapterConfig` and `RouteConfig` fields; demonstrates env-var name reference pattern for API keys — no credential values inline

---

## Acceptance Criteria (verified)

- [x] `docker build -f agents/adapters/http/Dockerfile .` builds successfully
- [x] `docker run --entrypoint whoami <image>` → `zynax` (non-root confirmed)
- [x] Container exits non-zero with `"ADAPTER_CONFIG env var is required"` when no config mounted
- [x] `gitleaks` pre-commit hook passes — no credentials or internal hostnames in any file

---

Closes #397 · Closes #380 · Parent epic #377

Assisted-by: Claude/claude-sonnet-4-6