### PR TITLE
chore: containerize gitleaks secret scan via TOOLS_IMAGE (#444)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -215,8 +215,8 @@ scan-image: ## Scan one service container image for CVEs: make scan-image SVC=ag
 	trivy image --exit-code 1 --severity HIGH,CRITICAL --ignorefile .trivyignore zynax/$(SVC):scan
 	docker rmi zynax/$(SVC):scan
 
-gitleaks: ## Scan local repo for secrets (requires gitleaks installed: brew install gitleaks)
-	gitleaks detect --source . --config tools/gitleaks-ai-context.toml --verbose
+gitleaks: ensure-tools ## Scan local repo for secrets via TOOLS_IMAGE (no local install required)
+	$(TOOLS_RUN) gitleaks detect --source . --config tools/gitleaks-ai-context.toml --verbose
 
 security-go: ensure-tools ## govulncheck on all Go services
 	@for svc in $(GO_SERVICES); do $(TOOLS_RUN) sh -c "cd services/$$svc && govulncheck ./..."; done

--- a/infra/docker/Dockerfile.tools
+++ b/infra/docker/Dockerfile.tools
@@ -21,6 +21,7 @@
 #   mockery             v2.53.6
 #   migrate             v4.17.1
 #   grpc-health-probe   v0.4.26
+#   gitleaks            v8.21.2  (.pre-commit-config.yaml rev: must match)
 #   uv                  0.5.10
 
 # ── Stage 1: Go binaries ────────────────────────────────────────────────────
@@ -75,6 +76,15 @@ RUN curl -fsSL \
       -o /usr/local/bin/buf \
     && chmod +x /usr/local/bin/buf
 
+# gitleaks — secret scanner; version must match .pre-commit-config.yaml rev:
+# renovate: datasource=github-releases depName=gitleaks/gitleaks
+RUN GITLEAKS_VERSION=v8.21.2 && \
+    curl -fsSL \
+      "https://github.com/gitleaks/gitleaks/releases/download/${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION#v}_linux_x64.tar.gz" \
+      -o /tmp/gitleaks.tar.gz \
+    && tar -xzf /tmp/gitleaks.tar.gz -C /usr/local/bin gitleaks \
+    && rm /tmp/gitleaks.tar.gz
+
 # zynax-ci — CI and developer toolchain (validation + AI context checker)
 COPY cmd/zynax-ci/ /src/zynax-ci/
 RUN cd /src/zynax-ci && GOWORK=off go build -trimpath -o /usr/local/bin/zynax-ci .
@@ -96,6 +106,7 @@ COPY --from=go-tools /go/bin/protoc-gen-go-grpc  /usr/local/bin/
 COPY --from=go-tools /go/bin/godog               /usr/local/bin/
 COPY --from=go-tools /go/bin/mockery             /usr/local/bin/
 COPY --from=go-tools /go/bin/migrate             /usr/local/bin/
+COPY --from=go-tools /usr/local/bin/gitleaks      /usr/local/bin/
 COPY --from=go-tools /usr/local/bin/zynax-ci     /usr/local/bin/
 
 # ── uv — Python package manager ──────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Adds `gitleaks` v8.21.2 to `Dockerfile.tools` Stage 1 via `curl` + `tar` download (same pattern as `grpc-health-probe` and `buf`). Copies binary to final stage.
- Updates `make gitleaks` to use `$(TOOLS_RUN)` and adds `ensure-tools` prerequisite — removes the "requires gitleaks installed: brew install gitleaks" requirement.
- Version pinned with `# renovate:` comment, matching `.pre-commit-config.yaml rev: v8.21.2` exactly.

## Before / After

| | Before | After |
|-|--------|-------|
| `make gitleaks` | Requires local `gitleaks` binary | Runs via `zynax-tools:local` — Docker only |
| New developer onboarding | Must `brew install gitleaks` separately | `make bootstrap` covers it |
| Version source of truth | `.pre-commit-config.yaml` only | Both files in sync, Renovate-managed |

## Canvas

Part of #442 — Fully Containerized Makefile Workflow (Step 2 of 4).
Canvas: `docs/spdd/442-containerized-make/canvas.md` (Status: Aligned)

Unblocks #445 (`make ci` top-level target).

## Test plan

- [ ] `make build-tools` succeeds with gitleaks in the final image
- [ ] `make gitleaks` exits 0 on this repo (no secrets found)
- [ ] CI gates pass

Closes #444

Assisted-by: Claude/claude-sonnet-4-6