### PR TITLE
chore: auto-discover Python agents in Makefile (#446)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,8 @@
 .DEFAULT_GOAL := help
 SHELL         := /bin/bash
 GO_SERVICES   := agent-registry task-broker memory-service event-bus api-gateway workflow-compiler engine-adapter
-AGENTS        := summarizer researcher calculator
+# Auto-discovered from agents/examples/*/pyproject.toml — no manual update needed when adding a new agent.
+AGENTS        := $(shell find agents/examples -maxdepth 2 -name pyproject.toml -exec dirname {} \; 2>/dev/null | xargs -rI{} basename {} | sort)
 COMPOSE       := docker compose -f infra/docker/docker-compose.yml
 COMPOSE_TOOLS := docker compose -f infra/docker/docker-compose.tools.yml
 # Override to skip the local build: make TOOLS_IMAGE=ghcr.io/zynax-io/zynax/tools:latest <target>


### PR DESCRIPTION
## Summary

- Replaces `AGENTS := summarizer researcher calculator` (hardcoded) with `$(shell find agents/examples -maxdepth 2 -name pyproject.toml ...)` so new agents are picked up automatically when their `pyproject.toml` is added — no Makefile edit required.
- `lint-agents`, `test-unit-agents`, `security-agents` continue to work: the loop guard `[ -f pyproject.toml ]` was already there; now the list is correct by construction.
- `lint-agent AGENT=x` and `test-unit-agent AGENT=x` single-agent targets are unaffected (they use `AGENT`, not `AGENTS`).

## Behaviour today vs after

| Before | After |
|--------|-------|
| `AGENTS = summarizer researcher calculator` (two non-existent agents silently skipped) | `AGENTS = ` (empty — no `pyproject.toml` files exist yet; correct) |
| Adding a new agent required a Makefile edit | Adding `agents/examples/my-agent/pyproject.toml` is sufficient |

## Canvas

Part of #442 — Fully Containerized Makefile Workflow (Step 4 of 4).
Canvas: `docs/spdd/442-containerized-make/canvas.md` (Status: Aligned)

## Test plan

- [ ] `make lint-agents` dry-run shows empty agent loop, SDK still linted
- [ ] `make lint-agent AGENT=summarizer` still resolves correctly
- [ ] CI gates pass (Makefile-only change — no Go/Python code touched)

Closes #446

Assisted-by: Claude/claude-sonnet-4-6