### PR TITLE
docs: M5 alignment pass — plan, tracking, and cross-links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,22 @@ Versioning follows [Semantic Versioning](https://semver.org).
 ## [Unreleased] — M5 (Adapter Library)
 
 ### Added
+- `task-broker` service: in-memory `TaskBrokerService` with 5 RPCs (`DispatchTask`, `AcknowledgeTask`, `GetTask`, `ListTasks`, `CancelTask`), hexagonal layout, async dispatch, round-robin agent selection, 92.7% domain coverage (#479 / PRs #520 #522 #523)
 - Bearer-token auth middleware for api-gateway mutating endpoints (`ZYNAX_GW_API_KEY`) (#482)
 - X-Request-ID HTTP middleware with gRPC metadata propagation across api-gateway, workflow-compiler, and engine-adapter (#484)
-- HTTP adapter skeleton (`agents/adapters/http/`) (#380)
+- Idempotent `zynax apply` — manifest hash derives stable workflow ID; resubmitting the same YAML returns the same `run_id` (#485)
+- HTTP adapter (`agents/adapters/http/`) — REST capability proxy, config-only route mapping, registry client with backoff (#380)
+
+### Fixed
+- `resolveTemplate` map-iteration non-determinism in `IRInterpreterWorkflow` — sorted-key iteration ensures Temporal determinism (#475)
+- `CompileWorkflow` now returns the full `CompilationError` list instead of only the first error (#477)
+- SSE `WriteTimeout` extended in api-gateway — `zynax logs` no longer disconnects at 30 s (#478)
+- Event publish errors in engine-adapter now log as `WARN` instead of being silently discarded (#483)
+
+### Changed
+- Docker Compose files consolidated to one canonical `infra/docker-compose/docker-compose.yml`; `ZYNAX_GW_REGISTRY_ADDR` corrected to use service name (#486)
+- CNCF Sandbox Candidate badge removed; replaced with "Built with CNCF-graduated technologies" (#472)
+- CHANGELOG phantom entries removed (Helm charts, argo engine, features that do not exist in git) (#473)
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,7 @@ any layer.
 | M2 — Workflow IR | **Complete** | v0.1.0 | [Epic #101](https://github.com/zynax-io/zynax/issues/101) |
 | M3 — Temporal Execution | ⚠ **Partial** | v0.2.0 | [Epic #214](https://github.com/zynax-io/zynax/issues/214) · [Canvas](docs/spdd/214-temporal-execution/canvas.md) · no task-broker (blocked by M5.C #460) |
 | M4 — YAML System + CLI | ⚠ **Partial** | v0.3.0 | [Epic #314](https://github.com/zynax-io/zynax/issues/314) · [Canvas](docs/spdd/314-yaml-system-cli/canvas.md) · no agent-registry (blocked by M5.C #460) |
+| **M5 — Adapter Library** | 🔄 **In Progress** | v0.4.0 | [Epic #377](https://github.com/zynax-io/zynax/issues/377) · [Plan](docs/milestones/M5-plan.md) · M5.D ✅ M5.E ✅ · M5.C in progress |
 
 M1 delivered: 8 gRPC contracts, AsyncAPI spec, JSON schemas, Go + Python generated stubs,
 140+ BDD scenarios across all services, 5 CI gates. All work tracked in Epic #1 (closed).
@@ -153,9 +154,9 @@ Full guide: `docs/patterns/spdd-guide.md` · Template: `docs/spdd/CANVAS_TEMPLAT
 | **M2** (Complete) | WorkflowIR structured fields in `workflow_compiler.proto`, `WorkflowCompilerService` skeleton (in-memory), JSON Schema for WorkflowIR | Temporal integration, persistence, CLI |
 | **M3** (⚠ Partial) | Temporal-backed `EngineAdapterService` — `WorkflowEngine` interface, `IRInterpreterWorkflow`, `DispatchCapabilityActivity`, `TemporalEngine`, gRPC wiring | Other engine adapters, K8s deployment · task-broker missing (M5.C #460) |
 | **M4** (⚠ Partial) | api-gateway REST layer, `zynax` CLI, `kind: AgentDef` routing, Docker Compose runner, GitOps watch | Observability, production hardening · agent-registry missing (M5.C #460) |
-| **M5** (Active) | Adapter library (http ✅, git, ci, llm, langgraph), task-broker MVP, agent-registry MVP | — |
+| **M5** (Active) | M5.A docs alignment, M5.B engine fixes, M5.C capability dispatch (task-broker ✅ code, agent-registry pending), M5.D security ✅, M5.E DX ✅, http-adapter ✅, git/ci/llm/langgraph adapters | Persistence, K8s deployment, event-bus |
 
-Active milestone: M5 (Adapter Library). See open issues labelled `milestone: M5`.
+Active milestone: M5 (Adapter Library). See [docs/milestones/M5-plan.md](docs/milestones/M5-plan.md) for the full execution plan.
 
 ## Common AI Anti-Patterns
 

--- a/README.md
+++ b/README.md
@@ -321,6 +321,7 @@ make test        # full suite (unit + BDD + coverage gate)
 | **M2 — Workflow IR** | **Complete** | v0.1.0 | [Epic #101](https://github.com/zynax-io/zynax/issues/101) |
 | **M3 — Temporal Execution** | ⚠ **Partial** | v0.2.0 | [Epic #214](https://github.com/zynax-io/zynax/issues/214) · [Canvas](docs/spdd/214-temporal-execution/canvas.md) · no task-broker — blocked by M5.C [#460](https://github.com/zynax-io/zynax/issues/460) |
 | **M4 — YAML System + CLI** | ⚠ **Partial** | v0.3.0 | [Epic #314](https://github.com/zynax-io/zynax/issues/314) · [Canvas](docs/spdd/314-yaml-system-cli/canvas.md) · no agent-registry — blocked by M5.C [#460](https://github.com/zynax-io/zynax/issues/460) |
+| **M5 — Adapter Library** | 🔄 **In Progress** | v0.4.0 | [Epic #377](https://github.com/zynax-io/zynax/issues/377) · [Plan](docs/milestones/M5-plan.md) · M5.D ✅ · M5.E ✅ · task-broker ✅ · agent-registry pending |
 
 **M1** delivered the contracts-only foundation: 8 gRPC services defined as protobuf contracts,
 AsyncAPI spec covering 11 event channels, generated Go + Python stubs, 140+ BDD contract

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -126,14 +126,49 @@ Each roadmap milestone maps to a GitHub Milestone:
 
 **Goal:** Existing systems become capabilities without SDK adoption.
 
-> Label: `milestone: M5`
+> Label: `milestone: M5` · Epic: [#377](https://github.com/zynax-io/zynax/issues/377)
+> Execution plan: [docs/milestones/M5-plan.md](docs/milestones/M5-plan.md)
 
-- [ ] `http-adapter`: wraps any REST API — config-only, no code
-- [ ] `llm-adapter`: Bedrock, Ollama, OpenAI — provider configurable
-- [ ] `git-adapter`: GitHub/GitLab capabilities + webhook → event-bus
-- [ ] `langgraph-adapter`: runs a LangGraph app as a capability
-- [ ] `LangGraphEngine` adapter in `engine-adapter` service
-- [ ] Adapter cookbook: documented patterns for CI, databases, messaging
+M5 is structured into five parallel tracks, each with a REASONS Canvas and child issues.
+
+### M5.A — Truth Pass ([#458](https://github.com/zynax-io/zynax/issues/458))
+
+- [x] Remove CNCF Sandbox Candidate badge (#472)
+- [x] Audit CHANGELOG for phantom entries (#473)
+- [ ] Python SDK decision (#474)
+
+### M5.B — Engine Correctness Hardening ([#459](https://github.com/zynax-io/zynax/issues/459))
+
+- [x] Fix `resolveTemplate` map-iteration non-determinism (#475)
+- [ ] Replace bespoke guard parser with `cel-go` (#476)
+- [x] Return full `CompilationError` list from `CompileWorkflow` (#477)
+- [x] Fix SSE `WriteTimeout` breaking `zynax logs` at 30 s (#478)
+
+### M5.C — Capability Dispatch End-to-End ([#460](https://github.com/zynax-io/zynax/issues/460))
+
+- [x] `task-broker` MVP: in-memory `TaskBrokerService`, 5 RPCs, hexagonal layout (#479 / PRs #520 #522 #523)
+- [ ] `agent-registry` MVP: in-memory `AgentRegistryService`, 5 RPCs (#480 — BDD trim → domain → wiring)
+- [ ] Docker Compose wiring: task-broker + agent-registry in `make run-local` (#481)
+
+### M5.D — Control Plane Security Baseline ([#461](https://github.com/zynax-io/zynax/issues/461)) ✅
+
+- [x] Bearer-token auth middleware for api-gateway (#482)
+- [x] Log event publish failures instead of discarding (#483)
+- [x] X-Request-ID propagation across all services (#484)
+- [x] Idempotent `zynax apply` — manifest hash derives stable workflow ID (#485)
+- [x] Consolidate Docker Compose files (#486)
+
+### M5.E — Developer Experience Polish ([#462](https://github.com/zynax-io/zynax/issues/462)) ✅
+
+- [x] Idempotent apply and compose consolidation (shared with M5.D: #485 #486)
+
+### Adapter Library ([#377](https://github.com/zynax-io/zynax/issues/377))
+
+- [x] `http-adapter`: REST API proxy — config-only, no code (#380)
+- [ ] `git-adapter`: GitHub/GitLab operations (`open_pr`, `request_review`, `get_diff`) (#381)
+- [ ] `ci-adapter`: CI pipeline triggers (`trigger_workflow`, `get_run_status`) (#382)
+- [ ] `llm-adapter`: OpenAI / Bedrock / Ollama inference (#383) — Python
+- [ ] `langgraph-adapter`: any LangGraph graph as a named capability (#384) — Python
 
 ---
 

--- a/docs/milestones/M5-plan.md
+++ b/docs/milestones/M5-plan.md
@@ -1,0 +1,137 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# M5 — Adapter Library Execution Plan
+
+**Milestone:** Adapter Library (M5) · v0.4.0
+**GitHub Milestone:** [Adapter Library (M5)](https://github.com/zynax-io/zynax/milestone/5)
+**Parent epic:** [#377](https://github.com/zynax-io/zynax/issues/377)
+**Status:** In Progress
+**Last updated:** 2026-05-19
+
+---
+
+## Structure
+
+M5 delivers five parallel tracks:
+
+| Track | Epic | Title | Status |
+|-------|------|-------|--------|
+| M5.A | [#458](https://github.com/zynax-io/zynax/issues/458) | Truth Pass — documentation alignment | In Progress (2/3 done) |
+| M5.B | [#459](https://github.com/zynax-io/zynax/issues/459) | Engine Correctness Hardening | In Progress (3/4 done) |
+| M5.C | [#460](https://github.com/zynax-io/zynax/issues/460) | Capability Dispatch End-to-End | In Progress |
+| M5.D | [#461](https://github.com/zynax-io/zynax/issues/461) | Control Plane Security Baseline | ✅ Complete |
+| M5.E | [#462](https://github.com/zynax-io/zynax/issues/462) | Developer Experience Polish | ✅ Complete |
+| Adapters | [#377](https://github.com/zynax-io/zynax/issues/377) | Adapter Library (http ✅ + git + ci + llm + langgraph) | In Progress (1/5 done) |
+| Tooling | [#442](https://github.com/zynax-io/zynax/issues/442) | Fully Containerized Makefile Dev Workflow | ✅ Complete |
+
+---
+
+## M5.A — Truth Pass (#458)
+
+**Canvas:** [docs/spdd/458-truth-pass/canvas.md](../spdd/458-truth-pass/canvas.md)
+
+Aligns all documentation with implementation reality following the 2026-05 architectural review.
+
+| Issue | Title | Status |
+|-------|-------|--------|
+| [#472](https://github.com/zynax-io/zynax/issues/472) | Remove CNCF badge + update milestone status | ✅ Done |
+| [#473](https://github.com/zynax-io/zynax/issues/473) | Audit CHANGELOG for phantom entries | ✅ Done |
+| [#474](https://github.com/zynax-io/zynax/issues/474) | Python SDK decision | ⬜ Open |
+
+---
+
+## M5.B — Engine Correctness Hardening (#459)
+
+**Canvas:** [docs/spdd/459-engine-correctness/canvas.md](../spdd/459-engine-correctness/canvas.md)
+
+Fixes four production-incident-grade bugs identified in the 2026-05 architectural review.
+
+| Issue | Title | Status |
+|-------|-------|--------|
+| [#475](https://github.com/zynax-io/zynax/issues/475) | resolveTemplate map-iteration determinism | ✅ Done |
+| [#476](https://github.com/zynax-io/zynax/issues/476) | Replace bespoke guard parser with cel-go | ⬜ Open |
+| [#477](https://github.com/zynax-io/zynax/issues/477) | CompileWorkflow structured error list | ✅ Done |
+| [#478](https://github.com/zynax-io/zynax/issues/478) | SSE WriteTimeout fix | ✅ Done |
+
+---
+
+## M5.C — Capability Dispatch End-to-End (#460)
+
+**Canvas:** [docs/spdd/460-capability-dispatch/canvas.md](../spdd/460-capability-dispatch/canvas.md)
+
+Delivers the two missing services that make `zynax apply → capability dispatch` work end-to-end.
+
+### task-broker MVP (#479)
+
+**Canvas:** [docs/spdd/479-task-broker/canvas.md](../spdd/479-task-broker/canvas.md)
+
+| Issue | Canvas step | Title | Status |
+|-------|-------------|-------|--------|
+| [#530](https://github.com/zynax-io/zynax/issues/530) | O6 | Update AGENTS.md | ⬜ Open |
+| [#531](https://github.com/zynax-io/zynax/issues/531) | O7 | Align service BDD + godog steps | ⬜ Open |
+| [#532](https://github.com/zynax-io/zynax/issues/532) | O8 | Handler unit tests (grpcErr coverage) | ⬜ Open |
+
+Implementation merged: PRs #520, #522, #523. Domain coverage: 92.7%.
+
+### agent-registry MVP (#480)
+
+**Canvas:** [docs/spdd/480-agent-registry/canvas.md](../spdd/480-agent-registry/canvas.md)
+
+Ordered delivery — step 1 must be CI-green before step 2 begins (ADR-016).
+
+| Issue | Canvas step | Title | Status |
+|-------|-------------|-------|--------|
+| [#526](https://github.com/zynax-io/zynax/issues/526) | O1 | Trim BDD to proto scope | ⬜ Open |
+| [#527](https://github.com/zynax-io/zynax/issues/527) | O2 | Domain layer | ⬜ Open (blocked on #526) |
+| [#528](https://github.com/zynax-io/zynax/issues/528) | O3 | gRPC wiring + cmd + go.work | ⬜ Open (blocked on #527) |
+
+### compose wiring (#481)
+
+| Issue | Title | Status |
+|-------|-------|--------|
+| [#481](https://github.com/zynax-io/zynax/issues/481) | Add task-broker + agent-registry to docker-compose | ⬜ Open (blocked on #528) |
+
+---
+
+## M5.D — Control Plane Security Baseline (#461) ✅ Complete
+
+**Canvas:** [docs/spdd/461-security-baseline/canvas.md](../spdd/461-security-baseline/canvas.md)
+
+All 5 child issues merged: #482 #483 #484 #485 #486.
+
+---
+
+## M5.E — Developer Experience Polish (#462) ✅ Complete
+
+**Canvas:** [docs/spdd/462-dx-polish/canvas.md](../spdd/462-dx-polish/canvas.md)
+
+Both child issues merged: #485 #486.
+
+---
+
+## Adapter Library (#377)
+
+**Canvas:** [docs/spdd/377-adapter-library/canvas.md](../spdd/377-adapter-library/canvas.md)
+
+| Adapter | Epic | Canvas | Step issues | Status |
+|---------|------|--------|-------------|--------|
+| http | [#380](https://github.com/zynax-io/zynax/issues/380) | [380 canvas](../spdd/380-http-adapter/canvas.md) | #391–#397 | ✅ Done |
+| git | [#381](https://github.com/zynax-io/zynax/issues/381) | [381 canvas](../spdd/381-git-adapter/canvas.md) | #399–#403 | BDD done; impl pending |
+| ci | [#382](https://github.com/zynax-io/zynax/issues/382) | [382 canvas](../spdd/382-ci-adapter/canvas.md) | #404–#408 | BDD done; impl pending |
+| llm | [#383](https://github.com/zynax-io/zynax/issues/383) | [383 canvas](../spdd/383-llm-adapter/canvas.md) | #409–#413 | BDD done; impl pending |
+| langgraph | [#384](https://github.com/zynax-io/zynax/issues/384) | [384 canvas](../spdd/384-langgraph-adapter/canvas.md) | #414–#418 | BDD done; impl pending |
+
+---
+
+## Tooling (#442) ✅ Complete
+
+**Canvas:** [docs/spdd/442-containerized-make/canvas.md](../spdd/442-containerized-make/canvas.md)
+
+All 4 child issues merged: #443 #444 #445 #446.
+
+---
+
+## Blocked / Parking
+
+- **#474** (Python SDK decision) — deliberate decision required before any implementation
+- **#476** (guard parser) — Option A (cel-go) vs Option B (rename + fail-closed) to be decided in issue

--- a/docs/spdd/460-capability-dispatch/canvas.md
+++ b/docs/spdd/460-capability-dispatch/canvas.md
@@ -9,7 +9,7 @@
 **Date:** 2026-05-18
 **Status:** Aligned
 
-**Child issues:** #479 (task-broker MVP) · #480 (agent-registry MVP) · #481 (compose wiring)
+**Child issues:** #479 (task-broker MVP — code merged; cleanup: #530 #531 #532) · #480 (agent-registry MVP — steps: #526 #527 #528) · #481 (compose wiring)
 
 ---
 
@@ -28,8 +28,8 @@
 ## E — Entities
 
 ### Existing entities (contracts unchanged)
-- **`TaskBrokerService`** (`protos/zynax/v1/task_broker.proto`) — existing proto contract with `SubmitTask`, `GetTask`, `WatchTask`, `ReportTaskEvent`. The implementation must honour this contract exactly.
-- **`AgentRegistryService`** (`protos/zynax/v1/agent_registry.proto`) — existing proto contract with `RegisterAgent`, `DeregisterAgent`, `GetAgent`, `ListAgents`.
+- **`TaskBrokerService`** (`protos/zynax/v1/task_broker.proto`) — existing proto contract with `DispatchTask`, `AcknowledgeTask`, `GetTask`, `ListTasks`, `CancelTask`. The implementation must honour this contract exactly.
+- **`AgentRegistryService`** (`protos/zynax/v1/agent_registry.proto`) — existing proto contract with `RegisterAgent`, `DeregisterAgent`, `GetAgent`, `ListAgents`, `FindByCapability`.
 - **`AgentDef`** / **`CapabilityDef`** — proto messages describing an agent and its capabilities.
 - **`TaskEvent`** — proto message streaming PROGRESS / COMPLETED / FAILED events from agent to broker.
 - **`DispatchCapabilityActivity`** — Temporal activity in engine-adapter that submits a task to the broker and waits for completion.
@@ -88,9 +88,9 @@
 
 ## O — Operations
 
-1. **[#479]** Implement `services/task-broker/` — BDD `.feature` file first, then implementation. `SubmitTask`, `GetTask`, `WatchTask`, `ReportTaskEvent`. In-memory round-robin assignment by capability name. ≥90% domain coverage.
-2. **[#480]** Implement `services/agent-registry/` — BDD `.feature` file first (update existing stub to test real server), then implementation. `RegisterAgent`, `DeregisterAgent`, `GetAgent`, `ListAgents`. ≥90% domain coverage.
-3. **[#481]** Wire both services into docker-compose; fix `ZYNAX_GW_REGISTRY_ADDR: "localhost:50052"` → `agent-registry:50052`; add http-adapter `RegisterAgent` call; verify end-to-end path; update README.
+1. **[#479]** ✅ Implement `services/task-broker/` — 5 RPCs (`DispatchTask`, `AcknowledgeTask`, `GetTask`, `ListTasks`, `CancelTask`). In-memory round-robin assignment by capability name. Domain coverage 92.7%. Child quality issues: #530 (AGENTS.md), #531 (BDD align), #532 (handler tests).
+2. **[#480]** Implement `services/agent-registry/` — BDD feature file trim (#526) first, then domain (#527) then gRPC wiring (#528). `RegisterAgent`, `DeregisterAgent`, `GetAgent`, `ListAgents`, `FindByCapability`. ≥90% domain coverage.
+3. **[#481]** Wire both services into docker-compose; fix `ZYNAX_GW_REGISTRY_ADDR: "localhost:50052"` → `agent-registry:50051`; verify end-to-end path; update README. Depends on #528.
 
 ---
 

--- a/state/current-milestone.md
+++ b/state/current-milestone.md
@@ -12,77 +12,86 @@
 |-----------|--------|---------|
 | M1 — Contracts Foundation | ✅ Complete | v0.1.0 |
 | M2 — Workflow IR | ✅ Complete | v0.1.0 |
-| M3 — Temporal Execution | ✅ Complete | v0.2.0 |
-| M4 — YAML System + CLI | ✅ Complete | v0.3.0 |
+| M3 — Temporal Execution | ⚠ Partial | v0.2.0 |
+| M4 — YAML System + CLI | ⚠ Partial | v0.3.0 |
 | **M5 — Adapter Library** | **In Progress** | v0.4.0 |
+
+M3/M4 are partial because task-broker and agent-registry were not delivered in those milestones.
+Both are in-progress under M5.C (#460). See [docs/milestones/M5-plan.md](../docs/milestones/M5-plan.md).
 
 ---
 
 ## M5 — Progress
 
-Goal: Deliver the Adapter Library (#377) — five production-ready adapter services
-(http, git, ci, llm, langgraph) that turn any external system into a Zynax capability.
-Accompanied by code quality, security supply-chain gates, and documentation that bring
-the whole platform to production readiness. Sets the foundation for M6 Helm deployment.
+M5 is structured into five parallel tracks. See full execution plan: **[docs/milestones/M5-plan.md](../docs/milestones/M5-plan.md)**.
 
-Epic: [#377 — M5 Adapter Library](https://github.com/zynax-io/zynax/issues/377)
-Canvas: `docs/spdd/377-adapter-library/canvas.md` (Status: Draft — PR #385)
+### Track Overview
 
-### Track 1 — Adapter Library (the main M5 deliverable)
-
-Each adapter requires a REASONS Canvas + BDD feature file before implementation.
-
-- [ ] feat(adapters/http): REST capability proxy adapter (#380, step 1) — Go
-- [ ] feat(adapters/git): GitHub/GitLab operations adapter (#381, step 2) — Go
-- [ ] feat(adapters/ci): CI pipeline trigger adapter (#382, step 3) — Go
-- [ ] feat(adapters/llm): LLM provider capability adapter (#383, step 4) — Python
-- [ ] feat(adapters/langgraph): LangGraph capability adapter (#384, step 5) — Python
-
-### Track 2 — Go Code Quality
-
-- [ ] refactor(workflow-compiler): naming, zero-value structs, functional options (#222)
-- [ ] refactor: context.Context propagation — parent (#223)
-  - [ ] refactor(workflow-compiler): thread ctx from gRPC boundary (#373, step 1)
-  - [ ] docs(services): ctx-first mandate + Temporal exemption in AGENTS.md (#374, step 2)
-- [ ] refactor: error chain consistency — %w, typed sentinels, errors.Is/As (#224)
-
-### Track 2 — Python SDK Quality
-
-- [ ] ci(agents): enable ruff Google-style docstring enforcement (#375) ← unblocked
-- [ ] feat(agents): SDK core modules — runtime, context, capability, server, platform, observability ← needs new issue
-- [ ] docs(agents): Google-style docstrings on all public SDK symbols (#228 / #376) ← blocked on SDK impl
-- [ ] refactor(agents): strip explanatory comments (#229) ← blocked on #376
-
-### Track 2 — Supply-Chain Security
-
-- [ ] ci: consolidate tools image publish to single workflow (#358) ← do first
-- [ ] ci: SBOM generation with syft (#235) ← after #358
-- [ ] ci: SLSA provenance — sign artifacts with cosign (#239) ← after #235
-
-### Track 2 — Architecture & Docs
-
-- [ ] docs: architecture fitness functions — document all CI gates (#232)
-- [ ] docs: AI-output review checklist (#248)
+| Track | Epic | Status |
+|-------|------|--------|
+| M5.A Truth Pass | [#458](https://github.com/zynax-io/zynax/issues/458) | In Progress — 2/3 children done; #474 open |
+| M5.B Engine Correctness | [#459](https://github.com/zynax-io/zynax/issues/459) | In Progress — 3/4 children done; #476 open |
+| M5.C Capability Dispatch | [#460](https://github.com/zynax-io/zynax/issues/460) | In Progress — task-broker code merged; agent-registry pending |
+| M5.D Security Baseline | [#461](https://github.com/zynax-io/zynax/issues/461) | ✅ Complete (closed) |
+| M5.E DX Polish | [#462](https://github.com/zynax-io/zynax/issues/462) | ✅ Complete (closed) |
+| Adapter Library | [#377](https://github.com/zynax-io/zynax/issues/377) | In Progress — http ✅; git/ci/llm/langgraph BDD done, impl pending |
+| Containerized Make | [#442](https://github.com/zynax-io/zynax/issues/442) | ✅ Complete (closed) |
 
 ---
 
-## Active PRs
+## Active Work (M5.C)
 
-| PR | Title | Status |
-|----|-------|--------|
-| [#385](https://github.com/zynax-io/zynax/pull/385) | docs: REASONS Canvas for M5 Adapter Library (#377) | Open — pending merge |
+### task-broker (#479) — code complete, quality in progress
+
+Implementation PRs #520, #522, #523 merged. Domain coverage: 92.7%.
+
+**Open cleanup issues (M5.C, `track: M5.C`):**
+
+| Issue | Step | Status |
+|-------|------|--------|
+| [#530](https://github.com/zynax-io/zynax/issues/530) | Update AGENTS.md | ready |
+| [#531](https://github.com/zynax-io/zynax/issues/531) | Align service BDD + godog steps | ready |
+| [#532](https://github.com/zynax-io/zynax/issues/532) | Handler unit tests | ready |
+
+### agent-registry (#480) — pending implementation
+
+Canvas aligned. Ordered delivery: #526 → #527 → #528 → #481.
+
+| Issue | Step | Status |
+|-------|------|--------|
+| [#526](https://github.com/zynax-io/zynax/issues/526) | Trim BDD to proto scope | ready (do first) |
+| [#527](https://github.com/zynax-io/zynax/issues/527) | Domain layer | blocked on #526 |
+| [#528](https://github.com/zynax-io/zynax/issues/528) | gRPC wiring + go.work | blocked on #527 |
+| [#481](https://github.com/zynax-io/zynax/issues/481) | Compose wiring | blocked on #528 |
+
+---
+
+## Active Work (Other Tracks)
+
+| Issue | Track | Title | Status |
+|-------|-------|-------|--------|
+| [#474](https://github.com/zynax-io/zynax/issues/474) | M5.A | Python SDK decision | open — decision required |
+| [#476](https://github.com/zynax-io/zynax/issues/476) | M5.B | Guard parser (cel-go) | open — option A/B to decide |
+| [#381](https://github.com/zynax-io/zynax/issues/381) | Adapters | git-adapter impl | open (#399 BDD done; #400+ pending) |
+| [#382](https://github.com/zynax-io/zynax/issues/382) | Adapters | ci-adapter impl | open (#404 BDD done; #405+ pending) |
+| [#383](https://github.com/zynax-io/zynax/issues/383) | Adapters | llm-adapter impl | open (#409 BDD done; #410+ pending) |
+| [#384](https://github.com/zynax-io/zynax/issues/384) | Adapters | langgraph-adapter impl | open (#414 BDD done; #415+ pending) |
 
 ---
 
 ## Known Blockers
 
-- **#376 (docstrings) and #229 (strip comments)** are blocked until a `feat(agents):` issue is created and merged for the SDK core module implementation.
-- **#239 (cosign)** depends on #358 (stable GHCR path) and #235 (SBOM).
+- **agent-registry (#480)** — BDD trim (#526) must merge before domain implementation (#527) begins (ADR-016).
+- **compose wiring (#481)** — depends on #528 (agent-registry gRPC wiring) landing first.
+- **#476 (guard parser)** — requires architectural decision (cel-go vs simple rename) documented in the issue.
+- **#474 (Python SDK)** — requires a deliberate decision before any implementation.
 
 ---
 
 ## Recently Closed
 
-- M1–M4 GitHub milestones closed (all issues complete).
-- M4 delivered: api-gateway REST, `zynax` CLI, Docker Compose runner, GitOps watch.
-  Step issues #315–#320 all merged. Canvas: `docs/spdd/314-yaml-system-cli/canvas.md`.
+- **#461 M5.D** — Control Plane Security Baseline: all 5 child issues merged (#482–#486).
+- **#462 M5.E** — Developer Experience Polish: all child issues merged (#485–#486).
+- **#442** — Fully Containerized Makefile: all 4 child issues merged (#443–#446).
+- **#529** — docs(agent-registry): REASONS Canvas for #480.
+- **#533** — docs(task-broker): REASONS Canvas for #479.


### PR DESCRIPTION
## Summary

This PR closes the documentation and GitHub tracking gap for the M5 milestone identified in the alignment audit.

### What changed

**New file:**
- `docs/milestones/M5-plan.md` — Full M5 execution plan: all five tracks (M5.A–E), adapter library, tooling; per-track child issue tables with current status.

**Updated files:**
- `state/current-milestone.md` — Rewritten to reflect current reality: M5.D/E/tooling complete; M5.C capability-dispatch in progress; ordered delivery for agent-registry.
- `ROADMAP.md` M5 section — Five-track structure with per-track checklists and issue references, replacing the stale single-track list.
- `CLAUDE.md` — M5 milestone row added; per-milestone scope table updated.
- `CHANGELOG.md` — All recently merged M5 items added (task-broker service, security baseline, idempotent apply, SSE fix, compose consolidation, CNCF badge removal, etc.).
- `docs/spdd/460-capability-dispatch/canvas.md` — Corrected stale entity section: task-broker RPC names (`DispatchTask` etc., not `SubmitTask/WatchTask`); added `FindByCapability` to agent-registry contract; O-steps updated to reflect that #479 code is merged.

### GitHub changes (done before this PR)

- Created `track: M5.A/B/C/D/E` labels
- Applied track labels to all M5 epics and child issues
- Assigned M5 milestone to #526, #527, #528, #530, #531, #532 (was missing)
- Added `area: agent-registry` / `area: task-broker` labels to the six issues above
- Closed #461 (M5.D), #462 (M5.E), #442 (containerized make) — all children merged
- Updated epic body of #460, #479, #480 with canvas links and child issue tables
- Updated issue bodies of #526–532 with parent epic + canvas step references

## Test plan

- [ ] No Go/Python code changed — CI lint/test not applicable
- [ ] `make gitleaks` passes (no secrets in new files)
- [ ] All markdown links in `M5-plan.md` are valid GitHub issue/file URLs
- [ ] Canvas `docs/spdd/460-capability-dispatch/canvas.md` PASS on security review (Tier-1 only, no email literals)

🤖 Generated with [Claude Code](https://claude.com/claude-code)