### PR TITLE
ci(release): add http-adapter to image build matrix (#556, step 4)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,7 +149,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        service: [api-gateway, engine-adapter, workflow-compiler, task-broker]
+        include:
+          - { service: api-gateway,       dockerfile: services/api-gateway/Dockerfile }
+          - { service: engine-adapter,    dockerfile: services/engine-adapter/Dockerfile }
+          - { service: workflow-compiler, dockerfile: services/workflow-compiler/Dockerfile }
+          - { service: task-broker,       dockerfile: services/task-broker/Dockerfile }
+          - { service: http-adapter,      dockerfile: agents/adapters/http/Dockerfile }
+          # add agent-registry here after #528 Dockerfile is merged
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -173,7 +179,7 @@ jobs:
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
-          file: services/${{ matrix.service }}/Dockerfile
+          file: ${{ matrix.dockerfile }}
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
@@ -307,9 +313,10 @@ jobs:
             docker pull ghcr.io/zynax-io/zynax/engine-adapter:${{ steps.ver.outputs.version }}
             docker pull ghcr.io/zynax-io/zynax/workflow-compiler:${{ steps.ver.outputs.version }}
             docker pull ghcr.io/zynax-io/zynax/task-broker:${{ steps.ver.outputs.version }}
+            docker pull ghcr.io/zynax-io/zynax/http-adapter:${{ steps.ver.outputs.version }}
             ```
 
-            CycloneDX SBOMs for all service images are attached to this release.
+            CycloneDX SBOMs for all service and adapter images are attached to this release.
 
             ### What's new
 

--- a/docs/milestones/M5-plan.md
+++ b/docs/milestones/M5-plan.md
@@ -6,7 +6,7 @@
 **GitHub Milestone:** [Adapter Library (M5)](https://github.com/zynax-io/zynax/milestone/5)
 **Parent epic:** [#377](https://github.com/zynax-io/zynax/issues/377)
 **Status:** In Progress
-**Last updated:** 2026-05-20 (rev 11 — #558 done; #559 already delivered in #557; BATCH 0 complete)
+**Last updated:** 2026-05-20 (rev 12 — #560 done; http-adapter added to release matrix)
 
 ---
 
@@ -93,8 +93,8 @@ Edit `.github/workflows/` YAML and GitHub repository settings only.
 
 | Issue | Title | Size | Dependency |
 |-------|-------|------|------------|
-| [#559](https://github.com/zynax-io/zynax/issues/559) | Add task-broker to service-release matrix | XS | After #557 |
-| [#560](https://github.com/zynax-io/zynax/issues/560) | Add http-adapter image to release pipeline | S | After #557 |
+| [#559](https://github.com/zynax-io/zynax/issues/559) | Add task-broker to service-release matrix | XS | ✅ Done (delivered in #557) |
+| [#560](https://github.com/zynax-io/zynax/issues/560) | Add http-adapter image to release pipeline | S | ✅ Done |
 | [#561](https://github.com/zynax-io/zynax/issues/561) | Push service/adapter images to GHCR on every main merge | S | After #559+#560 |
 | [#562](https://github.com/zynax-io/zynax/issues/562) | Make GHCR service/adapter images publicly readable | XS | After #561 |
 | [#566](https://github.com/zynax-io/zynax/issues/566) | README packages section with GHCR image pull commands | S | After #562 |
@@ -291,7 +291,7 @@ without rewriting the graph).
 | [#557](https://github.com/zynax-io/zynax/issues/557) | Fix release race condition — unified workflow | M | ✅ Done |
 | [#558](https://github.com/zynax-io/zynax/issues/558) | Cut v0.4.0 — first versioned release tag | XS | ✅ Done (CHANGELOG promoted; tag push pending user action) |
 | [#559](https://github.com/zynax-io/zynax/issues/559) | Add task-broker to service-release matrix | XS | ✅ Done (delivered in #557 — task-broker already in release.yml matrix) |
-| [#560](https://github.com/zynax-io/zynax/issues/560) | Add http-adapter image to release pipeline | S | P1 |
+| [#560](https://github.com/zynax-io/zynax/issues/560) | Add http-adapter image to release pipeline | S | ✅ Done |
 | [#561](https://github.com/zynax-io/zynax/issues/561) | Push service/adapter images to GHCR on every main merge | S | P1 |
 | [#562](https://github.com/zynax-io/zynax/issues/562) | Make GHCR images publicly readable | XS | P1 |
 | [#563](https://github.com/zynax-io/zynax/issues/563) | Deduplicate tools image (remove tools-publish.yml) | XS | P2 |

--- a/state/current-milestone.md
+++ b/state/current-milestone.md
@@ -30,8 +30,8 @@ M5 is structured into seven tracks. See full execution plan: **[docs/milestones/
 
 | Track | Epic | Status |
 |-------|------|--------|
-| **M5.F CI Sprint** | [#542](https://github.com/zynax-io/zynax/issues/542) | 🟡 In Progress — BATCH 0 complete; BATCH 1 (#560+) ready |
-| **M5.F.R Release Pipeline** | [#556](https://github.com/zynax-io/zynax/issues/556) | 🟡 In Progress — #557 #558 #559 done; tag push pending; #560+ ready |
+| **M5.F CI Sprint** | [#542](https://github.com/zynax-io/zynax/issues/542) | 🟡 In Progress — BATCH 0 complete; BATCH 1 — #560 done; #561+ ready |
+| **M5.F.R Release Pipeline** | [#556](https://github.com/zynax-io/zynax/issues/556) | 🟡 In Progress — #557 #558 #559 #560 done; tag push pending; #561+ ready |
 | M5.A Truth Pass | [#458](https://github.com/zynax-io/zynax/issues/458) | In Progress — 2/3 children done; #474 open |
 | M5.B Engine Correctness | [#459](https://github.com/zynax-io/zynax/issues/459) | In Progress — 3/4 children done; #476 open |
 | M5.C Capability Dispatch | [#460](https://github.com/zynax-io/zynax/issues/460) | In Progress — task-broker code merged; agent-registry pending |
@@ -57,6 +57,7 @@ Fix the CI pipeline before all other work. These are XS/S admin + YAML changes.
 | ~~[#557](https://github.com/zynax-io/zynax/issues/557)~~ | ~~Fix release race condition~~ | M | ✅ Done |
 | ~~[#558](https://github.com/zynax-io/zynax/issues/558)~~ | ~~Cut v0.4.0 — CHANGELOG promoted~~ | XS | ✅ Done (tag push: see below) |
 | ~~[#559](https://github.com/zynax-io/zynax/issues/559)~~ | ~~Add task-broker to service-release matrix~~ | XS | ✅ Done (delivered in #557) |
+| ~~[#560](https://github.com/zynax-io/zynax/issues/560)~~ | ~~Add http-adapter image to release pipeline~~ | S | ✅ Done (BATCH 1) |
 
 ---
 
@@ -106,7 +107,7 @@ Canvas aligned. Ordered delivery: #526 → #527 → #528 → #481.
 - **compose wiring (#481)** — depends on #528 (agent-registry gRPC wiring) landing first.
 - **adapter implementations** — wait for #481 (compose wiring) so adapters have a live registry.
 - **E2E demo** — blocked on #481 fully wired.
-- **CI throughput** — BATCH 0 complete: auto-merge, #545 concurrency, #589 merge_group, #546 push-to-main, #557 release coordinator, #558 CHANGELOG, #559 task-broker matrix — all done.
+- **CI throughput** — BATCH 0 complete; BATCH 1 started: #560 (http-adapter release matrix) done; #561+ next.
 - **v0.4.0 tag** — CHANGELOG promoted; run `git tag -a v0.4.0 -m "M5 Adapter Library" && git push origin v0.4.0` on main to trigger the release workflow and create GitHub Release assets.
 
 ---


### PR DESCRIPTION
## Summary

- Converts `build-push-images` matrix from a flat `service:` list to `include:` format with explicit `dockerfile` fields, enabling adapters (which live under `agents/`) to be included alongside services
- Adds `http-adapter` with `dockerfile: agents/adapters/http/Dockerfile` to the release build matrix — linux/amd64 + linux/arm64, SBOM generated, `:version` and `:latest` tags
- Updates release body to include `http-adapter` pull command and SBOM reference
- Leaves a comment noting `agent-registry` should be added here after `#528` Dockerfile merges
- Reconciles `#559` (already delivered in `#557`) and `#560` as ✅ in state files

## Why

`agents/adapters/http/Dockerfile` was shipped in M5 (#380) but the release pipeline only supported `services/*/Dockerfile` paths. This closes the gap so operators can `docker pull ghcr.io/zynax-io/zynax/http-adapter:v0.4.0` after the next release tag.

Closes #560

## State files updated

- `docs/milestones/M5-plan.md`: rev 12 — #559 and #560 ✅ in BATCH 1 table and M5.F.R section
- `state/current-milestone.md`: M5.F.R row updated; #560 added to IMMEDIATE done list; Known Blockers updated

## Architecture gaps addressed

—

## Test plan

### Local pre-flight
- [x] `make lint-fix` — exit 0 [evidence: `✅ Docker 29.4.1`, no errors]
- [x] `make lint-go` — (N/A — no Go changes)
- [x] `make lint-protos` — (N/A — no proto changes)
- [x] `make lint-agents` — (N/A — no Python changes)
- [x] `GOWORK=off go test ./... -race` — (N/A — no Go changes)
- [x] `make test-coverage` — (N/A — no domain code changes)
- [x] `make test-coverage-adapters` — (N/A — no adapter code changes)
- [x] `make test-bdd` — (N/A — no feature file changes)
- [x] `make security` — exit 0 [evidence: 0 issues by severity; idna CVE-2026-45409 is pre-existing Python dep, not introduced by this YAML change]
- [x] `make validate-spec` — (N/A — no spec changes)
- [x] YAML syntax — valid [evidence: `python3 -c "import yaml; yaml.safe_load(...)"` → YAML_VALID]

### Acceptance (from issue #560)
- [x] `task-broker` in service matrix — (N/A — already delivered in #557; #559 closed)
- [x] `http-adapter` entry added to matrix with `agents/adapters/http/Dockerfile` path — verified in diff
- [x] `platforms: linux/amd64,linux/arm64` — inherited from matrix job, verified in diff
- [x] Release body updated with `docker pull ghcr.io/zynax-io/zynax/http-adapter:VERSION` — verified in diff
- [x] SBOM upload covers http-adapter — `sbom-http-adapter` artifact uploaded via `actions/upload-artifact`, downloaded by `release` job via `sbom-*` pattern
- [x] `ghcr.io/zynax-io/zynax/http-adapter:v0.4.0` pullable after release tag push — will be verified when `git push origin v0.4.0` is run (user action)

### Engineering hygiene
- [x] Branched from fresh `origin/main` (b885c19)
- [x] PR ≤ 900 lines (excl. generated) — 18 lines changed
- [x] Every commit: `Signed-off-by: Oscar Gómez Manresa <ogomezmanresa@gmail.com>` + `Assisted-by: Claude/claude-sonnet-4-6`
- [x] No `Co-Authored-By:` for AI
- [x] No `panic` in prod paths; no silent `_ = err` — (N/A — no code changes)
- [x] No mTLS/SBOM/cosign claims added to docs
- [x] Gap scan done (G1/G4/G7/G16) — all N/A for CI YAML change
- [x] 4 state files updated (M5-plan.md ✅, current-milestone.md ✅, canvas N/A — ci: type, AGENTS.md N/A — no new capability)
- [x] `.feature` committed before impl — (N/A — no public boundary change)
- [x] No out-of-scope / drive-by edits

## Out of scope

- `agent-registry` image (Dockerfile not yet committed — awaits #528)
- `:main-{sha}` continuous tagging on every main push (separate issue)
- OCI source/revision labels (not required by acceptance criteria)
- git/ci/llm/langgraph adapters (implementations pending #481)
