### PR TITLE
fix: add service path negations to .dockerignore for image builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -56,6 +56,14 @@ infra/docker-compose/
 infra/helm/
 infra/k8s/
 
+# ── Service build allowlist (negations for services/*/Dockerfile) ────────────
+# Service Dockerfiles COPY from these subdirectories using context: repo root.
+# Without negations, the services/ exclusion above strips them from the context.
+!services/api-gateway/
+!services/engine-adapter/
+!services/workflow-compiler/
+!services/task-broker/
+
 # ── Adapter build allowlist (negations for agents/adapters/*/Dockerfile) ──────
 # Adapter Dockerfiles are built from repo root and need their module source
 # plus the generated proto stubs to resolve the workspace replace directive.


### PR DESCRIPTION
## Summary

- Add `!services/api-gateway/`, `!services/engine-adapter/`, `!services/workflow-compiler/`, and `!services/task-broker/` negation entries to `.dockerignore`
- The `services/` global exclusion (written for `Dockerfile.tools`) was stripping all service source code from the Docker build context, causing BuildKit to fail with `"/services/api-gateway": not found`

## Why

The `.dockerignore` was authored exclusively for `Dockerfile.tools` (`make build-tools`) and excluded `services/` wholesale. Service image Dockerfiles all use `context: .` (repo root) and COPY from `services/<svc>/` — so the build context was missing the source code entirely. The `http-adapter` already worked because `!agents/adapters/http/` was in the allowlist; services had no equivalent entries.

This bug was invisible until #597 added the main-branch push trigger and fired the first real service image build run. Discovered in run [26162093200](https://github.com/zynax-io/zynax/actions/runs/26162093200).

## State files updated

None — `.dockerignore` fix, no milestone tracking needed.

## Architecture gaps addressed

— (pre-existing config bug)

## Test plan

### Local pre-flight
- [x] `make lint-fix` — (N/A — `.dockerignore` only)
- [x] `make lint-go` — (N/A — no Go files changed)
- [x] `make lint-protos` — (N/A)
- [x] `make lint-agents` — (N/A)
- [x] `GOWORK=off go test ./... -race` — (N/A)
- [x] `make test-coverage` — (N/A)
- [x] `make test-coverage-adapters` — (N/A)
- [x] `make test-bdd` — (N/A)
- [x] `make security` — (N/A — gitleaks pre-commit: Passed)
- [x] `make validate-spec` — (N/A)

### Acceptance
- [x] `services/api-gateway/` negated in `.dockerignore` — present in commit
- [x] `services/engine-adapter/` negated — present
- [x] `services/workflow-compiler/` negated — present
- [x] `services/task-broker/` negated — present
- [x] `Dockerfile.tools` behaviour unchanged — it only COPYs from `cmd/zynax-ci/`, which is not negated, so that dir stays excluded from context (defence-in-depth preserved)
- [x] `http-adapter` and `protos/generated/go/` negations unchanged

### Engineering hygiene
- [x] Branched from fresh `origin/main` (e325f45)
- [x] PR ≤ 900 lines — 8 insertions, 0 deletions
- [x] Every commit: `Signed-off-by: Oscar Gómez Manresa <ogomezmanresa@gmail.com>` + `Assisted-by: Claude/claude-sonnet-4-6`
- [x] No `Co-Authored-By:` for AI
- [x] No `panic` in prod paths — (N/A — config file)
- [x] No mTLS/SBOM/cosign claims added to docs
- [x] Gap scan done — no G-series gaps touched
- [x] 4 state files updated — (N/A — `.dockerignore` config fix, no milestone row changes)
- [x] No out-of-scope / drive-by edits

## Out of scope

- Excluding `agents/` (only `agents/adapters/http/` needs to be in-context; this is already handled)
- Adding `agent-registry` negation (no Dockerfile yet — tracked in #528)

Fixes pre-existing bug revealed by #597
