### PR TITLE
feat(api-gateway): X-Request-ID middleware and gRPC metadata propagation (#484)

### DIFF
--- a/services/api-gateway/cmd/api-gateway/main.go
+++ b/services/api-gateway/cmd/api-gateway/main.go
@@ -67,7 +67,7 @@ func run(cfg config) error {
 
 	srv := &http.Server{
 		Addr:         fmt.Sprintf(":%d", cfg.HTTPPort),
-		Handler:      mux,
+		Handler:      api.RequestIDMiddleware(mux),
 		ReadTimeout:  30 * time.Second,
 		WriteTimeout: 30 * time.Second,
 	}

--- a/services/api-gateway/internal/api/handler_test.go
+++ b/services/api-gateway/internal/api/handler_test.go
@@ -428,6 +428,48 @@ func TestHandler_WorkflowLogs_NotFound_Returns404(t *testing.T) {
 	}
 }
 
+// ── X-Request-ID middleware ───────────────────────────────────────────────
+
+func newServerWithRequestID(c domain.CompilerPort, e domain.EnginePort) *httptest.Server {
+	svc := domain.NewApplyService(c, e, &stubRegistry{})
+	h := api.NewHandler(svc, "")
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+	return httptest.NewServer(api.RequestIDMiddleware(mux))
+}
+
+func TestRequestIDMiddleware_EchoesExistingID(t *testing.T) {
+	srv := newServerWithRequestID(&stubCompiler{}, &stubEngine{statusRun: domain.WorkflowRunSummary{RunID: "r1"}})
+	defer srv.Close()
+
+	req, _ := http.NewRequest(http.MethodGet, srv.URL+"/api/v1/workflows/r1", nil)
+	req.Header.Set("X-Request-ID", "trace-abc")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if got := resp.Header.Get("X-Request-ID"); got != "trace-abc" {
+		t.Errorf("X-Request-ID: got %q, want %q", got, "trace-abc")
+	}
+}
+
+func TestRequestIDMiddleware_GeneratesID_WhenAbsent(t *testing.T) {
+	srv := newServerWithRequestID(&stubCompiler{}, &stubEngine{statusRun: domain.WorkflowRunSummary{RunID: "r1"}})
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/v1/workflows/r1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if got := resp.Header.Get("X-Request-ID"); got == "" {
+		t.Error("X-Request-ID header must be set even when not provided by client")
+	}
+}
+
 // ── Bearer-token auth middleware ──────────────────────────────────────────
 
 func TestHandler_Auth_CorrectKey_Passes(t *testing.T) {

--- a/services/api-gateway/internal/api/requestid.go
+++ b/services/api-gateway/internal/api/requestid.go
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package api
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"net/http"
+
+	"github.com/zynax-io/zynax/services/api-gateway/internal/domain"
+)
+
+const requestIDHeader = "X-Request-ID"
+
+// RequestIDMiddleware reads X-Request-ID from the incoming request; if absent,
+// generates a random 16-byte hex ID. The ID is stored in the request context
+// and echoed as X-Request-ID on the response.
+func RequestIDMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		id := r.Header.Get(requestIDHeader)
+		if id == "" {
+			id = newRequestID()
+		}
+		ctx := domain.WithRequestID(r.Context(), id)
+		w.Header().Set(requestIDHeader, id)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+func newRequestID() string {
+	b := make([]byte, 16)
+	_, _ = rand.Read(b)
+	return hex.EncodeToString(b)
+}

--- a/services/api-gateway/internal/domain/requestid.go
+++ b/services/api-gateway/internal/domain/requestid.go
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package domain
+
+import "context"
+
+type reqIDKey struct{}
+
+// RequestIDFromContext returns the request ID stored in ctx, or "" if absent.
+func RequestIDFromContext(ctx context.Context) string {
+	v, _ := ctx.Value(reqIDKey{}).(string)
+	return v
+}
+
+// WithRequestID returns a new context carrying the given request ID.
+func WithRequestID(ctx context.Context, id string) context.Context {
+	return context.WithValue(ctx, reqIDKey{}, id)
+}

--- a/services/api-gateway/internal/domain/requestid_test.go
+++ b/services/api-gateway/internal/domain/requestid_test.go
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package domain
+
+import (
+	"context"
+	"testing"
+)
+
+func TestRequestIDFromContext_Present(t *testing.T) {
+	ctx := WithRequestID(context.Background(), "trace-123")
+	if got := RequestIDFromContext(ctx); got != "trace-123" {
+		t.Errorf("RequestIDFromContext = %q; want %q", got, "trace-123")
+	}
+}
+
+func TestRequestIDFromContext_Absent(t *testing.T) {
+	if got := RequestIDFromContext(context.Background()); got != "" {
+		t.Errorf("RequestIDFromContext on empty ctx = %q; want empty string", got)
+	}
+}

--- a/services/api-gateway/internal/infrastructure/clients.go
+++ b/services/api-gateway/internal/infrastructure/clients.go
@@ -16,6 +16,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 	"gopkg.in/yaml.v3"
@@ -32,16 +33,21 @@ type GatewayClients struct {
 // NewGatewayClients dials all three downstream gRPC services. The returned
 // cleanup function closes all connections and must be deferred by the caller.
 func NewGatewayClients(compilerAddr, engineAddr, registryAddr string) (*GatewayClients, func(), error) {
-	compConn, err := grpc.NewClient(compilerAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	dialOpts := []grpc.DialOption{
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithUnaryInterceptor(requestIDUnaryInterceptor),
+		grpc.WithStreamInterceptor(requestIDStreamInterceptor),
+	}
+	compConn, err := grpc.NewClient(compilerAddr, dialOpts...)
 	if err != nil {
 		return nil, func() {}, fmt.Errorf("api-gateway: compiler dial: %w", err)
 	}
-	engConn, err := grpc.NewClient(engineAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	engConn, err := grpc.NewClient(engineAddr, dialOpts...)
 	if err != nil {
 		_ = compConn.Close()
 		return nil, func() {}, fmt.Errorf("api-gateway: engine dial: %w", err)
 	}
-	regConn, err := grpc.NewClient(registryAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	regConn, err := grpc.NewClient(registryAddr, dialOpts...)
 	if err != nil {
 		_ = compConn.Close()
 		_ = engConn.Close()
@@ -224,6 +230,36 @@ func mapRegistryGRPCError(err error) error {
 	default:
 		return fmt.Errorf("api-gateway: registry: %w", err)
 	}
+}
+
+// ── gRPC client interceptors ──────────────────────────────────────────────
+
+func requestIDUnaryInterceptor(
+	ctx context.Context,
+	method string,
+	req, reply any,
+	cc *grpc.ClientConn,
+	invoker grpc.UnaryInvoker,
+	opts ...grpc.CallOption,
+) error {
+	if id := domain.RequestIDFromContext(ctx); id != "" {
+		ctx = metadata.AppendToOutgoingContext(ctx, "request-id", id)
+	}
+	return invoker(ctx, method, req, reply, cc, opts...)
+}
+
+func requestIDStreamInterceptor(
+	ctx context.Context,
+	desc *grpc.StreamDesc,
+	cc *grpc.ClientConn,
+	method string,
+	streamer grpc.Streamer,
+	opts ...grpc.CallOption,
+) (grpc.ClientStream, error) {
+	if id := domain.RequestIDFromContext(ctx); id != "" {
+		ctx = metadata.AppendToOutgoingContext(ctx, "request-id", id)
+	}
+	return streamer(ctx, desc, cc, method, opts...)
 }
 
 // ── proto conversion ──────────────────────────────────────────────────────

--- a/services/engine-adapter/cmd/engine-adapter/main.go
+++ b/services/engine-adapter/cmd/engine-adapter/main.go
@@ -23,6 +23,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/health"
 	"google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/reflection"
 
 	zynaxv1 "github.com/zynax-io/zynax/protos/generated/go/zynax/v1"
@@ -151,7 +152,9 @@ func buildEngine(cfg config) (domain.WorkflowEngine, func(), error) {
 }
 
 func startGRPC(cfg config, engine domain.WorkflowEngine) (*grpc.Server, error) {
-	srv := grpc.NewServer()
+	srv := grpc.NewServer(
+		grpc.ChainUnaryInterceptor(requestIDServerInterceptor),
+	)
 	reflection.Register(srv)
 
 	healthSvc := health.NewServer()
@@ -197,6 +200,20 @@ func startHTTP(cfg config) *http.Server {
 		}
 	}()
 	return srv
+}
+
+func requestIDServerInterceptor(
+	ctx context.Context,
+	req any,
+	info *grpc.UnaryServerInfo,
+	handler grpc.UnaryHandler,
+) (any, error) {
+	if md, ok := metadata.FromIncomingContext(ctx); ok {
+		if vals := md.Get("request-id"); len(vals) > 0 {
+			slog.Info("grpc request", "method", info.FullMethod, "request_id", vals[0])
+		}
+	}
+	return handler(ctx, req)
 }
 
 func getEnv(key, fallback string) string {

--- a/services/workflow-compiler/cmd/workflow-compiler/main.go
+++ b/services/workflow-compiler/cmd/workflow-compiler/main.go
@@ -17,6 +17,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health"
 	"google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/reflection"
 
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
@@ -41,6 +42,7 @@ func main() {
 
 	grpcServer := grpc.NewServer(
 		grpc.StatsHandler(otelgrpc.NewServerHandler()),
+		grpc.ChainUnaryInterceptor(requestIDServerInterceptor),
 	)
 	reflection.Register(grpcServer)
 
@@ -106,4 +108,18 @@ func parseLogLevel(level string) slog.Level {
 	default:
 		return slog.LevelInfo
 	}
+}
+
+func requestIDServerInterceptor(
+	ctx context.Context,
+	req any,
+	info *grpc.UnaryServerInfo,
+	handler grpc.UnaryHandler,
+) (any, error) {
+	if md, ok := metadata.FromIncomingContext(ctx); ok {
+		if vals := md.Get("request-id"); len(vals) > 0 {
+			slog.Info("grpc request", "method", info.FullMethod, "request_id", vals[0])
+		}
+	}
+	return handler(ctx, req)
 }


### PR DESCRIPTION
## Summary

- Add `RequestIDMiddleware` in `internal/api/requestid.go`: reads `X-Request-ID` from incoming request or generates a random 16-byte hex ID, stores in context, echoes on response
- Add `domain.WithRequestID` / `domain.RequestIDFromContext` context helpers in `internal/domain/requestid.go`
- Add gRPC client unary + stream interceptors in `internal/infrastructure/clients.go` that propagate `request-id` as gRPC metadata on all outgoing calls
- Apply middleware in `cmd/api-gateway/main.go`
- Add `requestIDServerInterceptor` in workflow-compiler and engine-adapter `cmd/` main.go that extracts and logs `request_id` on every incoming gRPC call

## Test plan

- [x] `TestRequestIDMiddleware_EchoesExistingID` — provided X-Request-ID is echoed in response header
- [x] `TestRequestIDMiddleware_GeneratesID_WhenAbsent` — missing header generates a non-empty ID
- [x] All existing handler and domain tests pass
- [x] `golangci-lint` clean on all three services
- [x] `go build ./...` passes on workflow-compiler and engine-adapter
- [x] `go test ./... -race` passes on api-gateway

Closes #484

Assisted-by: Claude/claude-sonnet-4-6