### PR TITLE
docs: align M5-plan and milestone state with #601 (Go Dockerfile fix)

### DIFF
--- a/docs/milestones/M5-plan.md
+++ b/docs/milestones/M5-plan.md
@@ -6,7 +6,7 @@
 **GitHub Milestone:** [Adapter Library (M5)](https://github.com/zynax-io/zynax/milestone/5)
 **Parent epic:** [#377](https://github.com/zynax-io/zynax/issues/377)
 **Status:** In Progress
-**Last updated:** 2026-05-20 (rev 16 — #540 done; CEL misrepresentation removed from AGENTS.md; BATCH 2 complete)
+**Last updated:** 2026-05-20 (rev 17 — #601 filed; Go 1.25→1.26.3 Dockerfile toolchain fix; #562 dependency updated; BATCH 1 reordered)
 
 ---
 
@@ -96,7 +96,8 @@ Edit `.github/workflows/` YAML and GitHub repository settings only.
 | [#559](https://github.com/zynax-io/zynax/issues/559) | Add task-broker to service-release matrix | XS | ✅ Done (delivered in #557) |
 | [#560](https://github.com/zynax-io/zynax/issues/560) | Add http-adapter image to release pipeline | S | ✅ Done |
 | [#561](https://github.com/zynax-io/zynax/issues/561) | Push service/adapter images to GHCR on every main merge | S | ✅ Done |
-| [#562](https://github.com/zynax-io/zynax/issues/562) | Make GHCR service/adapter images publicly readable | XS | After #561 |
+| [#601](https://github.com/zynax-io/zynax/issues/601) | **Fix Go builder base image to 1.26.3-alpine in service Dockerfiles** | XS | After #561 — **health-gate fix; do first** |
+| [#562](https://github.com/zynax-io/zynax/issues/562) | Make GHCR service/adapter images publicly readable | XS | After **#601** (images must exist) |
 | [#566](https://github.com/zynax-io/zynax/issues/566) | README packages section with GHCR image pull commands | S | After #562 |
 
 **Engineer profile:** DevOps / GitHub Actions specialist.
@@ -284,6 +285,7 @@ without rewriting the graph).
 - **task-broker excluded** from service-release matrix.
 - **http-adapter** has a Dockerfile but zero release pipeline.
 - **Two workflows build the tools image** to different names.
+- ~~**Go toolchain mismatch** — service Dockerfiles use `golang:1.25-alpine` but `go.mod` requires `go 1.26.3`; service image builds fail with `GOTOOLCHAIN=local` error.~~ → fixed by [#601](https://github.com/zynax-io/zynax/issues/601)
 
 ### Child issues (ordered execution plan)
 | Issue | Title | Size | Priority |
@@ -293,13 +295,15 @@ without rewriting the graph).
 | [#559](https://github.com/zynax-io/zynax/issues/559) | Add task-broker to service-release matrix | XS | ✅ Done (delivered in #557 — task-broker already in release.yml matrix) |
 | [#560](https://github.com/zynax-io/zynax/issues/560) | Add http-adapter image to release pipeline | S | ✅ Done |
 | [#561](https://github.com/zynax-io/zynax/issues/561) | Push service/adapter images to GHCR on every main merge | S | ✅ Done |
-| [#562](https://github.com/zynax-io/zynax/issues/562) | Make GHCR images publicly readable | XS | P1 |
+| [#601](https://github.com/zynax-io/zynax/issues/601) | **Fix Go builder base image 1.25→1.26.3-alpine in service Dockerfiles** | XS | **P0 — health-gate fix** · unblocks #562 |
+| [#562](https://github.com/zynax-io/zynax/issues/562) | Make GHCR images publicly readable | XS | P1 · blocked on **#601** |
 | [#563](https://github.com/zynax-io/zynax/issues/563) | Deduplicate tools image (remove tools-publish.yml) | XS | P2 |
 | [#564](https://github.com/zynax-io/zynax/issues/564) | Pin action digests + add linux/arm64 | XS | P2 |
 | [#565](https://github.com/zynax-io/zynax/issues/565) | Add trivy container scan gate before GHCR push | S | P2 |
-| [#566](https://github.com/zynax-io/zynax/issues/566) | README Docker Images section with pull commands | S | P1 |
+| [#566](https://github.com/zynax-io/zynax/issues/566) | README Docker Images section with pull commands | S | P1 · blocked on #562 |
 
 **Cross-links:**
+- #601 → #562 → #566: Strict chain — service images must build (#601) before they can be made public (#562) before they can be documented (#566).
 - #358 ↔ #562: Same admin action for two different image sets. Do in same org-settings session.
 - #235 → #489/#465: #235 (standalone SBOM) superseded by M6.C child #489; close #235 when M6 goes active.
 - #239 → #489/#465: Same supersession pattern.
@@ -352,7 +356,7 @@ without rewriting the graph).
 |-------|------|-------|--------|
 | [#538](https://github.com/zynax-io/zynax/issues/538) | O1 | Integrate cel-go into evalGuard | ✅ Done |
 | [#539](https://github.com/zynax-io/zynax/issues/539) | O2 | Test suite + fuzz seed | ✅ Done |
-| [#540](https://github.com/zynax-io/zynax/issues/540) | O3 | Remove CEL misrepresentation from docs | ⬜ Open (blocked on #538+#539) |
+| [#540](https://github.com/zynax-io/zynax/issues/540) | O3 | Remove CEL misrepresentation from docs | ✅ Done |
 
 ---
 

--- a/state/current-milestone.md
+++ b/state/current-milestone.md
@@ -30,8 +30,8 @@ M5 is structured into seven tracks. See full execution plan: **[docs/milestones/
 
 | Track | Epic | Status |
 |-------|------|--------|
-| **M5.F CI Sprint** | [#542](https://github.com/zynax-io/zynax/issues/542) | 🟡 In Progress — BATCH 0 complete; BATCH 1 — #560 #561 done; #562 pending (packages not yet public); BATCH 2 complete (#540 ✅) |
-| **M5.F.R Release Pipeline** | [#556](https://github.com/zynax-io/zynax/issues/556) | 🟡 In Progress — #557 #558 #559 #560 #561 done; tag push pending; #562+ ready |
+| **M5.F CI Sprint** | [#542](https://github.com/zynax-io/zynax/issues/542) | 🔴 Health gate — Release workflow red since #598; **#601** (Go 1.25→1.26.3 Dockerfile fix) must merge first; BATCH 2 complete (#540 ✅) |
+| **M5.F.R Release Pipeline** | [#556](https://github.com/zynax-io/zynax/issues/556) | 🔴 Health gate — **#601** pending (service image builds failing); unblocks #562 → #566 |
 | M5.A Truth Pass | [#458](https://github.com/zynax-io/zynax/issues/458) | In Progress — 2/3 children done; #474 open |
 | M5.B Engine Correctness | [#459](https://github.com/zynax-io/zynax/issues/459) | In Progress — #538 ✅ #539 ✅ #540 ✅; #476 parent open |
 | M5.C Capability Dispatch | [#460](https://github.com/zynax-io/zynax/issues/460) | In Progress — task-broker code merged; agent-registry pending |
@@ -42,22 +42,21 @@ M5 is structured into seven tracks. See full execution plan: **[docs/milestones/
 
 ---
 
-## IMMEDIATE — M5.F CI Sprint (BATCH 0, no dependencies)
+## IMMEDIATE — Health gate + BATCH 1 completion
 
-Fix the CI pipeline before all other work. These are XS/S admin + YAML changes.
+**Release workflow is red (run [26162881268](https://github.com/zynax-io/zynax/actions/runs/26162881268)) — fix #601 before any other new work.**
 
-| Issue | Title | Size | Why |
-|-------|-------|------|-----|
-| ~~[#547](https://github.com/zynax-io/zynax/issues/547)~~ | ~~Remove test-integration from required status checks~~ | XS | ✅ Done |
-| ~~[#544](https://github.com/zynax-io/zynax/issues/544)~~ | ~~Enable GitHub Merge Queue~~ | XS | ✅ Done (superseded — merge queue removed; strict: true + allow_auto_merge enabled via API — see #589) |
-| ~~[#548](https://github.com/zynax-io/zynax/issues/548)~~ | ~~Enable allow_auto_merge~~ | XS | ✅ Done via API |
-| ~~[#545](https://github.com/zynax-io/zynax/issues/545)~~ | ~~Fix CI concurrency — cancel stale runs~~ | XS | ✅ Done |
-| ~~[#589](https://github.com/zynax-io/zynax/issues/589)~~ | ~~Remove merge_group trigger from workflow files~~ | XS | ✅ Done |
-| ~~[#546](https://github.com/zynax-io/zynax/issues/546)~~ | ~~Remove push-to-main forced-true override~~ | S | ✅ Done |
-| ~~[#557](https://github.com/zynax-io/zynax/issues/557)~~ | ~~Fix release race condition~~ | M | ✅ Done |
-| ~~[#558](https://github.com/zynax-io/zynax/issues/558)~~ | ~~Cut v0.4.0 — CHANGELOG promoted~~ | XS | ✅ Done (tag push: see below) |
-| ~~[#559](https://github.com/zynax-io/zynax/issues/559)~~ | ~~Add task-broker to service-release matrix~~ | XS | ✅ Done (delivered in #557) |
-| ~~[#560](https://github.com/zynax-io/zynax/issues/560)~~ | ~~Add http-adapter image to release pipeline~~ | S | ✅ Done (BATCH 1) |
+### BATCH 0 — ✅ All done
+~~#547 #544 #548 #545 #589 #546 #557 #558 #559 #560~~
+
+### BATCH 1 — In Progress
+
+| Issue | Title | Size | Status |
+|-------|-------|------|--------|
+| ~~[#561](https://github.com/zynax-io/zynax/issues/561)~~ | ~~Push service/adapter images to GHCR on every main merge~~ | S | ✅ Done |
+| **[#601](https://github.com/zynax-io/zynax/issues/601)** | **Fix Go builder base image 1.25→1.26.3-alpine in service Dockerfiles** | XS | 🔴 **Do first** — health gate |
+| [#562](https://github.com/zynax-io/zynax/issues/562) | Make GHCR service/adapter images publicly readable | XS | ⬜ Blocked on #601 |
+| [#566](https://github.com/zynax-io/zynax/issues/566) | README packages section with GHCR image pull commands | S | ⬜ Blocked on #562 |
 
 ---
 
@@ -103,11 +102,14 @@ Canvas aligned. Ordered delivery: #526 → #527 → #528 → #481.
 
 ## Known Blockers
 
+- **🔴 Release workflow (health gate)** — [run 26162881268](https://github.com/zynax-io/zynax/actions/runs/26162881268) failed: service Dockerfiles use `golang:1.25-alpine` but `go.mod` requires `go 1.26.3`. Fix: **[#601](https://github.com/zynax-io/zynax/issues/601)** (XS — bump 4 Dockerfiles). Do first.
+- **GHCR service images absent** — `zynax/api-gateway`, `zynax/engine-adapter`, `zynax/workflow-compiler`, `zynax/task-broker` do not yet exist on GHCR. Blocked on **#601** merging and Release workflow succeeding.
+- **#562 (GHCR public visibility)** — blocked on #601. Cannot set visibility on non-existent packages.
+- **#566 (README pull commands)** — blocked on #562.
 - **agent-registry (#480)** — BDD trim (#526) must merge before domain (#527) begins (ADR-016).
 - **compose wiring (#481)** — depends on #528 (agent-registry gRPC wiring) landing first.
 - **adapter implementations** — wait for #481 (compose wiring) so adapters have a live registry.
 - **E2E demo** — blocked on #481 fully wired.
-- **CI throughput** — BATCH 0 complete; BATCH 1: #560 #561 done; #562 (GHCR public visibility) next.
 - **v0.4.0 tag** — CHANGELOG promoted; run `git tag -a v0.4.0 -m "M5 Adapter Library" && git push origin v0.4.0` on main to trigger the release workflow and create GitHub Release assets.
 
 ---


### PR DESCRIPTION
## Summary

- Insert [#601](https://github.com/zynax-io/zynax/issues/601) into BATCH 1 between #561 and #562 as P0 health-gate fix
- Update #562 dependency: `After #561` → `After #601` — service images must exist before visibility can be set
- Update #566 dependency: blocked on #562
- Add `#601 → #562 → #566` strict chain in M5.F.R cross-links
- Record Go toolchain mismatch in M5.F.R "Current state: what is broken"
- Flip #540 (Guard evaluator O3) to ✅ Done in M5.B epic table
- `state/current-milestone.md`: health-gate banner, BATCH 1 status table, Known Blockers rewrite with explicit #601 dependency chain

## Why

Issue #601 was just filed after diagnosing run [26162881268](https://github.com/zynax-io/zynax/actions/runs/26162881268) — the Release workflow has been failing since #598 merged because all four service Dockerfiles use `golang:1.25-alpine` while `go.mod` requires `go 1.26.3`. The plan and state files did not reflect this blocker. #562 and #566 had stale dependencies that made them appear ready when they are not.

## State files updated

- `docs/milestones/M5-plan.md` ✅
- `state/current-milestone.md` ✅
- canvas: N/A (docs PR)
- AGENTS.md: N/A

## Architecture gaps addressed

G2 (documentation truth pass — plan now matches repo reality)

## Test plan

### Local pre-flight
- [x] `make lint-fix` — (N/A — docs only)
- [x] `make lint-go` — (N/A)
- [x] `make lint-protos` — (N/A)
- [x] `make lint-agents` — (N/A)
- [x] `GOWORK=off go test ./... -race` — (N/A)
- [x] `make test-coverage` — (N/A)
- [x] `make test-coverage-adapters` — (N/A)
- [x] `make test-bdd` — (N/A)
- [x] `make security` — pre-commit gitleaks: Passed
- [x] `make validate-spec` — (N/A)

### Acceptance
- [x] `#601` row present in BATCH 1 table between #561 and #562 — verified in M5-plan.md
- [x] `#562` dependency column reads "After #601" — verified
- [x] `#566` dependency column reads "blocked on #562" — verified
- [x] `#601 → #562 → #566` chain in M5.F.R cross-links — verified
- [x] `state/current-milestone.md` Known Blockers lists #601 as health-gate item first — verified
- [x] `#540` shows ✅ Done in guard evaluator epic table — verified

### Engineering hygiene
- [x] Branched from fresh `origin/main` (29bb02e)
- [x] PR ≤ 900 lines — 28 insertions, 22 deletions
- [x] Every commit: `Signed-off-by:` + `Assisted-by: Claude/claude-sonnet-4-6`
- [x] No `Co-Authored-By:` for AI
- [x] No mTLS/SBOM/cosign claims added
- [x] No out-of-scope edits

## Out of scope

- Implementing #601 (that is the next PR)
- Any code changes

Refs #601