### PR TITLE
refactor(workflow-compiler): naming, zero-value structs, and functional options audit

### DIFF
--- a/services/workflow-compiler/internal/api/server.go
+++ b/services/workflow-compiler/internal/api/server.go
@@ -20,18 +20,22 @@ import (
 
 // Server implements WorkflowCompilerServiceServer using in-memory IR storage.
 // The in-memory store is appropriate for M2; a persistent backend is deferred.
+//
+// Server is not usable at zero value; always construct via New().
+// When future milestones add injectable dependencies (persistent store, tracer),
+// extend New() with functional options following the WithXxx(v) pattern.
 type Server struct {
 	zynaxv1.UnimplementedWorkflowCompilerServiceServer
-	mu    sync.RWMutex
-	store map[string]*zynaxv1.WorkflowIR
-	idGen func() string
+	mu         sync.RWMutex
+	store      map[string]*zynaxv1.WorkflowIR
+	generateID func() string
 }
 
 // New creates a Server ready to serve gRPC requests.
 func New() *Server {
 	return &Server{
-		store: make(map[string]*zynaxv1.WorkflowIR),
-		idGen: newWorkflowID,
+		store:      make(map[string]*zynaxv1.WorkflowIR),
+		generateID: generateWorkflowID,
 	}
 }
 
@@ -68,7 +72,7 @@ func (s *Server) CompileWorkflow(_ context.Context, req *zynaxv1.CompileWorkflow
 		}, nil
 	}
 
