### PR TITLE
refactor(workflow-compiler): propagate context.Context through domain layer

### DIFF
--- a/services/workflow-compiler/internal/api/server.go
+++ b/services/workflow-compiler/internal/api/server.go
@@ -41,14 +41,14 @@ func New() *Server {
 
 // CompileWorkflow parses, validates, and compiles a YAML manifest into a WorkflowIR.
 // The compiled IR is stored unless dry_run is true.
-func (s *Server) CompileWorkflow(_ context.Context, req *zynaxv1.CompileWorkflowRequest) (*zynaxv1.CompileWorkflowResponse, error) {
+func (s *Server) CompileWorkflow(ctx context.Context, req *zynaxv1.CompileWorkflowRequest) (*zynaxv1.CompileWorkflowResponse, error) {
 	if len(req.ManifestYaml) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "manifest_yaml must not be empty")
 	}
 
 	start := time.Now()
 
-	manifest, parseErrs := domain.ParseManifest(req.ManifestYaml)
+	manifest, parseErrs := domain.ParseManifest(ctx, req.ManifestYaml)
 	if len(parseErrs) > 0 {
 		return &zynaxv1.CompileWorkflowResponse{
 			Errors: toProtoErrors(parseErrs),
@@ -59,21 +59,21 @@ func (s *Server) CompileWorkflow(_ context.Context, req *zynaxv1.CompileWorkflow
 		manifest.Namespace = req.Namespace
 	}
 
-	g, buildErrs := domain.Build(manifest)
+	g, buildErrs := domain.Build(ctx, manifest)
 	if len(buildErrs) > 0 {
 		return &zynaxv1.CompileWorkflowResponse{
 			Errors: toProtoErrors(buildErrs),
 		}, nil
 	}
 
-	if validationErrs := validators.Run(g, validators.All()...); len(validationErrs) > 0 {
+	if validationErrs := validators.Run(ctx, g, validators.All()...); len(validationErrs) > 0 {
 		return &zynaxv1.CompileWorkflowResponse{
 			Errors: toProtoErrors(validationErrs),
 		}, nil
 	}
 
 	wfID := s.generateID()
-	wfIR, err := ir.ToIR(g, wfID, manifest.APIVersion, time.Now().UTC())
+	wfIR, err := ir.ToIR(ctx, g, wfID, manifest.APIVersion, time.Now().UTC())
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "IR generation: %v", err)
 	}
@@ -97,12 +97,12 @@ func (s *Server) CompileWorkflow(_ context.Context, req *zynaxv1.CompileWorkflow
 
 // ValidateManifest checks a manifest for structural correctness without persisting anything.
 // All errors found are returned — not just the first.
-func (s *Server) ValidateManifest(_ context.Context, req *zynaxv1.ValidateManifestRequest) (*zynaxv1.ValidateManifestResponse, error) {
+func (s *Server) ValidateManifest(ctx context.Context, req *zynaxv1.ValidateManifestRequest) (*zynaxv1.ValidateManifestResponse, error) {
 	if len(req.ManifestYaml) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "manifest_yaml must not be empty")
 	}
 
-	manifest, parseErrs := domain.ParseManifest(req.ManifestYaml)
+	manifest, parseErrs := domain.ParseManifest(ctx, req.ManifestYaml)
 	if len(parseErrs) > 0 {
 		return &zynaxv1.ValidateManifestResponse{
 			Valid:  false,
@@ -112,11 +112,11 @@ func (s *Server) ValidateManifest(_ context.Context, req *zynaxv1.ValidateManife
 
 	var allErrs []domain.ParseError
 
-	g, buildErrs := domain.Build(manifest)
+	g, buildErrs := domain.Build(ctx, manifest)
 	allErrs = append(allErrs, buildErrs...)
 
 	if g != nil {
-		allErrs = append(allErrs, validators.Run(g, validators.All()...)...)
+		allErrs = append(allErrs, validators.Run(ctx, g, validators.All()...)...)
 	}
 
 	return &zynaxv1.ValidateManifestResponse{

--- a/services/workflow-compiler/internal/domain/graph.go
+++ b/services/workflow-compiler/internal/domain/graph.go
@@ -1,6 +1,9 @@
 package domain
 
-import "fmt"
+import (
+	"context"
+	"fmt"
+)
 
 // WorkflowGraph is the directed state machine built from a parsed Manifest.
 // Nodes are States; edges are the Transitions embedded in each State,
@@ -19,7 +22,7 @@ type WorkflowGraph struct {
 //   - no orphan states (unreachable from initial_state via transitions)
 //
 // Returns all errors found — not just the first.
-func Build(m *Manifest) (*WorkflowGraph, ParseErrors) {
+func Build(_ context.Context, m *Manifest) (*WorkflowGraph, ParseErrors) {
 	var errs ParseErrors
 
 	// initial_state must reference a known state.

--- a/services/workflow-compiler/internal/domain/graph_test.go
+++ b/services/workflow-compiler/internal/domain/graph_test.go
@@ -1,6 +1,7 @@
 package domain
 
 import (
+	"context"
 	"testing"
 )
 
@@ -28,7 +29,7 @@ func buildMinimalManifest() *Manifest {
 }
 
 func TestBuild_Valid(t *testing.T) {
-	g, errs := Build(buildMinimalManifest())
+	g, errs := Build(context.Background(), buildMinimalManifest())
 	if len(errs) != 0 {
 		t.Fatalf("expected no errors, got %v", errs)
 	}
@@ -43,7 +44,7 @@ func TestBuild_Valid(t *testing.T) {
 func TestBuild_UnknownInitialState(t *testing.T) {
 	m := buildMinimalManifest()
 	m.InitialState = "nonexistent"
-	_, errs := Build(m)
+	_, errs := Build(context.Background(), m)
 	if len(errs) == 0 {
 		t.Fatal("expected error for unknown initial_state")
 	}
@@ -64,7 +65,7 @@ func TestBuild_TransitionToUnknownState(t *testing.T) {
 		EventType:   "oops",
 		TargetState: "ghost",
 	})
-	_, errs := Build(m)
+	_, errs := Build(context.Background(), m)
 	if len(errs) == 0 {
 		t.Fatal("expected error for unknown transition target")
 	}
@@ -101,7 +102,7 @@ func TestBuild_NoTerminalState(t *testing.T) {
 			},
 		},
 	}
-	_, errs := Build(m)
+	_, errs := Build(context.Background(), m)
 	if len(errs) == 0 {
 		t.Fatal("expected error for no terminal state")
 	}
@@ -139,7 +140,7 @@ func TestBuild_OrphanState(t *testing.T) {
 			},
 		},
 	}
-	_, errs := Build(m)
+	_, errs := Build(context.Background(), m)
 	if len(errs) == 0 {
 		t.Fatal("expected error for orphan state")
 	}
@@ -169,14 +170,14 @@ func TestBuild_MultipleErrors(t *testing.T) {
 			},
 		},
 	}
-	_, errs := Build(m)
+	_, errs := Build(context.Background(), m)
 	if len(errs) < 2 {
 		t.Errorf("expected multiple errors, got %d: %v", len(errs), errs)
 	}
 }
 
 func TestTransitionsFor_Match(t *testing.T) {
-	g, errs := Build(buildMinimalManifest())
+	g, errs := Build(context.Background(), buildMinimalManifest())
 	if len(errs) != 0 {
 		t.Fatalf("build failed: %v", errs)
 	}
@@ -187,7 +188,7 @@ func TestTransitionsFor_Match(t *testing.T) {
 }
 
 func TestTransitionsFor_NoMatch(t *testing.T) {
-	g, _ := Build(buildMinimalManifest())
+	g, _ := Build(context.Background(), buildMinimalManifest())
 	ts := g.TransitionsFor("start", "unknown.event")
 	if len(ts) != 0 {
 		t.Errorf("expected 0 transitions, got %d", len(ts))
@@ -195,7 +196,7 @@ func TestTransitionsFor_NoMatch(t *testing.T) {
 }
 
 func TestTransitionsFor_UnknownState(t *testing.T) {
-	g, _ := Build(buildMinimalManifest())
+	g, _ := Build(context.Background(), buildMinimalManifest())
 	ts := g.TransitionsFor("nonexistent", "any.event")
 	if ts != nil {
 		t.Errorf("expected nil for unknown state, got %v", ts)
@@ -203,7 +204,7 @@ func TestTransitionsFor_UnknownState(t *testing.T) {
 }
 
 func TestTerminalStates(t *testing.T) {
-	g, _ := Build(buildMinimalManifest())
+	g, _ := Build(context.Background(), buildMinimalManifest())
 	ts := g.TerminalStates()
 	if len(ts) != 1 || ts[0] != "done" {
 		t.Errorf("TerminalStates() = %v, want [done]", ts)
@@ -228,7 +229,7 @@ func TestTerminalStates_Multiple(t *testing.T) {
 			"failure": {ID: "failure", Type: StateTypeTerminal},
 		},
 	}
-	g, errs := Build(m)
+	g, errs := Build(context.Background(), m)
 	if len(errs) != 0 {
 		t.Fatalf("build failed: %v", errs)
 	}
@@ -256,11 +257,11 @@ spec:
     finish:
       type: terminal
 `)
-	m, parseErrs := ParseManifest(data)
+	m, parseErrs := ParseManifest(context.Background(), data)
 	if len(parseErrs) != 0 {
 		t.Fatalf("parse failed: %v", parseErrs)
 	}
-	g, buildErrs := Build(m)
+	g, buildErrs := Build(context.Background(), m)
 	if len(buildErrs) != 0 {
 		t.Fatalf("build failed: %v", buildErrs)
 	}

--- a/services/workflow-compiler/internal/domain/ir/ir.go
+++ b/services/workflow-compiler/internal/domain/ir/ir.go
@@ -2,6 +2,7 @@
 package ir
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"sort"
@@ -18,7 +19,7 @@ const irVersion = "v1"
 // ToIR converts a validated WorkflowGraph to a proto WorkflowIR.
 // workflowID and apiVersion are caller-supplied envelope values.
 // compiledAt defaults to time.Now() when zero.
-func ToIR(g *domain.WorkflowGraph, workflowID, apiVersion string, compiledAt time.Time) (*zynaxv1.WorkflowIR, error) {
+func ToIR(_ context.Context, g *domain.WorkflowGraph, workflowID, apiVersion string, compiledAt time.Time) (*zynaxv1.WorkflowIR, error) {
 	if g == nil {
 		return nil, fmt.Errorf("graph must not be nil")
 	}

--- a/services/workflow-compiler/internal/domain/ir/ir_test.go
+++ b/services/workflow-compiler/internal/domain/ir/ir_test.go
@@ -1,6 +1,7 @@
 package ir_test
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 	"time"
@@ -36,7 +37,7 @@ func minimalGraph() *domain.WorkflowGraph {
 }
 
 func call(g *domain.WorkflowGraph) (*zynaxv1.WorkflowIR, error) {
-	return ir.ToIR(g, "wf-001", "zynax.io/v1alpha1", time.Time{}) //nolint:wrapcheck
+	return ir.ToIR(context.Background(), g, "wf-001", "zynax.io/v1alpha1", time.Time{}) //nolint:wrapcheck
 }
 
 // ToIR basic shape ─────────────────────────────────────────────────────────────
@@ -121,7 +122,7 @@ func TestToIR_StateTypes(t *testing.T) {
 					"s": {ID: "s", Type: tc.domainType},
 				},
 			}
-			wfIR, err := ir.ToIR(g, "id", "v1", time.Time{})
+			wfIR, err := ir.ToIR(context.Background(), g, "id", "v1", time.Time{})
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -180,7 +181,7 @@ func TestToIR_TransitionConditions(t *testing.T) {
 			"b": {ID: "b", Type: domain.StateTypeTerminal},
 		},
 	}
-	wfIR, err := ir.ToIR(g, "id", "v1", time.Time{})
+	wfIR, err := ir.ToIR(context.Background(), g, "id", "v1", time.Time{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -222,7 +223,7 @@ func TestToIR_ActionFields(t *testing.T) {
 			},
 		},
 	}
-	wfIR, err := ir.ToIR(g, "id", "v1", time.Time{})
+	wfIR, err := ir.ToIR(context.Background(), g, "id", "v1", time.Time{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -276,7 +277,7 @@ func TestToIR_TerminalStateHasNoTransitions(t *testing.T) {
 
 func TestToIR_CompiledAtExplicit(t *testing.T) {
 	ts := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
-	wfIR, err := ir.ToIR(minimalGraph(), "id", "v1", ts)
+	wfIR, err := ir.ToIR(context.Background(), minimalGraph(), "id", "v1", ts)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -288,14 +289,14 @@ func TestToIR_CompiledAtExplicit(t *testing.T) {
 // Validation errors ────────────────────────────────────────────────────────────
 
 func TestToIR_NilGraphReturnsError(t *testing.T) {
-	_, err := ir.ToIR(nil, "id", "v1", time.Time{})
+	_, err := ir.ToIR(context.Background(), nil, "id", "v1", time.Time{})
 	if err == nil {
 		t.Error("expected error for nil graph, got nil")
 	}
 }
 
 func TestToIR_EmptyWorkflowIDReturnsError(t *testing.T) {
-	_, err := ir.ToIR(minimalGraph(), "", "v1", time.Time{})
+	_, err := ir.ToIR(context.Background(), minimalGraph(), "", "v1", time.Time{})
 	if err == nil {
 		t.Error("expected error for empty workflowID, got nil")
 	}
@@ -327,7 +328,7 @@ func TestToIR_HITLGraph(t *testing.T) {
 			"done": {ID: "done", Type: domain.StateTypeTerminal},
 		},
 	}
-	wfIR, err := ir.ToIR(g, "wf-002", "zynax.io/v1alpha1", time.Time{})
+	wfIR, err := ir.ToIR(context.Background(), g, "wf-002", "zynax.io/v1alpha1", time.Time{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/services/workflow-compiler/internal/domain/manifest.go
+++ b/services/workflow-compiler/internal/domain/manifest.go
@@ -1,6 +1,7 @@
 package domain
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -113,7 +114,7 @@ type yamlTransition struct {
 // ParseManifest parses raw YAML bytes into a domain Manifest.
 // Returns all errors found — not just the first — to let callers surface all
 // problems in a single response. Returns (nil, errs) on any error.
-func ParseManifest(data []byte) (*Manifest, ParseErrors) { //nolint:funlen // four sequential validation phases (YAML→decode→top-level→states) are one concern
+func ParseManifest(_ context.Context, data []byte) (*Manifest, ParseErrors) { //nolint:funlen // four sequential validation phases (YAML→decode→top-level→states) are one concern
 	// Phase 1: YAML syntax — parse into yaml.Node for source position info.
 	var root yaml.Node
 	if err := yaml.Unmarshal(data, &root); err != nil {

--- a/services/workflow-compiler/internal/domain/manifest_test.go
+++ b/services/workflow-compiler/internal/domain/manifest_test.go
@@ -1,6 +1,7 @@
 package domain
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -68,7 +69,7 @@ spec:
 }
 
 func TestParseManifest_MinimalValid(t *testing.T) {
-	m, errs := ParseManifest(minimalValid())
+	m, errs := ParseManifest(context.Background(), minimalValid())
 	if len(errs) != 0 {
 		t.Fatalf("expected no errors, got %v", errs)
 	}
@@ -91,7 +92,7 @@ func TestParseManifest_MinimalValid(t *testing.T) {
 }
 
 func TestParseManifest_FullValid(t *testing.T) {
-	m, errs := ParseManifest(fullValid())
+	m, errs := ParseManifest(context.Background(), fullValid())
 	if len(errs) != 0 {
 		t.Fatalf("expected no errors, got %v", errs)
 	}
@@ -144,7 +145,7 @@ func TestParseManifest_FullValid(t *testing.T) {
 
 func TestParseManifest_InvalidYAML(t *testing.T) {
 	bad := []byte("key: [unterminated")
-	_, errs := ParseManifest(bad)
+	_, errs := ParseManifest(context.Background(), bad)
 	if len(errs) == 0 {
 		t.Fatal("expected parse errors for invalid YAML")
 	}
@@ -154,7 +155,7 @@ func TestParseManifest_InvalidYAML(t *testing.T) {
 }
 
 func TestParseManifest_Empty(t *testing.T) {
-	_, errs := ParseManifest([]byte(""))
+	_, errs := ParseManifest(context.Background(), []byte(""))
 	if len(errs) == 0 {
 		t.Fatal("expected error for empty manifest")
 	}
@@ -175,7 +176,7 @@ spec:
     s:
       type: terminal
 `)
-	_, errs := ParseManifest(data)
+	_, errs := ParseManifest(context.Background(), data)
 	if len(errs) == 0 {
 		t.Fatal("expected error for wrong kind")
 	}
@@ -202,7 +203,7 @@ spec:
     s:
       type: terminal
 `)
-	_, errs := ParseManifest(data)
+	_, errs := ParseManifest(context.Background(), data)
 	if len(errs) == 0 {
 		t.Fatal("expected error for missing name")
 	}
@@ -222,7 +223,7 @@ spec:
     s:
       type: terminal
 `)
-	_, errs := ParseManifest(data)
+	_, errs := ParseManifest(context.Background(), data)
 	if len(errs) == 0 {
 		t.Fatal("expected error for missing initial_state")
 	}
@@ -246,7 +247,7 @@ metadata:
 spec:
   initial_state: s
 `)
-	_, errs := ParseManifest(data)
+	_, errs := ParseManifest(context.Background(), data)
 	if len(errs) == 0 {
 		t.Fatal("expected error for empty states")
 	}
@@ -264,7 +265,7 @@ spec:
     s:
       type: bogus_type
 `)
-	_, errs := ParseManifest(data)
+	_, errs := ParseManifest(context.Background(), data)
 	if len(errs) == 0 {
 		t.Fatal("expected error for invalid state type")
 	}
@@ -287,7 +288,7 @@ spec:
       actions:
         - timeout: 5s
 `)
-	_, errs := ParseManifest(data)
+	_, errs := ParseManifest(context.Background(), data)
 	if len(errs) == 0 {
 		t.Fatal("expected error for missing action capability")
 	}
@@ -311,7 +312,7 @@ spec:
         - capability: ping
           timeout: "not-a-duration"
 `)
-	_, errs := ParseManifest(data)
+	_, errs := ParseManifest(context.Background(), data)
 	if len(errs) == 0 {
 		t.Fatal("expected error for invalid timeout")
 	}
@@ -336,7 +337,7 @@ spec:
     done:
       type: terminal
 `)
-	_, errs := ParseManifest(data)
+	_, errs := ParseManifest(context.Background(), data)
 	if len(errs) == 0 {
 		t.Fatal("expected error for missing transition event")
 	}
@@ -361,7 +362,7 @@ spec:
     done:
       type: terminal
 `)
-	_, errs := ParseManifest(data)
+	_, errs := ParseManifest(context.Background(), data)
 	if len(errs) == 0 {
 		t.Fatal("expected error for missing transition goto")
 	}
@@ -371,7 +372,7 @@ spec:
 }
 
 func TestParseManifest_DefaultNamespace(t *testing.T) {
-	m, errs := ParseManifest(minimalValid())
+	m, errs := ParseManifest(context.Background(), minimalValid())
 	if len(errs) != 0 {
 		t.Fatalf("unexpected errors: %v", errs)
 	}
@@ -381,7 +382,7 @@ func TestParseManifest_DefaultNamespace(t *testing.T) {
 }
 
 func TestParseManifest_StateLineNumbers(t *testing.T) {
-	m, errs := ParseManifest(fullValid())
+	m, errs := ParseManifest(context.Background(), fullValid())
 	if len(errs) != 0 {
 		t.Fatalf("unexpected errors: %v", errs)
 	}

--- a/services/workflow-compiler/internal/domain/validators/semantic.go
+++ b/services/workflow-compiler/internal/domain/validators/semantic.go
@@ -1,6 +1,7 @@
 package validators
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 
@@ -26,7 +27,7 @@ type CapabilityRefValidator struct{}
 var reservedPrefixes = []string{"zynax_", "system_", "internal_"}
 
 // Validate implements Validator.
-func (CapabilityRefValidator) Validate(g *domain.WorkflowGraph) []domain.ParseError {
+func (CapabilityRefValidator) Validate(_ context.Context, g *domain.WorkflowGraph) []domain.ParseError {
 	var errs []domain.ParseError
 	for stateID, state := range g.States {
 		for i, action := range state.Actions {
@@ -61,7 +62,7 @@ func (CapabilityRefValidator) Validate(g *domain.WorkflowGraph) []domain.ParseEr
 type EventNameValidator struct{}
 
 // Validate implements Validator.
-func (EventNameValidator) Validate(g *domain.WorkflowGraph) []domain.ParseError {
+func (EventNameValidator) Validate(_ context.Context, g *domain.WorkflowGraph) []domain.ParseError {
 	var errs []domain.ParseError
 	for stateID, state := range g.States {
 		for _, t := range state.Transitions {
@@ -83,7 +84,7 @@ func (EventNameValidator) Validate(g *domain.WorkflowGraph) []domain.ParseError 
 type NamespaceValidator struct{}
 
 // Validate implements Validator.
-func (NamespaceValidator) Validate(g *domain.WorkflowGraph) []domain.ParseError {
+func (NamespaceValidator) Validate(_ context.Context, g *domain.WorkflowGraph) []domain.ParseError {
 	ns := g.Namespace
 	if ns == "" {
 		return nil // empty namespace is caught by the manifest parser
@@ -110,7 +111,7 @@ func (NamespaceValidator) Validate(g *domain.WorkflowGraph) []domain.ParseError 
 type DuplicateTransitionValidator struct{}
 
 // Validate implements Validator.
-func (DuplicateTransitionValidator) Validate(g *domain.WorkflowGraph) []domain.ParseError {
+func (DuplicateTransitionValidator) Validate(_ context.Context, g *domain.WorkflowGraph) []domain.ParseError {
 	var errs []domain.ParseError
 	for stateID, state := range g.States {
 		seen := make(map[string]struct{}, len(state.Transitions))

--- a/services/workflow-compiler/internal/domain/validators/semantic_test.go
+++ b/services/workflow-compiler/internal/domain/validators/semantic_test.go
@@ -1,6 +1,7 @@
 package validators_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/zynax-io/zynax/services/workflow-compiler/internal/domain"
@@ -43,7 +44,7 @@ func TestCapabilityRefValidator(t *testing.T) {
 					},
 				},
 			})
-			errs := v.Validate(g)
+			errs := v.Validate(context.Background(), g)
 			if tc.wantErr && len(errs) == 0 {
 				t.Errorf("capability %q: expected error, got none", tc.capability)
 			}
@@ -58,7 +59,7 @@ func TestCapabilityRefValidator_NoActions(t *testing.T) {
 	g := graphWith("s", map[string]*domain.State{
 		"s": {ID: "s", Type: domain.StateTypeTerminal},
 	})
-	if errs := (validators.CapabilityRefValidator{}).Validate(g); len(errs) != 0 {
+	if errs := (validators.CapabilityRefValidator{}).Validate(context.Background(), g); len(errs) != 0 {
 		t.Errorf("expected no errors for state with no actions, got %v", errs)
 	}
 }
@@ -91,7 +92,7 @@ func TestEventNameValidator(t *testing.T) {
 				"a": normalState("a", tr(tc.eventType, "b")),
 				"b": terminalState(),
 			})
-			errs := v.Validate(g)
+			errs := v.Validate(context.Background(), g)
 			if tc.wantErr && len(errs) == 0 {
 				t.Errorf("event_type %q: expected error, got none", tc.eventType)
 			}
@@ -106,7 +107,7 @@ func TestEventNameValidator_NoTransitions(t *testing.T) {
 	g := graphWith("s", map[string]*domain.State{
 		"s": {ID: "s", Type: domain.StateTypeTerminal},
 	})
-	if errs := (validators.EventNameValidator{}).Validate(g); len(errs) != 0 {
+	if errs := (validators.EventNameValidator{}).Validate(context.Background(), g); len(errs) != 0 {
 		t.Errorf("expected no errors for state with no transitions, got %v", errs)
 	}
 }
@@ -140,7 +141,7 @@ func TestNamespaceValidator(t *testing.T) {
 				"s": terminalState(),
 			})
 			g.Namespace = tc.namespace
-			errs := v.Validate(g)
+			errs := v.Validate(context.Background(), g)
 			if tc.wantErr && len(errs) == 0 {
 				t.Errorf("namespace %q: expected error, got none", tc.namespace)
 			}
@@ -209,7 +210,7 @@ func TestDuplicateTransitionValidator(t *testing.T) {
 	v := validators.DuplicateTransitionValidator{}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			errs := v.Validate(tc.g)
+			errs := v.Validate(context.Background(), tc.g)
 			if tc.wantErr && len(errs) == 0 {
 				t.Error("expected error, got none")
 			}

--- a/services/workflow-compiler/internal/domain/validators/structural.go
+++ b/services/workflow-compiler/internal/domain/validators/structural.go
@@ -1,6 +1,7 @@
 package validators
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -13,7 +14,7 @@ import (
 type TerminalStateValidator struct{}
 
 // Validate implements Validator.
-func (TerminalStateValidator) Validate(g *domain.WorkflowGraph) []domain.ParseError {
+func (TerminalStateValidator) Validate(_ context.Context, g *domain.WorkflowGraph) []domain.ParseError {
 	for _, s := range g.States {
 		if s.Type == domain.StateTypeTerminal {
 			return nil
@@ -30,7 +31,7 @@ func (TerminalStateValidator) Validate(g *domain.WorkflowGraph) []domain.ParseEr
 type OrphanStateValidator struct{}
 
 // Validate implements Validator.
-func (OrphanStateValidator) Validate(g *domain.WorkflowGraph) []domain.ParseError {
+func (OrphanStateValidator) Validate(_ context.Context, g *domain.WorkflowGraph) []domain.ParseError {
 	reachable := reachableFrom(g, g.InitialState)
 	var errs []domain.ParseError
 	for id, state := range g.States {
@@ -54,7 +55,7 @@ func (OrphanStateValidator) Validate(g *domain.WorkflowGraph) []domain.ParseErro
 type CircularTransitionDetector struct{}
 
 // Validate implements Validator.
-func (CircularTransitionDetector) Validate(g *domain.WorkflowGraph) []domain.ParseError { //nolint:funlen // DFS with cycle reporting requires tracking stack and visited sets in one pass
+func (CircularTransitionDetector) Validate(_ context.Context, g *domain.WorkflowGraph) []domain.ParseError { //nolint:funlen // DFS with cycle reporting requires tracking stack and visited sets in one pass
 	productive := productiveStates(g)
 
 	// DFS with three-colour marking:

--- a/services/workflow-compiler/internal/domain/validators/structural_test.go
+++ b/services/workflow-compiler/internal/domain/validators/structural_test.go
@@ -1,6 +1,7 @@
 package validators_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/zynax-io/zynax/services/workflow-compiler/internal/domain"
@@ -75,7 +76,7 @@ func TestTerminalStateValidator(t *testing.T) {
 	v := validators.TerminalStateValidator{}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			errs := v.Validate(tc.g)
+			errs := v.Validate(context.Background(), tc.g)
 			if tc.wantErr && len(errs) == 0 {
 				t.Error("expected error, got none")
 			}
@@ -125,7 +126,7 @@ func TestOrphanStateValidator(t *testing.T) {
 	v := validators.OrphanStateValidator{}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			errs := v.Validate(tc.g)
+			errs := v.Validate(context.Background(), tc.g)
 			if tc.wantOrphan == "" && len(errs) != 0 {
 				t.Errorf("expected no error, got %v", errs)
 			}
@@ -204,7 +205,7 @@ func TestCircularTransitionDetector(t *testing.T) {
 	v := validators.CircularTransitionDetector{}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			errs := v.Validate(tc.g)
+			errs := v.Validate(context.Background(), tc.g)
 			if tc.wantErr && len(errs) == 0 {
 				t.Error("expected error, got none")
 			}
@@ -225,7 +226,7 @@ func TestRun_AccumulatesErrors(t *testing.T) {
 		"a": normalState("a", tr("loop", "a")),
 		// no terminal + trapped cycle — two validators should each fire
 	})
-	errs := validators.Run(g, validators.All()...)
+	errs := validators.Run(context.Background(), g, validators.All()...)
 	if len(errs) == 0 {
 		t.Error("expected errors from multiple validators, got none")
 	}
@@ -236,7 +237,7 @@ func TestRun_NoErrors(t *testing.T) {
 		"a": normalState("a", tr("go", "b")),
 		"b": terminalState(),
 	})
-	errs := validators.Run(g, validators.All()...)
+	errs := validators.Run(context.Background(), g, validators.All()...)
 	if len(errs) != 0 {
 		t.Errorf("expected no errors, got %v", errs)
 	}

--- a/services/workflow-compiler/internal/domain/validators/validators.go
+++ b/services/workflow-compiler/internal/domain/validators/validators.go
@@ -6,20 +6,24 @@
 //	errs := validators.Run(graph, validators.All()...)
 package validators
 
-import "github.com/zynax-io/zynax/services/workflow-compiler/internal/domain"
+import (
+	"context"
+
+	"github.com/zynax-io/zynax/services/workflow-compiler/internal/domain"
+)
 
 // Validator checks a WorkflowGraph for a single category of errors.
 // Each implementation is stateless and safe for concurrent use.
 type Validator interface {
-	Validate(g *domain.WorkflowGraph) []domain.ParseError
+	Validate(ctx context.Context, g *domain.WorkflowGraph) []domain.ParseError
 }
 
 // Run applies each validator to g and accumulates all errors.
 // Validators are applied in order; all run even when earlier ones find errors.
-func Run(g *domain.WorkflowGraph, vs ...Validator) []domain.ParseError {
+func Run(ctx context.Context, g *domain.WorkflowGraph, vs ...Validator) []domain.ParseError {
 	var errs []domain.ParseError
 	for _, v := range vs {
-		errs = append(errs, v.Validate(g)...)
+		errs = append(errs, v.Validate(ctx, g)...)
 	}
 	return errs
 }


### PR DESCRIPTION
## Summary

Closes #223.

gRPC handlers in `workflow-compiler` previously discarded the incoming request context (`_ context.Context`). The seven public domain functions (`ParseManifest`, `Build`, `Validator.Validate`, `validators.Run`, `ir.ToIR`) accepted no context, making deadline and cancellation propagation impossible below the gRPC transport boundary. This refactor threads context from the two handlers that call domain code through to every domain function on the request path.

## Source

- Issue: #223
- Parent EPIC: #173 (Pillar 3 — Go Codebase Quality, GO-2)
- Canvas: N/A — `refactor:` PR, exempt from SPDD per ADR-019
- ADR(s): ADR-019 (SPDD scope: `feat:` only)

## Approach

- `CompileWorkflow` and `ValidateManifest` gRPC handlers renamed `_ context.Context` → `ctx context.Context` and thread ctx to all domain calls.
- `GetCompiledWorkflow` retains `_ context.Context` — its only operation is an in-memory map lookup; no downstream function accepts ctx.
- `ParseManifest`, `Build`, and `ir.ToIR` gain `_ context.Context` as first parameter (pure in-memory functions; `_` signals not used today but available for future I/O additions without a signature break).
- `Validator` interface gains `ctx context.Context` as first parameter; all seven implementations use `_ context.Context` (pure graph analysis, no I/O).
- `validators.Run` gains `ctx context.Context` and threads it to each `v.Validate(ctx, g)` call.
- 47 test call sites updated to pass `context.Background()` (test files are exempt from the domain context rule per the issue acceptance criteria).

## Test plan

Each box must be `- [x]` with concrete evidence inline before merge. CI required checks (`dco`, `lint-proto`, `lint-go`, `lint-python`, `test-unit`, `test-integration`, `security`, `pr-size`) are verified out-of-band via `gh pr checks <PR>` in Phase D.

### Local pre-flight (Phase B.6)
- [x] `make fmt` — no diff  [evidence: pre-commit `gofmt` hook: Passed]
- [x] `make lint-go` — exit 0  [evidence: pre-commit `golangci-lint` hook: Passed]
- [x] `make lint-proto` — exit 0 (N/A — no proto changes)
- [x] `make lint-python` — exit 0 (N/A — no Python changes)
- [x] `make test-unit` — exit 0  [evidence: `GOWORK=off go test ./... -race -timeout 60s -count=1` → ok internal/api 1.017s · ok internal/domain 1.014s · ok internal/domain/ir 1.013s · ok internal/domain/validators 1.012s]
- [x] `make test-coverage` — domain coverage ≥ 90%  [evidence: `GOWORK=off go test ./internal/domain/... -coverprofile=domain-coverage.out` → internal/domain: 96.2% · domain/ir: 91.8% · domain/validators: 95.3% · total: 95.1%]
- [x] `make test-coverage-adapters` — (N/A — not an adapter)
- [x] `make test-bdd` — (N/A — no contract changes; no .feature files touched)
- [x] `make security` — exit 0  [evidence: pre-commit `gitleaks` hook: Passed; govulncheck/trivy run via CI]
- [x] `make validate-spec` — (N/A — no spec changes)

### Acceptance (issue-specific)
- [x] Every domain function on the request path accepts `context.Context` as first parameter — verified by inspection of `server.go:44,100`, `manifest.go:117`, `graph.go:22`, `validators/validators.go:19`, `validators/structural.go:16,34,58`, `validators/semantic.go:29,64,86,113`, `ir/ir.go:21`
- [x] `context.Context` propagated from gRPC handler through to the deepest domain call — verified: `CompileWorkflow` passes ctx to `ParseManifest` → `Build` → `validators.Run` (which passes ctx to each validator) → `ir.ToIR`; `ValidateManifest` same path
- [x] No `context.Background()` or `context.TODO()` in domain production code (only in `_test.go`) — verified: `grep -rn "context\.Background\|context\.TODO" services/workflow-compiler/internal/domain/ --include="*.go" | grep -v "_test\.go"` → exit 0, no output
- [x] `GetCompiledWorkflow` correctly retains `_ context.Context` — no domain calls downstream accept ctx; verified by inspection of `server.go:129`
- [x] Engine-adapter infra `context.Background()` in `IRInterpreterWorkflow` — out of scope: Temporal SDK uses `workflow.Context`, not `context.Context`; domain cancellation propagates through the stored `workflow.Context` in the executor/publisher
- [x] `make test` passes — exit 0  [evidence: all 4 packages pass with -race, see test-unit above]

### Engineering hygiene
- [x] Branched from latest `origin/main`
- [x] PR size within hard limit (≤ 900 LOC excluding generated) — 87+71 = 158 LOC total
- [x] Every commit has `Signed-off-by:` (DCO) — `Signed-off-by: Oscar Gómez Manresa <ogomezmanresa@gmail.com>`
- [x] Every commit has `Assisted-by: Claude/claude-sonnet-4-6`
- [x] No `Co-Authored-By:` for AI
- [x] No `panic` in production paths
- [x] No silently-ignored errors (`_ = err`) without justification comment
- [x] No new `insecure.NewCredentials()` outside bufconn tests
- [x] No new direct dependencies
- [x] Canvas section updated (N/A — `refactor:` PR, no Canvas required per ADR-019)
- [x] `.feature` scenario added (N/A — no public gRPC boundary change; internal domain refactor only)
- [x] No out-of-scope changes — only `services/workflow-compiler/internal/` touched

## Out of scope

- engine-adapter infra `context.Background()` in `IRInterpreterWorkflow` (`temporal_workflow.go:31`) — the Temporal Go SDK uses `workflow.Context`, which is not `context.Context`; the domain correctly receives cancellation signals through errors returned by `workflow.ExecuteActivity().Get()` when Temporal cancels the workflow. Separate follow-up if needed.
- engine-adapter infra `_ context.Context` in `DispatchCapability` and `Publish` — intentional: these implementations use the stored `workflow.Context` and don't need the Go standard context.
- Integration tests for end-to-end deadline/cancellation propagation (api-gateway → workflow-compiler over gRPC with a running stack) — requires `testcontainers-go`; separate follow-up issue.
- Context propagation for `agent-registry`, `task-broker`, `memory-service`, `event-bus` — these services have no `internal/domain/` layer yet (M5 in-progress); domain ctx will be included when those layers are built.

## Risk

- **Blast radius:** `services/workflow-compiler` only; all domain functions are internal. No proto, REST, or CLI interface change.
- **Rollback:** revert this PR. No data migration required.
- **Behavioural change visible to users:** No — all changes are signature additions with no functional difference for callers passing the gRPC context.

---

🤖 *This PR was produced by Claude Code following the Resumable PR Pipeline prompt. Each checkbox is verified before merge per Phase D.3.*
