### PR TITLE
ci: remove test-integration from required status checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,12 +5,13 @@
 # status checks configured on `main`. Never rename a job without updating
 # the branch protection rules first (Settings → Branches → main).
 #
-# Required check names: dco · lint-proto · lint-go · lint-python · test-unit · test-integration · security
+# Required check names: dco · lint-proto · lint-go · lint-python · test-unit · security
+# (test-integration is non-required until real integration tests exist — see #227, #547)
 #
 # Job graph (all gates after dco):
 #   dco → changes → lint-proto ─╮
 #                ├─ lint-go   ──┴──→ test-unit         (skipped if code=false)
-#                │            └──→ test-integration    (skipped if code=false)
+#                │            └──→ test-integration    (non-required; no //go:build integration files yet — #227)
 #                └─ lint-python
 #   dco → security   (independent)
 #
@@ -1115,6 +1116,8 @@ jobs:
 #
 # `if: always()` mirrors test-unit — prevents the cascade-skip when lint-proto
 # and lint-python are skipped on Go-only PRs (same reasoning as above).
+# NOT a required status check: removed from branch protection in #547.
+# Re-add to required checks once real integration tests exist (#227 / M7.C).
   test-integration:
     name: test-integration
     runs-on: ubuntu-24.04

--- a/docs/milestones/M5-plan.md
+++ b/docs/milestones/M5-plan.md
@@ -6,7 +6,7 @@
 **GitHub Milestone:** [Adapter Library (M5)](https://github.com/zynax-io/zynax/milestone/5)
 **Parent epic:** [#377](https://github.com/zynax-io/zynax/issues/377)
 **Status:** In Progress
-**Last updated:** 2026-05-20 (rev 3 — post principal-architect review, CI sprint added)
+**Last updated:** 2026-05-20 (rev 4 — #547 done: test-integration removed from required checks)
 
 ---
 
@@ -73,7 +73,7 @@ PR cycle time from 25 min → 7 min before any code work begins.
 
 | Issue | Title | Size | Why first |
 |-------|-------|------|-----------|
-| [#547](https://github.com/zynax-io/zynax/issues/547) | Remove `test-integration` from required status checks | XS | Blocks every PR today |
+| [#547](https://github.com/zynax-io/zynax/issues/547) | Remove `test-integration` from required status checks | XS | ✅ Done |
 | [#544](https://github.com/zynax-io/zynax/issues/544) | Enable GitHub Merge Queue + remove `strict: true` | XS | Eliminates mandatory rebase overhead |
 | [#545](https://github.com/zynax-io/zynax/issues/545) | Fix CI concurrency — cancel stale runs per branch | XS | Prevents redundant runs eating quota |
 | [#548](https://github.com/zynax-io/zynax/issues/548) | Enable `allow_auto_merge` on repository | XS | Self-merge once all checks pass |
@@ -234,7 +234,7 @@ without rewriting the graph).
 | Issue | Title | Size | Priority |
 |-------|-------|------|----------|
 | [#544](https://github.com/zynax-io/zynax/issues/544) | Enable GitHub Merge Queue + remove `strict: true` | XS | **P0** |
-| [#547](https://github.com/zynax-io/zynax/issues/547) | Remove `test-integration` from required status checks | XS | **P0** |
+| [#547](https://github.com/zynax-io/zynax/issues/547) | Remove `test-integration` from required status checks | XS | ✅ Done |
 | [#548](https://github.com/zynax-io/zynax/issues/548) | Enable `allow_auto_merge` | XS | P1 |
 | [#545](https://github.com/zynax-io/zynax/issues/545) | Fix CI concurrency — cancel stale runs per branch | XS | P1 |
 | [#546](https://github.com/zynax-io/zynax/issues/546) | Remove push-to-main forced-true override | S | P1 |

--- a/state/current-milestone.md
+++ b/state/current-milestone.md
@@ -48,7 +48,7 @@ Fix the CI pipeline before all other work. These are XS/S admin + YAML changes.
 
 | Issue | Title | Size | Why |
 |-------|-------|------|-----|
-| [#547](https://github.com/zynax-io/zynax/issues/547) | Remove test-integration from required status checks | XS | Blocks every PR |
+| ~~[#547](https://github.com/zynax-io/zynax/issues/547)~~ | ~~Remove test-integration from required status checks~~ | XS | ✅ Done |
 | [#544](https://github.com/zynax-io/zynax/issues/544) | Enable GitHub Merge Queue + remove strict: true | XS | Eliminates forced rebase |
 | [#545](https://github.com/zynax-io/zynax/issues/545) | Fix CI concurrency — cancel stale runs | XS | Redundant runs |
 | [#548](https://github.com/zynax-io/zynax/issues/548) | Enable allow_auto_merge | XS | Self-merge |


### PR DESCRIPTION
## Summary

- Removed `test-integration` from the `main` branch-protection required status checks via the GitHub API (#547)
- Annotated the `test-integration` job in `.github/workflows/ci.yml` noting it is intentionally non-required until real integration tests exist (#227 / M7.C)
- Updated header comment and job-graph comment in `ci.yml` to reflect 10 required checks
- Updated `docs/milestones/M5-plan.md` and `state/current-milestone.md`

## Why

The `test-integration` job always succeeds as a no-op (zero `//go:build integration` files in the codebase). It was occupying a required-check slot and adding ~45 s of runner overhead per PR with zero correctness signal.

Closes #547

## State files updated

- `docs/milestones/M5-plan.md`: BATCH 0 + Group A table rows for #547 flipped to ✅ Done; "Last updated" bumped to rev 4
- `state/current-milestone.md`: #547 row struck through in IMMEDIATE table

## Architecture gaps addressed

— (admin/ci change; no code paths affected)

## Test plan

### Local pre-flight
- [x] `make lint-fix` — (N/A — YAML comments + docs only; no executable code changed)
- [x] `make lint-go` — (N/A — no Go changes)
- [x] `make lint-protos` — (N/A — no proto changes)
- [x] `make lint-agents` — (N/A — no Python changes)
- [x] `GOWORK=off go test ./... -race` — (N/A — no Go changes)
- [x] `make test-coverage` — (N/A — no domain changes)
- [x] `make test-coverage-adapters` — (N/A — no adapter changes)
- [x] `make test-bdd` — (N/A — no feature/contract changes)
- [x] `make security` — (N/A — no executable code changes; static YAML comments only)
- [x] `make validate-spec` — (N/A — no spec changes)

### Acceptance (from issue #547)
- [x] `test-integration` removed from `required_status_checks.contexts` in branch protection  [evidence: API verified — 10 checks returned, `test-integration` absent: `["dco","test-unit","security","lint-proto","lint-go","lint-python","GitHub Actions workflow lint","Conventional Commit title","PR size label","Secret scan (gitleaks)"]`]
- [x] `test-integration` job definition retained in `ci.yml` (not deleted)  [evidence: job still defined at ci.yml:1120]
- [x] Comment added to `test-integration` job noting it is non-required until #227 merged  [evidence: 2-line comment block inserted before `test-integration:` job definition]
- [x] All other 10 required checks remain in place  [evidence: API verified above]
- [x] State files updated  [evidence: M5-plan.md + current-milestone.md updated in this commit]

### Engineering hygiene
- [x] Branched from fresh `origin/main`
- [x] PR ≤ 900 lines (excl. generated) — 3 files, 9 insertions, 6 deletions
- [x] Every commit: `Signed-off-by: Oscar Gómez Manresa <ogomezmanresa@gmail.com>` + `Assisted-by: Claude/claude-sonnet-4-6`
- [x] No `Co-Authored-By:` for AI
- [x] No `panic` in prod paths; no silent `_ = err` — (N/A — YAML/docs only)
- [x] No mTLS/SBOM/cosign claims added to docs
- [x] Gap scan done (G1/G4/G7/G16) — no gap instances in changed files (YAML comments only)
- [x] 4 state files updated: M5-plan.md ✅ current-milestone.md ✅ canvas N/A (ci type) AGENTS.md N/A (no new capability)
- [x] `.feature` committed before impl — (N/A — `ci` type, ADR-019 exempt)
- [x] No out-of-scope / drive-by edits

## Out of scope

- Adding `//go:build integration` tags — that is #227
- Re-adding `test-integration` as required — that is the M7 issue after real tests exist (#553)
- Any Go or Python code changes
