### PR TITLE
fix(engine-adapter): log event publish failures instead of silently discarding (#483)

### DIFF
--- a/services/engine-adapter/internal/domain/interpreter.go
+++ b/services/engine-adapter/internal/domain/interpreter.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"math"
 	"sort"
 	"strings"
@@ -60,7 +61,9 @@ func (i *IRInterpreter) Run(
 			return fmt.Errorf("engine-adapter: state %q not found in IR", ec.CurrentState)
 		}
 		if state.GetType() == zynaxv1.StateType_STATE_TYPE_TERMINAL {
-			_ = pub.Publish(ctx, "zynax.workflow.completed", ec.WorkflowID, ec.CurrentState)
+			if err := pub.Publish(ctx, "zynax.workflow.completed", ec.WorkflowID, ec.CurrentState); err != nil {
+				slog.Warn("lifecycle event publish failed", "event", "zynax.workflow.completed", "workflow_id", ec.WorkflowID, "err", err)
+			}
 			return nil
 		}
 		if err := pub.Publish(ctx, "zynax.workflow.state.entered", ec.WorkflowID, ec.CurrentState); err != nil {
@@ -68,15 +71,21 @@ func (i *IRInterpreter) Run(
 		}
 		result, err := executeActions(ctx, state, ec, exec)
 		if err != nil {
-			_ = pub.Publish(ctx, "zynax.workflow.failed", ec.WorkflowID, ec.CurrentState)
+			if perr := pub.Publish(ctx, "zynax.workflow.failed", ec.WorkflowID, ec.CurrentState); perr != nil {
+				slog.Warn("lifecycle event publish failed", "event", "zynax.workflow.failed", "workflow_id", ec.WorkflowID, "err", perr)
+			}
 			return err
 		}
 		transition, err := resolveTransition(state.GetTransitions(), result, ec.Ctx)
 		if err != nil {
-			_ = pub.Publish(ctx, "zynax.workflow.failed", ec.WorkflowID, ec.CurrentState)
+			if perr := pub.Publish(ctx, "zynax.workflow.failed", ec.WorkflowID, ec.CurrentState); perr != nil {
+				slog.Warn("lifecycle event publish failed", "event", "zynax.workflow.failed", "workflow_id", ec.WorkflowID, "err", perr)
+			}
 			return err
 		}
-		_ = pub.Publish(ctx, "zynax.workflow.state.exited", ec.WorkflowID, ec.CurrentState)
+		if perr := pub.Publish(ctx, "zynax.workflow.state.exited", ec.WorkflowID, ec.CurrentState); perr != nil {
+			slog.Warn("lifecycle event publish failed", "event", "zynax.workflow.state.exited", "workflow_id", ec.WorkflowID, "err", perr)
+		}
 		mergePayload(ec.Ctx, result.Payload)
 		ec.CurrentState = transition.GetTargetState()
 	}

--- a/services/engine-adapter/internal/domain/interpreter_test.go
+++ b/services/engine-adapter/internal/domain/interpreter_test.go
@@ -5,8 +5,11 @@
 package domain
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"log/slog"
+	"strings"
 	"testing"
 
 	zynaxv1 "github.com/zynax-io/zynax/protos/generated/go/zynax/v1"
@@ -361,6 +364,26 @@ func TestResolveTemplate_Deterministic(t *testing.T) {
 		if got != first {
 			t.Fatalf("non-deterministic output on iteration %d:\n got  %s\n want %s", i, got, first)
 		}
+	}
+}
+
+func TestIRInterpreter_PublishErrorLogged(t *testing.T) {
+	// Redirect the default slog logger to a buffer so we can assert the Warn line.
+	var buf bytes.Buffer
+	old := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, nil)))
+	defer slog.SetDefault(old)
+
+	// Terminal-only IR: only the "completed" publish fires; publisher returns error.
+	ir := buildIR("wf-pub-err", "done", terminal("done"))
+	pub := &stubPublisher{err: errors.New("event bus down")}
+
+	// Run should succeed — publish failure is logged, not propagated.
+	if err := (&IRInterpreter{}).Run(context.Background(), ir, &stubExecutor{}, pub); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "lifecycle event publish failed") {
+		t.Errorf("expected slog.Warn log line, got: %s", buf.String())
 	}
 }
 


### PR DESCRIPTION
## Summary

- Fixes #483: all 4 `_ = pub.Publish(...)` sites in `IRInterpreter.Run` now check the error and emit `slog.Warn` when the event bus is unavailable
- Workflow execution is unaffected — publish remains best-effort — but failures now appear in structured logs for operator visibility
- Unit test added: mock publisher returning an error → asserts `"lifecycle event publish failed"` log line is emitted

## Changes

**[interpreter.go](services/engine-adapter/internal/domain/interpreter.go)**

Replaced all 4 silent discards with:
```go
if err := pub.Publish(ctx, eventType, workflowID, state); err != nil {
    slog.Warn("lifecycle event publish failed",
        "event", eventType,
        "workflow_id", workflowID,
        "err", err,
    )
}
```

Sites:
- `zynax.workflow.completed` (terminal state reached)
- `zynax.workflow.failed` ×2 (activity error, transition error)
- `zynax.workflow.state.exited` (before state advance)

The `zynax.workflow.state.entered` site already propagated its error; unchanged.

**[interpreter_test.go](services/engine-adapter/internal/domain/interpreter_test.go)**

`TestIRInterpreter_PublishErrorLogged` — redirects `slog.Default()` to a buffer, runs a terminal-only IR against a failing publisher, asserts the warn line appears.

## Test plan

- [x] `GOWORK=off go test ./... -race` in `services/engine-adapter/` passes
- [x] `make lint` passes (golangci-lint: 0 issues)
- [x] `TestIRInterpreter_PublishErrorLogged` asserts slog.Warn is emitted on publish failure
- [x] No `errcheck` suppressions — all publish errors are now handled

Assisted-by: Claude/claude-sonnet-4-6