### PR TITLE
ci(infra): add syft to Dockerfile.tools and make sbom target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@
 *.out
 /bin/
 
+# Generated SBOM artifacts
+sbom-*.json
+
 # Python
 __pycache__/
 *.py[cod]

--- a/Makefile
+++ b/Makefile
@@ -247,13 +247,22 @@ lint-protos: ensure-tools ## buf lint + format check on all proto files
 	@echo "✅ Proto lint passed"
 
 # ── Security ───────────────────────────────────────────────────────────────
-.PHONY: security security-go security-go-adapters security-agents scan-image audit gitleaks
+.PHONY: security security-go security-go-adapters security-agents scan-image sbom audit gitleaks
 security: security-go security-go-adapters security-agents ## Full security scan (govulncheck + bandit + pip-audit + trivy)
 
 scan-image: ## Scan one service container image for CVEs: make scan-image SVC=agent-registry
 	docker build -t zynax/$(SVC):scan services/$(SVC)/
 	trivy image --exit-code 1 --severity HIGH,CRITICAL --ignorefile .trivyignore zynax/$(SVC):scan
 	docker rmi zynax/$(SVC):scan
+
+sbom: ensure-tools ## Generate CycloneDX SBOM for one service image: make sbom SVC=api-gateway
+	docker build services/$(SVC) -t $(REGISTRY)/zynax-$(SVC):local
+	docker run --rm \
+	  -v /var/run/docker.sock:/var/run/docker.sock \
+	  -v "$(CURDIR):/workspace" -w /workspace \
+	  $(TOOLS_IMAGE) \
+	  syft $(REGISTRY)/zynax-$(SVC):local -o cyclonedx-json --file sbom-$(SVC).json
+	@echo "✅ SBOM written to sbom-$(SVC).json"
 
 gitleaks: ensure-tools ## Scan working tree for secrets/PII — mirrors the ci.yml Secret scan gate (no git history)
 	$(TOOLS_RUN) gitleaks detect --no-git --source . \

--- a/infra/docker/Dockerfile.tools
+++ b/infra/docker/Dockerfile.tools
@@ -22,6 +22,7 @@
 #   migrate             v4.17.1
 #   grpc-health-probe   v0.4.26
 #   gitleaks            v8.21.2  (.pre-commit-config.yaml rev: must match)
+#   syft                v1.44.0
 #   uv                  0.5.10
 
 # ── Stage 1: Go binaries ────────────────────────────────────────────────────
@@ -85,6 +86,15 @@ RUN GITLEAKS_VERSION=v8.21.2 && \
     && tar -xzf /tmp/gitleaks.tar.gz -C /usr/local/bin gitleaks \
     && rm /tmp/gitleaks.tar.gz
 
+# syft — CycloneDX SBOM generator
+# renovate: datasource=github-releases depName=anchore/syft
+RUN SYFT_VERSION=v1.44.0 && \
+    curl -fsSL \
+      "https://github.com/anchore/syft/releases/download/${SYFT_VERSION}/syft_${SYFT_VERSION#v}_linux_amd64.tar.gz" \
+      -o /tmp/syft.tar.gz \
+    && tar -xzf /tmp/syft.tar.gz -C /usr/local/bin syft \
+    && rm /tmp/syft.tar.gz
+
 # zynax-ci — CI and developer toolchain (validation + AI context checker)
 COPY cmd/zynax-ci/ /src/zynax-ci/
 RUN cd /src/zynax-ci && GOWORK=off go build -trimpath -o /usr/local/bin/zynax-ci .
@@ -107,6 +117,7 @@ COPY --from=go-tools /go/bin/godog               /usr/local/bin/
 COPY --from=go-tools /go/bin/mockery             /usr/local/bin/
 COPY --from=go-tools /go/bin/migrate             /usr/local/bin/
 COPY --from=go-tools /usr/local/bin/gitleaks      /usr/local/bin/
