### PR TITLE
ci(ci): add merge_group trigger to CI, pr-checks, pr-size workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@
 #   - lint lanes are skipped when no relevant files changed.
 #   - test-unit and test-integration are skipped entirely when the PR only
 #     touches docs/ or root *.md files (code=false from the changes job).
-#   - On push to main all lanes always run (no PR base to diff against).
+#   - On push to main or merge_group, all lanes always run (no PR diff available).
 #
 # Test coverage:
 #   test-unit covers: platform services (SERVICE_LIST), Go adapters (GO_ADAPTER_LIST),
@@ -37,6 +37,7 @@ on:
     branches: [main]
   push:
     branches: [main]
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.sha }}

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -28,6 +28,7 @@ on:
     types: [opened, synchronize, reopened]
   push:
     branches: [main]
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.sha }}

--- a/.github/workflows/pr-size.yml
+++ b/.github/workflows/pr-size.yml
@@ -15,6 +15,7 @@ name: PR Size
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+  merge_group:
 
 concurrency:
   group: pr-size-${{ github.ref }}
@@ -27,6 +28,7 @@ permissions:
 jobs:
   pr-size:
     name: PR size label
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/docs/milestones/M5-plan.md
+++ b/docs/milestones/M5-plan.md
@@ -6,7 +6,7 @@
 **GitHub Milestone:** [Adapter Library (M5)](https://github.com/zynax-io/zynax/milestone/5)
 **Parent epic:** [#377](https://github.com/zynax-io/zynax/issues/377)
 **Status:** In Progress
-**Last updated:** 2026-05-20 (rev 4 — #547 done: test-integration removed from required checks)
+**Last updated:** 2026-05-20 (rev 5 — #544 done: merge_group trigger added to ci/pr-checks/pr-size workflows)
 
 ---
 
@@ -74,7 +74,7 @@ PR cycle time from 25 min → 7 min before any code work begins.
 | Issue | Title | Size | Why first |
 |-------|-------|------|-----------|
 | [#547](https://github.com/zynax-io/zynax/issues/547) | Remove `test-integration` from required status checks | XS | ✅ Done |
-| [#544](https://github.com/zynax-io/zynax/issues/544) | Enable GitHub Merge Queue + remove `strict: true` | XS | Eliminates mandatory rebase overhead |
+| [#544](https://github.com/zynax-io/zynax/issues/544) | Enable GitHub Merge Queue + remove `strict: true` | XS | ✅ Done |
 | [#545](https://github.com/zynax-io/zynax/issues/545) | Fix CI concurrency — cancel stale runs per branch | XS | Prevents redundant runs eating quota |
 | [#548](https://github.com/zynax-io/zynax/issues/548) | Enable `allow_auto_merge` on repository | XS | Self-merge once all checks pass |
 | [#546](https://github.com/zynax-io/zynax/issues/546) | Remove push-to-main forced-true in change detection | S | Every PR runs all jobs regardless of changes |
@@ -233,7 +233,7 @@ without rewriting the graph).
 ### Group A — Branch protection, concurrency, force-run (P0/P1)
 | Issue | Title | Size | Priority |
 |-------|-------|------|----------|
-| [#544](https://github.com/zynax-io/zynax/issues/544) | Enable GitHub Merge Queue + remove `strict: true` | XS | **P0** |
+| [#544](https://github.com/zynax-io/zynax/issues/544) | Enable GitHub Merge Queue + remove `strict: true` | XS | ✅ Done |
 | [#547](https://github.com/zynax-io/zynax/issues/547) | Remove `test-integration` from required status checks | XS | ✅ Done |
 | [#548](https://github.com/zynax-io/zynax/issues/548) | Enable `allow_auto_merge` | XS | P1 |
 | [#545](https://github.com/zynax-io/zynax/issues/545) | Fix CI concurrency — cancel stale runs per branch | XS | P1 |

--- a/state/current-milestone.md
+++ b/state/current-milestone.md
@@ -49,7 +49,7 @@ Fix the CI pipeline before all other work. These are XS/S admin + YAML changes.
 | Issue | Title | Size | Why |
 |-------|-------|------|-----|
 | ~~[#547](https://github.com/zynax-io/zynax/issues/547)~~ | ~~Remove test-integration from required status checks~~ | XS | ✅ Done |
-| [#544](https://github.com/zynax-io/zynax/issues/544) | Enable GitHub Merge Queue + remove strict: true | XS | Eliminates forced rebase |
+| ~~[#544](https://github.com/zynax-io/zynax/issues/544)~~ | ~~Enable GitHub Merge Queue + remove strict: true~~ | XS | ✅ Done (workflows updated; admin must enable Merge Queue in GitHub Settings) |
 | [#545](https://github.com/zynax-io/zynax/issues/545) | Fix CI concurrency — cancel stale runs | XS | Redundant runs |
 | [#548](https://github.com/zynax-io/zynax/issues/548) | Enable allow_auto_merge | XS | Self-merge |
 | [#557](https://github.com/zynax-io/zynax/issues/557) | Fix release race condition | M | All install URLs → 404 |
@@ -103,7 +103,7 @@ Canvas aligned. Ordered delivery: #526 → #527 → #528 → #481.
 - **compose wiring (#481)** — depends on #528 (agent-registry gRPC wiring) landing first.
 - **adapter implementations** — wait for #481 (compose wiring) so adapters have a live registry.
 - **E2E demo** — blocked on #481 fully wired.
-- **CI throughput** — all PRs take 25+ minutes until #544/#547 land.
+- **CI throughput** — merge_group trigger added (#547 ✅ #544 ✅); admin must enable Merge Queue in GitHub Settings to activate.
 - **v0.4.0 release** — blocked on #557 (release race condition fix) then #558 (tag).
 
 ---


### PR DESCRIPTION
## Summary

- Add `merge_group:` event trigger to `ci.yml`, `pr-checks.yml`, and `pr-size.yml` so required status checks fire when a PR enters the GitHub Merge Queue
- Guard `pr-size` job with `if: github.event_name == 'pull_request'` — `context.issue.number` is undefined in queue context and would cause a runtime error
- PR-specific jobs in `pr-checks.yml` (conventional-commit, proto-breaking, etc.) are already gated on `event_name == 'pull_request'` and skip cleanly in queue context; `gitleaks-scan` runs unconditionally as before
- Update `ci.yml` header comment to reflect merge_group event behaviour

## Why

The merge queue needs required CI checks to run against the speculative merge commit — without `merge_group:` triggers the queue runs are blind and can't gate merges. Closes #544.

## Admin steps required after merge (not in this PR)

These must be done by a repository admin in GitHub Settings:
1. **Settings → General → Pull Requests → Merge Queue**: Enable, set method = Squash, min group = 1, max group = 3
2. **Settings → Branches → main → Branch protection**: Uncheck "Require branches to be up to date" (`strict: false`), check "Require merge queue"

Until these settings are applied, the `merge_group:` triggers are dormant (the event never fires).

## State files updated

- `docs/milestones/M5-plan.md`: #544 row ⬜→✅ (both BATCH 0 table and M5.F Group A table)
- `state/current-milestone.md`: #544 struck through; CI throughput blocker note updated

## Architecture gaps addressed

— (CI workflow plumbing, no gap coverage)

## Test plan

### Local pre-flight
- [x] `make lint-fix` — N/A (no Go/Python changes; pre-commit hooks passed at commit time)
- [x] `make lint-go` — (N/A — no Go changes)
- [x] `make lint-protos` — (N/A — no proto changes)
- [x] `make lint-agents` — (N/A — no Python changes)
- [x] `GOWORK=off go test ./... -race` — (N/A — no Go changes; workflow-only PR)
- [x] `make test-coverage` — (N/A — no domain/ changes)
- [x] `make test-coverage-adapters` — (N/A — no adapter changes)
- [x] `make test-bdd` — (N/A — no BDD changes)
- [x] `make security` — (N/A — no code changes; gitleaks pre-commit hook passed)
- [x] `make validate-spec` — (N/A — no spec/ changes)

### Acceptance (from issue #544)
- [x] `merge_group` event trigger added to `ci.yml` [evidence: `.github/workflows/ci.yml` line 40]
- [x] `merge_group` event trigger added to `pr-checks.yml` [evidence: `.github/workflows/pr-checks.yml` line 31]
- [x] `pr-size.yml` fires on `merge_group` [evidence: `.github/workflows/pr-size.yml` line 18]; `pr-size` job guarded so it skips safely in queue context [evidence: line 30]
- [x] All 11 required checks remain unchanged; PR-specific ones (`Conventional Commit title`, `PR size label`, proto checks) skip via existing guards — no new failures introduced
- [x] `GOWORK=off go test ./... -race` in engine-adapter — (N/A — no code touched; workflow-only change)
- [ ] GitHub Merge Queue enabled in Settings — **pending admin action** (see "Admin steps" above)
- [ ] Branch protection `strict: false` — **pending admin action** (see "Admin steps" above)
- [ ] Verified no "Update branch" required — **pending admin action** (unverifiable until queue is live)

> Note: three acceptance criteria require admin Settings actions that cannot be verified in this PR. They are documented above. Auto-merge is withheld; human review requested to confirm the admin steps are understood.

### Engineering hygiene
- [x] Branched from fresh `origin/main` (SHA 94db5fa)
- [x] PR ≤ 900 lines — 10 lines changed (well within limit)
- [x] Every commit: `Signed-off-by: Oscar Gómez Manresa <ogomezmanresa@gmail.com>` + `Assisted-by: Claude/claude-sonnet-4-6`
- [x] No `Co-Authored-By:` for AI
- [x] No `panic` in prod paths; no silent `_ = err` — (N/A — YAML only)
- [x] No mTLS/SBOM/cosign claims added to docs
- [x] Gap scan done (G1/G4/G7/G16) — no Go code touched; not applicable
- [x] 4 state files checked: M5-plan.md ✅, current-milestone.md ✅, canvas N/A (ci type), AGENTS.md N/A (no new capability)
- [x] `.feature` committed before impl — (N/A — ci type)
- [x] No out-of-scope / drive-by edits

Closes #544
