### PR TITLE
feat(task-broker): domain layer — model, ports, and TaskService

### DIFF
--- a/go.work
+++ b/go.work
@@ -9,5 +9,6 @@ use (
 	./protos/generated/go
 	./services/api-gateway
 	./services/engine-adapter
+	./services/task-broker
 	./services/workflow-compiler
 )

--- a/services/task-broker/go.mod
+++ b/services/task-broker/go.mod
@@ -1,0 +1,3 @@
+module github.com/zynax-io/zynax/services/task-broker
+
+go 1.22.0

--- a/services/task-broker/internal/domain/errors.go
+++ b/services/task-broker/internal/domain/errors.go
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package domain
+
+import "errors"
+
+// Sentinel errors returned by TaskService. All are safe to wrap with fmt.Errorf("%w", ...).
+var (
+	// ErrTaskNotFound is returned when a task_id is unknown.
+	ErrTaskNotFound = errors.New("task not found")
+	// ErrNoEligibleAgent is returned when no active agent declares the requested capability.
+	ErrNoEligibleAgent = errors.New("no eligible agent for capability")
+	// ErrTaskTerminal is returned when an operation is attempted on a terminal task.
+	ErrTaskTerminal = errors.New("task is in a terminal state")
+	// ErrInvalidArgument is returned when a request field fails validation.
+	ErrInvalidArgument = errors.New("invalid argument")
+)

--- a/services/task-broker/internal/domain/model.go
+++ b/services/task-broker/internal/domain/model.go
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package domain
+
+import "time"
+
+// TaskStatus mirrors the proto TaskStatus enum; values are stable (ADR-001).
+type TaskStatus int32
+
+// TaskStatus values; ordinal values are permanent — never reorder or reassign (ADR-001).
+const (
+	TaskStatusUnspecified TaskStatus = 0
+	TaskStatusPending     TaskStatus = 1
+	TaskStatusDispatched  TaskStatus = 2
+	TaskStatusRetrying    TaskStatus = 3
+	TaskStatusCompleted   TaskStatus = 4
+	TaskStatusFailed      TaskStatus = 5
+	TaskStatusCancelled   TaskStatus = 6
+)
+
+// IsTerminal reports whether s is a terminal state (COMPLETED, FAILED, or CANCELLED).
+func (s TaskStatus) IsTerminal() bool {
+	return s == TaskStatusCompleted || s == TaskStatusFailed || s == TaskStatusCancelled
+}
+
+// String returns the proto-style name of the status.
+func (s TaskStatus) String() string {
+	switch s {
+	case TaskStatusPending:
+		return "PENDING"
+	case TaskStatusDispatched:
+		return "DISPATCHED"
+	case TaskStatusRetrying:
+		return "RETRYING"
+	case TaskStatusCompleted:
+		return "COMPLETED"
+	case TaskStatusFailed:
+		return "FAILED"
+	case TaskStatusCancelled:
+		return "CANCELLED"
+	default:
+		return "UNSPECIFIED"
+	}
+}
+
+// Task is the broker's canonical task record.
+type Task struct {
+	TaskID         string
+	WorkflowID     string
+	CapabilityName string
+	InputPayload   []byte
+	TimeoutSeconds int32
+	MaxRetries     int32
+	RetryCount     int32
+	Status         TaskStatus
+	DispatchedTo   string
+	ResultPayload  []byte
+	Error          *TaskError
+	CreatedAt      time.Time
+	DispatchedAt   time.Time
+	CompletedAt    time.Time
+}
+
+// TaskError carries structured failure information from an execution.
+type TaskError struct {
+	Code    string
+	Message string
+	Details map[string]string
+}
+
+// AgentInfo carries the routing information needed to invoke an agent.
+type AgentInfo struct {
+	AgentID  string
+	Endpoint string
+}
+
+// ListFilter specifies the criteria for a ListTasks call.
+// A zero-value Status field means no status filter.
+type ListFilter struct {
+	WorkflowID string
+	Status     TaskStatus
+	AgentID    string
+	PageToken  string
+	PageSize   int32
+}
+
+// ListResult carries one page of matching tasks.
+type ListResult struct {
+	Tasks         []*Task
+	NextPageToken string
+}