+COPY --from=go-tools /usr/local/bin/syft          /usr/local/bin/
 COPY --from=go-tools /usr/local/bin/zynax-ci     /usr/local/bin/
 
 # ── uv — Python package manager ──────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes #378.

Adds `syft` v1.44.0 to the `infra/docker/Dockerfile.tools` tools image and a `make sbom SVC=<name>` target so any engineer can generate a CycloneDX JSON SBOM for a service image locally with a single command and no extra prerequisites beyond Docker. This is step 1 of #235 (SBOM generation); CI workflow integration (step 2, #379) requires syft to be in the tools image first.

## Source

- Issue: #378
- Parent EPIC: #235
- ADR(s): N/A

## Approach

- Pin `syft` v1.44.0 in the `go-tools` stage using the same `curl + tar` pattern as gitleaks; include a `# renovate:` datasource comment for automated version tracking.
- Copy the syft binary to the final `tools` stage alongside the other Go binaries.
- Add `make sbom SVC=<name>` target that first builds the service image (`docker build`) then runs syft from inside the tools container with the Docker socket mounted, writing `sbom-<SVC>.json` to the project root.
- Add `sbom-*.json` to `.gitignore` so generated SBOM files are never committed.

## Test plan

Each item must be checked with evidence (local command + exit code, or CI run URL) before merge.

### Local pre-flight (Phase B.5)
- [ ] `make fmt` — no diff
- [ ] `make lint-go` — exit 0  [evidence: N/A — no Go source changes]
- [ ] `make test-unit` — exit 0  [evidence: N/A — no source changes]
- [ ] `make security` — exit 0  [evidence: CI run]

### Acceptance (issue-specific)
- [ ] `syft` binary added to `go-tools` stage in `infra/docker/Dockerfile.tools` pinned to `v1.44.0` with `# renovate: datasource=github-releases depName=anchore/syft` comment.
- [ ] `syft` copied to the final `tools` stage (same `COPY --from=go-tools` pattern as other binaries).
- [ ] `make sbom SVC=api-gateway` builds `ghcr.io/zynax-io/zynax-api-gateway:local`, runs syft against it, exits 0.
- [ ] `sbom-api-gateway.json` written to project root in CycloneDX JSON format.
- [ ] `sbom-*.json` added to `.gitignore`.
- [ ] `make bootstrap` still passes after the Dockerfile change.
- [ ] `make lint` still passes (no regressions).

### Engineering hygiene
- [ ] Branched from latest `origin/main`
- [ ] PR size within hard limit (≤ 900 LOC excluding generated) — 24 LOC net
- [ ] Every commit has `Signed-off-by:` (DCO)
- [ ] Every commit has `Assisted-by: Claude/claude-sonnet-4-6`
- [ ] No `Co-Authored-By:` for AI
- [ ] No `panic` in production paths
- [ ] No silently-ignored errors (`_ = err`) without justification comment
- [ ] No new direct dependencies (or justified in PR description)
- [ ] Canvas section updated (or N/A for non-feat) — N/A (`ci:` type)
- [ ] `.feature` scenario added if `feat:` touches a public boundary — N/A (`ci:` type)
- [ ] No out-of-scope changes (no drive-by refactors)

## Out of scope

- CI workflow changes (story 2, #379)
- GHCR image publication
- GitHub Release SBOM artifact attachment
- cosign / SLSA provenance (#239)
- Agent image SBOMs

## Risk

- **Blast radius:** `infra/docker/Dockerfile.tools` only — tools image must be rebuilt before `make sbom` works. No service code affected.
- **Rollback:** revert this PR. `make sbom` will simply be unavailable.
- **Behavioural change visible to users:** No — `make sbom` is a new additive target; nothing existing changes.

---

🤖 *This PR was produced by Claude Code following the Resumable PR Pipeline prompt. Each checkbox is verified before merge per Phase D.3.*
