### PR TITLE
ci: remove merge_group trigger from all workflow files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@
 #   - lint lanes are skipped when no relevant files changed.
 #   - test-unit and test-integration are skipped entirely when the PR only
 #     touches docs/ or root *.md files (code=false from the changes job).
-#   - On push to main or merge_group, all lanes always run (no PR diff available).
+#   - On push to main, all lanes always run (no PR diff available).
 #
 # Test coverage:
 #   test-unit covers: platform services (SERVICE_LIST), Go adapters (GO_ADAPTER_LIST),
@@ -37,7 +37,6 @@ on:
     branches: [main]
   push:
     branches: [main]
-  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -28,7 +28,6 @@ on:
     types: [opened, synchronize, reopened]
   push:
     branches: [main]
-  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/pr-size.yml
+++ b/.github/workflows/pr-size.yml
@@ -15,7 +15,6 @@ name: PR Size
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-  merge_group:
 
 concurrency:
   group: pr-size-${{ github.ref }}

--- a/docs/milestones/M5-plan.md
+++ b/docs/milestones/M5-plan.md
@@ -6,7 +6,7 @@
 **GitHub Milestone:** [Adapter Library (M5)](https://github.com/zynax-io/zynax/milestone/5)
 **Parent epic:** [#377](https://github.com/zynax-io/zynax/issues/377)
 **Status:** In Progress
-**Last updated:** 2026-05-20 (rev 7 — #545 done, #548 done via API, #589 created; merge queue removed, auto-merge + strict: true enabled)
+**Last updated:** 2026-05-20 (rev 8 — #589 done; merge_group triggers removed from ci.yml, pr-checks.yml, pr-size.yml)
 
 ---
 
@@ -81,7 +81,7 @@ PR cycle time from 25 min → 7 min before any code work begins.
 | [#544](https://github.com/zynax-io/zynax/issues/544) | Enable GitHub Merge Queue + remove `strict: true` | XS | ✅ Done (superseded — merge queue removed; strict: true + allow_auto_merge enabled via API — see #589) |
 | [#548](https://github.com/zynax-io/zynax/issues/548) | Enable `allow_auto_merge` on repository | XS | ✅ Done via API |
 | [#545](https://github.com/zynax-io/zynax/issues/545) | Fix CI concurrency — cancel stale runs per branch | XS | ✅ Done |
-| [#589](https://github.com/zynax-io/zynax/issues/589) | Remove `merge_group` trigger from all workflow files | XS | Ready |
+| [#589](https://github.com/zynax-io/zynax/issues/589) | Remove `merge_group` trigger from all workflow files | XS | ✅ Done |
 | [#546](https://github.com/zynax-io/zynax/issues/546) | Remove push-to-main forced-true in change detection | S | Every PR runs all jobs regardless of changes |
 | [#557](https://github.com/zynax-io/zynax/issues/557) | Fix release race condition — unified release workflow | M | All install URLs return 404 today |
 | [#558](https://github.com/zynax-io/zynax/issues/558) | Cut v0.4.0 — first versioned release tag | XS | No downloadable artifacts exist |
@@ -243,7 +243,7 @@ without rewriting the graph).
 | [#547](https://github.com/zynax-io/zynax/issues/547) | Remove `test-integration` from required status checks | XS | ✅ Done |
 | [#548](https://github.com/zynax-io/zynax/issues/548) | Enable `allow_auto_merge` | XS | ✅ Done via API |
 | [#545](https://github.com/zynax-io/zynax/issues/545) | Fix CI concurrency — cancel stale runs per branch | XS | ✅ Done |
-| [#589](https://github.com/zynax-io/zynax/issues/589) | Remove `merge_group` trigger from all workflow files | XS | P1 |
+| [#589](https://github.com/zynax-io/zynax/issues/589) | Remove `merge_group` trigger from all workflow files | XS | ✅ Done |
 | [#546](https://github.com/zynax-io/zynax/issues/546) | Remove push-to-main forced-true override | S | P1 |
 | [#554](https://github.com/zynax-io/zynax/issues/554) | Force-full-pipeline trigger (dispatch, label, `[full-ci]`) | S | P1 |
 

--- a/state/current-milestone.md
+++ b/state/current-milestone.md
@@ -52,7 +52,7 @@ Fix the CI pipeline before all other work. These are XS/S admin + YAML changes.
 | ~~[#544](https://github.com/zynax-io/zynax/issues/544)~~ | ~~Enable GitHub Merge Queue~~ | XS | ✅ Done (superseded — merge queue removed; strict: true + allow_auto_merge enabled via API — see #589) |
 | ~~[#548](https://github.com/zynax-io/zynax/issues/548)~~ | ~~Enable allow_auto_merge~~ | XS | ✅ Done via API |
 | ~~[#545](https://github.com/zynax-io/zynax/issues/545)~~ | ~~Fix CI concurrency — cancel stale runs~~ | XS | ✅ Done |
-| [#589](https://github.com/zynax-io/zynax/issues/589) | Remove merge_group trigger from workflow files | XS | Ready |
+| ~~[#589](https://github.com/zynax-io/zynax/issues/589)~~ | ~~Remove merge_group trigger from workflow files~~ | XS | ✅ Done |
 | [#557](https://github.com/zynax-io/zynax/issues/557) | Fix release race condition | M | All install URLs → 404 |
 | [#558](https://github.com/zynax-io/zynax/issues/558) | Cut v0.4.0 — first versioned release tag | XS | No artifacts exist |
 
@@ -104,7 +104,7 @@ Canvas aligned. Ordered delivery: #526 → #527 → #528 → #481.
 - **compose wiring (#481)** — depends on #528 (agent-registry gRPC wiring) landing first.
 - **adapter implementations** — wait for #481 (compose wiring) so adapters have a live registry.
 - **E2E demo** — blocked on #481 fully wired.
-- **CI throughput** — auto-merge enabled (`allow_auto_merge: true`), `strict: true` branch protection set via API. Merge queue removed — developer rebases. Remaining: #545 concurrency fix (PR #588), #589 remove merge_group triggers, #546 push-to-main override.
+- **CI throughput** — auto-merge enabled (`allow_auto_merge: true`), `strict: true` branch protection set via API. Merge queue removed — developer rebases. Remaining: #546 push-to-main override.
 - **v0.4.0 release** — blocked on #557 (release race condition fix) then #558 (tag).
 
 ---


### PR DESCRIPTION
## Summary

- Remove `merge_group:` trigger from `ci.yml`, `pr-checks.yml`, and `pr-size.yml`
- Update header comment in `ci.yml` to remove the now-inaccurate merge_group reference
- Flip #589 ✅ in `M5-plan.md` and `state/current-milestone.md`

## Why

The merge queue strategy was abandoned (see #544). Branch protection now uses
`strict: true` + `allow_auto_merge: true` — developer rebases, auto-merge fires on green.
The `merge_group:` trigger is dead code that causes confusing phantom CI runs.
Closes #589.

## State files updated

- `docs/milestones/M5-plan.md`: #589 ⬜→✅, rev 7→8, both BATCH 0 tables updated
- `state/current-milestone.md`: #589 strikethrough+✅, blocker note updated

## Architecture gaps addressed

N/A — CI housekeeping only.

## Test plan

### Local pre-flight
- [x] `make lint-fix` — (N/A — no Go/Python code changed)
- [x] `make lint-go` — (N/A — no Go code changed)
- [x] `make lint-protos` — (N/A — no proto files changed)
- [x] `make lint-agents` — (N/A — no Python code changed)
- [x] `GOWORK=off go test ./... -race` — (N/A — no Go code changed)
- [x] `make test-coverage` — (N/A — no domain code changed)
- [x] `make test-coverage-adapters` — (N/A — no adapter code changed)
- [x] `make test-bdd` — (N/A — no feature files changed)
- [x] `make security` — (N/A — no new deps; actionlint covers YAML correctness in CI)
- [x] `make validate-spec` — (N/A — no spec files changed)

### Acceptance (from issue #589)
- [x] `merge_group:` removed from `ci.yml` `on:` block  [evidence: grep returns no matches]
- [x] `merge_group:` removed from `pr-checks.yml` `on:` block  [evidence: grep returns no matches]
- [x] `pr-size.yml`: `merge_group:` removed from `on:` block  [evidence: grep returns no matches]
- [x] Header comment in `ci.yml` updated  [evidence: line now reads "On push to main, all lanes always run"]
- [x] No `merge_group` remains in any of the three workflow files  [evidence: grep across all three → no output]

### Engineering hygiene
- [x] Branched from fresh `origin/main`
- [x] PR ≤ 900 lines (5 lines removed from workflows — XS)
- [x] Every commit: `Signed-off-by: Oscar Gómez Manresa <ogomezmanresa@gmail.com>` + `Assisted-by: Claude/claude-sonnet-4-6`
- [x] No `Co-Authored-By:` for AI
- [x] No `panic` in prod paths; no silent `_ = err` (N/A — no code)
- [x] No mTLS/SBOM/cosign claims added to docs
- [x] Gap scan done (G1/G4/G7/G16) — N/A to workflow-only changes
- [x] 4 state files updated: M5-plan.md ✅, current-milestone.md ✅, canvas N/A (ci: exempt), AGENTS.md N/A
- [x] `.feature` committed before impl — N/A (ci: PR, SPDD exempt per ADR-019)
- [x] No out-of-scope / drive-by edits

## Out of scope

- #546 (remove push-to-main forced-true override) — separate issue, next in BATCH 0

Closes #589
