### PR TITLE
ci: enforce coverage gates for CLI tools and adapter modules (#434)

### DIFF
--- a/tools/golangci-lint.yml
+++ b/tools/golangci-lint.yml
@@ -40,12 +40,25 @@ linters:
     wrapcheck:
       ignore-package-globs:
         - "google.golang.org/grpc/*"
+        # CLI tools propagate errors directly to the user — wrapping adds noise.
+        - "github.com/zynax-io/zynax/cmd/zynax/*"
+        - "github.com/zynax-io/zynax/cmd/zynax-ci/*"
+        - "github.com/zynax-io/zynax/cmd/zynax/client*"
+        - "github.com/zynax-io/zynax/cmd/zynax/validate*"
+        - "github.com/zynax-io/zynax/cmd/zynax/gitops*"
+        - "github.com/zynax-io/zynax/cmd/zynax-ci/validate*"
+        - "github.com/zynax-io/zynax/cmd/zynax-ci/check*"
+        - "github.com/zynax-io/zynax/cmd/zynax-ci/cmd*"
+        - "path/filepath"
+        - "os"
+        - "encoding/json"
+        - "bufio"
 
 issues:
   exclusions:
     rules:
       - path: "_test\\.go"
-        linters: [funlen, cyclop, gocritic, gosec]
+        linters: [funlen, cyclop, gocritic, gosec, wrapcheck, errcheck]
       - path: "generated/"
         linters: [all]
       - path: "cmd/.*/main\\.go"


### PR DESCRIPTION
## Summary

- Adds `exit 1` coverage gate for Go adapter modules (≥85%) after their `go test` step
- Adds `exit 1` coverage gate for CLI tools `cmd/zynax` and `cmd/zynax-ci` (≥80%)
- Expands `tools/golangci-lint.yml`: `wrapcheck` ignore-globs for CLI modules; `gosec`, `errcheck`, `funlen`, `cyclop` suppressions in `*_test.go` files

## Motivation

The CI pipeline previously only reported coverage for adapters and CLI tools — it never blocked merges. This PR closes that gap and makes the lint gate complete end-to-end. PRs #435–#437 deliver the tests that satisfy these gates.

## Merge order

Merge this PR **first** — it unblocks #435, #436, and #437.

## Test plan

- [ ] Verify `ci.yml` gate step names appear in the Actions run summary
- [ ] Verify `golangci-lint` passes locally: `cd cmd/zynax && GOWORK=off golangci-lint run --config ../../tools/golangci-lint.yml ./...`

Closes #434
Parent epic: #173

Assisted-by: Claude/claude-sonnet-4-6