### PR TITLE
chore: ignore compiled adapter binaries and pr-body.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,5 +45,8 @@ uv.lock
 .codeium/
 .aider*
 
+# Pipeline working files — local scratch, never committed
+pr-body.md
+
 # Generated proto stubs ARE committed — do not add protos/generated/ here
 docs/spdd/**/canvas.private.md

--- a/agents/adapters/http/.gitignore
+++ b/agents/adapters/http/.gitignore
@@ -1,0 +1,2 @@
+# Compiled adapter binaries produced by `go build ./cmd/...`
+*-adapter


### PR DESCRIPTION
## Summary

Two untracked items accumulated in the working tree with no matching gitignore patterns.

- **`agents/adapters/http/.gitignore`** — adds `*-adapter` so `go build ./cmd/...` output (`http-adapter`, and future `git-adapter`, `llm-adapter`, `ci-adapter`) is ignored. Pattern is scoped to this directory, no risk of over-matching.
- **`.gitignore`** — adds `pr-body.md` to silence the M5 PR pipeline working file that lives at the repo root between sessions.

No behaviour change. No code touched.

## Test plan

- [x] `make fmt` — (N/A — no Go/Python changes)
- [x] `make lint-go` — (N/A — no Go changes)
- [x] `make lint-proto` — (N/A)
- [x] `make lint-python` — (N/A)
- [x] `make test-unit` — (N/A — no code changes)
- [x] `make test-coverage` — (N/A)
- [x] `make test-coverage-adapters` — (N/A)
- [x] `make test-bdd` — (N/A)
- [x] `make security` — (N/A — no code changes; CI will confirm)
- [x] `make validate-spec` — (N/A)

### Acceptance
- [x] `git status --porcelain` shows neither `agents/adapters/http/http-adapter` nor `pr-body.md` after applying  [evidence: verified locally — only `.gitignore` and `agents/adapters/http/.gitignore` staged]
- [x] `*-adapter` pattern covers future adapter binaries without per-directory changes  [evidence: verified by inspection of `agents/adapters/http/.gitignore`]

### Engineering hygiene
- [x] Branched from latest `origin/main`
- [x] PR size ≤ 900 LOC  [evidence: 5 insertions, 0 deletions]
- [x] Every commit has `Signed-off-by:` (DCO)
- [x] Every commit has `Assisted-by: Claude/claude-sonnet-4-6`
- [x] No `Co-Authored-By:` for AI
- [x] No out-of-scope changes

## Risk
- Blast radius: 2 gitignore files only.
- Rollback: revert this PR.
- Behaviour change: none.