-	wfID := s.idGen()
+	wfID := s.generateID()
 	wfIR, err := ir.ToIR(g, wfID, manifest.APIVersion, time.Now().UTC())
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "IR generation: %v", err)
@@ -82,7 +86,7 @@ func (s *Server) CompileWorkflow(_ context.Context, req *zynaxv1.CompileWorkflow
 
 	durationMs := time.Since(start).Milliseconds()
 	if durationMs == 0 {
-		durationMs = 1
+		durationMs = minDurationMs
 	}
 
 	return &zynaxv1.CompileWorkflowResponse{
@@ -180,8 +184,12 @@ func toProtoErrors(errs []domain.ParseError) []*zynaxv1.CompilationError {
 	return out
 }
 
-func newWorkflowID() string {
-	b := make([]byte, 8)
-	_, _ = rand.Read(b) // crypto/rand.Read never errors on supported platforms
-	return fmt.Sprintf("wf-%s", hex.EncodeToString(b))
+// minDurationMs is the minimum value reported for compilation_duration_ms.
+// Prevents a zero duration from being misread as "not measured" by consumers.
+const minDurationMs = 1
+
+func generateWorkflowID() string {
+	randBytes := make([]byte, 8)
+	_, _ = rand.Read(randBytes) // crypto/rand.Read never errors on supported platforms
+	return fmt.Sprintf("wf-%s", hex.EncodeToString(randBytes))
 }

--- a/services/workflow-compiler/internal/domain/ir/ir.go
+++ b/services/workflow-compiler/internal/domain/ir/ir.go
@@ -110,11 +110,11 @@ func marshalInputTemplate(input map[string]interface{}) (string, error) {
 	if len(input) == 0 {
 		return "", nil
 	}
-	b, err := json.Marshal(input)
+	jsonBytes, err := json.Marshal(input)
 	if err != nil {
 		return "", fmt.Errorf("marshaling input template: %w", err)
 	}
-	return string(b), nil
+	return string(jsonBytes), nil
 }
 
 func convertTransitions(transitions []domain.Transition) []*zynaxv1.TransitionIR {

--- a/services/workflow-compiler/internal/domain/manifest.go
+++ b/services/workflow-compiler/internal/domain/manifest.go
@@ -333,10 +333,10 @@ func extractYAMLErrorLine(err error) int {
 	if err == nil {
 		return 0
 	}
-	m := yamlLineRe.FindStringSubmatch(err.Error())
-	if len(m) < 2 {
+	matches := yamlLineRe.FindStringSubmatch(err.Error())
+	if len(matches) < 2 {
 		return 0
 	}
-	n, _ := strconv.Atoi(m[1])
-	return n
+	lineNum, _ := strconv.Atoi(matches[1])
+	return lineNum
 }


### PR DESCRIPTION
## Summary

Closes #222.

Pure behaviour-preserving refactor of `services/workflow-compiler/internal/`. Renames `idGen` → `generateID` and `newWorkflowID` → `generateWorkflowID` for intent-revealing names. Extracts the magic constant `minDurationMs = 1`. Renames single-letter locals (`b` → `randBytes`, `b` → `jsonBytes`, `m`/`n` → `matches`/`lineNum`) per project convention. Documents the `Server` zero-value constraint and the functional-options extension pattern expectation on `New()`.

## Source

- Issue: #222
- Parent EPIC: #173 (Pillar 3 — Go Codebase Quality)
- Canvas: N/A — `refactor:` PR, exempt from SPDD per ADR-019
- ADR(s): ADR-019 (SPDD scope: feat: only)

## Approach

- Renamed `Server.idGen` field to `generateID` — removes an abbreviation, reveals the field's role as a function that generates IDs.
- Renamed the package-level function `newWorkflowID` → `generateWorkflowID` — "generate" is imperative and matches the field name; "new" was misleading (not a constructor).
- Extracted `const minDurationMs = 1` from the inline magic number; added a doc comment explaining why the floor exists (prevents zero being misread as "not measured").
- Renamed single-letter locals `b`, `m`, `n` → `randBytes`, `matches`, `lineNum` in three functions across two files.
- Added two-line doc extension to `Server` documenting the zero-value constraint and the future functional-options pattern expectation.

## Test plan

Each box must be `- [x]` with concrete evidence inline before merge.

CI required checks (`dco`, `lint-proto`, `lint-go`, `lint-python`, `test-unit`, `test-integration`, `security`, `pr-size`) are verified out-of-band via `gh pr checks <PR>` in Phase D and are not duplicated here.

### Local pre-flight (Phase B.6)
- [x] `make fmt` — no diff  [evidence: `gofmt -s -l .` produced no output; pre-commit gofmt hook: Passed]
- [x] `make lint-go` — exit 0  [evidence: pre-commit golangci-lint hook: Passed]
- [x] `make lint-proto` — exit 0 (N/A — no proto changes)
- [x] `make lint-python` — exit 0 (N/A — no Python changes)
- [x] `make test-unit` — exit 0  [evidence: `GOWORK=off go test ./... -race -timeout 60s -count=1` → ok internal/api 1.017s · ok internal/domain 1.015s · ok internal/domain/ir 1.012s · ok internal/domain/validators 1.012s]
- [x] `make test-coverage` — domain coverage ≥ 90%  [evidence: `GOWORK=off go test ./internal/domain/... -coverprofile=domain-coverage.out` → total: 95.1% (internal/domain: 96.2%, ir: 91.8%, validators: 95.3%)]
- [x] `make test-coverage-adapters` — (N/A — not an adapter)
- [x] `make test-bdd` — (N/A — no contract changes; no .feature files touched)
- [x] `make security` — exit 0  [evidence: pre-commit gitleaks hook: Passed; govulncheck/trivy run via CI]
- [x] `make validate-spec` — (N/A — no spec changes)

### Acceptance (issue-specific)
- [x] All domain structs audited — `Server` zero-value constraint documented in godoc; `Manifest`, `State`, `Action`, `Transition`, `WorkflowGraph`, all validator structs are zero-value usable (no constructor required).
- [x] Constructors with > 3 params use functional options — `New()` has 0 params; functional-options pattern documented for future extension; no other constructors with > 3 params exist in this service.
- [x] No single-letter variable names outside for-loop indices — verified by inspection: `b` → `randBytes` (server.go:186), `b` → `jsonBytes` (ir/ir.go:113), `m`/`n` → `matches`/`lineNum` (manifest.go:333); method receivers (`s`, `g`) are idiomatic Go and excluded per convention.
- [x] `make test` passes — exit 0 [evidence: all 4 packages pass with -race, see test-unit above]
- [x] `make lint` clean — exit 0 [evidence: golangci-lint hook passed; no new suppressions introduced]
- [x] Net line count delta neutral — [evidence: `git diff --stat`: 3 files changed, 25 insertions(+), 17 deletions(-). Net +8 is from added `Server` doc comment; implementation lines are neutral]
- [x] `grep -r "idGen\|newWorkflowID" services/workflow-compiler/` returns nothing [evidence: exit 0, output: clean]

### Engineering hygiene
- [x] Branched from latest `origin/main`
- [x] PR size within hard limit (≤ 900 LOC excluding generated) — 25+17 = 42 LOC total
- [x] Every commit has `Signed-off-by:` (DCO) — verified: `Signed-off-by: Oscar Gómez Manresa <ogomezmanresa@gmail.com>`
- [x] Every commit has `Assisted-by: Claude/claude-sonnet-4-6`
- [x] No `Co-Authored-By:` for AI
- [x] No `panic` in production paths
- [x] No silently-ignored errors (`_ = err`) without justification comment — existing `_, _ = rand.Read(randBytes)` retains its inline justification comment
- [x] No new `insecure.NewCredentials()` outside bufconn tests
- [x] No new direct dependencies
- [x] Canvas section updated (N/A — `refactor:` PR, no Canvas required per ADR-019)
- [x] `.feature` scenario added (N/A — no public gRPC boundary change)
- [x] No out-of-scope changes — only `internal/api/server.go`, `internal/domain/ir/ir.go`, `internal/domain/manifest.go` touched

## Out of scope

- Context propagation refactor (#223) — separate issue.
- Error chain consistency (#224) — separate issue.
- Functional options implementation — this PR documents the pattern expectation; implementation deferred to when > 3 injectable dependencies exist.
- `go mod tidy` on api-gateway / engine-adapter OTel indirect deps — noted in issue comment, affects different modules; not in scope for this workflow-compiler PR.

## Risk

- **Blast radius:** `services/workflow-compiler` only; `idGen`/`generateID` are unexported; no callers outside this package.
- **Rollback:** revert this PR. No data migration required.
- **Behavioural change visible to users:** No — all changes are internal renames and documentation.

---

🤖 *This PR was produced by Claude Code following the Resumable PR Pipeline prompt. Each checkbox is verified before merge per Phase D.3.*
