### PR TITLE
feat(api-gateway): bearer-token auth middleware for mutating endpoints (#482)

### DIFF
--- a/infra/AGENTS.md
+++ b/infra/AGENTS.md
@@ -46,6 +46,21 @@ No container may run as root or with elevated privileges.
 
 ---
 
+## api-gateway Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ZYNAX_GW_HTTP_PORT` | `8080` | HTTP listen port |
+| `ZYNAX_GW_COMPILER_ADDR` | `localhost:50051` | WorkflowCompilerService address |
+| `ZYNAX_GW_ENGINE_ADDR` | `localhost:50055` | EngineAdapterService address |
+| `ZYNAX_GW_REGISTRY_ADDR` | `localhost:50052` | AgentRegistryService address |
+| `ZYNAX_GW_LOG_LEVEL` | `info` | Log level (`debug`/`info`/`warn`/`error`) |
+| `ZYNAX_GW_API_KEY` | _(empty)_ | Bearer token for mutating endpoints (`POST /api/v1/apply`, `DELETE /api/v1/workflows/{id}`). When empty, auth is disabled and a `WARN api_key not set — auth disabled` line is logged at startup. Read-only endpoints (`GET`) are always open. |
+
+Set `ZYNAX_GW_API_KEY` in your `.env.local` (gitignored). Never commit a real key.
+
+---
+
 ## Hard Rules
 
 - Never store secrets in `values.yaml` or `values-production.yaml`.

--- a/infra/docker/.env.tools
+++ b/infra/docker/.env.tools
@@ -14,3 +14,6 @@ UV_CACHE_DIR=/root/.cache/uv
 DO_NOT_TRACK=1
 DISABLE_TELEMETRY=1
 GOTELEMETRY=off
+
+# api-gateway bearer auth — leave empty to disable (never commit a real value here)
+ZYNAX_GW_API_KEY=

--- a/services/api-gateway/cmd/api-gateway/main.go
+++ b/services/api-gateway/cmd/api-gateway/main.go
@@ -28,6 +28,7 @@ type config struct {
 	EngineAddr   string `envconfig:"ENGINE_ADDR" default:"localhost:50055"`
 	RegistryAddr string `envconfig:"REGISTRY_ADDR" default:"localhost:50052"`
 	LogLevel     string `envconfig:"LOG_LEVEL" default:"info"`
+	APIKey       string `envconfig:"API_KEY"`
 }
 
 func main() {
@@ -53,8 +54,12 @@ func run(cfg config) error {
 	}
 	defer cleanup()
 
+	if cfg.APIKey == "" {
+		slog.Warn("api_key not set — auth disabled")
+	}
+
 	svc := domain.NewApplyService(clients, clients, clients)
-	handler := api.NewHandler(svc)
+	handler := api.NewHandler(svc, cfg.APIKey)
 
 	mux := http.NewServeMux()
 	handler.RegisterRoutes(mux)

--- a/services/api-gateway/internal/api/auth.go
+++ b/services/api-gateway/internal/api/auth.go
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package api
+
+import "net/http"
+
+// requireBearer wraps next with bearer-token authentication when key is non-empty.
+// If key is empty the gate is disabled and all requests pass through unchanged.
+// Callers should log a warning at startup when key is empty (see main.go).
+func requireBearer(key string, next http.HandlerFunc) http.HandlerFunc {
+	if key == "" {
+		return next
+	}
+	want := "Bearer " + key
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != want {
+			writeError(w, http.StatusUnauthorized, "unauthorized", "UNAUTHORIZED")
+			return
+		}
+		next(w, r)
+	}
+}

--- a/services/api-gateway/internal/api/handler.go
+++ b/services/api-gateway/internal/api/handler.go
@@ -21,20 +21,24 @@ const maxBodyBytes = 1 << 20 // 1 MB
 
 // Handler handles HTTP requests for POST /api/v1/apply and GET /api/v1/workflows/{id}.
 type Handler struct {
-	svc *domain.ApplyService
+	svc    *domain.ApplyService
+	apiKey string
 }
 
 // NewHandler creates a Handler backed by the given ApplyService.
-func NewHandler(svc *domain.ApplyService) *Handler {
-	return &Handler{svc: svc}
+// apiKey is the value of ZYNAX_API_KEY; an empty string disables bearer auth.
+func NewHandler(svc *domain.ApplyService, apiKey string) *Handler {
+	return &Handler{svc: svc, apiKey: apiKey}
 }
 
 // RegisterRoutes registers all HTTP routes on mux. Requires Go 1.22+ ServeMux.
+// Mutating endpoints (POST, DELETE) are protected by bearer-token auth when
+// ZYNAX_API_KEY is set; read-only endpoints (GET) are always open.
 func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
-	mux.HandleFunc("POST /api/v1/apply", h.handleApply)
+	mux.HandleFunc("POST /api/v1/apply", requireBearer(h.apiKey, h.handleApply))
 	mux.HandleFunc("GET /api/v1/workflows/{id}/logs", h.handleWorkflowLogs)
 	mux.HandleFunc("GET /api/v1/workflows/{id}", h.handleGetWorkflow)
-	mux.HandleFunc("DELETE /api/v1/workflows/{id}", h.handleDeleteWorkflow)
+	mux.HandleFunc("DELETE /api/v1/workflows/{id}", requireBearer(h.apiKey, h.handleDeleteWorkflow))
 }
 
 func (h *Handler) handleApply(w http.ResponseWriter, r *http.Request) {

--- a/services/api-gateway/internal/api/handler_test.go
+++ b/services/api-gateway/internal/api/handler_test.go
@@ -77,8 +77,12 @@ func newServer(c domain.CompilerPort, e domain.EnginePort) *httptest.Server {
 }
 
 func newServerWithRegistry(c domain.CompilerPort, e domain.EnginePort, r domain.RegistryPort) *httptest.Server {
+	return newServerWithAuth(c, e, r, "")
+}
+
+func newServerWithAuth(c domain.CompilerPort, e domain.EnginePort, r domain.RegistryPort, apiKey string) *httptest.Server {
 	svc := domain.NewApplyService(c, e, r)
-	h := api.NewHandler(svc)
+	h := api.NewHandler(svc, apiKey)
 	mux := http.NewServeMux()
 	h.RegisterRoutes(mux)
 	return httptest.NewServer(mux)
@@ -421,5 +425,140 @@ func TestHandler_WorkflowLogs_NotFound_Returns404(t *testing.T) {
 
 	if resp.StatusCode != http.StatusNotFound {
 		t.Errorf("status: got %d, want 404", resp.StatusCode)
+	}
+}
+
+// ── Bearer-token auth middleware ──────────────────────────────────────────
+
+func TestHandler_Auth_CorrectKey_Passes(t *testing.T) {
+	srv := newServerWithAuth(
+		&stubCompiler{result: domain.CompileResult{IRBytes: []byte("ir")}},
+		&stubEngine{submitID: "run-auth"},
+		&stubRegistry{},
+		"secret-key",
+	)
+	defer srv.Close()
+
+	req, _ := http.NewRequest(http.MethodPost, srv.URL+"/api/v1/apply", bytes.NewBufferString(workflowYAML))
+	req.Header.Set("Content-Type", "application/yaml")
+	req.Header.Set("Authorization", "Bearer secret-key")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusAccepted {
+		t.Errorf("status: got %d, want 202", resp.StatusCode)
+	}
+}
+
+func TestHandler_Auth_MissingKey_Returns401(t *testing.T) {
+	srv := newServerWithAuth(
+		&stubCompiler{},
+		&stubEngine{},
+		&stubRegistry{},
+		"secret-key",
+	)
+	defer srv.Close()
+
+	resp, err := http.Post(srv.URL+"/api/v1/apply", "application/yaml", bytes.NewBufferString(workflowYAML))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("status: got %d, want 401", resp.StatusCode)
+	}
+	body := decodeBody(t, resp)
+	if body["code"] != "UNAUTHORIZED" {
+		t.Errorf("code: got %v, want UNAUTHORIZED", body["code"])
+	}
+}
+
+func TestHandler_Auth_WrongKey_Returns401(t *testing.T) {
+	srv := newServerWithAuth(
+		&stubCompiler{},
+		&stubEngine{},
+		&stubRegistry{},
+		"secret-key",
+	)
+	defer srv.Close()
+
+	req, _ := http.NewRequest(http.MethodPost, srv.URL+"/api/v1/apply", bytes.NewBufferString(workflowYAML))
+	req.Header.Set("Content-Type", "application/yaml")
+	req.Header.Set("Authorization", "Bearer wrong-key")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("status: got %d, want 401", resp.StatusCode)
+	}
+}
+
+func TestHandler_Auth_EmptyAPIKey_DisablesGate(t *testing.T) {
+	// When ZYNAX_API_KEY is empty, auth is disabled — unauthenticated requests must pass.
+	srv := newServerWithAuth(
+		&stubCompiler{result: domain.CompileResult{IRBytes: []byte("ir")}},
+		&stubEngine{submitID: "run-noauth"},
+		&stubRegistry{},
+		"",
+	)
+	defer srv.Close()
+
+	resp, err := http.Post(srv.URL+"/api/v1/apply", "application/yaml", bytes.NewBufferString(workflowYAML))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusAccepted {
+		t.Errorf("status: got %d, want 202 (auth disabled)", resp.StatusCode)
+	}
+}
+
+func TestHandler_Auth_DeleteWithKey_Returns401(t *testing.T) {
+	srv := newServerWithAuth(
+		&stubCompiler{},
+		&stubEngine{},
+		&stubRegistry{},
+		"secret-key",
+	)
+	defer srv.Close()
+
+	req, _ := http.NewRequest(http.MethodDelete, srv.URL+"/api/v1/workflows/run-abc", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("status: got %d, want 401", resp.StatusCode)
+	}
+}
+
+func TestHandler_Auth_GetNotProtected(t *testing.T) {
+	// GET endpoints must remain open even when ZYNAX_API_KEY is set.
+	srv := newServerWithAuth(
+		&stubCompiler{},
+		&stubEngine{statusRun: domain.WorkflowRunSummary{RunID: "r1", Status: "RUNNING"}},
+		&stubRegistry{},
+		"secret-key",
+	)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/v1/workflows/r1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status: got %d, want 200 (GET must not require auth)", resp.StatusCode)
 	}
 }


