### PR TITLE
ci: upgrade actions/cache to v5.0.5 and fix integration cache path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,7 +197,7 @@ jobs:
       - name: Cache gitleaks
         id: gitleaks-cache
         if: steps.ai-detect.outputs.has_changes != '0'
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: /usr/local/bin/gitleaks
           key: gitleaks-8.21.2-linux-x64
@@ -244,7 +244,7 @@ jobs:
       - name: Cache buf
         id: buf-cache
         if: steps.proto-detect.outputs.has_protos == '1'
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: /usr/local/bin/buf
           key: buf-${{ env.BUF_VERSION }}-linux-x86_64
@@ -387,7 +387,7 @@ jobs:
       - name: Cache golangci-lint
         id: golangci-cache
         if: steps.go-detect.outputs.has_go != '0'
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: /usr/local/bin/golangci-lint
           key: golangci-${{ env.GOLANGCI_VERSION }}-linux-amd64
@@ -1139,6 +1139,7 @@ jobs:
         if: steps.int-detect.outputs.has_integration != '0'
         with:
           go-version-file: go.work
+          cache-dependency-path: "**/go.sum"
 
       - name: Run integration tests
         if: steps.int-detect.outputs.has_integration != '0'
@@ -1186,7 +1187,7 @@ jobs:
       - name: Cache govulncheck
         id: govulncheck-cache
         if: steps.go-detect.outputs.has_go != '0'
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/go/bin/govulncheck
           key: govulncheck-${{ env.GOVULNCHECK_VERSION }}-go${{ hashFiles('go.work') }}
@@ -1262,7 +1263,7 @@ jobs:
 
       - name: Cache trivy binary
         id: trivy-bin-cache
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: /usr/local/bin/trivy
           key: trivy-${{ env.TRIVY_VERSION }}-linux-x64
@@ -1276,7 +1277,7 @@ jobs:
           tar -xzf /tmp/trivy.tar.gz -C /usr/local/bin trivy
 
       - name: Cache trivy vulnerability DB
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cache/trivy
           key: trivy-db-${{ env.TRIVY_VERSION }}-${{ steps.date.outputs.week }}

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Cache actionlint
         id: actionlint-cache
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: /usr/local/bin/actionlint
           key: actionlint-1.7.7-linux-amd64
@@ -120,7 +120,7 @@ jobs:
       - name: Cache buf
         id: buf-cache
         if: steps.proto-detect.outputs.proto_changed != '0'
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: /usr/local/bin/buf
           key: buf-1.47.2-linux-x86_64
@@ -345,7 +345,7 @@ jobs:
 
       - name: Cache gitleaks
         id: gitleaks-cache
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: /usr/local/bin/gitleaks
           key: gitleaks-8.21.2-linux-x64


### PR DESCRIPTION
## Summary

Fixes two CI annotation warnings from run [26119052143](https://github.com/zynax-io/zynax/actions/runs/26119052143).

**Warning 1 — Node.js 20 deprecation (deadline 2026-06-02):**
`actions/cache@5a3ec84 (v4)` uses Node.js 20. GitHub forces Node.js 24 by default on 2026-06-02 and removes Node.js 20 on 2026-09-16. Upgrades all 9 pinned occurrences across `ci.yml` (6) and `pr-checks.yml` (3) to `v5.0.5` (`27d5ce7f`), which ships Node.js 24.

**Warning 2 — test-integration cache miss:**
The `actions/setup-go` step in `test-integration` used `go-version-file: go.work` with no `cache-dependency-path`. setup-go then looks for `go.mod` at the repo root, finds none (only `go.work` lives there), and logs `Restore cache failed: Dependencies file is not found`. Added `cache-dependency-path: "**/go.sum"` — consistent with the `test-unit` job.

## Test plan

- [x] `make fmt` — (N/A — workflow files only)
- [x] `make lint-go` — (N/A)
- [x] `make lint-proto` — (N/A)
- [x] `make lint-python` — (N/A)
- [x] `make test-unit` — (N/A)
- [x] `make test-coverage` — (N/A)
- [x] `make test-coverage-adapters` — (N/A)
- [x] `make test-bdd` — (N/A)
- [x] `make security` — (N/A — no code changes; CI will confirm)
- [x] `make validate-spec` — (N/A)

### Acceptance
- [x] `grep -c '5a3ec84' .github/workflows/ci.yml pr-checks.yml` → 0 each  [evidence: verified locally]
- [x] `grep -c '27d5ce7f' .github/workflows/ci.yml` → 6, `pr-checks.yml` → 3  [evidence: verified locally]
- [x] `test-integration` setup-go step has `cache-dependency-path: "**/go.sum"`  [evidence: verified by inspection of ci.yml:1141-1142]
- [x] CI passes without Node.js 20 warning  [evidence: https://github.com/zynax-io/zynax/actions/runs/26120067800 — no Node.js 20 annotation in run]

### Engineering hygiene
- [x] Branched from latest `origin/main`
- [x] PR size ≤ 900 LOC  [evidence: 10 insertions, 9 deletions]
- [x] Every commit has `Signed-off-by:` (DCO)
- [x] Every commit has `Assisted-by: Claude/claude-sonnet-4-6`
- [x] No `Co-Authored-By:` for AI
- [x] No out-of-scope changes

## Risk
- Blast radius: 2 workflow files. No code, no protos, no specs.
- Rollback: revert this PR.
- Behaviour change: none on the happy path; cache restore now succeeds cleanly in `test-integration`.