--- a/services/task-broker/internal/domain/ports.go
+++ b/services/task-broker/internal/domain/ports.go
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package domain
+
+import "context"
+
+// TaskRepository persists and retrieves task records.
+type TaskRepository interface {
+	Save(ctx context.Context, task *Task) error
+	GetByID(ctx context.Context, taskID string) (*Task, error)
+	Update(ctx context.Context, task *Task) error
+	List(ctx context.Context, filter ListFilter) (ListResult, error)
+}
+
+// AgentFinder resolves which agents declare a given capability.
+type AgentFinder interface {
+	FindByCapability(ctx context.Context, capabilityName string) ([]AgentInfo, error)
+}
+
+// CapabilityExecutor invokes a capability on a specific agent and returns the outcome.
+// resultPayload is non-nil on success; taskErr is non-nil on failure; err signals infra errors.
+type CapabilityExecutor interface {
+	Execute(ctx context.Context, agent AgentInfo, task *Task) (resultPayload []byte, taskErr *TaskError, err error)
+}

--- a/services/task-broker/internal/domain/service.go
+++ b/services/task-broker/internal/domain/service.go
@@ -1,0 +1,213 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package domain contains the pure business logic for the task-broker service.
+// It has zero imports from the api or infrastructure layers (ADR-001).
+package domain
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// TaskService implements core broker logic: dispatch, acknowledge, cancel, and query.
+type TaskService struct {
+	repo      TaskRepository
+	finder    AgentFinder
+	executor  CapabilityExecutor
+	bg        sync.WaitGroup
+	nextAgent atomic.Uint64
+}
+
+// NewTaskService constructs a TaskService with the given port implementations.
+func NewTaskService(repo TaskRepository, finder AgentFinder, executor CapabilityExecutor) *TaskService {
+	return &TaskService{repo: repo, finder: finder, executor: executor}
+}
+
+// DispatchTask validates the request, records the task as PENDING, and launches
+// an async goroutine that routes to an agent and drives the lifecycle to completion.
+func (s *TaskService) DispatchTask(ctx context.Context, task *Task) (taskID string, createdAt time.Time, err error) {
+	if task.WorkflowID == "" {
+		return "", time.Time{}, fmt.Errorf("%w: workflow_id is required", ErrInvalidArgument)
+	}
+	if task.CapabilityName == "" {
+		return "", time.Time{}, fmt.Errorf("%w: capability_name is required", ErrInvalidArgument)
+	}
+	if !json.Valid(task.InputPayload) {
+		return "", time.Time{}, fmt.Errorf("%w: input_payload must be valid JSON", ErrInvalidArgument)
+	}
+
+	agents, err := s.finder.FindByCapability(ctx, task.CapabilityName)
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("task-broker: find agents: %w", err)
+	}
+	if len(agents) == 0 {
+		return "", time.Time{}, fmt.Errorf("%w: no agent registered for capability %q", ErrNoEligibleAgent, task.CapabilityName)
+	}
+
+	task.TaskID = newTaskID()
+	task.Status = TaskStatusPending
+	task.CreatedAt = time.Now()
+	if err := s.repo.Save(ctx, task); err != nil {
+		return "", time.Time{}, fmt.Errorf("task-broker: save: %w", err)
+	}
+
+	s.bg.Add(1)
+	// context.Background() is intentional: the request context expires when the RPC
+	// returns, but task execution must outlive it.
+	go func() { //nolint:contextcheck,gosec // G118: background ctx required for long-running work
+		defer s.bg.Done()
+		s.executeAsync(context.Background(), task.TaskID, agents)
+	}()
+
+	return task.TaskID, task.CreatedAt, nil
+}
+
+// AcknowledgeTask records the outcome of a capability execution.
+// COMPLETED requires a non-empty result_payload. FAILED triggers retry logic:
+// if retries remain the status becomes RETRYING, otherwise FAILED (terminal).
+func (s *TaskService) AcknowledgeTask(ctx context.Context, taskID string, newStatus TaskStatus, resultPayload []byte, taskErr *TaskError) (TaskStatus, error) {
+	if taskID == "" {
+		return 0, fmt.Errorf("%w: task_id is required", ErrInvalidArgument)
+	}
+	switch newStatus {
+	case TaskStatusUnspecified, TaskStatusPending, TaskStatusDispatched, TaskStatusRetrying:
+		return 0, fmt.Errorf("%w: status must be COMPLETED, FAILED, or CANCELLED", ErrInvalidArgument)
+	}
+	if newStatus == TaskStatusCompleted && len(resultPayload) == 0 {
+		return 0, fmt.Errorf("%w: result_payload is required for COMPLETED status", ErrInvalidArgument)
+	}
+
+	task, err := s.repo.GetByID(ctx, taskID)
+	if err != nil {
+		return 0, fmt.Errorf("task-broker: get task: %w", err)
+	}
+	if task.Status.IsTerminal() {
+		return 0, fmt.Errorf("%w: %s", ErrTaskTerminal, task.Status)
+	}
+
+	resulting := s.applyAcknowledgement(task, newStatus, resultPayload, taskErr)
+	if err := s.repo.Update(ctx, task); err != nil {
+		return 0, fmt.Errorf("task-broker: update: %w", err)
+	}
+	return resulting, nil
+}
+
+// GetTask returns the current state of a task by its broker-assigned id.
+func (s *TaskService) GetTask(ctx context.Context, taskID string) (*Task, error) {
+	if taskID == "" {
+		return nil, fmt.Errorf("%w: task_id is required", ErrInvalidArgument)
+	}
+	t, err := s.repo.GetByID(ctx, taskID)
+	if err != nil {
+		return nil, fmt.Errorf("task-broker: get task: %w", err)
+	}
+	return t, nil
+}
+
+// ListTasks returns a filtered, paginated list of tasks.
+func (s *TaskService) ListTasks(ctx context.Context, filter ListFilter) (ListResult, error) {
+	result, err := s.repo.List(ctx, filter)
+	if err != nil {
+		return ListResult{}, fmt.Errorf("task-broker: list tasks: %w", err)
+	}
+	return result, nil
+}
+
+// CancelTask transitions a non-terminal task to CANCELLED.
+func (s *TaskService) CancelTask(ctx context.Context, taskID string) (time.Time, error) {
+	if taskID == "" {
+		return time.Time{}, fmt.Errorf("%w: task_id is required", ErrInvalidArgument)
+	}
+	task, err := s.repo.GetByID(ctx, taskID)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("task-broker: get task: %w", err)
+	}
+	if task.Status.IsTerminal() {
+		return time.Time{}, fmt.Errorf("%w: %s", ErrTaskTerminal, task.Status)
+	}
+	task.Status = TaskStatusCancelled
+	task.CompletedAt = time.Now()
+	if err := s.repo.Update(ctx, task); err != nil {
+		return time.Time{}, fmt.Errorf("task-broker: update: %w", err)
+	}
+	return task.CompletedAt, nil
+}
+
+// WaitBackground blocks until all goroutines launched by DispatchTask have finished.
+// Intended for tests that need deterministic task-lifecycle assertions.
+func (s *TaskService) WaitBackground() { s.bg.Wait() }
+
+func (s *TaskService) executeAsync(ctx context.Context, taskID string, agents []AgentInfo) {
+	idx := s.nextAgent.Add(1) - 1
+	agent := agents[idx%uint64(len(agents))] //nolint:gosec // G115: idx bounded by len
+
+	task, err := s.repo.GetByID(ctx, taskID)
+	if err != nil || task.Status.IsTerminal() {
+		return
+	}
+	task.Status = TaskStatusDispatched
+	task.DispatchedTo = agent.AgentID
+	task.DispatchedAt = time.Now()
+	if err := s.repo.Update(ctx, task); err != nil {
+		return
+	}
+
+	resultPayload, taskErr, execErr := s.executor.Execute(ctx, agent, task)
+
+	task, err = s.repo.GetByID(ctx, taskID)
+	if err != nil || task.Status.IsTerminal() {
+		return
+	}
+
+	if execErr != nil {
+		taskErr = &TaskError{Code: "INTERNAL", Message: execErr.Error()}
+	}
+	if taskErr != nil {
+		s.applyAcknowledgement(task, TaskStatusFailed, nil, taskErr)
+	} else {
+		s.applyAcknowledgement(task, TaskStatusCompleted, resultPayload, nil)
+	}
+	_ = s.repo.Update(ctx, task)
+}
+
+func (s *TaskService) applyAcknowledgement(task *Task, newStatus TaskStatus, resultPayload []byte, taskErr *TaskError) TaskStatus {
+	switch newStatus {
+	case TaskStatusCompleted:
+		task.Status = TaskStatusCompleted
+		task.ResultPayload = resultPayload
+		task.CompletedAt = time.Now()
+		return TaskStatusCompleted
+
+	case TaskStatusFailed:
+		newCount := task.RetryCount + 1
+		if newCount <= task.MaxRetries {
+			task.Status = TaskStatusRetrying
+			task.RetryCount = newCount
+			return TaskStatusRetrying
+		}
+		task.Status = TaskStatusFailed
+		task.Error = taskErr
+		task.CompletedAt = time.Now()
+		return TaskStatusFailed
+
+	default: // TaskStatusCancelled
+		task.Status = TaskStatusCancelled
+		task.CompletedAt = time.Now()
+		return TaskStatusCancelled
+	}
+}
+
+func newTaskID() string {
+	b := make([]byte, 8)
+	if _, err := rand.Read(b); err != nil {
+		// crypto/rand failure is unrecoverable; the broker cannot safely assign IDs.
+		panic(fmt.Sprintf("task-broker: newTaskID: %v", err))
+	}
+	return "task-" + hex.EncodeToString(b)
+}

