### PR TITLE
feat(api-gateway): idempotent Apply — manifest-hash derives stable workflow ID

### DIFF
--- a/services/api-gateway/internal/api/handler.go
+++ b/services/api-gateway/internal/api/handler.go
@@ -83,7 +83,7 @@ func (h *Handler) applyWorkflow(w http.ResponseWriter, r *http.Request, body []b
 	case req.DryRun:
 		writeJSON(w, http.StatusOK, dryRunResp{DryRun: true, Warnings: result.Warnings})
 	default:
-		writeJSON(w, http.StatusAccepted, applyResp{RunID: result.RunID, Warnings: result.Warnings})
+		writeJSON(w, http.StatusAccepted, applyResp{RunID: result.RunID, Status: result.Status, Warnings: result.Warnings})
 	}
 }
 
@@ -197,6 +197,7 @@ type errResp struct {
 
 type applyResp struct {
 	RunID    string   `json:"run_id"`
+	Status   string   `json:"status,omitempty"`
 	Warnings []string `json:"warnings,omitempty"`
 }
 

--- a/services/api-gateway/internal/api/handler_test.go
+++ b/services/api-gateway/internal/api/handler_test.go
@@ -37,7 +37,7 @@ type stubEngine struct {
 	watchErr    error
 }
 
-func (s *stubEngine) SubmitWorkflow(_ context.Context, _ []byte, _ string) (string, error) {
+func (s *stubEngine) SubmitWorkflow(_ context.Context, _ []byte, _, _ string) (string, error) {
 	return s.submitID, s.submitErr
 }
 

--- a/services/api-gateway/internal/domain/apply.go
+++ b/services/api-gateway/internal/domain/apply.go
@@ -4,8 +4,13 @@ package domain
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
+	"time"
+
+	"gopkg.in/yaml.v3"
 )
 
 // Sentinel errors surfaced to the HTTP handler for status-code mapping.
@@ -15,6 +20,46 @@ var (
 	ErrNotFound           = errors.New("api-gateway: not found")
 	ErrAgentAlreadyExists = errors.New("api-gateway: agent already registered")
 )
+
+// manifestIDLen is the number of hex characters used as the workflow ID suffix.
+// 16 hex chars = 8 bytes = 64 bits of the SHA-256 digest — sufficient for
+// workflow-scoped uniqueness within a single Temporal namespace.
+const manifestIDLen = 16
+
+// status values from the proto WorkflowStatus enum (via String()).
+const (
+	statusRunning   = "WORKFLOW_STATUS_RUNNING"
+	statusCompleted = "WORKFLOW_STATUS_COMPLETED"
+)
+
+// ManifestWorkflowID derives a deterministic workflow identifier from raw
+// manifest YAML. The YAML is canonicalised before hashing so that semantically
+// equivalent documents (differing only in whitespace or indentation) produce
+// the same ID. Format: "wf-" + first manifestIDLen hex chars of SHA-256.
+func ManifestWorkflowID(manifestYAML []byte) string {
+	sum := sha256.Sum256(canonicaliseYAML(manifestYAML))
+	return "wf-" + hex.EncodeToString(sum[:])[:manifestIDLen]
+}
+
+// canonicaliseYAML parses and re-marshals YAML to normalise trailing
+// whitespace and indentation differences. Falls back to raw bytes on error.
+func canonicaliseYAML(raw []byte) []byte {
+	var v any
+	if err := yaml.Unmarshal(raw, &v); err != nil {
+		return raw
+	}
+	out, err := yaml.Marshal(v)
+	if err != nil {
+		return raw
+	}
+	return out
+}
+
+// rerunWorkflowID appends a Unix-second timestamp to baseID so that a re-run
+// of a completed workflow gets a unique Temporal workflow ID.
+func rerunWorkflowID(baseID string, t time.Time) string {
+	return fmt.Sprintf("%s-%d", baseID, t.Unix())
+}
 
 // ApplyRequest carries the parameters for a manifest apply operation.
 type ApplyRequest struct {
@@ -30,6 +75,10 @@ type ApplyResult struct {
 	AgentID  string
 	Warnings []string
 	Errors   []CompileError
+	// Status is "new" when a fresh workflow was started, "existing" when a
+	// running workflow with the same manifest hash was found. Empty for dry
+	// runs and agent registrations.
+	Status string
 }
 
 // ApplyService orchestrates manifest apply operations.
@@ -58,15 +107,35 @@ func (s *ApplyService) ApplyWorkflow(ctx context.Context, req ApplyRequest) (App
 	if req.DryRun {
 		return ApplyResult{Warnings: compiled.Warnings}, nil
 	}
-	return s.submit(ctx, compiled, req.EngineHint)
+	return s.submit(ctx, req.ManifestYAML, compiled, req.EngineHint)
 }
 
-func (s *ApplyService) submit(ctx context.Context, compiled CompileResult, engineHint string) (ApplyResult, error) {
-	runID, err := s.engine.SubmitWorkflow(ctx, compiled.IRBytes, engineHint)
+// submit checks for an existing workflow execution with the hash-derived ID
+// and applies idempotency logic before starting a new run:
+//   - Running  → return existing run_id with Status "existing"
+//   - Completed → start new run with a timestamp-suffixed ID (re-run)
+//   - Not found / failed / other terminal → start new run with hash ID
+func (s *ApplyService) submit(ctx context.Context, manifestYAML []byte, compiled CompileResult, engineHint string) (ApplyResult, error) {
+	workflowID := ManifestWorkflowID(manifestYAML)
+
+	existing, err := s.engine.GetWorkflowStatus(ctx, workflowID)
+	if err != nil && !errors.Is(err, ErrNotFound) {
+		return ApplyResult{}, fmt.Errorf("api-gateway: check existing workflow: %w", err)
+	}
+	if err == nil {
+		switch existing.Status {
+		case statusRunning:
+			return ApplyResult{RunID: existing.RunID, Warnings: compiled.Warnings, Status: "existing"}, nil
+		case statusCompleted:
+			workflowID = rerunWorkflowID(workflowID, time.Now())
+		}
+	}
+
+	runID, err := s.engine.SubmitWorkflow(ctx, compiled.IRBytes, engineHint, workflowID)
 	if err != nil {
 		return ApplyResult{}, fmt.Errorf("api-gateway: %w", err)
 	}
-	return ApplyResult{RunID: runID, Warnings: compiled.Warnings}, nil
+	return ApplyResult{RunID: runID, Warnings: compiled.Warnings, Status: "new"}, nil
 }
 
 // ApplyAgentDef registers an AgentDef manifest with the agent registry.

--- a/services/api-gateway/internal/domain/apply_test.go
+++ b/services/api-gateway/internal/domain/apply_test.go
@@ -5,6 +5,7 @@ package domain_test
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/zynax-io/zynax/services/api-gateway/internal/domain"
@@ -22,16 +23,18 @@ func (s *stubCompiler) CompileWorkflow(_ context.Context, _ []byte, _ string, _ 
 
 // stubEngine is a test double for EnginePort.
 type stubEngine struct {
-	submitID    string
-	submitErr   error
-	statusRun   domain.WorkflowRunSummary
-	statusErr   error
-	cancelErr   error
-	watchEvents []domain.WatchEvent
-	watchErr    error
+	submitID           string
+	submitErr          error
+	capturedWorkflowID string
+	statusRun          domain.WorkflowRunSummary
+	statusErr          error
+	cancelErr          error
+	watchEvents        []domain.WatchEvent
+	watchErr           error
 }
 
-func (s *stubEngine) SubmitWorkflow(_ context.Context, _ []byte, _ string) (string, error) {
+func (s *stubEngine) SubmitWorkflow(_ context.Context, _ []byte, _, workflowID string) (string, error) {
+	s.capturedWorkflowID = workflowID
 	return s.submitID, s.submitErr
 }
 
@@ -239,5 +242,136 @@ func TestApplyService_WatchWorkflowLogs_NotFound(t *testing.T) {
 	err := svc.WatchWorkflowLogs(context.Background(), "ghost", func(_ domain.WatchEvent) error { return nil })
 	if !errors.Is(err, domain.ErrNotFound) {
 		t.Fatalf("got %v, want ErrNotFound", err)
+	}
+}
+
+// ── CancelWorkflow ───────────────────────────────────────────────────────────
+
+func TestApplyService_CancelWorkflow_Success(t *testing.T) {
+	svc := domain.NewApplyService(&stubCompiler{}, &stubEngine{}, &stubRegistry{})
+	if err := svc.CancelWorkflow(context.Background(), "r1"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestApplyService_CancelWorkflow_NotFound(t *testing.T) {
+	svc := domain.NewApplyService(&stubCompiler{}, &stubEngine{cancelErr: domain.ErrNotFound}, &stubRegistry{})
+	err := svc.CancelWorkflow(context.Background(), "ghost")
+	if !errors.Is(err, domain.ErrNotFound) {
+		t.Fatalf("got %v, want ErrNotFound", err)
+	}
+}
+
+// ── ManifestWorkflowID ───────────────────────────────────────────────────────
+
+func TestManifestWorkflowID_Deterministic(t *testing.T) {
+	yaml := []byte("kind: Workflow\nmetadata:\n  name: test\n")
+	want := domain.ManifestWorkflowID(yaml)
+	for i := range 100 {
+		if got := domain.ManifestWorkflowID(yaml); got != want {
+			t.Fatalf("not deterministic on iteration %d: got %q, want %q", i, got, want)
+		}
+	}
+}
+
+func TestManifestWorkflowID_Format(t *testing.T) {
+	id := domain.ManifestWorkflowID([]byte("kind: Workflow"))
+	if !strings.HasPrefix(id, "wf-") {
+		t.Errorf("want wf- prefix, got %q", id)
+	}
+	if len(id) != 3+16 {
+		t.Errorf("want len 19 (wf- + 16 hex chars), got %d (%q)", len(id), id)
+	}
+}
+
+func TestManifestWorkflowID_DifferentInputs_DifferentIDs(t *testing.T) {
+	id1 := domain.ManifestWorkflowID([]byte("kind: Workflow\nname: alpha"))
+	id2 := domain.ManifestWorkflowID([]byte("kind: Workflow\nname: beta"))
+	if id1 == id2 {
+		t.Error("different manifests must produce different IDs")
+	}
+}
+
+func TestManifestWorkflowID_WhitespaceInsensitive(t *testing.T) {
+	base := []byte("kind: Workflow\nmetadata:\n  name: test\n")
+	trailing := []byte("kind: Workflow\nmetadata:\n  name: test\n\n\n")
+	if domain.ManifestWorkflowID(base) != domain.ManifestWorkflowID(trailing) {
+		t.Error("trailing newlines must not change the workflow ID")
+	}
+}
+
+// ── Idempotent Apply ─────────────────────────────────────────────────────────
+
+func TestApplyService_ApplyWorkflow_Idempotent_Running_ReturnsExisting(t *testing.T) {
+	yaml := []byte("kind: Workflow\nmetadata:\n  name: idem\n")
+	wfID := domain.ManifestWorkflowID(yaml)
+	engine := &stubEngine{
+		statusRun: domain.WorkflowRunSummary{RunID: wfID, Status: "WORKFLOW_STATUS_RUNNING"},
+	}
+	svc := domain.NewApplyService(
+		&stubCompiler{result: domain.CompileResult{IRBytes: []byte("ir")}},
+		engine,
+		&stubRegistry{},
+	)
+	result, err := svc.ApplyWorkflow(context.Background(), domain.ApplyRequest{ManifestYAML: yaml})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.RunID != wfID {
+		t.Errorf("got run_id %q, want %q", result.RunID, wfID)
+	}
+	if result.Status != "existing" {
+		t.Errorf("got status %q, want existing", result.Status)
+	}
+	if engine.capturedWorkflowID != "" {
+		t.Error("SubmitWorkflow must not be called when workflow is already running")
+	}
+}
+
+func TestApplyService_ApplyWorkflow_Idempotent_Completed_StartsRerun(t *testing.T) {
+	yaml := []byte("kind: Workflow\nmetadata:\n  name: idem\n")
+	wfID := domain.ManifestWorkflowID(yaml)
+	engine := &stubEngine{
+		statusRun: domain.WorkflowRunSummary{RunID: wfID, Status: "WORKFLOW_STATUS_COMPLETED"},
+		submitID:  "rerun-id",
+	}
+	svc := domain.NewApplyService(
+		&stubCompiler{result: domain.CompileResult{IRBytes: []byte("ir")}},
+		engine,
+		&stubRegistry{},
+	)
+	result, err := svc.ApplyWorkflow(context.Background(), domain.ApplyRequest{ManifestYAML: yaml})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != "new" {
+		t.Errorf("got status %q, want new", result.Status)
+	}
+	if !strings.HasPrefix(engine.capturedWorkflowID, wfID+"-") {
+		t.Errorf("rerun workflow ID must start with %q-, got %q", wfID, engine.capturedWorkflowID)
+	}
+}
+
+func TestApplyService_ApplyWorkflow_New_UsesHashID(t *testing.T) {
+	yaml := []byte("kind: Workflow\nmetadata:\n  name: fresh\n")
+	wfID := domain.ManifestWorkflowID(yaml)
+	engine := &stubEngine{
+		statusErr: domain.ErrNotFound,
+		submitID:  wfID,
+	}
+	svc := domain.NewApplyService(
+		&stubCompiler{result: domain.CompileResult{IRBytes: []byte("ir")}},
+		engine,
+		&stubRegistry{},
+	)
+	result, err := svc.ApplyWorkflow(context.Background(), domain.ApplyRequest{ManifestYAML: yaml})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != "new" {
+		t.Errorf("got status %q, want new", result.Status)
+	}
+	if engine.capturedWorkflowID != wfID {
+		t.Errorf("new workflow must use hash ID %q, got %q", wfID, engine.capturedWorkflowID)
 	}
 }

--- a/services/api-gateway/internal/domain/ports.go
+++ b/services/api-gateway/internal/domain/ports.go
@@ -49,7 +49,10 @@ type CompilerPort interface {
 
 // EnginePort is the gateway's outbound dependency on EngineAdapterService.
 type EnginePort interface {
-	SubmitWorkflow(ctx context.Context, irBytes []byte, engineHint string) (string, error)
+	// SubmitWorkflow submits irBytes to the engine under the given workflowID.
+	// The engine uses workflowID as the Temporal workflow identifier so that
+	// subsequent DescribeWorkflowExecution lookups find the same execution.
+	SubmitWorkflow(ctx context.Context, irBytes []byte, engineHint, workflowID string) (string, error)
 	GetWorkflowStatus(ctx context.Context, runID string) (WorkflowRunSummary, error)
 	CancelWorkflow(ctx context.Context, runID string) error
 	// WatchWorkflow streams lifecycle events for runID, calling send for each.

--- a/services/api-gateway/internal/infrastructure/clients.go
+++ b/services/api-gateway/internal/infrastructure/clients.go
@@ -78,11 +78,14 @@ func (c *GatewayClients) CompileWorkflow(ctx context.Context, manifestYAML []byt
 }
 
 // SubmitWorkflow implements domain.EnginePort.
-func (c *GatewayClients) SubmitWorkflow(ctx context.Context, irBytes []byte, engineHint string) (string, error) {
+// workflowID overrides the compiler-assigned WorkflowId in the IR so that
+// Temporal uses the hash-derived deterministic identifier for deduplication.
+func (c *GatewayClients) SubmitWorkflow(ctx context.Context, irBytes []byte, engineHint, workflowID string) (string, error) {
 	ir := &zynaxv1.WorkflowIR{}
 	if err := proto.Unmarshal(irBytes, ir); err != nil {
 		return "", fmt.Errorf("api-gateway: unmarshal IR: %w", err)
 	}
+	ir.WorkflowId = workflowID
 	resp, err := c.engine.SubmitWorkflow(ctx, &zynaxv1.SubmitWorkflowRequest{
 		WorkflowIr: ir,
 		EngineHint: engineHint,

--- a/services/api-gateway/tests/features/api_gateway.feature
+++ b/services/api-gateway/tests/features/api_gateway.feature
@@ -107,6 +107,25 @@ Feature: API Gateway
     Then the HTTP status is 409
     And the response code is "ALREADY_EXISTS"
 
+  # ── POST /api/v1/apply — Idempotent Apply (#485) ────────────────────────
+
+  Scenario: POST /api/v1/apply with same manifest while workflow is running returns existing run_id
+    Given a WorkflowCompilerService that compiles the manifest successfully
+    And an EngineAdapterService that reports a running workflow for the derived manifest hash
+    When POST /api/v1/apply is called with a valid kind: Workflow YAML body
+    Then the HTTP status is 202
+    And the response contains a non-empty run_id
+    And the response has status "existing"
+
+  Scenario: POST /api/v1/apply after the workflow completes starts a new workflow run
+    Given a WorkflowCompilerService that compiles the manifest successfully
+    And an EngineAdapterService that reports a completed workflow for the derived manifest hash
+    And an EngineAdapterService that accepts a new workflow submission for re-run
+    When POST /api/v1/apply is called with a valid kind: Workflow YAML body
+    Then the HTTP status is 202
+    And the response contains a non-empty run_id
+    And the response has status "new"
+
   # ── GET /api/v1/workflows/{id}/logs (M4 step 4, issue #318) ─────────────
 
   Scenario: GET /api/v1/workflows/{id}/logs streams SSE events and closes on terminal


### PR DESCRIPTION
## Summary

Closes #485.

Implements idempotent `zynax apply` behaviour so that resubmitting the same
manifest YAML does not spawn a duplicate Temporal workflow. A SHA-256 hash of
the canonicalised manifest YAML derives a deterministic `wf-<16-char-hex>` ID.
Before starting a new execution the domain layer checks Temporal via
`GetWorkflowStatus`; it returns the existing `run_id` if the workflow is still
running, or starts a timestamped re-run if it has completed.

## Source

- Issue: #485
- Parent EPIC: #462
- Canvas: `docs/spdd/462-dx-polish/canvas.md` O1
- ADR(s): ADR-011 (declarative YAML), ADR-008 (no shared DB)

## Approach

- `ManifestWorkflowID(yaml []byte) string` — canonicalises YAML (parse + re-marshal) then takes SHA-256; first 16 hex chars prefixed with `wf-`.
- `submit()` in `ApplyService` — calls `engine.GetWorkflowStatus` with the derived ID before submitting; routes Running → return existing, Completed → re-run with Unix-timestamp suffix, else → new run.
- `EnginePort.SubmitWorkflow` extended with `workflowID string`; infrastructure overrides `ir.WorkflowId` before the gRPC call so Temporal registers the deterministic ID.
- HTTP response gains an optional `status` field (`"new"` | `"existing"`).
- 2 BDD scenarios committed before implementation (`.feature`-first, ADR-016).

## Test plan

### Local pre-flight (Phase B.5)
- [x] `gofmt -s -l .` — no diff  [exit 0]
- [x] `golangci-lint` — exit 0  [pre-commit hook passed]
- [x] `GOWORK=off go test ./... -count=1` — exit 0  [51 tests pass]
- [x] domain coverage — 94.5% ≥ 90%  [evidence: `go tool cover` total: 94.5%]

### CI required checks (Phase D)
- [ ] `dco` — green  [link]
- [ ] `lint-proto` — green or skipped  [link]
- [ ] `lint-go` — green or skipped  [link]
- [ ] `lint-python` — green or skipped  [link]
- [ ] `test-unit` — green or skipped  [link]
- [ ] `test-integration` — green or skipped  [link]
- [ ] `security` — green  [link]
- [ ] `pr-size` — green  [link]

### Acceptance (issue-specific)
- [x] Same manifest YAML → same `workflow_id` across 100 calls (`TestManifestWorkflowID_Deterministic`)
- [x] Whitespace-insensitive: trailing newlines produce same ID (`TestManifestWorkflowID_WhitespaceInsensitive`)
- [x] Different manifest content → different ID (`TestManifestWorkflowID_DifferentInputs_DifferentIDs`)
- [x] Running workflow → return existing `run_id`, status "existing" (`TestApplyService_ApplyWorkflow_Idempotent_Running_ReturnsExisting`)
- [x] Completed workflow → start new run with `wf-<hash>-<ts>` suffix (`TestApplyService_ApplyWorkflow_Idempotent_Completed_StartsRerun`)
- [x] New workflow → submitted with hash-derived ID (`TestApplyService_ApplyWorkflow_New_UsesHashID`)
- [x] BDD scenarios added to `services/api-gateway/tests/features/api_gateway.feature`

### Engineering hygiene
- [x] Branched from latest `origin/main`
- [x] PR size within hard limit (226 insertions, well ≤ 900 LOC)
- [x] Every commit has `Signed-off-by: Oscar Gómez Manresa <ogomezmanresa@gmail.com>` (DCO)
- [x] Every commit has `Assisted-by: Claude/claude-sonnet-4-6`
- [x] No `Co-Authored-By:` for AI
- [x] No `panic` in production paths
- [x] No silently-ignored errors (`_ = err`) without justification
- [x] No new `insecure.NewCredentials()` outside bufconn tests
- [x] No new direct dependencies (uses existing `gopkg.in/yaml.v3` and `crypto/sha256`)
- [x] Canvas O1 addressed
- [x] `.feature` scenarios committed before implementation
- [x] No out-of-scope changes

## Out of scope

- Full GitOps reconciliation loop (separate future feature)
- Changing Temporal workflow implementation or `IRInterpreterWorkflow` logic
- End-to-end integration test against a live Temporal cluster (covered by CI `test-integration` job)

## Risk

- **Blast radius:** `api-gateway` only; no other service is touched.
- **Rollback:** revert this PR. Existing random-ID workflows already in Temporal are unaffected; subsequent applies of the same manifest will generate a new hash-based ID (no collision with the old random IDs).
- **Behavioural change visible to users:** Yes — `POST /api/v1/apply` now returns `"status": "existing"` when the workflow is already running, and the `run_id` is now deterministic rather than random.

---

🤖 *This PR was produced by Claude Code following the Resumable PR Pipeline prompt. Each checkbox is verified before merge per Phase D.3.*