### PR TITLE
ci: unified release coordinator, retire per-workflow tag triggers

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -1,25 +1,18 @@
 # SPDX-License-Identifier: Apache-2.0
 #
-# CLI Release — builds the zynax binary for five platforms and publishes a
-# GitHub Release with checksums when a v*.*.* tag is pushed.
+# CLI Release — manual trigger only. Tag-triggered releases are handled by
+# release.yml (unified coordinator). Use this for dry-run builds.
 #
-# Trigger:
-#   git tag v0.3.0 && git push origin v0.3.0
-#
-# To also trigger manually:
+# Manual trigger:
 #   Actions → CLI Release → Run workflow → enter tag
 
 name: CLI Release
 
 on:
-  push:
-    tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
-      - 'v[0-9]+.[0-9]+.[0-9]+-*'   # pre-releases: v0.4.0-rc.1
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Version tag to publish (e.g. v0.3.0)'
+        description: 'Version tag to publish (e.g. v0.4.0)'
         required: true
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,322 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Release coordinator — single workflow triggered by a version tag.
+# Fans out to parallel build jobs, then creates ONE GitHub Release with
+# all artifacts attached. Replaces the three legacy tag-triggered workflows
+# (cli-release.yml, service-release.yml, zynax-ci-release.yml), which are
+# now workflow_dispatch-only for manual/dry-run use.
+#
+# Trigger:
+#   git tag v0.4.0 && git push origin v0.4.0
+#
+# Dry-run (manual):
+#   Actions → Release → Run workflow → enter tag
+
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+-*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Version tag (e.g. v0.4.0)'
+        required: true
+
+permissions:
+  contents: write
+  packages: write
+  id-token: write   # reserved for cosign OIDC signing (#239) — do not remove
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_PREFIX: ghcr.io/zynax-io/zynax
+  SYFT_VERSION: "1.44.0"
+
+# ── CLI binary — 5 platforms ──────────────────────────────────────────────────
+
+jobs:
+  build-cli:
+    name: CLI — ${{ matrix.goos }}/${{ matrix.goarch }}
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        include:
+          - { goos: linux,   goarch: amd64, archive: tar.gz }
+          - { goos: linux,   goarch: arm64, archive: tar.gz }
+          - { goos: darwin,  goarch: amd64, archive: tar.gz }
+          - { goos: darwin,  goarch: arm64, archive: tar.gz }
+          - { goos: windows, goarch: amd64, archive: zip    }
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version-file: cmd/zynax/go.mod
+          cache-dependency-path: cmd/zynax/go.sum
+
+      - name: Resolve version
+        id: ver
+        run: |
+          TAG="${{ inputs.tag || github.ref_name }}"
+          echo "version=${TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Build
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+          CGO_ENABLED: "0"
+        run: |
+          VERSION="${{ steps.ver.outputs.version }}"
+          BINARY=zynax
+          [ "$GOOS" = "windows" ] && BINARY=zynax.exe
+          cd cmd/zynax
+          GOWORK=off go build -trimpath \
+            -ldflags "-s -w -X github.com/zynax-io/zynax/cmd/zynax/cmd.Version=${VERSION}" \
+            -o "${BINARY}" .
+
+      - name: Package
+        id: pkg
+        run: |
+          VERSION="${{ steps.ver.outputs.version }}"
+          NAME="zynax_${VERSION}_${{ matrix.goos }}_${{ matrix.goarch }}"
+          cd cmd/zynax
+          if [ "${{ matrix.archive }}" = "zip" ]; then
+            zip "${NAME}.zip" zynax.exe
+            echo "file=${NAME}.zip" >> "$GITHUB_OUTPUT"
+          else
+            tar czf "${NAME}.tar.gz" zynax
+            echo "file=${NAME}.tar.gz" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: cli-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: cmd/zynax/${{ steps.pkg.outputs.file }}
+          retention-days: 7
+
+# ── zynax-ci binary — 4 platforms ────────────────────────────────────────────
+
+  build-zynax-ci:
+    name: zynax-ci — ${{ matrix.goos }}/${{ matrix.goarch }}
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        include:
+          - { goos: linux,  goarch: amd64, suffix: linux-amd64  }
+          - { goos: linux,  goarch: arm64, suffix: linux-arm64  }
+          - { goos: darwin, goarch: amd64, suffix: darwin-amd64 }
+          - { goos: darwin, goarch: arm64, suffix: darwin-arm64 }
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version-file: cmd/zynax-ci/go.mod
+          cache: true
+          cache-dependency-path: cmd/zynax-ci/go.sum
+
+      - name: Resolve version
+        id: ver
+        run: |
+          TAG="${{ inputs.tag || github.ref_name }}"
+          echo "version=${TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Build
+        working-directory: cmd/zynax-ci
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+          CGO_ENABLED: "0"
+        run: |
+          GOWORK=off go build -trimpath \
+            -ldflags "-s -w -X github.com/zynax-io/zynax/cmd/zynax-ci/cmd.Version=${{ steps.ver.outputs.version }}" \
+            -o zynax-ci-${{ matrix.suffix }} .
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: zynax-ci-${{ matrix.suffix }}
+          path: cmd/zynax-ci/zynax-ci-${{ matrix.suffix }}
+          retention-days: 7
+
+# ── Service images + CycloneDX SBOMs ─────────────────────────────────────────
+
+  build-push-images:
+    name: Image & SBOM — ${{ matrix.service }}
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        service: [api-gateway, engine-adapter, workflow-compiler, task-broker]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Resolve version
+        id: ver
+        run: |
+          TAG="${{ inputs.tag || github.ref_name }}"
+          echo "version=${TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to GHCR
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Build and push
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          context: .
+          file: services/${{ matrix.service }}/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ env.IMAGE_PREFIX }}/${{ matrix.service }}:${{ steps.ver.outputs.version }}
+            ${{ env.IMAGE_PREFIX }}/${{ matrix.service }}:latest
+
+      - name: Install syft ${{ env.SYFT_VERSION }}
+        run: |
+          curl -sSfL \
+            "https://github.com/anchore/syft/releases/download/v${SYFT_VERSION}/syft_${SYFT_VERSION}_linux_amd64.tar.gz" \
+            -o /tmp/syft.tar.gz
+          tar -xzf /tmp/syft.tar.gz -C /usr/local/bin syft
+          rm /tmp/syft.tar.gz
+
+      - name: Generate SBOM
+        run: |
+          syft \
+            "${{ env.IMAGE_PREFIX }}/${{ matrix.service }}:${{ steps.ver.outputs.version }}" \
+            -o cyclonedx-json \
+            --file "${{ matrix.service }}-sbom.json"
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: sbom-${{ matrix.service }}
+          path: ${{ matrix.service }}-sbom.json
+          retention-days: 7
+
+# ── Single GitHub Release ─────────────────────────────────────────────────────
+
+  release:
+    name: Create GitHub Release
+    needs: [build-cli, build-zynax-ci, build-push-images]
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Resolve version
+        id: ver
+        run: |
+          TAG="${{ inputs.tag || github.ref_name }}"
+          echo "version=${TAG}" >> "$GITHUB_OUTPUT"
+          if [[ "${TAG}" == *-* ]]; then
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          pattern: cli-*
+          merge-multiple: true
+          path: dist/cli/
+
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          pattern: zynax-ci-*
+          merge-multiple: true
+          path: dist/zynax-ci/
+
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          pattern: sbom-*
+          merge-multiple: true
+          path: dist/sboms/
+
+      - name: Generate checksums
+        run: |
+          (cd dist/cli     && sha256sum * > ../checksums-cli.txt)
+          (cd dist/zynax-ci && sha256sum * > ../checksums-zynax-ci.txt)
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
+        with:
+          tag_name: ${{ steps.ver.outputs.version }}
+          name: Zynax ${{ steps.ver.outputs.version }}
+          prerelease: ${{ steps.ver.outputs.prerelease == 'true' }}
+          body: |
+            ## Zynax ${{ steps.ver.outputs.version }}
+
+            Declarative AI-workflow control plane — CLI, CI toolchain, and service images.
+
+            ### Install zynax CLI
+
+            **macOS (Apple Silicon):**
+            ```bash
+            curl -L https://github.com/zynax-io/zynax/releases/download/${{ steps.ver.outputs.version }}/zynax_${{ steps.ver.outputs.version }}_darwin_arm64.tar.gz | tar xz && sudo mv zynax /usr/local/bin/
+            ```
+
+            **macOS (Intel):**
+            ```bash
+            curl -L https://github.com/zynax-io/zynax/releases/download/${{ steps.ver.outputs.version }}/zynax_${{ steps.ver.outputs.version }}_darwin_amd64.tar.gz | tar xz && sudo mv zynax /usr/local/bin/
+            ```
+
+            **Linux (amd64):**
+            ```bash
+            curl -L https://github.com/zynax-io/zynax/releases/download/${{ steps.ver.outputs.version }}/zynax_${{ steps.ver.outputs.version }}_linux_amd64.tar.gz | tar xz && sudo mv zynax /usr/local/bin/
+            ```
+
+            **Linux (arm64):**
+            ```bash
+            curl -L https://github.com/zynax-io/zynax/releases/download/${{ steps.ver.outputs.version }}/zynax_${{ steps.ver.outputs.version }}_linux_arm64.tar.gz | tar xz && sudo mv zynax /usr/local/bin/
+            ```
+
+            **Windows (amd64):** download `zynax_${{ steps.ver.outputs.version }}_windows_amd64.zip`
+
+            **Build from source:**
+            ```bash
+            git clone https://github.com/zynax-io/zynax.git && cd zynax/cmd/zynax
+            GOWORK=off go build -o zynax . && sudo mv zynax /usr/local/bin/
+            ```
+
+            **Verify checksums:**
+            ```bash
+            sha256sum -c checksums-cli.txt
+            ```
+
+            ### Install zynax-ci
+
+            ```bash
+            # Linux (amd64)
+            curl -fsSL https://github.com/zynax-io/zynax/releases/download/${{ steps.ver.outputs.version }}/zynax-ci-linux-amd64 \
+              -o ~/bin/zynax-ci && chmod +x ~/bin/zynax-ci
+
+            # macOS (Apple Silicon)
+            curl -fsSL https://github.com/zynax-io/zynax/releases/download/${{ steps.ver.outputs.version }}/zynax-ci-darwin-arm64 \
+              -o ~/bin/zynax-ci && chmod +x ~/bin/zynax-ci
+            ```
+
+            ### Service images (GHCR)
+
+            ```bash
+            docker pull ghcr.io/zynax-io/zynax/api-gateway:${{ steps.ver.outputs.version }}
+            docker pull ghcr.io/zynax-io/zynax/engine-adapter:${{ steps.ver.outputs.version }}
+            docker pull ghcr.io/zynax-io/zynax/workflow-compiler:${{ steps.ver.outputs.version }}
+            docker pull ghcr.io/zynax-io/zynax/task-broker:${{ steps.ver.outputs.version }}
+            ```
+
+            CycloneDX SBOMs for all service images are attached to this release.
+
+            ### What's new
+
+            See [CHANGELOG.md](https://github.com/zynax-io/zynax/blob/main/CHANGELOG.md) for full release notes.
+          files: |
+            dist/cli/*
+            dist/zynax-ci/*
+            dist/sboms/*
+            dist/checksums-cli.txt
+            dist/checksums-zynax-ci.txt

--- a/.github/workflows/service-release.yml
+++ b/.github/workflows/service-release.yml
@@ -1,18 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 #
-# Service Image Release — builds multi-arch container images for each platform
-# service that has a Dockerfile, pushes them to GHCR, generates a CycloneDX
-# SBOM with syft for each image, and attaches the SBOMs to a GitHub Release.
+# Service Image Release — manual trigger only. Tag-triggered releases are
+# handled by release.yml (unified coordinator). Use this for dry-run builds.
 #
-# Trigger:
-#   git tag v0.5.0 && git push origin v0.5.0
-#
-# Manual trigger (dry-run / pre-release validation):
+# Manual trigger:
 #   Actions → Service Image Release → Run workflow → enter tag
-#
-# Services built: api-gateway · engine-adapter · workflow-compiler
-# Stub services (agent-registry, task-broker, memory-service, event-bus) are
-# excluded until they have Dockerfiles.
 #
 # Image name convention:
 #   ghcr.io/zynax-io/zynax/<svc>:<version>   (semver — e.g. v0.5.0)
@@ -25,10 +17,6 @@
 name: Service Image Release
 
 on:
-  push:
-    tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
-      - 'v[0-9]+.[0-9]+.[0-9]+-*'   # pre-releases: v0.5.0-rc.1
   workflow_dispatch:
     inputs:
       tag:

--- a/.github/workflows/zynax-ci-release.yml
+++ b/.github/workflows/zynax-ci-release.yml
@@ -1,20 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
-# Zynax — zynax-ci binary release
+# Zynax — zynax-ci binary release (manual trigger only)
 #
-# Triggered on version tags (v*.*.*). Builds static binaries for
-# linux/amd64, darwin/amd64, and darwin/arm64, then creates a
-# GitHub Release with all three as downloadable assets.
+# Tag-triggered releases are handled by release.yml (unified coordinator).
+# Use this for dry-run builds.
 
 name: zynax-ci release
 
 on:
-  push:
-    tags:
-      - 'v*.*.*'
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Tag to build (e.g. v0.3.0)'
+        description: 'Tag to build (e.g. v0.4.0)'
         required: true
 
 permissions:

--- a/docs/milestones/M5-plan.md
+++ b/docs/milestones/M5-plan.md
@@ -6,7 +6,7 @@
 **GitHub Milestone:** [Adapter Library (M5)](https://github.com/zynax-io/zynax/milestone/5)
 **Parent epic:** [#377](https://github.com/zynax-io/zynax/issues/377)
 **Status:** In Progress
-**Last updated:** 2026-05-20 (rev 9 — #589 done, #546 done; BATCH 0 only #557+#558 remain)
+**Last updated:** 2026-05-20 (rev 10 — #557 done; BATCH 0 only #558 remains)
 
 ---
 
@@ -83,7 +83,7 @@ PR cycle time from 25 min → 7 min before any code work begins.
 | [#545](https://github.com/zynax-io/zynax/issues/545) | Fix CI concurrency — cancel stale runs per branch | XS | ✅ Done |
 | [#589](https://github.com/zynax-io/zynax/issues/589) | Remove `merge_group` trigger from all workflow files | XS | ✅ Done |
 | [#546](https://github.com/zynax-io/zynax/issues/546) | Remove push-to-main forced-true in change detection | S | ✅ Done |
-| [#557](https://github.com/zynax-io/zynax/issues/557) | Fix release race condition — unified release workflow | M | All install URLs return 404 today |
+| [#557](https://github.com/zynax-io/zynax/issues/557) | Fix release race condition — unified release workflow | M | ✅ Done |
 | [#558](https://github.com/zynax-io/zynax/issues/558) | Cut v0.4.0 — first versioned release tag | XS | No downloadable artifacts exist |
 
 **Engineer profile:** DevOps / GitHub Actions specialist. No Go/Python knowledge required.
@@ -288,7 +288,7 @@ without rewriting the graph).
 ### Child issues (ordered execution plan)
 | Issue | Title | Size | Priority |
 |-------|-------|------|----------|
-| [#557](https://github.com/zynax-io/zynax/issues/557) | Fix release race condition — unified workflow | M | **P0** |
+| [#557](https://github.com/zynax-io/zynax/issues/557) | Fix release race condition — unified workflow | M | ✅ Done |
 | [#558](https://github.com/zynax-io/zynax/issues/558) | Cut v0.4.0 — first versioned release tag | XS | **P0** |
 | [#559](https://github.com/zynax-io/zynax/issues/559) | Add task-broker to service-release matrix | XS | **P0** |
 | [#560](https://github.com/zynax-io/zynax/issues/560) | Add http-adapter image to release pipeline | S | P1 |

--- a/state/current-milestone.md
+++ b/state/current-milestone.md
@@ -54,8 +54,8 @@ Fix the CI pipeline before all other work. These are XS/S admin + YAML changes.
 | ~~[#545](https://github.com/zynax-io/zynax/issues/545)~~ | ~~Fix CI concurrency — cancel stale runs~~ | XS | ✅ Done |
 | ~~[#589](https://github.com/zynax-io/zynax/issues/589)~~ | ~~Remove merge_group trigger from workflow files~~ | XS | ✅ Done |
 | ~~[#546](https://github.com/zynax-io/zynax/issues/546)~~ | ~~Remove push-to-main forced-true override~~ | S | ✅ Done |
-| [#557](https://github.com/zynax-io/zynax/issues/557) | Fix release race condition | M | All install URLs → 404 |
-| [#558](https://github.com/zynax-io/zynax/issues/558) | Cut v0.4.0 — first versioned release tag | XS | No artifacts exist |
+| ~~[#557](https://github.com/zynax-io/zynax/issues/557)~~ | ~~Fix release race condition~~ | M | ✅ Done |
+| [#558](https://github.com/zynax-io/zynax/issues/558) | Cut v0.4.0 — first versioned release tag | XS | No artifacts exist — **do next** |
 
 ---
 
@@ -105,8 +105,8 @@ Canvas aligned. Ordered delivery: #526 → #527 → #528 → #481.
 - **compose wiring (#481)** — depends on #528 (agent-registry gRPC wiring) landing first.
 - **adapter implementations** — wait for #481 (compose wiring) so adapters have a live registry.
 - **E2E demo** — blocked on #481 fully wired.
-- **CI throughput** — auto-merge enabled, `strict: true` + merge queue removed, #545 concurrency fix, #589 merge_group removed, #546 push-to-main override done. BATCH 0 complete; next: #557 release pipeline.
-- **v0.4.0 release** — blocked on #557 (release race condition fix) then #558 (tag).
+- **CI throughput** — BATCH 0 complete: auto-merge, #545 concurrency, #589 merge_group, #546 push-to-main, #557 release coordinator all done.
+- **v0.4.0 release** — blocked on #558 (cut v0.4.0 tag); release coordinator (#557) merged.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds `release.yml` as the single tag-triggered release coordinator: fans out to parallel jobs (`build-cli` × 5 platforms, `build-zynax-ci` × 4 platforms, `build-push-images` × 4 services), then creates **one** GitHub Release via `softprops/action-gh-release`
- Removes `push: tags:` triggers from `cli-release.yml`, `service-release.yml`, and `zynax-ci-release.yml` so they no longer race to create the same Release — each is now `workflow_dispatch`-only (manual dry-run)
- Adds `task-broker` to the service image matrix (it now has a Dockerfile); adds `linux/arm64` as a 4th zynax-ci platform
- All actions use pinned SHAs and `ubuntu-24.04`; `GOWORK=off` on every Go build step (ADR-017)

## Why

Three workflows all triggered on `v*.*.*` tags and all called `softprops/action-gh-release` with the same tag — a race condition that would silently fail two of three workflows on every release. Closes #557 (#556 M5.F.R step 1).

## State files updated

- `docs/milestones/M5-plan.md`: #557 ⬜→✅ in BATCH 0 and M5.F.R table; rev 10
- `state/current-milestone.md`: #557 struck-through in IMMEDIATE table; Known Blockers updated

## Architecture gaps addressed

None directly. Unlocks #558 (v0.4.0 tag cut), the remaining BATCH 0 issue.

## Test plan

### Local pre-flight
- [x] `make lint-fix` — (N/A — no Go/Python changes)
- [x] `make lint-go` — (N/A — no Go source changes)
- [x] `make lint-protos` — (N/A — no proto changes)
- [x] `make lint-agents` — (N/A — no Python changes)
- [x] `GOWORK=off go test ./... -race` — (N/A — no Go changes)
- [x] `make test-coverage` — (N/A — no domain code changes)
- [x] `make test-coverage-adapters` — (N/A — no adapter changes)
- [x] `make test-bdd` — (N/A — no feature/contract changes)
- [x] `make security` — (N/A — no source code; pre-commit secret scan passed on commit)
- [x] `make validate-spec` — (N/A — no spec changes)

### Acceptance (from issue #557)
- [x] `release.yml` exists and is the sole tag-triggered coordinator [evidence: `.github/workflows/release.yml` created, triggers on `v[0-9]+.[0-9]+.[0-9]+` and `v[0-9]+.[0-9]+.[0-9]+-*`]
- [x] Old workflows updated to `workflow_dispatch`-only [evidence: `push: tags:` removed from `cli-release.yml`, `service-release.yml`, `zynax-ci-release.yml`]
- [x] One `softprops/action-gh-release` call per tag-triggered run [evidence: only the `release` job in `release.yml` calls it on tag push]
- [x] Assets: zynax CLI (5 platforms), zynax-ci (4 platforms), service SBOMs (4 services with Dockerfiles) [evidence: build-cli matrix 5 entries; build-zynax-ci 4 entries; build-push-images: api-gateway/engine-adapter/workflow-compiler/task-broker]
- [x] Service images pushed to GHCR as part of release [evidence: `build-push-images` calls `docker/build-push-action` with `push: true`]
- [x] Release body includes image pull commands, install commands, checksum verification, CHANGELOG link [evidence: `body:` block in `release` job]
- [x] All `uses:` and `runs-on:` use pinned SHAs and `ubuntu-24.04` [evidence: checkout@de0fac2e, setup-go@4a3601, upload-artifact@ea165f8d, download-artifact@d3f86a10, login-action@4907a6dd, buildx@4d04d5d9, build-push@bcafcacb, gh-release@b4309332; all jobs `ubuntu-24.04`]
- [x] `softprops/action-gh-release` called exactly once per release run [evidence: single call in `release` job; old workflows are not tag-triggered]
- [x] `workflow_dispatch` input allows manual tag override for dry-run [evidence: `inputs.tag` in `release.yml`]
- [x] `GOWORK=off go build` for all Go binaries [evidence: `build-cli` and `build-zynax-ci` jobs both use `GOWORK=off go build`]

### Engineering hygiene
- [x] Branched from fresh `origin/main` (sha `2488eec`)
- [x] PR ≤ 900 lines (`.github/workflows/` excluded from count; state files: 6 lines net change)
- [x] Every commit: `Signed-off-by: Oscar Gómez Manresa <ogomezmanresa@gmail.com>` + `Assisted-by: Claude/claude-sonnet-4-6`
- [x] No `Co-Authored-By:` for AI
- [x] No `panic` in prod paths; no silent `_ = err` (N/A — workflow YAML only)
- [x] No mTLS/SBOM/cosign claims added to docs
- [x] Gap scan done (G1/G4/G7/G16) — no Go code touched; N/A
- [x] 4 state files updated (M5-plan ✅, current-milestone ✅, canvas N/A, AGENTS.md N/A)
- [x] `.feature` committed before impl (N/A — ci type)
- [x] No out-of-scope / drive-by edits

## Out of scope

- Adding new platforms to existing matrices (#564)
- Trivy container scan gate in release (#565)
- cosign signing (#239 / #489, M6+)
- Making GHCR images publicly readable (#562)

Closes #557
