### PR TITLE
docs: remove CNCF badge and mark M3/M4 as partial (#472)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,8 +10,8 @@ any layer.
 |-----------|--------|---------|--------|
 | M1 — Contracts Foundation | **Complete** | v0.1.0 | [Engineering Review](docs/milestones/M1-engineering-review.md) · [Release Notes](docs/milestones/M1-release-notes.md) |
 | M2 — Workflow IR | **Complete** | v0.1.0 | [Epic #101](https://github.com/zynax-io/zynax/issues/101) |
-| M3 — Temporal Execution | **Complete** | v0.2.0 | [Epic #214](https://github.com/zynax-io/zynax/issues/214) · [Canvas](docs/spdd/214-temporal-execution/canvas.md) |
-| M4 — YAML System + CLI | **Complete** | v0.3.0 | [Epic #314](https://github.com/zynax-io/zynax/issues/314) · [Canvas](docs/spdd/314-yaml-system-cli/canvas.md) |
+| M3 — Temporal Execution | ⚠ **Partial** | v0.2.0 | [Epic #214](https://github.com/zynax-io/zynax/issues/214) · [Canvas](docs/spdd/214-temporal-execution/canvas.md) · no task-broker (blocked by M5.C #460) |
+| M4 — YAML System + CLI | ⚠ **Partial** | v0.3.0 | [Epic #314](https://github.com/zynax-io/zynax/issues/314) · [Canvas](docs/spdd/314-yaml-system-cli/canvas.md) · no agent-registry (blocked by M5.C #460) |
 
 M1 delivered: 8 gRPC contracts, AsyncAPI spec, JSON schemas, Go + Python generated stubs,
 140+ BDD scenarios across all services, 5 CI gates. All work tracked in Epic #1 (closed).
@@ -151,11 +151,11 @@ Full guide: `docs/patterns/spdd-guide.md` · Template: `docs/spdd/CANVAS_TEMPLAT
 |-----------|----------|----------------------|
 | **M1** (Complete) | Proto contracts, AsyncAPI spec, generated stubs, BDD scenarios, CI gates | Service implementations, DB schemas, runtime |
 | **M2** (Complete) | WorkflowIR structured fields in `workflow_compiler.proto`, `WorkflowCompilerService` skeleton (in-memory), JSON Schema for WorkflowIR | Temporal integration, persistence, CLI |
-| **M3** (Complete) | Temporal-backed `EngineAdapterService` — `WorkflowEngine` interface, `IRInterpreterWorkflow`, `DispatchCapabilityActivity`, `TemporalEngine`, gRPC wiring | Other engine adapters, K8s deployment |
-| **M4** (Complete) | api-gateway REST layer, `zynax` CLI, `kind: AgentDef` routing, Docker Compose runner, GitOps watch | Observability, production hardening |
-| **M5+** | Adapter library (http, llm, git, ci adapters), additional engine backends | — |
+| **M3** (⚠ Partial) | Temporal-backed `EngineAdapterService` — `WorkflowEngine` interface, `IRInterpreterWorkflow`, `DispatchCapabilityActivity`, `TemporalEngine`, gRPC wiring | Other engine adapters, K8s deployment · task-broker missing (M5.C #460) |
+| **M4** (⚠ Partial) | api-gateway REST layer, `zynax` CLI, `kind: AgentDef` routing, Docker Compose runner, GitOps watch | Observability, production hardening · agent-registry missing (M5.C #460) |
+| **M5** (Active) | Adapter library (http ✅, git, ci, llm, langgraph), task-broker MVP, agent-registry MVP | — |
 
-M4 complete. Active milestone: M5 (Adapter Library). See open issues labelled `milestone: M5`.
+Active milestone: M5 (Adapter Library). See open issues labelled `milestone: M5`.
 
 ## Common AI Anti-Patterns
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![CI](https://github.com/zynax-io/zynax/actions/workflows/ci.yml/badge.svg)](https://github.com/zynax-io/zynax/actions/workflows/ci.yml)
 [![AI Context Budget](https://github.com/zynax-io/zynax/actions/workflows/ai-context-budget.yml/badge.svg)](https://github.com/zynax-io/zynax/actions/workflows/ai-context-budget.yml)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
-[![CNCF Sandbox Candidate](https://img.shields.io/badge/CNCF-Sandbox_Candidate-026be0.svg)](https://cncf.io)
+[![Built with CNCF-graduated technologies](https://img.shields.io/badge/built_with-CNCF_graduated_tech-026be0.svg)](https://www.cncf.io/projects/)
 [![Go version](https://img.shields.io/github/go-mod/go-version/zynax-io/zynax?filename=go.work&label=go&color=00add8)](go.work)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/zynax-io/zynax/badge)](https://securityscorecards.dev)
 
@@ -319,8 +319,8 @@ make test        # full suite (unit + BDD + coverage gate)
 |-----------|--------|---------|------|
 | **M1 — Contracts Foundation** | **Complete** | v0.1.0 | [Engineering Review](docs/milestones/M1-engineering-review.md) · [Release Notes](docs/milestones/M1-release-notes.md) |
 | **M2 — Workflow IR** | **Complete** | v0.1.0 | [Epic #101](https://github.com/zynax-io/zynax/issues/101) |
-| **M3 — Temporal Execution** | **Complete** | v0.2.0 | [Epic #214](https://github.com/zynax-io/zynax/issues/214) · [Canvas](docs/spdd/214-temporal-execution/canvas.md) |
-| **M4 — YAML System + CLI** | **Complete** | v0.3.0 | [Epic #314](https://github.com/zynax-io/zynax/issues/314) · [Canvas](docs/spdd/314-yaml-system-cli/canvas.md) |
+| **M3 — Temporal Execution** | ⚠ **Partial** | v0.2.0 | [Epic #214](https://github.com/zynax-io/zynax/issues/214) · [Canvas](docs/spdd/214-temporal-execution/canvas.md) · no task-broker — blocked by M5.C [#460](https://github.com/zynax-io/zynax/issues/460) |
+| **M4 — YAML System + CLI** | ⚠ **Partial** | v0.3.0 | [Epic #314](https://github.com/zynax-io/zynax/issues/314) · [Canvas](docs/spdd/314-yaml-system-cli/canvas.md) · no agent-registry — blocked by M5.C [#460](https://github.com/zynax-io/zynax/issues/460) |
 
 **M1** delivered the contracts-only foundation: 8 gRPC services defined as protobuf contracts,
 AsyncAPI spec covering 11 event channels, generated Go + Python stubs, 140+ BDD contract
@@ -415,5 +415,5 @@ SPDX-License-Identifier: Apache-2.0
 ---
 
 <div align="center">
-<sub>Zynax is a CNCF Sandbox candidate project.</sub>
+<sub>Zynax is built with CNCF-graduated technologies (Temporal, gRPC, OpenTelemetry). It is not an official CNCF project.</sub>
 </div>


### PR DESCRIPTION
## Summary

- Replaces self-applied `CNCF-Sandbox_Candidate` badge with honest "built with CNCF-graduated technologies" signal (no implied official CNCF status)
- Updates M3 and M4 milestone status from **Complete** → ⚠ **Partial** in both `README.md` and `CLAUDE.md`, with blocking notes pointing to M5.C (#460)
- Removes "Zynax is a CNCF Sandbox candidate project" footer copy
- Updates Per-Milestone Scope table in `CLAUDE.md` to show M5 as Active and http-adapter as ✅ delivered

## Test plan

- [ ] README.md badge renders correctly in GitHub preview
- [ ] No `shields.io/badge/CNCF-Sandbox` string remains in the repo (`grep -r "CNCF-Sandbox" .`)
- [ ] Milestone tables in README.md and CLAUDE.md show M3/M4 as ⚠ Partial with #460 links
- [ ] `make gitleaks` passes

Closes #472
Part of Epic #458 (M5.A Truth Pass)

Assisted-by: Claude/claude-sonnet-4-6