### PR TITLE
test(engine-adapter): guard evaluator test suite and fuzz seed

### DIFF
--- a/docs/milestones/M5-plan.md
+++ b/docs/milestones/M5-plan.md
@@ -6,7 +6,7 @@
 **GitHub Milestone:** [Adapter Library (M5)](https://github.com/zynax-io/zynax/milestone/5)
 **Parent epic:** [#377](https://github.com/zynax-io/zynax/issues/377)
 **Status:** In Progress
-**Last updated:** 2026-05-20 (rev 14 — #561 done; push images to GHCR on every main merge)
+**Last updated:** 2026-05-20 (rev 15 — #539 done; guard evaluator test suite + fuzz seed; #538 status corrected in M5.B epic table)
 
 ---
 
@@ -108,7 +108,7 @@ These can run in parallel with BATCH 0/1.
 | Issue | Title | Size | Dependency | Why |
 |-------|-------|------|------------|-----|
 | [#538](https://github.com/zynax-io/zynax/issues/538) | Integrate cel-go as guard evaluator | M | None | ✅ Done |
-| [#539](https://github.com/zynax-io/zynax/issues/539) | Guard evaluator test suite + fuzz seed | S | After #538 | Prevent regression |
+| [#539](https://github.com/zynax-io/zynax/issues/539) | Guard evaluator test suite + fuzz seed | S | After #538 | ✅ Done |
 | [#540](https://github.com/zynax-io/zynax/issues/540) | Remove CEL misrepresentation from AGENTS.md | XS | After #538+#539 | Truth pass |
 
 **Engineer profile:** Go engineer familiar with cel-go library. Read ADR-014 and
@@ -350,8 +350,8 @@ without rewriting the graph).
 
 | Issue | Step | Title | Status |
 |-------|------|-------|--------|
-| [#538](https://github.com/zynax-io/zynax/issues/538) | O1 | Integrate cel-go into evalGuard | ⬜ Open |
-| [#539](https://github.com/zynax-io/zynax/issues/539) | O2 | Test suite + fuzz seed | ⬜ Open (blocked on #538) |
+| [#538](https://github.com/zynax-io/zynax/issues/538) | O1 | Integrate cel-go into evalGuard | ✅ Done |
+| [#539](https://github.com/zynax-io/zynax/issues/539) | O2 | Test suite + fuzz seed | ✅ Done |
 | [#540](https://github.com/zynax-io/zynax/issues/540) | O3 | Remove CEL misrepresentation from docs | ⬜ Open (blocked on #538+#539) |
 
 ---

--- a/services/engine-adapter/internal/domain/interpreter_test.go
+++ b/services/engine-adapter/internal/domain/interpreter_test.go
@@ -444,6 +444,49 @@ func TestIRInterpreter_PublishErrorLogged(t *testing.T) {
 	}
 }
 
+// TestEvalGuard_FailClosed_InvalidExpressions verifies fail-closed for specific
+// expressions called out in the issue-#539 acceptance criteria.
+func TestEvalGuard_FailClosed_InvalidExpressions(t *testing.T) {
+	cases := []struct {
+		name string
+		expr string
+	}{
+		{"invalid-keywords", "not a valid expression !!!"},
+		{"malformed-parenthesis", `ctx.x == ("y"`},
+	}
+	ctx := map[string]string{"x": "y"}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if evalGuard(tc.expr, ctx) {
+				t.Errorf("expression %q should be fail-closed (false)", tc.expr)
+			}
+		})
+	}
+}
+
+func TestEvalGuard_BooleanLiteral(t *testing.T) {
+	if !evalGuard("true", map[string]string{}) {
+		t.Error(`evalGuard("true", {}) should return true`)
+	}
+	if evalGuard("false", map[string]string{}) {
+		t.Error(`evalGuard("false", {}) should return false`)
+	}
+}
+
+// FuzzEvalGuard verifies that evalGuard never panics for any input combination.
+// Full fuzz execution is deferred to M7.C (#469); this seed enables the corpus.
+func FuzzEvalGuard(f *testing.F) {
+	f.Add(`ctx.status == "approved"`, "status", "approved")
+	f.Add(`ctx.status != "rejected"`, "status", "ok")
+	f.Add("true", "key", "val")
+	f.Add("false", "key", "val")
+	f.Add("", "key", "val")
+	f.Add("not a valid expression !!!", "key", "val")
+	f.Fuzz(func(_ *testing.T, expr, key, val string) {
+		_ = evalGuard(expr, map[string]string{key: val})
+	})
+}
+
 // --- helpers ---
 
 func equalSlice(a, b []string) bool {

--- a/services/engine-adapter/internal/domain/testdata/fuzz/FuzzEvalGuard/seed1
+++ b/services/engine-adapter/internal/domain/testdata/fuzz/FuzzEvalGuard/seed1
@@ -1,0 +1,4 @@
+go test fuzz v1
+string("ctx.status == \"approved\"")
+string("status")
+string("approved")

--- a/state/current-milestone.md
+++ b/state/current-milestone.md
@@ -93,7 +93,7 @@ Canvas aligned. Ordered delivery: #526 → #527 → #528 → #481.
 | Issue | Track | Title | Status |
 |-------|-------|-------|--------|
 | [#474](https://github.com/zynax-io/zynax/issues/474) | M5.A | Python SDK Agent base class | open — Option A chosen, impl pending |
-| [#476](https://github.com/zynax-io/zynax/issues/476) | M5.B | Guard parser (cel-go) | open — #538 done; #539 (test suite + fuzz seed) next |
+| [#476](https://github.com/zynax-io/zynax/issues/476) | M5.B | Guard parser (cel-go) | open — #538 done; #539 done; #540 (docs update) next |
 | [#381](https://github.com/zynax-io/zynax/issues/381) | Adapters | git-adapter impl | open (#399 BDD done; #400+ pending, wait for #481) |
 | [#382](https://github.com/zynax-io/zynax/issues/382) | Adapters | ci-adapter impl | open (#404 BDD done; #405+ pending, wait for #481) |
 | [#383](https://github.com/zynax-io/zynax/issues/383) | Adapters | llm-adapter impl | open (#409 BDD done; #410+ pending, wait for #481) |


### PR DESCRIPTION
## Summary

- Adds `TestEvalGuard_FailClosed_InvalidExpressions`: table-driven subtests for `"not a valid expression !!!"` and unclosed-parenthesis `ctx.x == ("y"` — both must return `false`
- Adds `TestEvalGuard_BooleanLiteral`: asserts `evalGuard("true", {})` → `true` and `evalGuard("false", {})` → `false`
- Adds `FuzzEvalGuard`: never-panic invariant with 6 in-memory seeds; file-based corpus entry committed at `testdata/fuzz/FuzzEvalGuard/seed1`
- Corrects stale `⬜ Open` status for #538 in `M5-plan.md` §M5.B epic table (BATCH 2 table was already correct)

## Why

Canvas O2 for epic #476 (cel-go guard evaluator) calls for extended fail-closed coverage and a committed fuzz corpus so M7.C (#469) has a starting seed without extra archaeology. Closes #539.

## State files updated

- `docs/milestones/M5-plan.md`: #539 → ✅ Done (BATCH 2 table + M5.B epic table); #538 status corrected in M5.B epic table; rev 15
- `state/current-milestone.md`: M5.B row updated to show #539 done, #540 next
- canvas: N/A (`test` type — SPDD exempt per ADR-019)
- AGENTS.md: N/A (no new public capability)

## Architecture gaps addressed

— (test-only change; no G-series gaps touched directly; supports G12 regression prevention via #539)

## Test plan

### Local pre-flight
- [x] `make lint-fix` — pre-commit hooks ran on commit: Passed (golangci-lint, gofmt, detect-secrets all green)
- [x] `make lint-go` — N/A (pre-commit golangci-lint is equivalent; no linter errors)
- [x] `make lint-protos` — (N/A — no proto files changed)
- [x] `make lint-agents` — (N/A — no Python files changed)
- [x] `GOWORK=off go test ./internal/domain/... -race -count=1 -timeout 60s` — PASS: `ok github.com/zynax-io/zynax/services/engine-adapter/internal/domain 1.031s`
- [x] `make test-coverage` — domain coverage: 91.4% (≥ 90% gate) [evidence: `coverage: 91.4% of statements`]
- [x] `make test-coverage-adapters` — (N/A — no adapter code changed)
- [x] `make test-bdd` — (N/A — no feature files changed)
- [x] `make security` — (N/A — test-only change; gitleaks pre-commit hook: Passed)
- [x] `make validate-spec` — (N/A — no spec files changed)

### Acceptance (from issue #539 body / Canvas O2)
- [x] `evalGuard("not a valid expression !!!", ctx)` → `false` — `TestEvalGuard_FailClosed_InvalidExpressions/invalid-keywords` PASS
- [x] `evalGuard("ctx.x == (\"y\"", ctx)` → `false` — `TestEvalGuard_FailClosed_InvalidExpressions/malformed-parenthesis` PASS
- [x] `evalGuard("", ctx)` → `false` — covered by existing `TestEvalGuard_FailClosed_EmptyExpr` ✅
- [x] `evalGuard("ctx.missing == \"x\"", map{})` → `false` — covered by existing `TestEvalGuard_FailClosed_MissingKey` ✅
- [x] `evalGuard("ctx.a == \"b\"", map{"a":"b"})` → `true` — covered by existing `TestEvalGuard_Equality` ✅
- [x] `evalGuard("ctx.a != \"b\"", map{"a":"c"})` → `true` — covered by existing `TestEvalGuard_Inequality` ✅
- [x] `evalGuard("true", ctx)` → `true`; `evalGuard("false", ctx)` → `false` — `TestEvalGuard_BooleanLiteral` PASS
- [x] Fuzz seed directory committed: `services/engine-adapter/internal/domain/testdata/fuzz/FuzzEvalGuard/seed1` exists
- [x] `GOWORK=off go test ./internal/domain/... -race -cover` — domain ≥ 90%: **91.4%**

### Engineering hygiene
- [x] Branched from fresh `origin/main` (e325f459)
- [x] PR ≤ 900 lines — 52 insertions, 5 deletions (test-only; no generated files)
- [x] Every commit: `Signed-off-by: Oscar Gómez Manresa <ogomezmanresa@gmail.com>` + `Assisted-by: Claude/claude-sonnet-4-6`
- [x] No `Co-Authored-By:` for AI
- [x] No `panic` in prod paths; no silent `_ = err` — (N/A — test-only change)
- [x] No mTLS/SBOM/cosign claims added to docs
- [x] Gap scan done (G1/G4/G7/G16) — no gaps in files touched; test file only
- [x] 4 state files updated (M5-plan.md ✅, current-milestone.md ✅, canvas N/A `test` type, AGENTS.md N/A no new capability)
- [x] `.feature` committed before impl — (N/A — test type, no new public gRPC boundary)
- [x] No out-of-scope / drive-by edits

## Out of scope

- Running fuzz tests in CI (deferred to M7.C #469)
- Benchmark tests (M7)
- Integration tests against real Temporal
- Docs update for CEL misrepresentation (#540, next in BATCH 2)

Closes #539
