### PR TITLE
ci(ci): fix concurrency group — use ref not sha, cancel stale PR runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,8 +40,8 @@ on:
   merge_group:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.sha }}
-  cancel-in-progress: false
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -31,8 +31,8 @@ on:
   merge_group:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.sha }}
-  cancel-in-progress: false
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read

--- a/docs/milestones/M5-plan.md
+++ b/docs/milestones/M5-plan.md
@@ -6,7 +6,7 @@
 **GitHub Milestone:** [Adapter Library (M5)](https://github.com/zynax-io/zynax/milestone/5)
 **Parent epic:** [#377](https://github.com/zynax-io/zynax/issues/377)
 **Status:** In Progress
-**Last updated:** 2026-05-20 (rev 5 — #544 done: merge_group trigger added to ci/pr-checks/pr-size workflows)
+**Last updated:** 2026-05-20 (rev 6 — #545 done: fix CI concurrency group to use github.ref, cancel stale runs)
 
 ---
 
@@ -75,7 +75,7 @@ PR cycle time from 25 min → 7 min before any code work begins.
 |-------|-------|------|-----------|
 | [#547](https://github.com/zynax-io/zynax/issues/547) | Remove `test-integration` from required status checks | XS | ✅ Done |
 | [#544](https://github.com/zynax-io/zynax/issues/544) | Enable GitHub Merge Queue + remove `strict: true` | XS | ✅ Done |
-| [#545](https://github.com/zynax-io/zynax/issues/545) | Fix CI concurrency — cancel stale runs per branch | XS | Prevents redundant runs eating quota |
+| [#545](https://github.com/zynax-io/zynax/issues/545) | Fix CI concurrency — cancel stale runs per branch | XS | ✅ Done |
 | [#548](https://github.com/zynax-io/zynax/issues/548) | Enable `allow_auto_merge` on repository | XS | Self-merge once all checks pass |
 | [#546](https://github.com/zynax-io/zynax/issues/546) | Remove push-to-main forced-true in change detection | S | Every PR runs all jobs regardless of changes |
 | [#557](https://github.com/zynax-io/zynax/issues/557) | Fix release race condition — unified release workflow | M | All install URLs return 404 today |
@@ -236,7 +236,7 @@ without rewriting the graph).
 | [#544](https://github.com/zynax-io/zynax/issues/544) | Enable GitHub Merge Queue + remove `strict: true` | XS | ✅ Done |
 | [#547](https://github.com/zynax-io/zynax/issues/547) | Remove `test-integration` from required status checks | XS | ✅ Done |
 | [#548](https://github.com/zynax-io/zynax/issues/548) | Enable `allow_auto_merge` | XS | P1 |
-| [#545](https://github.com/zynax-io/zynax/issues/545) | Fix CI concurrency — cancel stale runs per branch | XS | P1 |
+| [#545](https://github.com/zynax-io/zynax/issues/545) | Fix CI concurrency — cancel stale runs per branch | XS | ✅ Done |
 | [#546](https://github.com/zynax-io/zynax/issues/546) | Remove push-to-main forced-true override | S | P1 |
 | [#554](https://github.com/zynax-io/zynax/issues/554) | Force-full-pipeline trigger (dispatch, label, `[full-ci]`) | S | P1 |
 

--- a/state/current-milestone.md
+++ b/state/current-milestone.md
@@ -50,7 +50,7 @@ Fix the CI pipeline before all other work. These are XS/S admin + YAML changes.
 |-------|-------|------|-----|
 | ~~[#547](https://github.com/zynax-io/zynax/issues/547)~~ | ~~Remove test-integration from required status checks~~ | XS | ✅ Done |
 | ~~[#544](https://github.com/zynax-io/zynax/issues/544)~~ | ~~Enable GitHub Merge Queue + remove strict: true~~ | XS | ✅ Done (workflows updated; admin must enable Merge Queue in GitHub Settings) |
-| [#545](https://github.com/zynax-io/zynax/issues/545) | Fix CI concurrency — cancel stale runs | XS | Redundant runs |
+| ~~[#545](https://github.com/zynax-io/zynax/issues/545)~~ | ~~Fix CI concurrency — cancel stale runs~~ | XS | ✅ Done |
 | [#548](https://github.com/zynax-io/zynax/issues/548) | Enable allow_auto_merge | XS | Self-merge |
 | [#557](https://github.com/zynax-io/zynax/issues/557) | Fix release race condition | M | All install URLs → 404 |
 | [#558](https://github.com/zynax-io/zynax/issues/558) | Cut v0.4.0 — first versioned release tag | XS | No artifacts exist |


### PR DESCRIPTION
## Summary

- Fix `ci.yml` and `pr-checks.yml` concurrency groups to use `github.ref` (branch) instead of `github.ref + github.sha` (per-commit unique key)
- Set `cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}` so stale PR/merge-queue runs are cancelled while main-branch runs are never interrupted
- Audited all 12 workflow files: `pr-size.yml` and `kb-preview.yml` already correct; release workflows have no concurrency blocks

## Why

The previous `github.sha`-keyed concurrency group was unique per commit, making `cancel-in-progress: false` a no-op. Two rapid pushes to the same PR branch launched parallel CI runs consuming double the runner quota. Closes #545.

## State files updated

- `docs/milestones/M5-plan.md`: #545 → ✅ Done (both BATCH 0 table and Group A table)
- `state/current-milestone.md`: #545 → ✅ Done in IMMEDIATE table
- Canvas: N/A (ci: type, SPDD exempt)
- AGENTS.md: N/A (no new capability)

## Architecture gaps addressed

— (YAML-only change; no Go/Python code paths affected)

## Test plan

> CI YAML: `actionlint` in `pr-checks.yml` validates the expression syntax on this PR.

### Local pre-flight
- [x] `make lint-fix` — (N/A — no Go/Python changes)
- [x] `make lint-go` — (N/A — no Go changes)
- [x] `make lint-protos` — (N/A — no proto changes)
- [x] `make lint-agents` — (N/A — no Python changes)
- [x] `GOWORK=off go test ./... -race` — (N/A — no Go changes)
- [x] `make test-coverage` — (N/A — no domain code changes)
- [x] `make test-coverage-adapters` — (N/A)
- [x] `make test-bdd` — (N/A — no contract changes)
- [x] `make security` — (N/A — YAML-only change)
- [x] `make validate-spec` — (N/A — no spec changes)

### Acceptance (from issue body)
- [x] `ci.yml` concurrency block uses `github.ref` as the group key [evidence: line 43 `group: ${{ github.workflow }}-${{ github.ref }}`]
- [x] `cancel-in-progress` is `true` for `pull_request` and `merge_group` events [evidence: `${{ github.ref != 'refs/heads/main' }}` → true for refs/pull/* and refs/heads/gh-readonly-queue/*]
- [x] `cancel-in-progress` is `false` for `push` to `main` [evidence: `github.ref == 'refs/heads/main'` → expression evaluates to false]
- [x] Force-push cancels previous run within 30 s [evidence: structurally verified — standard GitHub Actions pattern; functional verification occurs on first force-push after merge; actionlint validates expression syntax in CI]
- [x] Same pattern applied to `pr-checks.yml` [evidence: line 33-35, identical one-liner]
- [x] All other workflow files audited; same fix applied where applicable [evidence: `pr-size.yml` uses `pr-size-${{ github.ref }}` + `cancel-in-progress: true` ✅; `kb-preview.yml` uses `${{ github.workflow }}-${{ github.ref }}` + `cancel-in-progress: true` ✅; release/publish workflows have no concurrency blocks — correct since they run on tags/main and must not be cancelled]

### Engineering hygiene
- [x] Branched from fresh `origin/main` (69d1342)
- [x] PR ≤ 900 lines — 4 lines changed (YAML only; excluded by pr-size.yml pattern)
- [x] Every commit: `Signed-off-by: Oscar Gómez Manresa <ogomezmanresa@gmail.com>` + `Assisted-by: Claude/claude-sonnet-4-6`
- [x] No `Co-Authored-By:` for AI
- [x] No `panic` in prod paths; no silent `_ = err` (N/A — YAML only)
- [x] No mTLS/SBOM/cosign claims added to docs
- [x] Gap scan done (G1/G4/G7/G16) — N/A for YAML workflow changes
- [x] 4 state files updated (M5-plan.md ✅, current-milestone.md ✅, canvas N/A, AGENTS.md N/A)
- [x] `.feature` committed before impl (N/A — ci: type)
- [x] No out-of-scope / drive-by edits

## Out of scope

- Per-service change detection (#546), force-full-pipeline trigger (#554), and other BATCH 0/5 items
- Release workflow concurrency (release workflows correctly have no concurrency block — cancelling a release mid-flight would be destructive)

Closes #545
