### PR TITLE
fix(api-gateway): disable WriteTimeout for SSE log-streaming handler (#478)

### DIFF
--- a/services/api-gateway/internal/api/handler.go
+++ b/services/api-gateway/internal/api/handler.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"time"
 
 	"github.com/zynax-io/zynax/services/api-gateway/internal/domain"
 )
@@ -131,6 +132,11 @@ func (h *Handler) handleWorkflowLogs(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, "streaming not supported", "INTERNAL")
 		return
 	}
+	// Disable the server-level WriteTimeout for this connection so long-running
+	// workflows are not forcibly cut off at 30 s. Non-streaming endpoints keep
+	// the server-wide deadline because they never call this code path.
+	rc := http.NewResponseController(w)
+	_ = rc.SetWriteDeadline(time.Time{})
 	started := false
 	err := h.svc.WatchWorkflowLogs(r.Context(), id, func(ev domain.WatchEvent) error {
 		if !started {


### PR DESCRIPTION
## Summary

- Fixes #478: `zynax logs wf-<hex>` was killed at exactly 30 s because the server-wide `WriteTimeout` applied to the SSE connection
- Use `http.ResponseController.SetWriteDeadline(time.Time{})` to remove the deadline per-handler for the streaming path only
- Non-streaming endpoints (`POST /api/v1/apply`, `GET /api/v1/workflows/{id}`) keep the 30 s server-wide timeout unchanged

## Changes

[handler.go:134-136](services/api-gateway/internal/api/handler.go#L134) — after the `http.Flusher` check succeeds, clear the write deadline on this connection before starting the log stream:

```go
rc := http.NewResponseController(w)
_ = rc.SetWriteDeadline(time.Time{})
```

`ResponseController` is Go 1.20+ (already required by `go.mod`).

## Test plan

- [x] `GOWORK=off go test ./... -race` in `services/api-gateway/` passes
- [x] `make lint` passes (CI + local golangci-lint: 0 issues)
- [ ] `zynax logs wf-<hex>` keeps connection open beyond 30 s (manual — requires running stack)
- [ ] Non-streaming endpoints still time out correctly under load (manual — requires running stack)

Assisted-by: Claude/claude-sonnet-4-6