### PR TITLE
fix(engine-adapter): resolveTemplate map-iteration determinism (#475)

### DIFF
--- a/services/engine-adapter/internal/domain/interpreter.go
+++ b/services/engine-adapter/internal/domain/interpreter.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"sort"
 	"strings"
 
 	zynaxv1 "github.com/zynax-io/zynax/protos/generated/go/zynax/v1"
@@ -185,11 +186,17 @@ func resolveOperand(expr string, ctx map[string]string) string {
 }
 
 // resolveTemplate substitutes {{ .ctx.<key> }} placeholders in the JSON template
-// with values from the ctx map.
+// with values from the ctx map. Keys are sorted to guarantee deterministic output
+// across workflow replays (map iteration order is non-deterministic in Go).
 func resolveTemplate(template string, ctx map[string]string) []byte {
+	keys := make([]string, 0, len(ctx))
+	for k := range ctx {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
 	result := template
-	for k, v := range ctx {
-		result = strings.ReplaceAll(result, "{{ .ctx."+k+" }}", v)
+	for _, k := range keys {
+		result = strings.ReplaceAll(result, "{{ .ctx."+k+" }}", ctx[k])
 	}
 	return []byte(result)
 }

--- a/services/engine-adapter/internal/domain/interpreter_test.go
+++ b/services/engine-adapter/internal/domain/interpreter_test.go
@@ -343,6 +343,27 @@ func TestResolveTemplate(t *testing.T) {
 	}
 }
 
+// TestResolveTemplate_Deterministic asserts that resolveTemplate produces
+// byte-identical output across repeated calls with the same multi-key ctx,
+// guarding against non-determinism from map iteration order.
+func TestResolveTemplate_Deterministic(t *testing.T) {
+	ctx := map[string]string{
+		"alpha":   "A",
+		"beta":    "B",
+		"gamma":   "G",
+		"delta":   "D",
+		"epsilon": "E",
+	}
+	tmpl := `{"a":"{{ .ctx.alpha }}","b":"{{ .ctx.beta }}","g":"{{ .ctx.gamma }}","d":"{{ .ctx.delta }}","e":"{{ .ctx.epsilon }}"}`
+	first := string(resolveTemplate(tmpl, ctx))
+	for i := 0; i < 50; i++ {
+		got := string(resolveTemplate(tmpl, ctx))
+		if got != first {
+			t.Fatalf("non-deterministic output on iteration %d:\n got  %s\n want %s", i, got, first)
+		}
+	}
+}
+
 // --- helpers ---
 
 func equalSlice(a, b []string) bool {


### PR DESCRIPTION
## Summary

- Sort `ctx` keys before iterating in `resolveTemplate` so substitution order is deterministic across Temporal workflow replays
- Non-deterministic Go map iteration could cause divergence between the original execution and replay, violating Temporal's determinism constraint
- Adds a 50-iteration regression test (`TestResolveTemplate_Deterministic`) with a 5-key context map

## Test plan

- [x] `GOWORK=off go test ./internal/domain/... -race` passes (all 20 tests green)
- [x] New `TestResolveTemplate_Deterministic` test confirms byte-identical output across 50 iterations
- [x] No behaviour change for single-key templates (existing `TestResolveTemplate` still passes)

Closes #475

Assisted-by: Claude/claude-sonnet-4-6