### PR TITLE
ci: service image release workflow — build, push, SBOM

### DIFF
--- a/.github/workflows/service-release.yml
+++ b/.github/workflows/service-release.yml
@@ -1,0 +1,175 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Service Image Release — builds multi-arch container images for each platform
+# service that has a Dockerfile, pushes them to GHCR, generates a CycloneDX
+# SBOM with syft for each image, and attaches the SBOMs to a GitHub Release.
+#
+# Trigger:
+#   git tag v0.5.0 && git push origin v0.5.0
+#
+# Manual trigger (dry-run / pre-release validation):
+#   Actions → Service Image Release → Run workflow → enter tag
+#
+# Services built: api-gateway · engine-adapter · workflow-compiler
+# Stub services (agent-registry, task-broker, memory-service, event-bus) are
+# excluded until they have Dockerfiles.
+#
+# Image name convention:
+#   ghcr.io/zynax-io/zynax/<svc>:<version>   (semver — e.g. v0.5.0)
+#   ghcr.io/zynax-io/zynax/<svc>:latest       (floating — updated on every push)
+#
+# This workflow is designed to be extended by #239 (cosign image signing +
+# SLSA provenance). The id-token: write permission below is reserved for that
+# follow-on work and must not be removed.
+
+name: Service Image Release
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+-*'   # pre-releases: v0.5.0-rc.1
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Version tag to publish (e.g. v0.5.0)'
+        required: true
+
+permissions:
+  contents: write   # create GitHub Release and upload SBOM assets
+  packages: write   # push container images to GHCR
+  id-token: write   # reserved for cosign OIDC signing (#239) — do not remove
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_PREFIX: ghcr.io/zynax-io/zynax
+  SYFT_VERSION: "1.44.0"   # keep in sync with infra/docker/Dockerfile.tools
+
+# ── Build, push, and generate SBOM ───────────────────────────────────────────
+# One job per service (matrix). Each job builds a multi-arch image, pushes it
+# to GHCR, runs syft to produce a CycloneDX JSON SBOM, and uploads the SBOM
+# as a workflow artifact for the release job to attach.
+
+jobs:
+  build-push-sbom:
+    name: Build, push and SBOM — ${{ matrix.service }}
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        service: [api-gateway, engine-adapter, workflow-compiler]
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Resolve version
+        id: ver
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "version=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Log in to GHCR
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Build and push ${{ matrix.service }}
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          context: .
+          file: services/${{ matrix.service }}/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ env.IMAGE_PREFIX }}/${{ matrix.service }}:${{ steps.ver.outputs.version }}
+            ${{ env.IMAGE_PREFIX }}/${{ matrix.service }}:latest
+
+      - name: Install syft v${{ env.SYFT_VERSION }}
+        run: |
+          curl -sSfL \
+            "https://github.com/anchore/syft/releases/download/v${SYFT_VERSION}/syft_${SYFT_VERSION}_linux_amd64.tar.gz" \
+            -o /tmp/syft.tar.gz
+          tar -xzf /tmp/syft.tar.gz -C /usr/local/bin syft
+          rm /tmp/syft.tar.gz
+          syft version
+
+      - name: Generate SBOM — ${{ matrix.service }}
+        run: |
+          syft \
+            "${{ env.IMAGE_PREFIX }}/${{ matrix.service }}:${{ steps.ver.outputs.version }}" \
+            -o cyclonedx-json \
+            --file "${{ matrix.service }}-sbom.json"
+
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: sbom-${{ matrix.service }}
+          path: ${{ matrix.service }}-sbom.json
+          retention-days: 7
+
+# ── GitHub Release ────────────────────────────────────────────────────────────
+# Collects the three SBOM artifacts from the matrix jobs and attaches them to
+# a GitHub Release for the triggering tag.
+
+  release:
+    name: Create GitHub Release
+    needs: build-push-sbom
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Resolve version
+        id: ver
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "version=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Download SBOM artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          pattern: sbom-*
+          merge-multiple: true
+          path: sboms/
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
+        with:
+          tag_name: ${{ steps.ver.outputs.version }}
+          name: Zynax Services ${{ steps.ver.outputs.version }}
+          prerelease: ${{ contains(steps.ver.outputs.version, '-') }}
+          body: |
+            ## Zynax Services ${{ steps.ver.outputs.version }}
+
+            Service container images published to GHCR.
+
+            ### Published images
+
+            | Service | Image |
+            |---------|-------|
+            | api-gateway | `ghcr.io/zynax-io/zynax/api-gateway:${{ steps.ver.outputs.version }}` |
+            | engine-adapter | `ghcr.io/zynax-io/zynax/engine-adapter:${{ steps.ver.outputs.version }}` |
+            | workflow-compiler | `ghcr.io/zynax-io/zynax/workflow-compiler:${{ steps.ver.outputs.version }}` |
+
+            ### Verify images
+
+            ```bash
+            docker pull ghcr.io/zynax-io/zynax/api-gateway:${{ steps.ver.outputs.version }}
+            docker pull ghcr.io/zynax-io/zynax/engine-adapter:${{ steps.ver.outputs.version }}
+            docker pull ghcr.io/zynax-io/zynax/workflow-compiler:${{ steps.ver.outputs.version }}
+            ```
+
+            ### Software Bill of Materials
+
+            CycloneDX SBOM files (`api-gateway-sbom.json`, `engine-adapter-sbom.json`,
+            `workflow-compiler-sbom.json`) are attached to this release for each service image.
+          files: sboms/*.json


### PR DESCRIPTION
## Summary

Closes #379.

Adds `.github/workflows/service-release.yml` — a new workflow that builds
multi-architecture container images for the three platform services with
Dockerfiles today (`api-gateway`, `engine-adapter`, `workflow-compiler`),
pushes them to GHCR, generates a CycloneDX SBOM with syft per image, and
attaches all three SBOMs to the GitHub Release created from the triggering
tag. This is step 2 of the SBOM epic (#235); step 1 (syft in the tools image)
landed in #513.

## Source

- Issue: #379
- Parent EPIC: #235
- Canvas: N/A (`ci:` PR — exempt from SPDD per ADR-019 §Scope)
- ADR(s): ADR-016 (Layered Testing), ADR-019 (SPDD scope)
- External review section: N/A

## Approach

- **Matrix build job** (`build-push-sbom`): one job per service (`api-gateway`,
  `engine-adapter`, `workflow-compiler`) running in parallel with
  `fail-fast: false`. Each job logs in to GHCR, builds a multi-arch image
  (linux/amd64 + linux/arm64) via `docker/build-push-action`, installs
  syft v1.44.0 (pinned to match `infra/docker/Dockerfile.tools`), runs syft
  against the pushed image in `cyclonedx-json` format, and uploads the SBOM
  as a workflow artifact.
- **Release job**: depends on all matrix jobs; downloads the three SBOM
  artifacts and attaches them to the GitHub Release via
  `softprops/action-gh-release`. Release body includes the version, image
  list with GHCR pull commands, and SBOM attachment notes.
- **Trigger**: `v*.*.* tag push` (semver + pre-release) and `workflow_dispatch`
  (for manual dry-run validation per acceptance criteria).
- **Permissions**: `contents: write` (release assets), `packages: write`
  (GHCR push), `id-token: write` (reserved for cosign OIDC in #239 — must
  not be removed).
- **Action SHA pinning**: all `uses:` references are digest-pinned per project
  convention (see `pr-checks.yml` for examples).

## Test plan

Each local check must be checked with evidence (command + exit code) before merge.
CI required checks (`dco`, `lint-proto`, `lint-go`, `lint-python`, `test-unit`,
`test-integration`, `security`, `pr-size`) are verified out-of-band via
`gh pr checks <PR>` in Phase D and are not duplicated here.

### Local pre-flight (Phase B.6)
- [x] `make fmt` — N/A (no Go/Python changes)
- [x] `make lint-go` — exit 0 [0 issues across all services]
- [ ] `make lint-proto` — N/A (no proto changes)
- [ ] `make lint-python` — N/A (no Python changes)
- [x] `make test-unit` — exit 0 [all Go + Python tests pass; coverage 100% Python, ≥90% Go domain]
- [ ] `make test-coverage` — N/A (no domain/ changes)
- [ ] `make test-coverage-adapters` — N/A (no adapter changes)
- [ ] `make test-bdd` — N/A (no .feature or contract code changes)
- [x] `make gitleaks` — exit 0 [no leaks found in 201ms]
- [ ] `make validate-spec` — N/A (no spec changes)

### Acceptance (issue-specific)
- [ ] `.github/workflows/service-release.yml` created, triggering on `v*.*.*` tags and `workflow_dispatch`
- [ ] Builds container images for exactly: `api-gateway`, `engine-adapter`, `workflow-compiler`
- [ ] Each image pushed to GHCR as `ghcr.io/zynax-io/zynax/<svc>:v*.*.*` and `:latest`
- [ ] syft runs against each pushed image, `cyclonedx-json` format, output `<svc>-sbom.json`
- [ ] Three `<svc>-sbom.json` files attached to the GitHub Release
- [ ] Release notes include: version, list of images, `docker pull` instructions
- [ ] Workflow permissions include `contents: write`, `packages: write`, `id-token: write`
- [ ] SBOM generation step exits 0; non-zero exit fails the workflow
- [ ] All `uses:` action references are digest-pinned
- [ ] `actionlint` passes (validated by `pr-checks.yml` actionlint job — CI evidence)
- [ ] Dry-run validated on a feature branch with `workflow_dispatch` — CI actionlint + manual post-merge

### Engineering hygiene
- [x] Branched from latest `origin/main`
- [x] PR size within hard limit (175 LOC — `.github/workflows/` excluded per policy)
- [x] Every commit has `Signed-off-by:` (DCO)
- [x] Every commit has `Assisted-by: Claude/claude-sonnet-4-6`
- [x] No `Co-Authored-By:` for AI
- [x] No `panic` in production paths (workflow file only)
- [x] No silently-ignored errors — N/A
- [x] No new `insecure.NewCredentials()` — N/A
- [x] No new direct dependencies (workflow uses already-approved actions)
- [x] Canvas section updated — N/A (`ci:` PR, exempt per ADR-019)
- [x] `.feature` scenario added — N/A (no new gRPC boundary)
- [x] No out-of-scope changes

## Out of scope

- cosign image signing and SLSA provenance (tracked in #239 — extends this workflow)
- Agent image publication (no Dockerfiles)
- Stub service images (`agent-registry`, `task-broker`, `memory-service`, `event-bus`) — no Dockerfiles
- `make sbom` Makefile target (landed in #378 / PR #513)

## Risk

- **Blast radius:** new workflow only — no existing workflows modified, no service code touched
- **Rollback:** revert this PR. Any images pushed to GHCR remain but the release workflow stops running.
- **Behavioural change visible to users:** yes — on next `v*.*.* tag push`, service images will be published to GHCR and SBOMs attached to the release

---

🤖 *This PR was produced by Claude Code following the Resumable PR Pipeline prompt. Each checkbox is verified before merge per Phase D.3.*
