### PR TITLE
fix(infra): bump Go builder base image to 1.26.3-alpine

### DIFF
--- a/docs/milestones/M5-plan.md
+++ b/docs/milestones/M5-plan.md
@@ -6,7 +6,7 @@
 **GitHub Milestone:** [Adapter Library (M5)](https://github.com/zynax-io/zynax/milestone/5)
 **Parent epic:** [#377](https://github.com/zynax-io/zynax/issues/377)
 **Status:** In Progress
-**Last updated:** 2026-05-20 (rev 17 — #601 filed; Go 1.25→1.26.3 Dockerfile toolchain fix; #562 dependency updated; BATCH 1 reordered)
+**Last updated:** 2026-05-20 (rev 18 — #601 ✅; Go 1.25→1.26.3 Dockerfile fix merged; #562 unblocked)
 
 ---
 
@@ -96,7 +96,7 @@ Edit `.github/workflows/` YAML and GitHub repository settings only.
 | [#559](https://github.com/zynax-io/zynax/issues/559) | Add task-broker to service-release matrix | XS | ✅ Done (delivered in #557) |
 | [#560](https://github.com/zynax-io/zynax/issues/560) | Add http-adapter image to release pipeline | S | ✅ Done |
 | [#561](https://github.com/zynax-io/zynax/issues/561) | Push service/adapter images to GHCR on every main merge | S | ✅ Done |
-| [#601](https://github.com/zynax-io/zynax/issues/601) | **Fix Go builder base image to 1.26.3-alpine in service Dockerfiles** | XS | After #561 — **health-gate fix; do first** |
+| [#601](https://github.com/zynax-io/zynax/issues/601) | Fix Go builder base image to 1.26.3-alpine in service Dockerfiles | XS | ✅ Done |
 | [#562](https://github.com/zynax-io/zynax/issues/562) | Make GHCR service/adapter images publicly readable | XS | After **#601** (images must exist) |
 | [#566](https://github.com/zynax-io/zynax/issues/566) | README packages section with GHCR image pull commands | S | After #562 |
 
@@ -285,7 +285,7 @@ without rewriting the graph).
 - **task-broker excluded** from service-release matrix.
 - **http-adapter** has a Dockerfile but zero release pipeline.
 - **Two workflows build the tools image** to different names.
-- ~~**Go toolchain mismatch** — service Dockerfiles use `golang:1.25-alpine` but `go.mod` requires `go 1.26.3`; service image builds fail with `GOTOOLCHAIN=local` error.~~ → fixed by [#601](https://github.com/zynax-io/zynax/issues/601)
+- ~~**Go toolchain mismatch** — service Dockerfiles used `golang:1.25-alpine` but `go.mod` requires `go 1.26.3`; service image builds failed with `GOTOOLCHAIN=local` error.~~ ✅ Fixed by [#601](https://github.com/zynax-io/zynax/issues/601)
 
 ### Child issues (ordered execution plan)
 | Issue | Title | Size | Priority |
@@ -295,7 +295,7 @@ without rewriting the graph).
 | [#559](https://github.com/zynax-io/zynax/issues/559) | Add task-broker to service-release matrix | XS | ✅ Done (delivered in #557 — task-broker already in release.yml matrix) |
 | [#560](https://github.com/zynax-io/zynax/issues/560) | Add http-adapter image to release pipeline | S | ✅ Done |
 | [#561](https://github.com/zynax-io/zynax/issues/561) | Push service/adapter images to GHCR on every main merge | S | ✅ Done |
-| [#601](https://github.com/zynax-io/zynax/issues/601) | **Fix Go builder base image 1.25→1.26.3-alpine in service Dockerfiles** | XS | **P0 — health-gate fix** · unblocks #562 |
+| [#601](https://github.com/zynax-io/zynax/issues/601) | Fix Go builder base image 1.25→1.26.3-alpine in service Dockerfiles | XS | ✅ Done · unblocked #562 |
 | [#562](https://github.com/zynax-io/zynax/issues/562) | Make GHCR images publicly readable | XS | P1 · blocked on **#601** |
 | [#563](https://github.com/zynax-io/zynax/issues/563) | Deduplicate tools image (remove tools-publish.yml) | XS | P2 |
 | [#564](https://github.com/zynax-io/zynax/issues/564) | Pin action digests + add linux/arm64 | XS | P2 |

--- a/services/api-gateway/Dockerfile
+++ b/services/api-gateway/Dockerfile
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Build context: repo root  (docker build -f services/api-gateway/Dockerfile .)
-FROM golang:1.25-alpine AS builder
+FROM golang:1.26.3-alpine AS builder
 WORKDIR /workspace
 COPY protos/generated/go/go.mod protos/generated/go/go.sum ./protos/generated/go/
 COPY services/api-gateway/go.mod services/api-gateway/go.sum ./services/api-gateway/

--- a/services/engine-adapter/AGENTS.md
+++ b/services/engine-adapter/AGENTS.md
@@ -1,6 +1,6 @@
 # services/engine-adapter — AGENTS.md
 
-> Go 1.25+. Inherits rules from root `AGENTS.md` and `services/AGENTS.md`.
+> Go 1.26.3+. Inherits rules from root `AGENTS.md` and `services/AGENTS.md`.
 > **Status: M3 Complete.** Temporal backend fully implemented; LangGraph/Argo deferred to M5/M6.
 
 ---

--- a/services/engine-adapter/Dockerfile
+++ b/services/engine-adapter/Dockerfile
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Build context: repo root  (docker build -f services/engine-adapter/Dockerfile .)
-FROM golang:1.25-alpine AS builder
+FROM golang:1.26.3-alpine AS builder
 WORKDIR /workspace
 COPY protos/generated/go/go.mod protos/generated/go/go.sum ./protos/generated/go/
 COPY services/engine-adapter/go.mod services/engine-adapter/go.sum ./services/engine-adapter/

--- a/services/task-broker/Dockerfile
+++ b/services/task-broker/Dockerfile
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Build context: repo root  (docker build -f services/task-broker/Dockerfile .)
-FROM golang:1.25-alpine AS builder
+FROM golang:1.26.3-alpine AS builder
 WORKDIR /workspace
 COPY protos/generated/go/go.mod protos/generated/go/go.sum ./protos/generated/go/
 COPY services/task-broker/go.mod services/task-broker/go.sum ./services/task-broker/

--- a/services/workflow-compiler/Dockerfile
+++ b/services/workflow-compiler/Dockerfile
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Build context: repo root  (docker build -f services/workflow-compiler/Dockerfile .)
-FROM golang:1.25-alpine AS builder
+FROM golang:1.26.3-alpine AS builder
 WORKDIR /workspace
 COPY protos/generated/go/go.mod protos/generated/go/go.sum ./protos/generated/go/
 COPY services/workflow-compiler/go.mod services/workflow-compiler/go.sum ./services/workflow-compiler/

--- a/state/current-milestone.md
+++ b/state/current-milestone.md
@@ -30,8 +30,8 @@ M5 is structured into seven tracks. See full execution plan: **[docs/milestones/
 
 | Track | Epic | Status |
 |-------|------|--------|
-| **M5.F CI Sprint** | [#542](https://github.com/zynax-io/zynax/issues/542) | 🔴 Health gate — Release workflow red since #598; **#601** (Go 1.25→1.26.3 Dockerfile fix) must merge first; BATCH 2 complete (#540 ✅) |
-| **M5.F.R Release Pipeline** | [#556](https://github.com/zynax-io/zynax/issues/556) | 🔴 Health gate — **#601** pending (service image builds failing); unblocks #562 → #566 |
+| **M5.F CI Sprint** | [#542](https://github.com/zynax-io/zynax/issues/542) | 🟡 In Progress — Release workflow fix merged (#601 ✅); BATCH 2 complete (#540 ✅); awaiting #562 → #566 |
+| **M5.F.R Release Pipeline** | [#556](https://github.com/zynax-io/zynax/issues/556) | 🟡 In Progress — **#601 ✅** merged; next: #562 (make GHCR images public) → #566 (README) |
 | M5.A Truth Pass | [#458](https://github.com/zynax-io/zynax/issues/458) | In Progress — 2/3 children done; #474 open |
 | M5.B Engine Correctness | [#459](https://github.com/zynax-io/zynax/issues/459) | In Progress — #538 ✅ #539 ✅ #540 ✅; #476 parent open |
 | M5.C Capability Dispatch | [#460](https://github.com/zynax-io/zynax/issues/460) | In Progress — task-broker code merged; agent-registry pending |
@@ -42,9 +42,7 @@ M5 is structured into seven tracks. See full execution plan: **[docs/milestones/
 
 ---
 
-## IMMEDIATE — Health gate + BATCH 1 completion
-
-**Release workflow is red (run [26162881268](https://github.com/zynax-io/zynax/actions/runs/26162881268)) — fix #601 before any other new work.**
+## IMMEDIATE — BATCH 1 completion (wait for #601 images, then #562)
 
 ### BATCH 0 — ✅ All done
 ~~#547 #544 #548 #545 #589 #546 #557 #558 #559 #560~~
@@ -54,8 +52,8 @@ M5 is structured into seven tracks. See full execution plan: **[docs/milestones/
 | Issue | Title | Size | Status |
 |-------|-------|------|--------|
 | ~~[#561](https://github.com/zynax-io/zynax/issues/561)~~ | ~~Push service/adapter images to GHCR on every main merge~~ | S | ✅ Done |
-| **[#601](https://github.com/zynax-io/zynax/issues/601)** | **Fix Go builder base image 1.25→1.26.3-alpine in service Dockerfiles** | XS | 🔴 **Do first** — health gate |
-| [#562](https://github.com/zynax-io/zynax/issues/562) | Make GHCR service/adapter images publicly readable | XS | ⬜ Blocked on #601 |
+| ~~[#601](https://github.com/zynax-io/zynax/issues/601)~~ | ~~Fix Go builder base image 1.25→1.26.3-alpine in service Dockerfiles~~ | XS | ✅ Done — confirm GHCR images appear after CI |
+| [#562](https://github.com/zynax-io/zynax/issues/562) | Make GHCR service/adapter images publicly readable | XS | ⬜ Unblocked — wait for GHCR images to appear |
 | [#566](https://github.com/zynax-io/zynax/issues/566) | README packages section with GHCR image pull commands | S | ⬜ Blocked on #562 |
 
 ---
@@ -102,9 +100,8 @@ Canvas aligned. Ordered delivery: #526 → #527 → #528 → #481.
 
 ## Known Blockers
 
-- **🔴 Release workflow (health gate)** — [run 26162881268](https://github.com/zynax-io/zynax/actions/runs/26162881268) failed: service Dockerfiles use `golang:1.25-alpine` but `go.mod` requires `go 1.26.3`. Fix: **[#601](https://github.com/zynax-io/zynax/issues/601)** (XS — bump 4 Dockerfiles). Do first.
-- **GHCR service images absent** — `zynax/api-gateway`, `zynax/engine-adapter`, `zynax/workflow-compiler`, `zynax/task-broker` do not yet exist on GHCR. Blocked on **#601** merging and Release workflow succeeding.
-- **#562 (GHCR public visibility)** — blocked on #601. Cannot set visibility on non-existent packages.
+- **GHCR service images pending** — `zynax/api-gateway`, `zynax/engine-adapter`, `zynax/workflow-compiler`, `zynax/task-broker` will appear on GHCR after **#601** merges and the Release workflow succeeds. Confirm before starting #562.
+- **#562 (GHCR public visibility)** — unblocked by #601; start once GHCR packages exist.
 - **#566 (README pull commands)** — blocked on #562.
 - **agent-registry (#480)** — BDD trim (#526) must merge before domain (#527) begins (ADR-016).
 - **compose wiring (#481)** — depends on #528 (agent-registry gRPC wiring) landing first.


### PR DESCRIPTION
## Summary

- Bumps all four service Dockerfiles (`api-gateway`, `engine-adapter`, `workflow-compiler`, `task-broker`) from `golang:1.25-alpine` to `golang:1.26.3-alpine` in the builder stage.
- Corrects the Go version reference in `services/engine-adapter/AGENTS.md` (1.25+ → 1.26.3+).

## Why

All service `go.mod` files declare `go 1.26.3` as the minimum toolchain. With `GOTOOLCHAIN=local` set in the Alpine image, Go 1.25 refuses to process modules that require a higher version, causing `go mod download` to exit non-zero. This broke the Release workflow on every `main` merge since #598 — service images (`api-gateway`, `engine-adapter`, `workflow-compiler`, `task-broker`) have never been pushed to GHCR.

The `http-adapter` already used `golang:1.26.3-alpine` and succeeded in the same run that flagged the failure. This PR brings the four services into alignment.

Closes #601

## State files updated

- `docs/milestones/M5-plan.md`: #601 row ⬜→✅; strikethrough on Go toolchain mismatch entry in "Current state: what is broken"
- `state/current-milestone.md`: #601 status ⬜→✅ in BATCH 1 table; #562 unblocked; health gate entry updated

## Architecture gaps addressed

None directly. This is a CI health-gate fix.

## Test plan

### Local pre-flight
- [x] `make lint-fix` — N/A (no Go/Python source changes; Dockerfiles and AGENTS.md only)
- [x] `make lint-go` — N/A (no .go files changed)
- [x] `make lint-protos` — N/A (no .proto files changed)
- [x] `make lint-agents` — N/A (no Python files changed)
- [x] `GOWORK=off go test ./... -race` — N/A (no Go source files changed)
- [x] `make test-coverage` — N/A (no domain logic changed)
- [x] `make test-coverage-adapters` — N/A
- [x] `make test-bdd` — N/A (no .feature files changed)
- [x] `make security` — N/A (secret-detection pre-commit hook passed on commit)
- [x] `make validate-spec` — N/A (no spec/ changes)

### Acceptance (from issue body)
- [x] All four service Dockerfiles use `golang:1.26.3-alpine` in the builder stage — verified via `git diff`; grep confirms `golang:1.26.3-alpine` in all four files
- [x] `services/engine-adapter/AGENTS.md` heading reads `Go 1.26.3+` — verified in diff
- [ ] Release workflow re-runs on next `main` merge and all five "Build and push" jobs succeed — requires CI after merge
- [ ] GHCR packages `zynax/api-gateway`, `zynax/engine-adapter`, `zynax/workflow-compiler`, `zynax/task-broker` appear under `ghcr.io/zynax-io/zynax/` — requires CI after merge

### Engineering hygiene
- [x] Branched from fresh `origin/main`
- [x] PR ≤ 900 lines (5 lines changed)
- [x] Every commit: `Signed-off-by:` + `Assisted-by: Claude/claude-sonnet-4-6`
- [x] No `Co-Authored-By:` for AI
- [x] No `panic` in prod paths; no silent `_ = err` — N/A (no code changes)
- [x] No mTLS/SBOM/cosign claims added to docs
- [x] Gap scan done (G1/G4/G7/G16) — none triggered by this infra-only change
- [x] 4 state files updated (M5-plan, current-milestone, canvas N/A — fix type, AGENTS.md updated for engine-adapter Go version)
- [x] `.feature` committed before impl — N/A (fix type, no new gRPC boundary)
- [x] No out-of-scope / drive-by edits

## Out of scope

- `go.mod` toolchain directive changes (not needed — go.mod already correct)
- Runtime/final stage image changes (still `alpine:3.20` — correct)
- `linux/arm64` cross-compile support (#564)
- Trivy container scan gate (#565)
