### PR TITLE
ci(release): push service and adapter images to GHCR on main merge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,11 @@ on:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
       - 'v[0-9]+.[0-9]+.[0-9]+-*'
+    branches:
+      - main
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
   workflow_dispatch:
     inputs:
       tag:
@@ -40,6 +45,7 @@ env:
 jobs:
   build-cli:
     name: CLI — ${{ matrix.goos }}/${{ matrix.goarch }}
+    if: github.ref_type == 'tag' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-24.04
     strategy:
       matrix:
@@ -101,6 +107,7 @@ jobs:
 
   build-zynax-ci:
     name: zynax-ci — ${{ matrix.goos }}/${{ matrix.goarch }}
+    if: github.ref_type == 'tag' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-24.04
     strategy:
       matrix:
@@ -165,6 +172,19 @@ jobs:
           TAG="${{ inputs.tag || github.ref_name }}"
           echo "version=${TAG}" >> "$GITHUB_OUTPUT"
 
+      - name: Compute image tags
+        id: img
+        run: |
+          PREFIX="${{ env.IMAGE_PREFIX }}/${{ matrix.service }}"
+          SHA="${{ github.sha }}"
+          if [[ "${{ github.ref_type }}" == "branch" && "${{ github.event_name }}" != "workflow_dispatch" ]]; then
+            echo "tags=${PREFIX}:main,${PREFIX}:main-${SHA:0:8}" >> "$GITHUB_OUTPUT"
+          else
+            TAG="${{ steps.ver.outputs.version }}"
+            echo "tags=${PREFIX}:${TAG},${PREFIX}:latest" >> "$GITHUB_OUTPUT"
+          fi
+          echo "created=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+
       - name: Log in to GHCR
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
@@ -182,11 +202,14 @@ jobs:
           file: ${{ matrix.dockerfile }}
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: |
-            ${{ env.IMAGE_PREFIX }}/${{ matrix.service }}:${{ steps.ver.outputs.version }}
-            ${{ env.IMAGE_PREFIX }}/${{ matrix.service }}:latest
+          tags: ${{ steps.img.outputs.tags }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.created=${{ steps.img.outputs.created }}
 
       - name: Install syft ${{ env.SYFT_VERSION }}
+        if: github.ref_type == 'tag' || github.event_name == 'workflow_dispatch'
         run: |
           curl -sSfL \
             "https://github.com/anchore/syft/releases/download/v${SYFT_VERSION}/syft_${SYFT_VERSION}_linux_amd64.tar.gz" \
@@ -195,6 +218,7 @@ jobs:
           rm /tmp/syft.tar.gz
 
       - name: Generate SBOM
+        if: github.ref_type == 'tag' || github.event_name == 'workflow_dispatch'
         run: |
           syft \
             "${{ env.IMAGE_PREFIX }}/${{ matrix.service }}:${{ steps.ver.outputs.version }}" \
@@ -202,6 +226,7 @@ jobs:
             --file "${{ matrix.service }}-sbom.json"
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: github.ref_type == 'tag' || github.event_name == 'workflow_dispatch'
         with:
           name: sbom-${{ matrix.service }}
           path: ${{ matrix.service }}-sbom.json
@@ -212,6 +237,7 @@ jobs:
   release:
     name: Create GitHub Release
     needs: [build-cli, build-zynax-ci, build-push-images]
+    if: github.ref_type == 'tag' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-24.04
     steps:
       - name: Resolve version

--- a/docs/milestones/M5-plan.md
+++ b/docs/milestones/M5-plan.md
@@ -6,7 +6,7 @@
 **GitHub Milestone:** [Adapter Library (M5)](https://github.com/zynax-io/zynax/milestone/5)
 **Parent epic:** [#377](https://github.com/zynax-io/zynax/issues/377)
 **Status:** In Progress
-**Last updated:** 2026-05-20 (rev 13 — #538 done; cel-go guard evaluator integrated, fail-closed)
+**Last updated:** 2026-05-20 (rev 14 — #561 done; push images to GHCR on every main merge)
 
 ---
 
@@ -95,7 +95,7 @@ Edit `.github/workflows/` YAML and GitHub repository settings only.
 |-------|-------|------|------------|
 | [#559](https://github.com/zynax-io/zynax/issues/559) | Add task-broker to service-release matrix | XS | ✅ Done (delivered in #557) |
 | [#560](https://github.com/zynax-io/zynax/issues/560) | Add http-adapter image to release pipeline | S | ✅ Done |
-| [#561](https://github.com/zynax-io/zynax/issues/561) | Push service/adapter images to GHCR on every main merge | S | After #559+#560 |
+| [#561](https://github.com/zynax-io/zynax/issues/561) | Push service/adapter images to GHCR on every main merge | S | ✅ Done |
 | [#562](https://github.com/zynax-io/zynax/issues/562) | Make GHCR service/adapter images publicly readable | XS | After #561 |
 | [#566](https://github.com/zynax-io/zynax/issues/566) | README packages section with GHCR image pull commands | S | After #562 |
 
@@ -292,7 +292,7 @@ without rewriting the graph).
 | [#558](https://github.com/zynax-io/zynax/issues/558) | Cut v0.4.0 — first versioned release tag | XS | ✅ Done (CHANGELOG promoted; tag push pending user action) |
 | [#559](https://github.com/zynax-io/zynax/issues/559) | Add task-broker to service-release matrix | XS | ✅ Done (delivered in #557 — task-broker already in release.yml matrix) |
 | [#560](https://github.com/zynax-io/zynax/issues/560) | Add http-adapter image to release pipeline | S | ✅ Done |
-| [#561](https://github.com/zynax-io/zynax/issues/561) | Push service/adapter images to GHCR on every main merge | S | P1 |
+| [#561](https://github.com/zynax-io/zynax/issues/561) | Push service/adapter images to GHCR on every main merge | S | ✅ Done |
 | [#562](https://github.com/zynax-io/zynax/issues/562) | Make GHCR images publicly readable | XS | P1 |
 | [#563](https://github.com/zynax-io/zynax/issues/563) | Deduplicate tools image (remove tools-publish.yml) | XS | P2 |
 | [#564](https://github.com/zynax-io/zynax/issues/564) | Pin action digests + add linux/arm64 | XS | P2 |

--- a/state/current-milestone.md
+++ b/state/current-milestone.md
@@ -30,8 +30,8 @@ M5 is structured into seven tracks. See full execution plan: **[docs/milestones/
 
 | Track | Epic | Status |
 |-------|------|--------|
-| **M5.F CI Sprint** | [#542](https://github.com/zynax-io/zynax/issues/542) | 🟡 In Progress — BATCH 0 complete; BATCH 1 — #560 done; #561+ ready |
-| **M5.F.R Release Pipeline** | [#556](https://github.com/zynax-io/zynax/issues/556) | 🟡 In Progress — #557 #558 #559 #560 done; tag push pending; #561+ ready |
+| **M5.F CI Sprint** | [#542](https://github.com/zynax-io/zynax/issues/542) | 🟡 In Progress — BATCH 0 complete; BATCH 1 — #560 #561 done; #562+ ready |
+| **M5.F.R Release Pipeline** | [#556](https://github.com/zynax-io/zynax/issues/556) | 🟡 In Progress — #557 #558 #559 #560 #561 done; tag push pending; #562+ ready |
 | M5.A Truth Pass | [#458](https://github.com/zynax-io/zynax/issues/458) | In Progress — 2/3 children done; #474 open |
 | M5.B Engine Correctness | [#459](https://github.com/zynax-io/zynax/issues/459) | In Progress — 3/4 children done; #476 open (#538 done) |
 | M5.C Capability Dispatch | [#460](https://github.com/zynax-io/zynax/issues/460) | In Progress — task-broker code merged; agent-registry pending |
@@ -107,7 +107,7 @@ Canvas aligned. Ordered delivery: #526 → #527 → #528 → #481.
 - **compose wiring (#481)** — depends on #528 (agent-registry gRPC wiring) landing first.
 - **adapter implementations** — wait for #481 (compose wiring) so adapters have a live registry.
 - **E2E demo** — blocked on #481 fully wired.
-- **CI throughput** — BATCH 0 complete; BATCH 1 started: #560 (http-adapter release matrix) done; #561+ next.
+- **CI throughput** — BATCH 0 complete; BATCH 1: #560 #561 done; #562 (GHCR public visibility) next.
 - **v0.4.0 tag** — CHANGELOG promoted; run `git tag -a v0.4.0 -m "M5 Adapter Library" && git push origin v0.4.0` on main to trigger the release workflow and create GitHub Release assets.
 
 ---


### PR DESCRIPTION
## Summary

- Add `push: branches: [main]` trigger to `release.yml` so every merge to `main` produces `:main` and `:main-{sha8}` Docker images for all 5 services (`api-gateway`, `engine-adapter`, `workflow-compiler`, `task-broker`, `http-adapter`)
- CLI binary builds and GitHub Release creation are guarded by `github.ref_type == 'tag' || github.event_name == 'workflow_dispatch'` — they do not run on main-push
- SBOM generation is similarly skipped on main-push (release artifacts only); OCI `source`, `revision`, and `created` labels added to all image builds
- `paths-ignore` on `**.md` and `docs/**` prevents the workflow from firing on documentation-only commits

## Why

#595 landed the http-adapter in the release matrix, but images are only published on version tags — and zero tags have been pushed. Developers following README `docker pull` instructions get 404. This gives teams a stable `:main` integration build after every merge. Closes #561 (M5.F.R step 5, BATCH 1).

## State files updated

- `docs/milestones/M5-plan.md`: #561 → ✅ Done (both BATCH 1 table and M5.F.R child-issues table); rev 14
- `state/current-milestone.md`: M5.F CI Sprint + M5.F.R Release Pipeline track rows updated; #562 noted as next

## Architecture gaps addressed

— (CI workflow change; no G-series gaps touched)

## Test plan

### Local pre-flight
- [x] `make lint-fix` — (N/A — no Go/Python changed; pre-commit hooks ran on commit: Passed)
- [x] `make lint-go` — (N/A — no Go files changed)
- [x] `make lint-protos` — (N/A — no proto files changed)
- [x] `make lint-agents` — (N/A — no Python files changed)
- [x] `GOWORK=off go test ./... -race` — (N/A — no Go files changed)
- [x] `make test-coverage` — (N/A — domain unchanged)
- [x] `make test-coverage-adapters` — (N/A — no adapter code changed)
- [x] `make test-bdd` — (N/A — no feature files changed)
- [x] `make security` — (N/A — no code changed; gitleaks pre-commit hook: Passed)
- [x] `make validate-spec` — (N/A — no spec files changed)

### Acceptance (from issue #561 body)
- [x] After any merge to `main`, all service and http-adapter images tagged `:main` and `:main-{sha}` produced — `push: branches: [main]` trigger added; `Compute image tags` step emits `PREFIX:main,PREFIX:main-${SHA:0:8}` when `ref_type == branch`
- [x] Version-tag builds continue to produce `:v{version}` and `:latest` — `else` branch of compute step passes `PREFIX:${TAG},PREFIX:latest`; tag-triggered jobs unchanged
- [x] `:main` tag is idempotent — second merge overwrites the rolling `:main` tag via `docker/build-push-action` push (no append, replaces)
- [x] All images are multi-arch (linux/amd64 + linux/arm64) — `platforms: linux/amd64,linux/arm64` unchanged
- [x] Workflow does not run on `.md`/`docs/` only commits — `paths-ignore: ['**.md', 'docs/**']` on the push trigger

### Engineering hygiene
- [x] Branched from fresh `origin/main` (5a9d461)
- [x] PR ≤ 900 lines — 35 insertions, 9 deletions (excl. state files: 32+6 = 38 net)
- [x] Every commit: `Signed-off-by: Oscar Gómez Manresa <ogomezmanresa@gmail.com>` + `Assisted-by: Claude/claude-sonnet-4-6`
- [x] No `Co-Authored-By:` for AI
- [x] No `panic` in prod paths; no silent `_ = err` — (N/A — workflow YAML only)
- [x] No mTLS/SBOM/cosign claims added to docs
- [x] Gap scan done (G1/G4/G7/G16) — no gaps touched; YAML-only change
- [x] 4 state files updated (M5-plan.md ✅, current-milestone.md ✅, canvas N/A `ci` type, AGENTS.md N/A no new capability)
- [x] `.feature` committed before impl — (N/A — CI workflow, no public gRPC boundary)
- [x] No out-of-scope / drive-by edits

## Out of scope

- GHCR image visibility (#562 — separate issue, next in BATCH 1)
- Trivy scan gate (#565)
- agent-registry image (blocked on #528)
- CLI `zynax-ci` binary main-push builds (tag-release only by design)

Closes #561
