### PR TITLE
chore: promote CHANGELOG to v0.4.0, reconcile BATCH 0 (#558)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,11 @@ Versioning follows [Semantic Versioning](https://semver.org).
 
 ---
 
-## [Unreleased] — M5 (Adapter Library)
+## [Unreleased]
+
+---
+
+## [0.4.0] — M5 (Adapter Library) — 2026-05-20
 
 ### Added
 - `task-broker` service: in-memory `TaskBrokerService` with 5 RPCs (`DispatchTask`, `AcknowledgeTask`, `GetTask`, `ListTasks`, `CancelTask`), hexagonal layout, async dispatch, round-robin agent selection, 92.7% domain coverage (#479 / PRs #520 #522 #523)
@@ -20,17 +24,21 @@ Versioning follows [Semantic Versioning](https://semver.org).
 - X-Request-ID HTTP middleware with gRPC metadata propagation across api-gateway, workflow-compiler, and engine-adapter (#484)
 - Idempotent `zynax apply` — manifest hash derives stable workflow ID; resubmitting the same YAML returns the same `run_id` (#485)
 - HTTP adapter (`agents/adapters/http/`) — REST capability proxy, config-only route mapping, registry client with backoff (#380)
+- Unified release workflow (`release.yml`) — single tag-triggered job fans out to parallel CLI binary, zynax-ci binary, and service image builds, then creates one GitHub Release with all assets (#557)
 
 ### Fixed
 - `resolveTemplate` map-iteration non-determinism in `IRInterpreterWorkflow` — sorted-key iteration ensures Temporal determinism (#475)
 - `CompileWorkflow` now returns the full `CompilationError` list instead of only the first error (#477)
 - SSE `WriteTimeout` extended in api-gateway — `zynax logs` no longer disconnects at 30 s (#478)
 - Event publish errors in engine-adapter now log as `WARN` instead of being silently discarded (#483)
+- Release race condition between three legacy tag-triggered workflows eliminated — replaced by unified coordinator (#557)
 
 ### Changed
 - Docker Compose files consolidated to one canonical `infra/docker-compose/docker-compose.yml`; `ZYNAX_GW_REGISTRY_ADDR` corrected to use service name (#486)
 - CNCF Sandbox Candidate badge removed; replaced with "Built with CNCF-graduated technologies" (#472)
 - CHANGELOG phantom entries removed (Helm charts, argo engine, features that do not exist in git) (#473)
+- CI concurrency fixed — stale runs per branch cancelled; `merge_group` trigger removed (#545 #589)
+- Push-to-main forced-true override removed from change-detection job (#546)
 
 ---
 

--- a/docs/milestones/M5-plan.md
+++ b/docs/milestones/M5-plan.md
@@ -6,7 +6,7 @@
 **GitHub Milestone:** [Adapter Library (M5)](https://github.com/zynax-io/zynax/milestone/5)
 **Parent epic:** [#377](https://github.com/zynax-io/zynax/issues/377)
 **Status:** In Progress
-**Last updated:** 2026-05-20 (rev 10 — #557 done; BATCH 0 only #558 remains)
+**Last updated:** 2026-05-20 (rev 11 — #558 done; #559 already delivered in #557; BATCH 0 complete)
 
 ---
 
@@ -84,7 +84,7 @@ PR cycle time from 25 min → 7 min before any code work begins.
 | [#589](https://github.com/zynax-io/zynax/issues/589) | Remove `merge_group` trigger from all workflow files | XS | ✅ Done |
 | [#546](https://github.com/zynax-io/zynax/issues/546) | Remove push-to-main forced-true in change detection | S | ✅ Done |
 | [#557](https://github.com/zynax-io/zynax/issues/557) | Fix release race condition — unified release workflow | M | ✅ Done |
-| [#558](https://github.com/zynax-io/zynax/issues/558) | Cut v0.4.0 — first versioned release tag | XS | No downloadable artifacts exist |
+| [#558](https://github.com/zynax-io/zynax/issues/558) | Cut v0.4.0 — first versioned release tag | XS | ✅ Done (CHANGELOG promoted; tag push pending user action) |
 
 **Engineer profile:** DevOps / GitHub Actions specialist. No Go/Python knowledge required.
 Edit `.github/workflows/` YAML and GitHub repository settings only.
@@ -289,8 +289,8 @@ without rewriting the graph).
 | Issue | Title | Size | Priority |
 |-------|-------|------|----------|
 | [#557](https://github.com/zynax-io/zynax/issues/557) | Fix release race condition — unified workflow | M | ✅ Done |
-| [#558](https://github.com/zynax-io/zynax/issues/558) | Cut v0.4.0 — first versioned release tag | XS | **P0** |
-| [#559](https://github.com/zynax-io/zynax/issues/559) | Add task-broker to service-release matrix | XS | **P0** |
+| [#558](https://github.com/zynax-io/zynax/issues/558) | Cut v0.4.0 — first versioned release tag | XS | ✅ Done (CHANGELOG promoted; tag push pending user action) |
+| [#559](https://github.com/zynax-io/zynax/issues/559) | Add task-broker to service-release matrix | XS | ✅ Done (delivered in #557 — task-broker already in release.yml matrix) |
 | [#560](https://github.com/zynax-io/zynax/issues/560) | Add http-adapter image to release pipeline | S | P1 |
 | [#561](https://github.com/zynax-io/zynax/issues/561) | Push service/adapter images to GHCR on every main merge | S | P1 |
 | [#562](https://github.com/zynax-io/zynax/issues/562) | Make GHCR images publicly readable | XS | P1 |

--- a/state/current-milestone.md
+++ b/state/current-milestone.md
@@ -30,8 +30,8 @@ M5 is structured into seven tracks. See full execution plan: **[docs/milestones/
 
 | Track | Epic | Status |
 |-------|------|--------|
-| **M5.F CI Sprint** | [#542](https://github.com/zynax-io/zynax/issues/542) | 🔴 **Priority — do first** |
-| **M5.F.R Release Pipeline** | [#556](https://github.com/zynax-io/zynax/issues/556) | 🔴 **Priority — do first** |
+| **M5.F CI Sprint** | [#542](https://github.com/zynax-io/zynax/issues/542) | 🟡 In Progress — BATCH 0 complete; BATCH 1 (#560+) ready |
+| **M5.F.R Release Pipeline** | [#556](https://github.com/zynax-io/zynax/issues/556) | 🟡 In Progress — #557 #558 #559 done; tag push pending; #560+ ready |
 | M5.A Truth Pass | [#458](https://github.com/zynax-io/zynax/issues/458) | In Progress — 2/3 children done; #474 open |
 | M5.B Engine Correctness | [#459](https://github.com/zynax-io/zynax/issues/459) | In Progress — 3/4 children done; #476 open |
 | M5.C Capability Dispatch | [#460](https://github.com/zynax-io/zynax/issues/460) | In Progress — task-broker code merged; agent-registry pending |
@@ -55,7 +55,8 @@ Fix the CI pipeline before all other work. These are XS/S admin + YAML changes.
 | ~~[#589](https://github.com/zynax-io/zynax/issues/589)~~ | ~~Remove merge_group trigger from workflow files~~ | XS | ✅ Done |
 | ~~[#546](https://github.com/zynax-io/zynax/issues/546)~~ | ~~Remove push-to-main forced-true override~~ | S | ✅ Done |
 | ~~[#557](https://github.com/zynax-io/zynax/issues/557)~~ | ~~Fix release race condition~~ | M | ✅ Done |
-| [#558](https://github.com/zynax-io/zynax/issues/558) | Cut v0.4.0 — first versioned release tag | XS | No artifacts exist — **do next** |
+| ~~[#558](https://github.com/zynax-io/zynax/issues/558)~~ | ~~Cut v0.4.0 — CHANGELOG promoted~~ | XS | ✅ Done (tag push: see below) |
+| ~~[#559](https://github.com/zynax-io/zynax/issues/559)~~ | ~~Add task-broker to service-release matrix~~ | XS | ✅ Done (delivered in #557) |
 
 ---
 
@@ -105,8 +106,8 @@ Canvas aligned. Ordered delivery: #526 → #527 → #528 → #481.
 - **compose wiring (#481)** — depends on #528 (agent-registry gRPC wiring) landing first.
 - **adapter implementations** — wait for #481 (compose wiring) so adapters have a live registry.
 - **E2E demo** — blocked on #481 fully wired.
-- **CI throughput** — BATCH 0 complete: auto-merge, #545 concurrency, #589 merge_group, #546 push-to-main, #557 release coordinator all done.
-- **v0.4.0 release** — blocked on #558 (cut v0.4.0 tag); release coordinator (#557) merged.
+- **CI throughput** — BATCH 0 complete: auto-merge, #545 concurrency, #589 merge_group, #546 push-to-main, #557 release coordinator, #558 CHANGELOG, #559 task-broker matrix — all done.
+- **v0.4.0 tag** — CHANGELOG promoted; run `git tag -a v0.4.0 -m "M5 Adapter Library" && git push origin v0.4.0` on main to trigger the release workflow and create GitHub Release assets.
 
 ---
 


### PR DESCRIPTION
## Summary

- Promotes `CHANGELOG.md` `[Unreleased]` section to `[0.4.0] — M5 (Adapter Library) — 2026-05-20`, adding the #557 unified release workflow entry and CI improvements (#545 #546 #589)
- Reconciles BATCH 0 state: marks #558 done (CHANGELOG step), marks #559 done (task-broker was already added to the `release.yml` matrix in #557 — no code change needed), closes #559 on GitHub
- Updates `state/current-milestone.md` and `docs/milestones/M5-plan.md` — BATCH 0 is now fully complete

## Why

The `[Unreleased]` section must be promoted to `[0.4.0]` before pushing the `v0.4.0` tag so the GitHub Release page links to accurate changelog content. Closes #558.

**Tag push is a separate step:** After this PR merges to main, run:
```bash
git checkout main && git pull --rebase origin main
git tag -a v0.4.0 -m "M5 Adapter Library — task-broker, api-gateway, engine-adapter, workflow-compiler, zynax CLI"
git push origin v0.4.0
```
This triggers `release.yml` and creates the GitHub Release with all artifacts.

## State files updated

- `CHANGELOG.md` — `[Unreleased]` promoted to `[0.4.0] — 2026-05-20`
- `docs/milestones/M5-plan.md` — #558 ✅, #559 ✅, Last updated bumped (rev 11)
- `state/current-milestone.md` — BATCH 0 complete, tag-push note added, M5.F/M5.F.R status updated
- `services/*/AGENTS.md` — N/A (no new capability)

## Architecture gaps addressed

— (no gaps directly addressed; BATCH 0 completion enables BATCH 1 release pipeline work)

## Test plan

### Local pre-flight
- [x] `make lint-fix` — N/A (no code changes, pre-commit hooks passed clean)
- [x] `make lint-go` — N/A (no Go changes)
- [x] `make lint-protos` — N/A (no proto changes)
- [x] `make lint-agents` — N/A (no Python changes)
- [x] `GOWORK=off go test ./... -race` — N/A (no Go changes)
- [x] `make test-coverage` — N/A (no domain changes)
- [x] `make test-coverage-adapters` — N/A (no adapter changes)
- [x] `make test-bdd` — N/A (no feature/contract changes)
- [x] `make security` — N/A (no code changes; pre-commit secret scan passed)
- [x] `make validate-spec` — N/A (no spec changes)

### Acceptance (from issue #558)
- [x] `CHANGELOG.md` `[Unreleased]` promoted to `[0.4.0] — M5 (Adapter Library) — 2026-05-20` [evidence: CHANGELOG.md lines 15-42]
- [x] State files updated — #558 and #559 marked done in M5-plan.md and current-milestone.md [evidence: both files in this commit]
- [x] Tag push not in this PR — correctly flagged as a separate confirmed action in PR body
- [x] `#559` closed on GitHub with explanation (task-broker already in release.yml matrix via #557)

### Engineering hygiene
- [x] Branched from fresh `origin/main` (3dff8e2)
- [x] PR ≤ 900 lines (3 files, 19 additions, 10 deletions)
- [x] Every commit: `Signed-off-by` + `Assisted-by: Claude/claude-sonnet-4-6`
- [x] No `Co-Authored-By:` for AI
- [x] No `panic` in prod paths; no silent `_ = err` (N/A — no code changes)
- [x] No mTLS/SBOM/cosign claims added to docs
- [x] Gap scan done (G1/G4/G7/G16) — N/A (no code touched)
- [x] 4 state files updated (M5-plan ✅, current-milestone ✅, canvas N/A, AGENTS.md N/A)
- [x] `.feature` committed before impl — N/A (chore type)
- [x] No out-of-scope / drive-by edits

## Out of scope

- Pushing the `v0.4.0` git tag (requires manual user confirmation — irreversible public action)
- Making GHCR images public (#562)
- Adding http-adapter to release pipeline (#560)

Closes #558
