### PR TITLE
fix(task-broker): replace panic in newRequestID with error return

### DIFF
--- a/services/task-broker/internal/infrastructure/agent_executor.go
+++ b/services/task-broker/internal/infrastructure/agent_executor.go
@@ -32,9 +32,14 @@ func (e *AgentExecutor) Execute(ctx context.Context, agent domain.AgentInfo, tas
 	}
 	defer func() { _ = conn.Close() }()
 
+	reqID, err := newRequestID()
+	if err != nil {
+		return nil, nil, fmt.Errorf("task-broker: generate request ID: %w", err)
+	}
+
 	client := zynaxv1.NewAgentServiceClient(conn)
 	stream, err := client.ExecuteCapability(ctx, &zynaxv1.ExecuteCapabilityRequest{
-		RequestId:      newRequestID(),
+		RequestId:      reqID,
 		TaskId:         task.TaskID,
 		WorkflowId:     task.WorkflowID,
 		CapabilityName: task.CapabilityName,
@@ -69,10 +74,10 @@ func (e *AgentExecutor) Execute(ctx context.Context, agent domain.AgentInfo, tas
 	return nil, nil, nil
 }
 
-func newRequestID() string {
+func newRequestID() (string, error) {
 	b := make([]byte, 8)
 	if _, err := rand.Read(b); err != nil {
-		panic(fmt.Sprintf("task-broker: newRequestID: %v", err))
+		return "", fmt.Errorf("task-broker: rand.Read: %w", err)
 	}
-	return hex.EncodeToString(b)
+	return hex.EncodeToString(b), nil
 }


### PR DESCRIPTION
## Summary

Closes #479.

PR #522 merged the gRPC wiring for task-broker but carried a `panic` in `newRequestID`: if `crypto/rand.Read` ever fails the binary crashes rather than returning a proper error. This PR replaces the `panic` with a `(string, error)` return and propagates the error up through `Execute()` via `fmt.Errorf` wrapping. No behaviour change on the happy path; `crypto/rand.Read` reliably succeeds on Linux, but a crash in a production path is never acceptable.

## Source

- Issue: #479  | Parent EPIC: #460
- Canvas: `docs/spdd/460-capability-dispatch/canvas.md` O1
- ADR(s): ADR-016 (no-panic policy)
- External review §: —

## Approach

- Change `newRequestID() string` → `newRequestID() (string, error)`.
- Propagate the error in `Execute()` as `fmt.Errorf("task-broker: generate request ID: %w", err)`.
- 9-line change, no new dependencies, no interface changes.

## Test plan

Every box must be `- [x]` with evidence at merge (Phase D.3.2 enforces). N/A → `- [x] (N/A — <reason>)`. CI required checks (`dco`, `lint-proto`, `lint-go`, `lint-python`, `test-unit`, `test-integration`, `security`, `pr-size`) verified out-of-band via `gh pr checks`. Post-merge workflows watched in Phase F, reported via PR comment.

### Local pre-flight (Phase B.6)
- [x] `make fmt` — no diff  [evidence: pre-commit gofmt hook: Passed]
- [x] `make lint-go` — exit 0  [evidence: pre-commit golangci-lint hook: Passed]
- [x] `make lint-proto` — exit 0  (N/A — no proto changes)
- [x] `make lint-python` — exit 0  (N/A — no Python changes)
- [x] `make test-unit` — exit 0  [evidence: `GOWORK=off go test ./... -race -timeout 60s` → ok github.com/zynax-io/zynax/services/task-broker/internal/domain 1.008s]
- [x] `make test-coverage` — domain ≥ 90 %  [evidence: `GOWORK=off go test ./internal/domain/... -cover` → coverage: 92.7% of statements]
- [x] `make test-coverage-adapters` — (N/A — no adapter changes)
- [x] `make test-bdd` — (N/A — no .feature changes)
- [x] `make security` — CI-dependent  [evidence: https://github.com/zynax-io/zynax/actions/runs/26118698984/job/76814671620]
- [x] `make validate-spec` — (N/A — no spec/ changes)

### Acceptance (issue #479 — final close)
- [x] `.feature` file for `TaskBrokerService` committed before implementation PR  [evidence: `services/task-broker/tests/features/task_broker.feature` exists on main (pre-dates this PR)]
- [x] `SubmitTask` (`DispatchTask`) returns a task ID  [evidence: on main via PR #522 `handler.go:34-44`]
- [x] `GetTask` returns the task state  [evidence: on main via PR #522 `handler.go:62-68`]
- [x] `GOWORK=off go test ./... -race` passes in `services/task-broker/`  [evidence: exit 0, ok all packages — domain: 1.008s]
- [x] ≥90% domain coverage  [evidence: 92.7%]
- [x] No `panic` in prod paths  [evidence: `newRequestID` now returns `(string, error)` — verified by inspection of `services/task-broker/internal/infrastructure/agent_executor.go:72-78`]

### Engineering hygiene
- [x] Branched from latest `origin/main` (rebased after #522 merged)
- [x] PR size ≤ 900 LOC (excl. generated)  [evidence: 9 insertions, 4 deletions]
- [x] Every commit has `Signed-off-by:` (DCO)  [evidence: `git log --format='%B'` verified]
- [x] Every commit has `Assisted-by: Claude/claude-sonnet-4-6`  [evidence: verified]
- [x] No `Co-Authored-By:` for AI  [evidence: grep clean]
- [x] No `panic` in prod paths  [evidence: this PR is the fix]
- [x] No silent `_ = err` without justification  [evidence: no new `_ = err`]
- [x] No new `insecure.NewCredentials()` outside bufconn  [evidence: no new calls — pre-existing ones from #522 are consistent with api-gateway/engine-adapter pattern; mTLS deferred to #464]
- [x] No new direct dependencies  [evidence: no go.mod changes]
- [x] Canvas section updated (N/A — canvas Aligned; this is a fix commit)
- [x] No out-of-scope changes / drive-by refactors  [evidence: 1 file changed]

## Out of scope

- mTLS / TLS (#464)
- BDD godog step runner for infrastructure layer (#481)

## Risk

- Blast radius: 1 file, `services/task-broker/internal/infrastructure/agent_executor.go`.
- Rollback: revert this PR. `crypto/rand.Read` fails so rarely in practice that there is no functional regression risk.
- Behaviour change visible to users: none — happy path unchanged; only error-path improved.

---
🤖 Produced by Claude Code per the M5 PR Pipeline prompt.