### PR TITLE
ci: add make ci top-level target as single local CI gate (#445)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,11 @@ install-ci-tools: ## Build and install zynax-ci toolchain to ~/bin/zynax-ci (req
 	cd cmd/zynax-ci && GOWORK=off go build -trimpath -o ~/bin/zynax-ci .
 	@echo "✅ zynax-ci installed → ~/bin/zynax-ci  (ensure ~/bin is on your PATH)"
 
+# ── Local CI gate ──────────────────────────────────────────────────────────
+.PHONY: ci
+ci: lint test security gitleaks ## ★ Full local CI gate — lint → test (incl. validate-spec) → security → secret scan
+	@echo "✅ Local CI gate passed — ready to push"
+
 # ── Lint ───────────────────────────────────────────────────────────────────
 .PHONY: lint lint-go lint-go-adapters lint-agents lint-go-svc lint-agent lint-fix
 lint: lint-protos lint-go lint-go-adapters lint-agents ## Lint everything (proto + Go services + Go adapters + Python)

--- a/agents/sdk/pyproject.toml
+++ b/agents/sdk/pyproject.toml
@@ -15,6 +15,7 @@ license = { text = "Apache-2.0" }
 
 dependencies = [
     "grpcio>=1.80.0",
+    "urllib3>=2.7.0",  # CVE-2026-44431, CVE-2026-44432 — pin floor via transitive grpcio dep
     "protobuf>=7.34.1",
     "pydantic>=2.7.0",
     "pydantic-settings>=2.3.0",

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -40,6 +40,7 @@ Everything else runs inside containers. No Go, Python, or buf installation neede
 
 | Command | What it does | When to use |
 |---------|-------------|-------------|
+| `make ci` | **Full local CI gate** — lint → test → security → secret scan in sequence | Before opening a PR |
 | `make lint` | Proto + Go + Python lint (ruff, mypy, golangci-lint, buf) | Before every commit |
 | `make test` | Full suite: spec validation + Go unit tests + BDD contracts + Python tests | Before pushing |
 | `make test-unit-go` | Go unit tests with coverage report for all services | During Go development |
@@ -62,6 +63,7 @@ make lint          # catch style issues early
 make test-unit-go  # fast feedback loop while coding
 # ... write code ...
 make test          # full suite before pushing
+make ci            # full CI gate before opening a PR
 ```
 
 Work happens in `services/<service-name>/`. Use `GOWORK=off` for any `go` command run
@@ -73,6 +75,7 @@ directly (not via make) inside a service directory — see `CLAUDE.md` for why.
 make lint              # ruff + mypy on agents/
 make test-unit-agents  # pytest-bdd for SDK and examples
 make security-agents   # bandit + pip-audit
+make ci                # full CI gate before opening a PR
 ```
 
 Work happens in `agents/sdk/` or `agents/examples/<agent>/`. Each agent is an isolated
@@ -85,7 +88,7 @@ make lint-protos        # buf lint + format check
 # ... edit .proto files ...
 make generate-protos    # regenerate stubs — always commit the output
 make test-bdd           # verify BDD contract tests still pass
-make lint               # full lint pass before PR
+make ci                 # full CI gate before opening a PR
 ```
 
 Proto changes require a `.feature` file committed first (ADR-016). Generated stubs in


### PR DESCRIPTION
## Summary

Canvas #442 step 3. Closes #445.

- Adds `make ci` target sequencing all gates in fail-fast order: `lint → test (incl. validate-spec) → security → gitleaks`
- Adds `★` marker in `make help` output to make it discoverable
- Updates `docs/local-dev.md` to reference `make ci` as the recommended pre-PR command across all three contributor personas (Go service, Python agent, proto author)

**Bundled fix:** pins `urllib3>=2.7.0` in `agents/sdk/pyproject.toml` to resolve `CVE-2026-44431` and `CVE-2026-44432` (transitive via `grpcio`) — discovered when running `make ci` end-to-end for the first time. This is a security hygiene fix that belongs alongside the target that caught it.

## Local test results

```
make ci   → ✅ Local CI gate passed — ready to push
```

Full sequence verified locally:
- lint (proto + Go services + Go adapters + Python) ✅
- test (validate-spec + unit + BDD + coverage gates) ✅
- security (govulncheck + bandit + pip-audit — 0 CVEs after urllib3 fix) ✅
- gitleaks (no leaks found) ✅

## Test plan
- [x] `make ci` exits 0 on clean repo
- [x] `make help` shows `ci` with `★` marker
- [x] `docs/local-dev.md` references `make ci` in daily commands table and all persona paths
- [x] urllib3 CVE-2026-44431 / CVE-2026-44432 resolved in agents/sdk

Assisted-by: Claude/claude-sonnet-4-6