### PR DESCRIPTION
## Summary

- Add `requireBearer` middleware in `internal/api/auth.go` that checks `Authorization: Bearer <key>` on mutating endpoints
- `POST /api/v1/apply` and `DELETE /api/v1/workflows/{id}` are protected; GET endpoints remain open
- `ZYNAX_GW_API_KEY` env var controls the key; when empty, auth is disabled and a `WARN api_key not set — auth disabled` line is logged at startup
- Unauthorized requests get `401 {"error":"unauthorized","code":"UNAUTHORIZED"}`
- Documented in `infra/AGENTS.md`; placeholder added to `infra/docker/.env.tools`

## Test plan

- [x] `TestHandler_Auth_CorrectKey_Passes` — valid bearer passes through to handler (202)
- [x] `TestHandler_Auth_MissingKey_Returns401` — missing Authorization header → 401
- [x] `TestHandler_Auth_WrongKey_Returns401` — wrong bearer token → 401
- [x] `TestHandler_Auth_EmptyAPIKey_DisablesGate` — empty `ZYNAX_GW_API_KEY` → no auth (202)
- [x] `TestHandler_Auth_DeleteWithKey_Returns401` — DELETE without token → 401
- [x] `TestHandler_Auth_GetNotProtected` — GET /workflows/{id} always open (200)
- [x] All existing handler tests pass (auth disabled by default in test helpers)
- [x] `golangci-lint` clean
- [x] `go test ./... -race` passes

Closes #482

Assisted-by: Claude/claude-sonnet-4-6