### PR TITLE
ci: fix push-to-main change detection — use git diff HEAD^1 HEAD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@
 #   - lint lanes are skipped when no relevant files changed.
 #   - test-unit and test-integration are skipped entirely when the PR only
 #     touches docs/ or root *.md files (code=false from the changes job).
-#   - On push to main, all lanes always run (no PR diff available).
+#   - On push to main, path-based skipping works via git diff HEAD^1 HEAD.
 #
 # Test coverage:
 #   test-unit covers: platform services (SERVICE_LIST), Go adapters (GO_ADAPTER_LIST),
@@ -109,7 +109,7 @@ jobs:
 #   proto  — true when protos/, spec/, or AI context files change
 #   go     — true when any Go code changes (services/, cmd/, Go adapters)
 #   python — true when Python agents change
-# On push to main all outputs are "true" — no reliable base SHA to diff.
+# On push to main uses git diff HEAD^1 HEAD; on PR uses the PR diff range.
   changes:
     name: changes
     runs-on: ubuntu-24.04
@@ -127,20 +127,23 @@ jobs:
       - name: Detect changed path groups
         id: detect
         run: |
-          if [ "${{ github.event_name }}" != "pull_request" ]; then
+          if [ "${{ github.event_name }}" = "push" ]; then
+            BASE="HEAD^1"
+            HEAD_SHA="HEAD"
+          elif [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE="${{ github.event.pull_request.base.sha }}"
+            HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          else
             {
               echo "code=true"
               echo "proto=true"
               echo "go=true"
               echo "python=true"
             } >> "$GITHUB_OUTPUT"
-            echo "ℹ️  Push to main — all lanes enabled."
+            echo "ℹ️  Unknown event '${{ github.event_name }}' — all lanes enabled."
             exit 0
           fi
-
-          BASE="${{ github.event.pull_request.base.sha }}"
-          HEAD="${{ github.event.pull_request.head.sha }}"
-          FILES=$(git diff --name-only "${BASE}...${HEAD}" 2>/dev/null || echo "")
+          FILES=$(git diff --name-only "${BASE}...${HEAD_SHA}" 2>/dev/null || echo "")
 
           code=false proto=false go=false python=false
 
@@ -1170,7 +1173,9 @@ jobs:
   security:
     name: security
     runs-on: ubuntu-24.04
-    needs: [dco]
+    needs: [dco, changes]
+    # PRs: always run (satisfies required check). Push to main: skip on docs-only changes.
+    if: github.event_name != 'push' || needs.changes.outputs.code == 'true'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 

--- a/docs/milestones/M5-plan.md
+++ b/docs/milestones/M5-plan.md
@@ -6,7 +6,7 @@
 **GitHub Milestone:** [Adapter Library (M5)](https://github.com/zynax-io/zynax/milestone/5)
 **Parent epic:** [#377](https://github.com/zynax-io/zynax/issues/377)
 **Status:** In Progress
-**Last updated:** 2026-05-20 (rev 8 — #589 done; merge_group triggers removed from ci.yml, pr-checks.yml, pr-size.yml)
+**Last updated:** 2026-05-20 (rev 9 — #589 done, #546 done; BATCH 0 only #557+#558 remain)
 
 ---
 
@@ -82,7 +82,7 @@ PR cycle time from 25 min → 7 min before any code work begins.
 | [#548](https://github.com/zynax-io/zynax/issues/548) | Enable `allow_auto_merge` on repository | XS | ✅ Done via API |
 | [#545](https://github.com/zynax-io/zynax/issues/545) | Fix CI concurrency — cancel stale runs per branch | XS | ✅ Done |
 | [#589](https://github.com/zynax-io/zynax/issues/589) | Remove `merge_group` trigger from all workflow files | XS | ✅ Done |
-| [#546](https://github.com/zynax-io/zynax/issues/546) | Remove push-to-main forced-true in change detection | S | Every PR runs all jobs regardless of changes |
+| [#546](https://github.com/zynax-io/zynax/issues/546) | Remove push-to-main forced-true in change detection | S | ✅ Done |
 | [#557](https://github.com/zynax-io/zynax/issues/557) | Fix release race condition — unified release workflow | M | All install URLs return 404 today |
 | [#558](https://github.com/zynax-io/zynax/issues/558) | Cut v0.4.0 — first versioned release tag | XS | No downloadable artifacts exist |
 
@@ -244,7 +244,7 @@ without rewriting the graph).
 | [#548](https://github.com/zynax-io/zynax/issues/548) | Enable `allow_auto_merge` | XS | ✅ Done via API |
 | [#545](https://github.com/zynax-io/zynax/issues/545) | Fix CI concurrency — cancel stale runs per branch | XS | ✅ Done |
 | [#589](https://github.com/zynax-io/zynax/issues/589) | Remove `merge_group` trigger from all workflow files | XS | ✅ Done |
-| [#546](https://github.com/zynax-io/zynax/issues/546) | Remove push-to-main forced-true override | S | P1 |
+| [#546](https://github.com/zynax-io/zynax/issues/546) | Remove push-to-main forced-true override | S | ✅ Done |
 | [#554](https://github.com/zynax-io/zynax/issues/554) | Force-full-pipeline trigger (dispatch, label, `[full-ci]`) | S | P1 |
 
 ### Group B — Per-service change detection (P2)

--- a/state/current-milestone.md
+++ b/state/current-milestone.md
@@ -53,6 +53,7 @@ Fix the CI pipeline before all other work. These are XS/S admin + YAML changes.
 | ~~[#548](https://github.com/zynax-io/zynax/issues/548)~~ | ~~Enable allow_auto_merge~~ | XS | ✅ Done via API |
 | ~~[#545](https://github.com/zynax-io/zynax/issues/545)~~ | ~~Fix CI concurrency — cancel stale runs~~ | XS | ✅ Done |
 | ~~[#589](https://github.com/zynax-io/zynax/issues/589)~~ | ~~Remove merge_group trigger from workflow files~~ | XS | ✅ Done |
+| ~~[#546](https://github.com/zynax-io/zynax/issues/546)~~ | ~~Remove push-to-main forced-true override~~ | S | ✅ Done |
 | [#557](https://github.com/zynax-io/zynax/issues/557) | Fix release race condition | M | All install URLs → 404 |
 | [#558](https://github.com/zynax-io/zynax/issues/558) | Cut v0.4.0 — first versioned release tag | XS | No artifacts exist |
 
@@ -104,7 +105,7 @@ Canvas aligned. Ordered delivery: #526 → #527 → #528 → #481.
 - **compose wiring (#481)** — depends on #528 (agent-registry gRPC wiring) landing first.
 - **adapter implementations** — wait for #481 (compose wiring) so adapters have a live registry.
 - **E2E demo** — blocked on #481 fully wired.
-- **CI throughput** — auto-merge enabled (`allow_auto_merge: true`), `strict: true` branch protection set via API. Merge queue removed — developer rebases. Remaining: #546 push-to-main override.
+- **CI throughput** — auto-merge enabled, `strict: true` + merge queue removed, #545 concurrency fix, #589 merge_group removed, #546 push-to-main override done. BATCH 0 complete; next: #557 release pipeline.
 - **v0.4.0 release** — blocked on #557 (release race condition fix) then #558 (tag).
 
 ---


### PR DESCRIPTION
## Summary

- Removes the forced-true early-exit in the `changes` job that set all path-filter outputs to `true` on every push to `main`, regardless of what files actually changed
- Replaces it with `git diff HEAD^1 HEAD` diff detection for push events, matching the PR path-filter logic already in place
- Gates the `security` job for push events so it only fires when `code=true` (docs-only pushes skip it), while staying unconditional for PRs (required check must always pass)
- Updates two stale comments and both state files

## Why

Docs-only merges (canvas updates, ADR edits, README fixes) currently trigger the full CI pipeline — lint-go, test-unit, security — wasting ~15 minutes of runner time per merge. This completes M5.F Group A (BATCH 0), unblocking the faster feedback loop for all subsequent M5 PRs.

Closes #546

## State files updated

- `docs/milestones/M5-plan.md`: #546 row ⬜→✅ in both BATCH 0 and Group A tables; rev 9
- `state/current-milestone.md`: #546 added to IMMEDIATE table as ✅ Done; Known Blockers updated (BATCH 0 complete, next: #557)

## Architecture gaps addressed

None directly. This issue reduces CI cycle time for all future gap-fix PRs.

## Test plan

### Local pre-flight
- [x] `make lint-fix` — (N/A — no Go/Python changes; workflow lint handled by CI)
- [x] `make lint-go` — (N/A — no Go source changes)
- [x] `make lint-protos` — (N/A — no proto changes)
- [x] `make lint-agents` — (N/A — no Python changes)
- [x] `GOWORK=off go test ./... -race` — (N/A — no Go source changes)
- [x] `make test-coverage` — (N/A — no domain changes)
- [x] `make test-coverage-adapters` — (N/A — no adapter changes)
- [x] `make test-bdd` — (N/A — no .feature or contract changes)
- [x] `make security` — (N/A — no Go/Python/Dockerfile changes)
- [x] `make validate-spec` — (N/A — no spec changes)

### Acceptance (from issue body)
- [x] Early-exit `if [ event != pull_request ]; then force all=true; exit 0; fi` removed from `changes` job — confirmed: replaced with push/PR/unknown event dispatch at ci.yml:130-149
- [x] Push events use `git diff HEAD^1 HEAD` — confirmed: `BASE="HEAD^1"` / `HEAD_SHA="HEAD"` branch at ci.yml:131-133
- [x] docs-only push does NOT trigger `lint-go`, `test-unit` — confirmed: both jobs gate on `needs.changes.outputs.go == 'true'` and `code == 'true'` respectively; with the fix these will be `false` for docs-only diffs
- [x] docs-only push does NOT trigger `security` — confirmed: security now has `if: github.event_name != 'push' || needs.changes.outputs.code == 'true'`; docs-only push gives `code=false` → security skips
- [x] code-touching push DOES trigger all lanes — confirmed: any file under services/ or agents/ sets `go=true`; `code=true`; all lanes fire
- [x] All 10 required status checks still pass on code-touching PRs — behavior unchanged for PRs; PR path uses same diff logic as before
- [x] `test-unit` `if: always()` condition audited — condition reads `needs.changes.outputs.code == 'true'`; for push events this now comes from the actual diff, not a forced-true; still correct

### Engineering hygiene
- [x] Branched from fresh `origin/main` (ee1131d — post-merge CI green)
- [x] PR ≤ 900 lines: 3 files, 19 insertions, 13 deletions (excl. generated)
- [x] Every commit: `Signed-off-by: Oscar Gómez Manresa <ogomezmanresa@gmail.com>` + `Assisted-by: Claude/claude-sonnet-4-6`
- [x] No `Co-Authored-By:` for AI
- [x] No `panic` in prod paths; no silent `_ = err` (N/A — YAML only)
- [x] No mTLS/SBOM/cosign claims added to docs
- [x] Gap scan done (G1/G4/G7/G16): no gap-related code touched
- [x] 4 state files updated (M5-plan ✅, current-milestone ✅, canvas N/A — ci: exempt, AGENTS.md N/A — no new capability)
- [x] `.feature` committed before impl (N/A — ci: type, exempt)
- [x] No out-of-scope / drive-by edits

## Out of scope

- Per-service change-detection granularity (#549) — follow-up
- `lint-go` internal push early-exit (lines 362-368) is also a forced-true; left in place since `lint-go` only runs when `go=true` from the changes job — it will be a no-op on docs-only pushes now. Can be cleaned up in #549.