--- a/services/task-broker/internal/domain/service_test.go
+++ b/services/task-broker/internal/domain/service_test.go
@@ -90,9 +90,13 @@ func (e *fakeExecutor) Execute(_ context.Context, _ domain.AgentInfo, _ *domain.
 	return e.resultPayload, e.taskErr, e.execErr
 }
 
-type blockingExecutor struct{ block chan struct{} }
+type blockingExecutor struct {
+	started chan struct{}
+	block   chan struct{}
+}
 
 func (e *blockingExecutor) Execute(_ context.Context, _ domain.AgentInfo, _ *domain.Task) ([]byte, *domain.TaskError, error) {
+	close(e.started)
 	<-e.block
 	return []byte(`{}`), nil, nil
 }
@@ -144,18 +148,31 @@ func TestDispatchTask_HappyPath(t *testing.T) {
 	}
 }
 
-func TestDispatchTask_BlockUntilPending(t *testing.T) {
+func TestDispatchTask_NonBlocking(t *testing.T) {
 	repo := newFakeRepo()
 	block := make(chan struct{})
-	svc := domain.NewTaskService(repo, &fakeFinder{agents: oneAgent()}, &blockingExecutor{block: block})
+	started := make(chan struct{})
+	svc := domain.NewTaskService(repo, &fakeFinder{agents: oneAgent()}, &blockingExecutor{started: started, block: block})
 
-	taskID, _, _ := svc.DispatchTask(context.Background(), validTask())
-	task, _ := repo.GetByID(context.Background(), taskID)
-	if task.Status != domain.TaskStatusPending {
-		t.Errorf("status before execution = %s", task.Status)
+	taskID, _, err := svc.DispatchTask(context.Background(), validTask())
+	if err != nil {
+		t.Fatalf("DispatchTask: %v", err)
 	}
+
+	// Wait until executeAsync has set status=DISPATCHED and called Execute.
+	<-started
+	task, _ := repo.GetByID(context.Background(), taskID)
+	if task.Status != domain.TaskStatusDispatched {
+		t.Errorf("want DISPATCHED while executor is blocked, got %s", task.Status)
+	}
+
 	close(block)
 	svc.WaitBackground()
+
+	task, _ = repo.GetByID(context.Background(), taskID)
+	if task.Status != domain.TaskStatusCompleted {
+		t.Errorf("want COMPLETED after executor finishes, got %s", task.Status)
+	}
 }
 
 func TestDispatchTask_ExecutorFailure(t *testing.T) {

--- a/services/task-broker/internal/domain/service_test.go
+++ b/services/task-broker/internal/domain/service_test.go
@@ -1,0 +1,438 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package domain_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/zynax-io/zynax/services/task-broker/internal/domain"
+)
+
+// ── fakes ──────────────────────────────────────────────────────────────────
+
+type fakeRepo struct {
+	mu    sync.Mutex
+	tasks map[string]*domain.Task
+}
+
+func newFakeRepo() *fakeRepo { return &fakeRepo{tasks: make(map[string]*domain.Task)} }
+
+func (r *fakeRepo) Save(_ context.Context, task *domain.Task) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	c := *task
+	r.tasks[c.TaskID] = &c
+	return nil
+}
+
+func (r *fakeRepo) GetByID(_ context.Context, taskID string) (*domain.Task, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	t, ok := r.tasks[taskID]
+	if !ok {
+		return nil, fmt.Errorf("%w: %q", domain.ErrTaskNotFound, taskID)
+	}
+	c := *t
+	return &c, nil
+}
+
+func (r *fakeRepo) Update(_ context.Context, task *domain.Task) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, ok := r.tasks[task.TaskID]; !ok {
+		return fmt.Errorf("%w: %q", domain.ErrTaskNotFound, task.TaskID)
+	}
+	c := *task
+	r.tasks[task.TaskID] = &c
+	return nil
+}
+
+func (r *fakeRepo) List(_ context.Context, filter domain.ListFilter) (domain.ListResult, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var out []*domain.Task
+	for _, t := range r.tasks {
+		if filter.WorkflowID != "" && t.WorkflowID != filter.WorkflowID {
+			continue
+		}
+		if filter.Status != domain.TaskStatusUnspecified && t.Status != filter.Status {
+			continue
+		}
+		c := *t
+		out = append(out, &c)
+	}
+	return domain.ListResult{Tasks: out}, nil
+}
+
+type fakeFinder struct{ agents map[string][]domain.AgentInfo }
+
+func (f *fakeFinder) FindByCapability(_ context.Context, capName string) ([]domain.AgentInfo, error) {
+	return f.agents[capName], nil
+}
+
+type errorFinder struct{ err error }
+
+func (f *errorFinder) FindByCapability(_ context.Context, _ string) ([]domain.AgentInfo, error) {
+	return nil, f.err
+}
+
+type fakeExecutor struct {
+	resultPayload []byte
+	taskErr       *domain.TaskError
+	execErr       error
+}
+
+func (e *fakeExecutor) Execute(_ context.Context, _ domain.AgentInfo, _ *domain.Task) ([]byte, *domain.TaskError, error) {
+	return e.resultPayload, e.taskErr, e.execErr
+}
+
+type blockingExecutor struct{ block chan struct{} }
+
+func (e *blockingExecutor) Execute(_ context.Context, _ domain.AgentInfo, _ *domain.Task) ([]byte, *domain.TaskError, error) {
+	<-e.block
+	return []byte(`{}`), nil, nil
+}
+
+// ── helpers ────────────────────────────────────────────────────────────────
+
+func oneAgent() map[string][]domain.AgentInfo {
+	return map[string][]domain.AgentInfo{"summarize": {{AgentID: "a1", Endpoint: "localhost:9000"}}}
+}
+
+func validTask() *domain.Task {
+	return &domain.Task{WorkflowID: "wf-001", CapabilityName: "summarize", InputPayload: []byte(`{}`)}
+}
+
+func storeTask(t *testing.T, repo *fakeRepo, task *domain.Task) {
+	t.Helper()
+	if err := repo.Save(context.Background(), task); err != nil {
+		t.Fatalf("seed task: %v", err)
+	}
+}
+
+func dispatched(id string) *domain.Task {
+	return &domain.Task{TaskID: id, WorkflowID: "wf", CapabilityName: "cap",
+		InputPayload: []byte(`{}`), Status: domain.TaskStatusDispatched}
+}
+
+// ── DispatchTask ───────────────────────────────────────────────────────────
+
+func TestDispatchTask_HappyPath(t *testing.T) {
+	repo := newFakeRepo()
+	svc := domain.NewTaskService(repo, &fakeFinder{agents: oneAgent()}, &fakeExecutor{resultPayload: []byte(`{"ok":true}`)})
+
+	taskID, createdAt, err := svc.DispatchTask(context.Background(), validTask())
+	if err != nil || taskID == "" || createdAt.IsZero() {
+		t.Fatalf("DispatchTask: err=%v taskID=%q", err, taskID)
+	}
+
+	// Immediately after dispatch the task must be PENDING.
+	task, _ := repo.GetByID(context.Background(), taskID)
+	if task.Status != domain.TaskStatusPending {
+		t.Errorf("want PENDING, got %s", task.Status)
+	}
+
+	svc.WaitBackground()
+
+	task, _ = repo.GetByID(context.Background(), taskID)
+	if task.Status != domain.TaskStatusCompleted {
+		t.Errorf("want COMPLETED, got %s", task.Status)
+	}
+}
+
+func TestDispatchTask_BlockUntilPending(t *testing.T) {
+	repo := newFakeRepo()
+	block := make(chan struct{})
+	svc := domain.NewTaskService(repo, &fakeFinder{agents: oneAgent()}, &blockingExecutor{block: block})
+
+	taskID, _, _ := svc.DispatchTask(context.Background(), validTask())
+	task, _ := repo.GetByID(context.Background(), taskID)
+	if task.Status != domain.TaskStatusPending {
+		t.Errorf("status before execution = %s", task.Status)
+	}
+	close(block)
+	svc.WaitBackground()
+}
+
+func TestDispatchTask_ExecutorFailure(t *testing.T) {
+	repo := newFakeRepo()
+	svc := domain.NewTaskService(repo, &fakeFinder{agents: oneAgent()}, &fakeExecutor{execErr: fmt.Errorf("dial timeout")})
+
+	taskID, _, _ := svc.DispatchTask(context.Background(), validTask())
+	svc.WaitBackground()
+
+	task, _ := repo.GetByID(context.Background(), taskID)
+	if task.Status != domain.TaskStatusFailed {
+		t.Errorf("want FAILED, got %s", task.Status)
+	}
+}
+
+func TestDispatchTask_Validation(t *testing.T) {
+	svc := domain.NewTaskService(newFakeRepo(), &fakeFinder{}, &fakeExecutor{})
+	cases := []struct {
+		name    string
+		mutate  func(*domain.Task)
+		wantErr error
+	}{
+		{"empty workflow_id", func(tk *domain.Task) { tk.WorkflowID = "" }, domain.ErrInvalidArgument},
+		{"empty capability_name", func(tk *domain.Task) { tk.CapabilityName = "" }, domain.ErrInvalidArgument},
+		{"invalid JSON", func(tk *domain.Task) { tk.InputPayload = []byte("not json") }, domain.ErrInvalidArgument},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tk := validTask()
+			tc.mutate(tk)
+			_, _, err := svc.DispatchTask(context.Background(), tk)
+			if !errors.Is(err, tc.wantErr) {
+				t.Errorf("err = %v, want %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestDispatchTask_NoAgent(t *testing.T) {
+	svc := domain.NewTaskService(newFakeRepo(), &fakeFinder{}, &fakeExecutor{})
+	_, _, err := svc.DispatchTask(context.Background(), validTask())
+	if !errors.Is(err, domain.ErrNoEligibleAgent) {
+		t.Errorf("err = %v, want ErrNoEligibleAgent", err)
+	}
+}
+
+func TestDispatchTask_FinderError(t *testing.T) {
+	svc := domain.NewTaskService(newFakeRepo(), &errorFinder{err: fmt.Errorf("registry down")}, &fakeExecutor{})
+	_, _, err := svc.DispatchTask(context.Background(), validTask())
+	if err == nil || errors.Is(err, domain.ErrInvalidArgument) {
+		t.Errorf("expected wrapped finder error, got %v", err)
+	}
+}
+
+// ── AcknowledgeTask ────────────────────────────────────────────────────────
+
+func TestAcknowledgeTask_Completed(t *testing.T) {
+	repo := newFakeRepo()
+	svc := domain.NewTaskService(repo, &fakeFinder{}, &fakeExecutor{})
+	storeTask(t, repo, dispatched("t1"))
+
+	res, err := svc.AcknowledgeTask(context.Background(), "t1", domain.TaskStatusCompleted, []byte(`{"r":1}`), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res != domain.TaskStatusCompleted {
+		t.Errorf("resulting = %s", res)
+	}
+	task, _ := repo.GetByID(context.Background(), "t1")
+	if task.Status != domain.TaskStatusCompleted || string(task.ResultPayload) != `{"r":1}` {
+		t.Errorf("status=%s payload=%s", task.Status, task.ResultPayload)
+	}
+}
+
+func TestAcknowledgeTask_Cancelled(t *testing.T) {
+	repo := newFakeRepo()
+	svc := domain.NewTaskService(repo, &fakeFinder{}, &fakeExecutor{})
+	storeTask(t, repo, dispatched("t-cancel"))
+
+	res, err := svc.AcknowledgeTask(context.Background(), "t-cancel", domain.TaskStatusCancelled, nil, nil)
+	if err != nil || res != domain.TaskStatusCancelled {
+		t.Errorf("err=%v resulting=%s", err, res)
+	}
+}
+
+func TestAcknowledgeTask_FailedTransitions(t *testing.T) {
+	cases := []struct {
+		name       string
+		maxRetries int32
+		retryCount int32
+		wantStatus domain.TaskStatus
+		wantCount  int32
+	}{
+		{"no_retries", 0, 0, domain.TaskStatusFailed, 0},
+		{"retries_remain", 2, 1, domain.TaskStatusRetrying, 2},
+		{"retries_exhausted", 2, 2, domain.TaskStatusFailed, 2},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := newFakeRepo()
+			svc := domain.NewTaskService(repo, &fakeFinder{}, &fakeExecutor{})
+			storeTask(t, repo, &domain.Task{
+				TaskID: "tf", WorkflowID: "wf", CapabilityName: "cap",
+				InputPayload: []byte(`{}`), Status: domain.TaskStatusDispatched,
+				MaxRetries: tc.maxRetries, RetryCount: tc.retryCount,
+			})
+
+			res, err := svc.AcknowledgeTask(context.Background(), "tf", domain.TaskStatusFailed, nil,
+				&domain.TaskError{Code: "TIMEOUT", Message: "timed out"})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if res != tc.wantStatus {
+				t.Errorf("resulting = %s, want %s", res, tc.wantStatus)
+			}
+			task, _ := repo.GetByID(context.Background(), "tf")
+			if task.Status != tc.wantStatus {
+				t.Errorf("stored status = %s", task.Status)
+			}
+			if tc.wantStatus == domain.TaskStatusRetrying && task.RetryCount != tc.wantCount {
+				t.Errorf("retry_count = %d, want %d", task.RetryCount, tc.wantCount)
+			}
+		})
+	}
+}
+
+func TestAcknowledgeTask_Errors(t *testing.T) {
+	repo := newFakeRepo()
+	svc := domain.NewTaskService(repo, &fakeFinder{}, &fakeExecutor{})
+	storeTask(t, repo, &domain.Task{
+		TaskID: "terminal", WorkflowID: "wf", CapabilityName: "cap",
+		InputPayload: []byte(`{}`), Status: domain.TaskStatusCompleted,
+	})
+
+	cases := []struct {
+		name    string
+		taskID  string
+		status  domain.TaskStatus
+		payload []byte
+		wantErr error
+	}{
+		{"empty_task_id", "", domain.TaskStatusCompleted, []byte(`{}`), domain.ErrInvalidArgument},
+		{"unspecified_status", "any", domain.TaskStatusUnspecified, nil, domain.ErrInvalidArgument},
+		{"completed_no_payload", "any", domain.TaskStatusCompleted, nil, domain.ErrInvalidArgument},
+		{"unknown_task", "ghost-task", domain.TaskStatusCompleted, []byte(`{}`), domain.ErrTaskNotFound},
+		{"terminal_task", "terminal", domain.TaskStatusCompleted, []byte(`{}`), domain.ErrTaskTerminal},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := svc.AcknowledgeTask(context.Background(), tc.taskID, tc.status, tc.payload, nil)
+			if !errors.Is(err, tc.wantErr) {
+				t.Errorf("err = %v, want %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// ── CancelTask ─────────────────────────────────────────────────────────────
+
+func TestCancelTask(t *testing.T) {
+	repo := newFakeRepo()
+	svc := domain.NewTaskService(repo, &fakeFinder{}, &fakeExecutor{})
+	storeTask(t, repo, &domain.Task{
+		TaskID: "c1", WorkflowID: "wf", CapabilityName: "cap",
+		InputPayload: []byte(`{}`), Status: domain.TaskStatusPending,
+	})
+
+	cancelledAt, err := svc.CancelTask(context.Background(), "c1")
+	if err != nil || cancelledAt.IsZero() {
+		t.Fatalf("CancelTask: err=%v", err)
+	}
+	task, _ := repo.GetByID(context.Background(), "c1")
+	if task.Status != domain.TaskStatusCancelled {
+		t.Errorf("status = %s", task.Status)
+	}
+}
+
+func TestCancelTask_Errors(t *testing.T) {
+	repo := newFakeRepo()
+	svc := domain.NewTaskService(repo, &fakeFinder{}, &fakeExecutor{})
+	storeTask(t, repo, &domain.Task{
+		TaskID: "completed", WorkflowID: "wf", CapabilityName: "cap",
+		InputPayload: []byte(`{}`), Status: domain.TaskStatusCompleted,
+	})
+
+	cases := []struct {
+		name    string
+		taskID  string
+		wantErr error
+	}{
+		{"empty_id", "", domain.ErrInvalidArgument},
+		{"unknown_task", "nonexistent", domain.ErrTaskNotFound},
+		{"terminal_task", "completed", domain.ErrTaskTerminal},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := svc.CancelTask(context.Background(), tc.taskID)
+			if !errors.Is(err, tc.wantErr) {
+				t.Errorf("err = %v, want %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// ── GetTask ────────────────────────────────────────────────────────────────
+
+func TestGetTask(t *testing.T) {
+	repo := newFakeRepo()
+	svc := domain.NewTaskService(repo, &fakeFinder{}, &fakeExecutor{})
+	storeTask(t, repo, &domain.Task{TaskID: "g1", WorkflowID: "wf-get", CapabilityName: "cap", InputPayload: []byte(`{}`), Status: domain.TaskStatusPending})
+
+	task, err := svc.GetTask(context.Background(), "g1")
+	if err != nil || task.WorkflowID != "wf-get" {
+		t.Errorf("err=%v wfID=%s", err, task.WorkflowID)
+	}
+
+	_, err = svc.GetTask(context.Background(), "nonexistent-task")
+	if !errors.Is(err, domain.ErrTaskNotFound) {
+		t.Errorf("err = %v, want ErrTaskNotFound", err)
+	}
+
+	_, err = svc.GetTask(context.Background(), "")
+	if !errors.Is(err, domain.ErrInvalidArgument) {
+		t.Errorf("err = %v, want ErrInvalidArgument", err)
+	}
+}
+
+// ── ListTasks ──────────────────────────────────────────────────────────────
+
+func TestListTasks(t *testing.T) {
+	repo := newFakeRepo()
+	svc := domain.NewTaskService(repo, &fakeFinder{}, &fakeExecutor{})
+
+	storeTask(t, repo, &domain.Task{TaskID: "la", WorkflowID: "wf-A", CapabilityName: "cap", InputPayload: []byte(`{}`), Status: domain.TaskStatusPending})
+	storeTask(t, repo, &domain.Task{TaskID: "lb", WorkflowID: "wf-B", CapabilityName: "cap", InputPayload: []byte(`{}`), Status: domain.TaskStatusCompleted})
+
+	// Filter by workflow_id.
+	res, err := svc.ListTasks(context.Background(), domain.ListFilter{WorkflowID: "wf-A"})
+	if err != nil || len(res.Tasks) != 1 || res.Tasks[0].TaskID != "la" {
+		t.Errorf("workflow filter: err=%v tasks=%v", err, res.Tasks)
+	}
+
+	// Filter by status.
+	res, err = svc.ListTasks(context.Background(), domain.ListFilter{Status: domain.TaskStatusCompleted})
+	if err != nil || len(res.Tasks) != 1 || res.Tasks[0].TaskID != "lb" {
+		t.Errorf("status filter: err=%v tasks=%v", err, res.Tasks)
+	}
+}
+
+// ── TaskStatus ─────────────────────────────────────────────────────────────
+
+func TestTaskStatus_IsTerminal(t *testing.T) {
+	for _, s := range []domain.TaskStatus{domain.TaskStatusCompleted, domain.TaskStatusFailed, domain.TaskStatusCancelled} {
+		if !s.IsTerminal() {
+			t.Errorf("%s should be terminal", s)
+		}
+	}
+	for _, s := range []domain.TaskStatus{domain.TaskStatusUnspecified, domain.TaskStatusPending, domain.TaskStatusDispatched, domain.TaskStatusRetrying} {
+		if s.IsTerminal() {
+			t.Errorf("%s should not be terminal", s)
+		}
+	}
+}
+
+func TestTaskStatus_String(t *testing.T) {
+	cases := map[domain.TaskStatus]string{
+		domain.TaskStatusUnspecified: "UNSPECIFIED",
+		domain.TaskStatusPending:     "PENDING",
+		domain.TaskStatusDispatched:  "DISPATCHED",
+		domain.TaskStatusRetrying:    "RETRYING",
+		domain.TaskStatusCompleted:   "COMPLETED",
+		domain.TaskStatusFailed:      "FAILED",
+		domain.TaskStatusCancelled:   "CANCELLED",
+	}
+	for s, want := range cases {
+		if got := s.String(); got != want {
+			t.Errorf("TaskStatus(%d).String() = %q, want %q", s, got, want)
+		}
+	}
+}


### PR DESCRIPTION
**Parent epic:** [#479 Task Broker MVP](https://github.com/zynax-io/zynax/issues/479) · [#460 M5.C Capability Dispatch](https://github.com/zynax-io/zynax/issues/460)
**Canvas:** [docs/spdd/479-task-broker/canvas.md](https://github.com/zynax-io/zynax/blob/main/docs/spdd/479-task-broker/canvas.md) — O1-O4 (domain layer, part 1 of 2)

---

## Story

As a **platform developer**, I want a pure-domain layer for the task-broker service — `Task` model, `TaskRepository`/`AgentFinder`/`CapabilityExecutor` ports, and `TaskService` with 5 operations — so that the business rules are tested in isolation with zero external dependencies before any gRPC wiring is added.

---

## Implemented

| File | Purpose |
|------|---------|
| `go.mod` | Minimal module declaration (stdlib-only) |
| `domain/errors.go` | Sentinel errors: `ErrTaskNotFound`, `ErrNoEligibleAgent`, `ErrTaskTerminal`, `ErrInvalidArgument` |
| `domain/model.go` | `Task`, `TaskError`, `AgentInfo`, `ListFilter`, `ListResult`, `TaskStatus` with `IsTerminal()` / `String()` |
| `domain/ports.go` | `TaskRepository`, `AgentFinder`, `CapabilityExecutor` interfaces |
| `domain/service.go` | `TaskService` — 5 methods + round-robin agent selection + background goroutine |
| `domain/service_test.go` | 93.3% statement coverage |

`context.Background()` is intentional in `executeAsync` — the request context expires when the RPC returns, but task execution must outlive it.

---

## Acceptance Criteria (verified)

- [x] Zero imports from `api/` or `infrastructure/` in `internal/domain/`
- [x] `GOWORK=off go test ./internal/domain/... -race` passes; 93.3% coverage
- [x] Round-robin uses `atomic.Uint64` — race-safe without a lock
- [x] `WaitBackground()` test hook available for deterministic test teardown

---

Part 1 of 2. gRPC wiring in #522. Together implement #479 / #460 (task-broker MVP).

Assisted-by: Claude/claude-sonnet-4-6