### PR TITLE
docs: promote #474 and #476 to epics with REASONS Canvases

### DIFF
--- a/docs/milestones/M5-plan.md
+++ b/docs/milestones/M5-plan.md
@@ -6,7 +6,7 @@
 **GitHub Milestone:** [Adapter Library (M5)](https://github.com/zynax-io/zynax/milestone/5)
 **Parent epic:** [#377](https://github.com/zynax-io/zynax/issues/377)
 **Status:** In Progress
-**Last updated:** 2026-05-19
+**Last updated:** 2026-05-19 (rev 2)
 
 ---
 
@@ -36,7 +36,18 @@ Aligns all documentation with implementation reality following the 2026-05 archi
 |-------|-------|--------|
 | [#472](https://github.com/zynax-io/zynax/issues/472) | Remove CNCF badge + update milestone status | ✅ Done |
 | [#473](https://github.com/zynax-io/zynax/issues/473) | Audit CHANGELOG for phantom entries | ✅ Done |
-| [#474](https://github.com/zynax-io/zynax/issues/474) | Python SDK decision | ⬜ Open |
+| [#474](https://github.com/zynax-io/zynax/issues/474) | **Python SDK** — Agent base class epic | ⬜ Epic (see below) |
+
+### Python SDK epic (#474) — promoted
+
+**Canvas:** [docs/spdd/474-python-sdk/canvas.md](../spdd/474-python-sdk/canvas.md)
+**Decision:** Option A chosen — implement minimal `Agent` base class.
+
+| Issue | Step | Title | Status |
+|-------|------|-------|--------|
+| [#535](https://github.com/zynax-io/zynax/issues/535) | O1 | Implement Agent base class | ⬜ Open |
+| [#536](https://github.com/zynax-io/zynax/issues/536) | O2 | Unit tests (≥ 85% coverage) | ⬜ Open (blocked on #535) |
+| [#537](https://github.com/zynax-io/zynax/issues/537) | O3 | Docs update — README, ARCHITECTURE.md, AGENTS.md | ⬜ Open (blocked on #535+#536) |
 
 ---
 
@@ -49,9 +60,20 @@ Fixes four production-incident-grade bugs identified in the 2026-05 architectura
 | Issue | Title | Status |
 |-------|-------|--------|
 | [#475](https://github.com/zynax-io/zynax/issues/475) | resolveTemplate map-iteration determinism | ✅ Done |
-| [#476](https://github.com/zynax-io/zynax/issues/476) | Replace bespoke guard parser with cel-go | ⬜ Open |
+| [#476](https://github.com/zynax-io/zynax/issues/476) | **Guard evaluator** — cel-go epic | ⬜ Epic (see below) |
 | [#477](https://github.com/zynax-io/zynax/issues/477) | CompileWorkflow structured error list | ✅ Done |
 | [#478](https://github.com/zynax-io/zynax/issues/478) | SSE WriteTimeout fix | ✅ Done |
+
+### Guard evaluator epic (#476) — promoted
+
+**Canvas:** [docs/spdd/476-guard-parser/canvas.md](../spdd/476-guard-parser/canvas.md)
+**Decision:** Option A — integrate `github.com/google/cel-go` (fail-closed on eval error).
+
+| Issue | Step | Title | Status |
+|-------|------|-------|--------|
+| [#538](https://github.com/zynax-io/zynax/issues/538) | O1 | Integrate cel-go into evalGuard | ⬜ Open |
+| [#539](https://github.com/zynax-io/zynax/issues/539) | O2 | Test suite + fuzz seed | ⬜ Open (blocked on #538) |
+| [#540](https://github.com/zynax-io/zynax/issues/540) | O3 | Remove CEL misrepresentation from docs | ⬜ Open (blocked on #538+#539) |
 
 ---
 
@@ -113,13 +135,57 @@ Both child issues merged: #485 #486.
 
 **Canvas:** [docs/spdd/377-adapter-library/canvas.md](../spdd/377-adapter-library/canvas.md)
 
-| Adapter | Epic | Canvas | Step issues | Status |
-|---------|------|--------|-------------|--------|
-| http | [#380](https://github.com/zynax-io/zynax/issues/380) | [380 canvas](../spdd/380-http-adapter/canvas.md) | #391–#397 | ✅ Done |
-| git | [#381](https://github.com/zynax-io/zynax/issues/381) | [381 canvas](../spdd/381-git-adapter/canvas.md) | #399–#403 | BDD done; impl pending |
-| ci | [#382](https://github.com/zynax-io/zynax/issues/382) | [382 canvas](../spdd/382-ci-adapter/canvas.md) | #404–#408 | BDD done; impl pending |
-| llm | [#383](https://github.com/zynax-io/zynax/issues/383) | [383 canvas](../spdd/383-llm-adapter/canvas.md) | #409–#413 | BDD done; impl pending |
-| langgraph | [#384](https://github.com/zynax-io/zynax/issues/384) | [384 canvas](../spdd/384-langgraph-adapter/canvas.md) | #414–#418 | BDD done; impl pending |
+### http-adapter (#380) ✅ Complete
+
+All step issues merged: #391 #392 #393 #394 #395 #396 #397.
+
+### git-adapter (#381)
+
+**Canvas:** [docs/spdd/381-git-adapter/canvas.md](../spdd/381-git-adapter/canvas.md) · Capabilities: `open_pr`, `request_review`, `get_diff`
+
+| Issue | Step | Title | Status |
+|-------|------|-------|--------|
+| [#399](https://github.com/zynax-io/zynax/issues/399) | O1 | BDD contract feature file | ✅ Done |
+| [#400](https://github.com/zynax-io/zynax/issues/400) | O2 | Go module scaffold + config layer | ⬜ Open |
+| [#401](https://github.com/zynax-io/zynax/issues/401) | O3 | Capability handler (open_pr, request_review, get_diff) | ⬜ Open (blocked on #400) |
+| [#402](https://github.com/zynax-io/zynax/issues/402) | O4 | Registry client + bootstrap | ⬜ Open (blocked on #401) |
+| [#403](https://github.com/zynax-io/zynax/issues/403) | O5 | Dockerfile, docker-compose, AGENTS.md | ⬜ Open (blocked on #402) |
+
+### ci-adapter (#382)
+
+**Canvas:** [docs/spdd/382-ci-adapter/canvas.md](../spdd/382-ci-adapter/canvas.md) · Capabilities: `trigger_workflow`, `get_run_status`
+
+| Issue | Step | Title | Status |
+|-------|------|-------|--------|
+| [#404](https://github.com/zynax-io/zynax/issues/404) | O1 | BDD contract feature file | ✅ Done |
+| [#405](https://github.com/zynax-io/zynax/issues/405) | O2 | Go module scaffold + config layer | ⬜ Open |
+| [#406](https://github.com/zynax-io/zynax/issues/406) | O3 | CIHandler + PollLoop | ⬜ Open (blocked on #405) |
+| [#407](https://github.com/zynax-io/zynax/issues/407) | O4 | Registry client + bootstrap | ⬜ Open (blocked on #406) |
+| [#408](https://github.com/zynax-io/zynax/issues/408) | O5 | Dockerfile, docker-compose, AGENTS.md | ⬜ Open (blocked on #407) |
+
+### llm-adapter (#383)
+
+**Canvas:** [docs/spdd/383-llm-adapter/canvas.md](../spdd/383-llm-adapter/canvas.md) · Capability: `chat_completion` · Python
+
+| Issue | Step | Title | Status |
+|-------|------|-------|--------|
+| [#409](https://github.com/zynax-io/zynax/issues/409) | O1 | BDD contract feature file | ✅ Done |
+| [#410](https://github.com/zynax-io/zynax/issues/410) | O2 | Module scaffold + ProviderConfig | ⬜ Open |
+| [#411](https://github.com/zynax-io/zynax/issues/411) | O3 | Provider handlers (OpenAI, Bedrock, Ollama) | ⬜ Open (blocked on #410) |
+| [#412](https://github.com/zynax-io/zynax/issues/412) | O4 | Registry client + bootstrap | ⬜ Open (blocked on #411) |
+| [#413](https://github.com/zynax-io/zynax/issues/413) | O5 | Dockerfile, docker-compose, AGENTS.md | ⬜ Open (blocked on #412) |
+
+### langgraph-adapter (#384)
+
+**Canvas:** [docs/spdd/384-langgraph-adapter/canvas.md](../spdd/384-langgraph-adapter/canvas.md) · Maps LangGraph StateGraph to capabilities · Python
+
+| Issue | Step | Title | Status |
+|-------|------|-------|--------|
+| [#414](https://github.com/zynax-io/zynax/issues/414) | O1 | BDD contract feature file | ✅ Done |
+| [#415](https://github.com/zynax-io/zynax/issues/415) | O2 | Module scaffold + GraphMount config | ⬜ Open |
+| [#416](https://github.com/zynax-io/zynax/issues/416) | O3 | GraphLoader + LangGraphHandler | ⬜ Open (blocked on #415) |
+| [#417](https://github.com/zynax-io/zynax/issues/417) | O4 | Registry client + bootstrap | ⬜ Open (blocked on #416) |
+| [#418](https://github.com/zynax-io/zynax/issues/418) | O5 | Dockerfile, docker-compose, AGENTS.md | ⬜ Open (blocked on #417) |
 
 ---
 

--- a/docs/spdd/474-python-sdk/canvas.md
+++ b/docs/spdd/474-python-sdk/canvas.md
@@ -1,0 +1,137 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# REASONS Canvas — Python SDK: Minimal Agent Base Class
+
+> **All content in this Canvas is Tier 1 (public-safe).**
+
+**Issue:** #474 (Epic)
+**Author:** Oscar Gómez Manresa
+**Date:** 2026-05-19
+**Status:** Aligned
+
+**Parent epic:** [#458 M5.A Truth Pass](https://github.com/zynax-io/zynax/issues/458)
+**Track:** M5.A
+
+**Child issues:** #535 (Agent base class impl) · #536 (tests) · #537 (docs update)
+
+---
+
+## R — Requirements
+
+**Problem:** `agents/sdk/src/zynax_sdk/__init__.py` is a 5-line empty package whose only content is `__version__ = "0.1.0"` and a placeholder comment. README, ARCHITECTURE.md, and AGENTS.md all describe a Python SDK as an existing, operational component. Developers following the documentation to build Python agents hit a dead end — there is no `Agent` base class, no `execute_capability()` method, no `report_event()` helper, and no gRPC initialization assistance. The mismatch between documentation and reality is a M5.A truth-pass gap (review C7).
+
+**Definition of done:**
+- `agents/sdk/src/zynax_sdk/agent.py` exists with a working `Agent` base class covering the canonical execution loop: receive `ExecuteCapabilityRequest`, route to a handler, emit `TaskEvent` PROGRESS and COMPLETED/FAILED events.
+- `GOWORK=off`-equivalent: `uv run pytest tests/` passes at ≥ 85% coverage in `agents/sdk/`.
+- README, ARCHITECTURE.md, and `agents/sdk/AGENTS.md` accurately describe the SDK capability. No phantom claims remain.
+- `pyproject.toml` description reflects delivered functionality.
+- `make gitleaks` passes.
+
+---
+
+## E — Entities
+
+### Existing entities (unchanged contracts)
+
+- **`AgentService`** (`protos/zynax/v1/agent.proto`) — two-RPC contract: `ExecuteCapability` (server-streaming `TaskEvent`) and `GetCapabilitySchema`. The SDK wraps this contract; the proto itself is not modified (ADR-001).
+- **`ExecuteCapabilityRequest`** (proto message) — input to `ExecuteCapability`; carries `request_id`, `capability_name`, `task_id`, `workflow_id`, `input_payload` (JSON bytes), `timeout_seconds`.
+- **`TaskEvent`** (proto message) — streaming output; `event_type` is `PROGRESS`, `COMPLETED`, or `FAILED`; carries `task_id`, `payload` (JSON bytes), `timestamp`, optional `CapabilityError`.
+- **`CapabilityError`** (proto message) — `code` (well-known string), `message` (human-readable, sanitised).
+- **`agents/sdk/src/zynax_sdk/__init__.py`** — current empty package; `__version__` will be preserved.
+- **`agents/sdk/pyproject.toml`** — package manifest; description updated.
+
+### New entities
+
+- **`Agent`** (`agents/sdk/src/zynax_sdk/agent.py`) — abstract base class. Subclass + implement `handle(request: ExecuteCapabilityRequest) -> AsyncIterator[TaskEvent]`. Owns gRPC server lifecycle, structured logging, and capability routing.
+- **`report_progress(task_id, payload)`** — helper method on `Agent`; emits a single `TASK_EVENT_TYPE_PROGRESS` `TaskEvent` to the active stream.
+- **`report_completed(task_id, payload)`** — helper method; emits terminal `TASK_EVENT_TYPE_COMPLETED`.
+- **`report_failed(task_id, code, message)`** — helper method; emits terminal `TASK_EVENT_TYPE_FAILED` with `CapabilityError`.
+- **`CapabilityRouter`** — dispatches `capability_name` to registered handler callables within an `Agent` subclass. Registered via `@agent.capability("name")` decorator.
+- **`agents/sdk/tests/test_agent.py`** — unit test suite. Uses `grpc.aio` test channel (or `unittest.mock`) to verify routing, event emission, and error handling without a live gRPC connection.
+
+---
+
+## A — Approach
+
+**What we WILL do (Option A — implement minimal SDK):**
+- Implement the `Agent` abstract base class (~200 LOC) with `execute_capability()` gRPC handler, `report_progress/completed/failed` helpers, and a `@capability` decorator for routing.
+- Use `grpc.aio` (async gRPC) consistent with the existing llm-adapter and langgraph-adapter pattern.
+- Follow the same `pyproject.toml` + `uv` structure as `agents/adapters/llm/` and `agents/adapters/langgraph/`.
+- Tests use `pytest-asyncio`; coverage gate ≥ 85%.
+- Update README, ARCHITECTURE.md, `agents/sdk/AGENTS.md` to accurately describe what the SDK provides.
+
+**What we WON'T do:**
+- Implement a full SDK with registry client, health probes, or Dockerfile (that is M6+).
+- Change any proto field numbers or method names (ADR-001).
+- Add persistence or event-bus integration (M6+).
+- Create a new gRPC proto contract — the SDK implements the existing `AgentService` contract.
+
+**Option B (rejected):** Remove the SDK promise from docs and leave the package as an empty placeholder. Rejected because the llm-adapter and langgraph-adapter already demonstrate the need for a reusable Python base class. Implementing it now removes per-adapter boilerplate and gives the M5 Python adapters a shared execution foundation.
+
+**ADR references:**
+- ADR-001: gRPC inter-service protocol — SDK implements `AgentService` exactly; no proto changes.
+- ADR-002: Python 3.12 as the agent runtime.
+- ADR-003: `uv` as the Python package manager.
+- ADR-013: Adapter-first — SDK is optional; raw gRPC stubs remain valid. SDK lowers the barrier but does not replace the gRPC contract.
+- ADR-016: Layered testing — coverage gate ≥ 85% on `agents/sdk/`.
+- ADR-019: SPDD — this Canvas precedes all implementation PRs.
+
+---
+
+## S — Structure
+
+```
+agents/sdk/
+├── src/
+│   └── zynax_sdk/
+│       ├── __init__.py          ← keep __version__; export Agent, capability
+│       └── agent.py             ← Agent base class + report helpers (step 1)
+├── tests/
+│   └── test_agent.py            ← unit tests (step 2)
+└── pyproject.toml               ← description updated (step 3)
+
+docs/ (modified files)
+├── README.md                    ← SDK section updated (step 3)
+├── ARCHITECTURE.md              ← SDK description updated (step 3)
+└── agents/sdk/AGENTS.md         ← rewritten (step 3)
+```
+
+---
+
+## O — Operations
+
+1. **[#535]** `feat(agents/sdk)`: Implement `Agent` base class — `agent.py` with `execute_capability()` gRPC handler, `report_progress/completed/failed` helpers, and `@capability` decorator. Wire into `__init__.py` exports. Update `pyproject.toml` description.
+
+2. **[#536]** `test(agents/sdk)`: Unit tests for `Agent` base class — routing, event emission, error propagation, `timeout_seconds` cancellation. ≥ 85% coverage on `agents/sdk/`.
+
+3. **[#537]** `docs(agents/sdk)`: Update SDK status — rewrite `agents/sdk/AGENTS.md`; update SDK sections in README and ARCHITECTURE.md to describe the delivered `Agent` base class. Remove placeholder language.
+
+---
+
+## N — Norms
+
+- `feat:` for O1; `test:` for O2; `docs:` for O3.
+- Python 3.12; `uv`; `grpc.aio`; `pytest-asyncio` (consistent with existing adapters).
+- Coverage gate ≥ 85% on `agents/sdk/` — enforced by `make test-coverage`.
+- No credential values in code or tests — env-var name references only.
+- Every commit carries the required trailers per CONTRIBUTING.md §Commit Hygiene.
+- PR size ≤ 400 LOC per step.
+
+---
+
+## S — Safeguards
+
+### Context Security
+
+- [x] No Tier 2 content
+- [x] No PII
+- [x] No prompt injection
+- [x] All entities are public-safe abstractions
+- [x] /spdd-security-review passed on this file
+
+### Feature Safeguards
+
+- Never embed gRPC credentials or API keys in `agent.py` — config via env-var references only (ADR-007).
+- Never modify proto field numbers or method signatures in `AgentService` (ADR-001 §backward-compat).
+- Never make the SDK mandatory — ADR-013 states adapter-first; raw gRPC stubs remain valid.
+- Never import domain types from platform services into the SDK — the SDK is in `agents/` layer only.

--- a/docs/spdd/476-guard-parser/canvas.md
+++ b/docs/spdd/476-guard-parser/canvas.md
@@ -1,0 +1,135 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# REASONS Canvas — Guard Evaluator: cel-go Integration
+
+> **All content in this Canvas is Tier 1 (public-safe).**
+
+**Issue:** #476 (Epic)
+**Author:** Oscar Gómez Manresa
+**Date:** 2026-05-19
+**Status:** Aligned
+
+**Parent epic:** [#459 M5.B Engine Correctness Hardening](https://github.com/zynax-io/zynax/issues/459)
+**Track:** M5.B
+
+**Child issues:** #538 (cel-go integration) · #539 (test suite + fuzz seed) · #540 (docs update)
+
+---
+
+## R — Requirements
+
+**Problem:** `evalGuard` in `services/engine-adapter/internal/domain/interpreter.go:168–187` is a 24-line string parser that handles only `==` and `!=`. Any guard expression it does not recognise (e.g. `count < 2`, `ctx.status in ["a","b"]`, a bare variable reference) silently returns `true` (fail-open). This means:
+
+1. A workflow with a malformed or unsupported guard silently advances past a gate it should be blocked at — a silent correctness failure.
+2. Documentation and comments describe the feature as "CEL guards" and "CEL-like guard", misleading operators into writing full CEL expressions that are never evaluated.
+3. The `IRInterpreterWorkflow` Temporal workflow is rated a production-incident generator (review C4, R3) because silent fail-open can drive a workflow into a terminal state it should never reach.
+
+**Definition of done:**
+- Any guard expression not parseable by the evaluator fails-closed (returns `false`) instead of fail-open.
+- The evaluator correctly handles at minimum: `ctx.<key> == "value"`, `ctx.<key> != "value"`, and the full `cel-go` expression set (if Option A chosen).
+- All existing `==` / `!=` guards in `spec/workflows/examples/*.yaml` pass without change.
+- Documentation and code comments contain no claims of "CEL" semantics unless `cel-go` is integrated.
+- A fuzz test seed file is committed (execution deferred to M7.C #469, but seed is committed now).
+- `GOWORK=off go test ./... -race` passes in `services/engine-adapter/`.
+
+---
+
+## E — Entities
+
+- **`evalGuard(expr string, ctx map[string]string) bool`** — current function at `interpreter.go:168–187`; 24-line string parser; fail-open on unknown expressions.
+- **`resolveOperand(expr string, ctx map[string]string) string`** — operand resolver called by `evalGuard`; handles `ctx.<key>` references.
+- **`IRInterpreterWorkflow`** — Temporal workflow that calls `evalGuard` at `interpreter.go:157`; must remain deterministic (ADR-015, Temporal contract).
+- **`github.com/google/cel-go`** — Go CEL implementation; evaluates Common Expression Language expressions. Deterministic — safe inside Temporal workflow boundary.
+- **`cel.Program`** — compiled CEL expression; computed once at workflow invocation time (not per-step) to remain deterministic.
+- **`interpreter_test.go`** — existing test file in `services/engine-adapter/internal/domain/`; extended in O2.
+- **Fuzz seed** — `services/engine-adapter/internal/domain/testdata/fuzz/FuzzEvalGuard/` — empty input corpus committed as the seed.
+
+---
+
+## A — Approach
+
+**What we WILL do (Option A — cel-go integration, recommended):**
+- Replace the 24-line `evalGuard` string parser with a `cel-go`-based evaluator (~80 LOC including tests).
+- The `cel.Environment` is created once at process startup (or lazily on first call). `cel.Program` is compiled per unique expression string and cached in a `sync.Map` to avoid recompilation on repeated evaluations.
+- Fail-closed on `cel.Compile` or `cel.Program.Eval` error (return `false`, log the error at WARN level).
+- The `ctx` map is passed to CEL as a `map<string, string>` variable named `ctx`; existing `ctx.<key>` guard expressions work unchanged.
+- Remove all "CEL-like" / "CEL" comments and replace with "cel-go (github.com/google/cel-go)".
+- Commit fuzz seed under `testdata/fuzz/FuzzEvalGuard/`.
+
+**What we WON'T do:**
+- Run full fuzz testing in CI (deferred to M7.C #469 — fuzz testing is expensive and belongs in a dedicated test-rigor pass).
+- Change the `evalGuard` function signature (callers remain unchanged).
+- Add persistence, event publishing, or any infrastructure changes.
+- Touch any proto files (ADR-001).
+
+**Why not Option B (rename + fail-closed)?** Renaming `evalGuard` → `evalSimpleEquality` and flipping the default to `return false` fixes the immediate correctness bug but leaves operators with no path to richer conditions. Documentation would need to say "simple equality only" — which is a regression from the advertised "CEL guards" and blocks M6 use cases. `cel-go` adds ~80 LOC and zero new dependencies beyond the cel-go module; the correctness and expressiveness gain justifies the choice.
+
+**ADR references:**
+- ADR-001: No proto changes in this epic.
+- ADR-015: Pluggable workflow engines — `IRInterpreterWorkflow` must remain Temporal-deterministic; `cel.Program.Eval` is pure-function and deterministic.
+- ADR-016: Layered testing — domain coverage target ≥ 90% on `internal/domain/` post-fix.
+- ADR-017: `GOWORK=off go test ./... -race` in `services/engine-adapter/`.
+
+---
+
+## S — Structure
+
+```
+services/engine-adapter/
+└── internal/
+    └── domain/
+        ├── interpreter.go              ← replace evalGuard body (O1)
+        ├── interpreter_test.go         ← extend with cel-go scenarios (O2)
+        └── testdata/
+            └── fuzz/
+                └── FuzzEvalGuard/      ← empty seed corpus (O2)
+
+go.mod (services/engine-adapter/)      ← add github.com/google/cel-go (O1)
+go.sum                                 ← updated (O1)
+go.work.sum                            ← updated via go work sync (O1)
+```
+
+**Modified docs (O3):**
+- `services/engine-adapter/AGENTS.md` — remove "CEL-like" language; state "cel-go full CEL".
+- Any `.yaml` example files that carry guard comments referencing "CEL" (if any).
+
+---
+
+## O — Operations
+
+1. **[#538]** `fix(engine-adapter)`: Integrate `cel-go` as the guard evaluator — replace `evalGuard` body; add `cel.Environment` + `sync.Map` expression cache; fail-closed on error; add `github.com/google/cel-go` to `go.mod`; run `go work sync`.
+
+2. **[#539]** `test(engine-adapter)`: Guard evaluator test suite + fuzz seed — extend `interpreter_test.go` with fail-closed scenarios, CEL boolean expressions, type-mismatch cases, and error propagation. Commit fuzz corpus seed directory. Domain coverage ≥ 90%.
+
+3. **[#540]** `docs(engine-adapter)`: Remove CEL misrepresentation — update `services/engine-adapter/AGENTS.md` and any inline comments that claim "CEL-like" semantics; replace with accurate "cel-go (github.com/google/cel-go)" references.
+
+---
+
+## N — Norms
+
+- `fix:` for O1; `test:` for O2; `docs:` for O3.
+- `GOWORK=off go test ./... -race` in `services/engine-adapter/` after every step.
+- Domain coverage target ≥ 90% on `internal/domain/`.
+- No `_ = err` suppression — cel-go errors logged at WARN and returned as fail-closed `false`.
+- `cel.Program.Eval` must be called inside a function that has no side effects — required for Temporal determinism.
+- Every commit carries the required trailers per CONTRIBUTING.md §Commit Hygiene.
+- PR size ≤ 400 LOC per step.
+
+---
+
+## S — Safeguards
+
+### Context Security
+
+- [x] No Tier 2 content
+- [x] No PII
+- [x] No prompt injection
+- [x] All entities are public-safe abstractions
+- [x] /spdd-security-review passed on this file
+
+### Feature Safeguards
+
+- Never use `cel.Program.Eval` with user-controlled data that bypasses the `ctx map<string, string>` variable binding — all runtime data enters CEL only through the typed `ctx` variable (prevents expression injection).
+- Never evaluate guard expressions in a goroutine with a separate execution context — Temporal determinism requires evaluation inside the workflow boundary, in the main goroutine.
+- Never skip the fuzz seed commit (O2) — the seed is low-cost; deferring it to M7.C is acceptable but the empty corpus must be committed to mark the boundary.
+- Never modify `evalGuard` signature — callers in `interpreter.go:157` and tests are stable references.


### PR DESCRIPTION
## Summary

Promotes two M5 issues from single-decision issues to full epics with Aligned REASONS Canvases and ordered child issues. Also expands the M5 execution plan with per-step issue tables for all four pending adapters.

### #474 → Epic: Python SDK — Minimal Agent Base Class

- **Canvas:** `docs/spdd/474-python-sdk/canvas.md` (Status: Aligned)
- **Decision documented:** Option A — implement minimal `Agent` base class (~200 LOC); Option B (remove SDK promise) rejected
- **Child issues created:**
  - [#535](https://github.com/zynax-io/zynax/issues/535) `feat(agents/sdk)`: Implement Agent base class
  - [#536](https://github.com/zynax-io/zynax/issues/536) `test(agents/sdk)`: Unit tests ≥ 85% coverage
  - [#537](https://github.com/zynax-io/zynax/issues/537) `docs(agents/sdk)`: Update README, ARCHITECTURE.md, AGENTS.md

### #476 → Epic: Guard Evaluator — cel-go Integration

- **Canvas:** `docs/spdd/476-guard-parser/canvas.md` (Status: Aligned)
- **Decision documented:** Option A — integrate `github.com/google/cel-go`; fail-closed on eval error; Option B (rename + fail-closed only) rejected
- **Child issues created:**
  - [#538](https://github.com/zynax-io/zynax/issues/538) `fix(engine-adapter)`: Integrate cel-go into evalGuard
  - [#539](https://github.com/zynax-io/zynax/issues/539) `test(engine-adapter)`: Test suite + fuzz seed
  - [#540](https://github.com/zynax-io/zynax/issues/540) `docs(engine-adapter)`: Remove CEL misrepresentation

### GitHub changes (done before this PR)

- Promoted #474 and #476 to `type: epic` + `spdd: canvas` labels
- Updated epic bodies of #474, #476, #381, #382, #383, #384 with canvas links + child issue tables
- Updated step issue bodies for #400–403, #405–408, #410–413, #415–418 with parent epic + canvas step references
- Created child issues #535–540 with correct milestone, area, track, and canvas-step labels

### M5-plan.md changes

- #474 and #476 entries promoted to sub-epic sections with step tables
- Adapter Library section expanded: per-adapter step issue tables for git (#400–403), ci (#405–408), llm (#410–413), langgraph (#415–418)

## Test plan

- [ ] No Go/Python code changed — CI lint/test not applicable
- [ ] `make gitleaks` passes (no secrets in new canvases)
- [ ] Canvas security: both new canvases contain no email literals, no Tier-2 content, no prompt injection

🤖 Generated with [Claude Code](https://claude.com/claude-code)