### PR TITLE
chore: default TOOLS_IMAGE to GHCR, auto-pull on ensure-tools (#452)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,7 @@ One commit per logical change · one PR per issue · never squash unrelated work
 ## Development workflow
 
 ```bash
-make bootstrap       # one-time setup (builds zynax-tools Docker image)
+make bootstrap       # one-time setup (pulls ghcr.io/zynax-io/zynax-tools:main from GHCR)
 make lint            # proto + Go + Python lint
 make test            # all unit tests
 make generate-protos # regenerate Go + Python stubs (commit the output)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,7 @@ Read this document before opening your first PR.
 ```bash
 git clone https://github.com/zynax-io/zynax.git
 cd zynax
-make bootstrap        # Builds tools Docker image + runs `pre-commit install`
+make bootstrap        # Pulls ghcr.io/zynax-io/zynax-tools:main from GHCR + runs `pre-commit install`
 ```
 
 `make bootstrap` wires the pre-commit hooks into `.git/hooks/` so they fire

--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,10 @@ GO_SERVICES   := agent-registry task-broker memory-service event-bus api-gateway
 AGENTS        := $(shell find agents/examples -maxdepth 2 -name pyproject.toml -exec dirname {} \; 2>/dev/null | xargs -rI{} basename {} | sort)
 COMPOSE       := docker compose -f infra/docker/docker-compose.yml
 COMPOSE_TOOLS := docker compose -f infra/docker/docker-compose.tools.yml
-# Override to skip the local build: make TOOLS_IMAGE=ghcr.io/zynax-io/zynax/tools:latest <target>
-TOOLS_IMAGE   ?= zynax-tools:local
+# Override to use a local build: make TOOLS_IMAGE=zynax-tools:local build-tools
+TOOLS_IMAGE   ?= ghcr.io/zynax-io/zynax-tools:main
 REGISTRY      := ghcr.io/zynax-io
-GHCR_TOOLS    := ghcr.io/zynax-io/zynax/tools:latest
+GHCR_TOOLS    := ghcr.io/zynax-io/zynax-tools:main
 TOOLS_RUN     := docker run --rm -v "$(PWD)":/workspace -w /workspace --env-file infra/docker/.env.tools $(TOOLS_IMAGE)
 
 .PHONY: help
@@ -22,7 +22,7 @@ help:
 		| awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 .PHONY: bootstrap check-docker build-tools
-bootstrap: check-docker build-tools ## ★ Run once after clone — builds tools image and installs pre-commit hooks
+bootstrap: ensure-tools ## ★ Run once after clone — pulls tools image from GHCR and installs pre-commit hooks
 	@if command -v pre-commit >/dev/null 2>&1; then \
 	  pre-commit install && echo "✅ pre-commit hooks installed"; \
 	else \
@@ -45,13 +45,16 @@ pull-tools: check-docker ## Pull tools image from GHCR (authenticates via `gh au
 	@echo "✅ Pulled $(GHCR_TOOLS)"
 	@echo "   Run targets with: make TOOLS_IMAGE=$(GHCR_TOOLS) <target>"
 
-# Internal: build local image only when TOOLS_IMAGE is the local default.
-# Targets that use this as a prereq skip the Docker build when the caller
-# overrides TOOLS_IMAGE (e.g. TOOLS_IMAGE=ghcr.io/zynax-io/zynax/tools:latest).
+# Internal prereq used by every tool-backed target.
+# - local image (zynax-tools:local): builds from Dockerfile.tools
+# - remote image (default GHCR): pulls only when not already cached locally
 .PHONY: ensure-tools
 ensure-tools: check-docker
 ifeq ($(TOOLS_IMAGE),zynax-tools:local)
 	$(MAKE) build-tools
+else
+	@docker image inspect $(TOOLS_IMAGE) >/dev/null 2>&1 \
+		|| (echo "⬇️  Pulling $(TOOLS_IMAGE)..." && docker pull $(TOOLS_IMAGE))
 endif
 
 # ── Local environment ──────────────────────────────────────────────────────

--- a/README.md
+++ b/README.md
@@ -131,31 +131,35 @@ curl -fsSL https://github.com/zynax-io/zynax/releases/latest/download/zynax-ci-d
 
 ### Developer tools Docker image
 
-`ghcr.io/zynax-io/zynax/tools` is the canonical developer tools image. It ships:
+`ghcr.io/zynax-io/zynax-tools:main` is the canonical developer tools image. It ships:
 `golangci-lint`, `buf`, `govulncheck`, `godog`, `mockery`, `migrate`,
-`grpc_health_probe`, `protoc-gen-go`, `protoc-gen-go-grpc`, `uv`,
+`grpc_health_probe`, `protoc-gen-go`, `protoc-gen-go-grpc`, `gitleaks`, `uv`,
 `ruff`, `mypy`, `bandit`, `pip-audit`, `pytest`, and **`zynax-ci`**.
 
-The image is rebuilt and pushed to GHCR on every merge to `main` that changes
-`infra/docker/Dockerfile.tools` or `cmd/zynax-ci/**` (via
-[`.github/workflows/tools-image.yml`](.github/workflows/tools-image.yml)).
+The image is rebuilt and pushed to GHCR automatically on every merge to `main` that
+changes `infra/docker/Dockerfile.tools` (via
+[`.github/workflows/tools-publish.yml`](.github/workflows/tools-publish.yml)).
 
-**Pull the image** (alternative to `make build-tools`):
+**Default behaviour — pull from GHCR (recommended):**
+
+`make bootstrap` pulls the published image automatically on first use. No manual step needed:
 ```bash
-docker pull ghcr.io/zynax-io/zynax/tools:latest
+make bootstrap   # pulls ghcr.io/zynax-io/zynax-tools:main, installs pre-commit hooks
+make lint        # uses cached image on all subsequent runs
 ```
 
-**Use with make targets** (skips the local build step):
+**Build locally** (only needed when editing `Dockerfile.tools` itself):
 ```bash
-make TOOLS_IMAGE=ghcr.io/zynax-io/zynax/tools:latest lint
-make TOOLS_IMAGE=ghcr.io/zynax-io/zynax/tools:latest test
-make TOOLS_IMAGE=ghcr.io/zynax-io/zynax/tools:latest validate-spec
-```
-
-Or set it once in your shell:
-```bash
-export TOOLS_IMAGE=ghcr.io/zynax-io/zynax/tools:latest
+make TOOLS_IMAGE=zynax-tools:local build-tools   # build once
+make TOOLS_IMAGE=zynax-tools:local lint          # use local image for this run
+# or export for the whole shell session:
+export TOOLS_IMAGE=zynax-tools:local
 make lint test validate-spec
+```
+
+**Pin to a specific SHA** (for reproducible CI references):
+```bash
+make TOOLS_IMAGE=ghcr.io/zynax-io/zynax-tools:a205d01 lint
 ```
 
 ---
@@ -279,8 +283,7 @@ Port map while the stack is running:
 **Prerequisites:** Docker Desktop only (Go, Python, buf are not needed locally).
 
 ```bash
-# Prerequisites: Docker, Go 1.26+, pip install pre-commit
-make bootstrap   # one-time per clone: builds tools image + installs pre-commit hooks
+make bootstrap   # one-time per clone: pulls ghcr.io/zynax-io/zynax-tools:main + installs pre-commit hooks
 make lint        # proto + Go + Python lint
 make test        # full suite (unit + BDD + coverage gate)
 ```
@@ -303,8 +306,8 @@ make test        # full suite (unit + BDD + coverage gate)
 | `make validate-spec` | Validate all YAML manifests against JSON schemas (via `zynax-ci`) |
 | `make validate-canvas` | Validate REASONS Canvas files under `docs/spdd/` (via `zynax-ci`) |
 | `make generate-protos` | Regenerate Go + Python stubs from `.proto` files |
-| `make build-tools` | Build the `zynax-tools:local` Docker image from source (one-time after clone) |
-| `make pull-tools` | Pull `ghcr.io/zynax-io/zynax/tools:latest` from GHCR (faster than building) |
+| `make build-tools` | Build `zynax-tools:local` from source — use when editing `Dockerfile.tools` |
+| `make pull-tools` | Pull `ghcr.io/zynax-io/zynax-tools:main` from GHCR explicitly (bootstrap does this automatically) |
 | `make install-cli` | Build and install `zynax` CLI to `~/bin/zynax` |
 | `make install-ci-tools` | Build and install `zynax-ci` toolchain to `~/bin/zynax-ci` |
 

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -29,7 +29,7 @@ cd cmd/zynax && GOWORK=off go build -o ~/bin/zynax .
 ```bash
 git clone https://github.com/zynax-io/zynax.git
 cd zynax
-make bootstrap    # builds the zynax-tools:local Docker image — run once after clone
+make bootstrap    # pulls ghcr.io/zynax-io/zynax-tools:main from GHCR — run once after clone
 ```
 
 Everything else runs inside containers. No Go, Python, or buf installation needed locally.


### PR DESCRIPTION
## Summary

- Changes `TOOLS_IMAGE` default from `zynax-tools:local` → `ghcr.io/zynax-io/zynax-tools:main`
- Fixes `GHCR_TOOLS` which pointed to the wrong path (`zynax-io/zynax/tools:latest`)
- Updates `ensure-tools` to auto-pull the remote image when not cached locally
- Changes `bootstrap` dependency from `build-tools` → `ensure-tools` so `make bootstrap` pulls instead of builds

## Developer experience after this change

```bash
# Before — required a 5-minute local build
make bootstrap   # → docker build -f infra/docker/Dockerfile.tools ...

# After — pulls the published image in ~30 seconds
make bootstrap   # → docker pull ghcr.io/zynax-io/zynax-tools:main  (first run only)
make lint        # → uses cached GHCR image on repeat runs

# To build locally (e.g. to test a Dockerfile.tools change):
make TOOLS_IMAGE=zynax-tools:local build-tools
```

## Closes #452

Assisted-by: Claude/claude-sonnet-4-6