### PR TITLE
docs: add tools-image rebuild and #563 to BATCH 1 order

### DIFF
--- a/docs/milestones/M5-plan.md
+++ b/docs/milestones/M5-plan.md
@@ -6,7 +6,7 @@
 **GitHub Milestone:** [Adapter Library (M5)](https://github.com/zynax-io/zynax/milestone/5)
 **Parent epic:** [#377](https://github.com/zynax-io/zynax/issues/377)
 **Status:** In Progress
-**Last updated:** 2026-05-20 (rev 19 — #562 ✅; GHCR packages public; #566 unblocked)
+**Last updated:** 2026-05-20 (rev 20 — #562 ✅; tools-image rebuild in progress; #563 promoted to P1; order: tools-public → #563 → #566)
 
 ---
 
@@ -97,8 +97,10 @@ Edit `.github/workflows/` YAML and GitHub repository settings only.
 | [#560](https://github.com/zynax-io/zynax/issues/560) | Add http-adapter image to release pipeline | S | ✅ Done |
 | [#561](https://github.com/zynax-io/zynax/issues/561) | Push service/adapter images to GHCR on every main merge | S | ✅ Done |
 | [#601](https://github.com/zynax-io/zynax/issues/601) | Fix Go builder base image to 1.26.3-alpine in service Dockerfiles | XS | ✅ Done |
-| [#562](https://github.com/zynax-io/zynax/issues/562) | Make GHCR service/adapter images publicly readable | XS | ✅ Done |
-| [#566](https://github.com/zynax-io/zynax/issues/566) | README packages section with GHCR image pull commands | S | ⬜ Unblocked — next |
+| [#562](https://github.com/zynax-io/zynax/issues/562) | Make GHCR service/adapter images publicly readable | XS | ✅ Done — 5 service/adapter images public |
+| (admin) | Confirm zynax/tools published + set public | — | ⬜ After tools-image.yml run succeeds |
+| [#563](https://github.com/zynax-io/zynax/issues/563) | Deduplicate tools image — remove tools-publish.yml + delete zynax-tools | XS | ⬜ After zynax/tools is public |
+| [#566](https://github.com/zynax-io/zynax/issues/566) | README packages section with GHCR image pull commands | S | ⬜ After #563 |
 
 **Engineer profile:** DevOps / GitHub Actions specialist.
 
@@ -296,15 +298,16 @@ without rewriting the graph).
 | [#560](https://github.com/zynax-io/zynax/issues/560) | Add http-adapter image to release pipeline | S | ✅ Done |
 | [#561](https://github.com/zynax-io/zynax/issues/561) | Push service/adapter images to GHCR on every main merge | S | ✅ Done |
 | [#601](https://github.com/zynax-io/zynax/issues/601) | Fix Go builder base image 1.25→1.26.3-alpine in service Dockerfiles | XS | ✅ Done · unblocked #562 |
-| [#562](https://github.com/zynax-io/zynax/issues/562) | Make GHCR images publicly readable | XS | ✅ Done · unblocked #566 |
-| [#563](https://github.com/zynax-io/zynax/issues/563) | Deduplicate tools image (remove tools-publish.yml) | XS | P2 |
+| [#562](https://github.com/zynax-io/zynax/issues/562) | Make GHCR images publicly readable | XS | ✅ Done · unblocked tools+#563+#566 |
+| (admin) | Confirm zynax/tools published + set public | — | ⬜ After tools-image.yml run |
+| [#563](https://github.com/zynax-io/zynax/issues/563) | Deduplicate tools image (remove tools-publish.yml) | XS | ⬜ P1 · after zynax/tools public |
 | [#564](https://github.com/zynax-io/zynax/issues/564) | Pin action digests + add linux/arm64 | XS | P2 |
 | [#565](https://github.com/zynax-io/zynax/issues/565) | Add trivy container scan gate before GHCR push | S | P2 |
-| [#566](https://github.com/zynax-io/zynax/issues/566) | README Docker Images section with pull commands | S | P1 · blocked on #562 |
+| [#566](https://github.com/zynax-io/zynax/issues/566) | README Docker Images section with pull commands | S | P1 · after zynax/tools public + #563 |
 
 **Cross-links:**
-- #601 → #562 → #566: Strict chain — service images must build (#601) before they can be made public (#562) before they can be documented (#566).
-- #358 ↔ #562: Same admin action for two different image sets. Do in same org-settings session.
+- #601 → #562 → tools-public → #563 → #566: Full chain — service Dockerfiles fixed → images made public → zynax/tools rebuilt and made public → old zynax-tools removed → README documented.
+- #358 ↔ #563: #358 (publish tools image securely) is superseded by #563 (deduplication); close #358 when #563 merges.
 - #235 → #489/#465: #235 (standalone SBOM) superseded by M6.C child #489; close #235 when M6 goes active.
 - #239 → #489/#465: Same supersession pattern.
 - #565 ↔ #236: Complementary; #565 = trivy in release, #236 = trivy in security CI.

--- a/state/current-milestone.md
+++ b/state/current-milestone.md
@@ -42,7 +42,7 @@ M5 is structured into seven tracks. See full execution plan: **[docs/milestones/
 
 ---
 
-## IMMEDIATE — BATCH 1 completion (#566 next)
+## IMMEDIATE — BATCH 1 completion (tools visibility → #563 → #566)
 
 ### BATCH 0 — ✅ All done
 ~~#547 #544 #548 #545 #589 #546 #557 #558 #559 #560~~
@@ -53,8 +53,11 @@ M5 is structured into seven tracks. See full execution plan: **[docs/milestones/
 |-------|-------|------|--------|
 | ~~[#561](https://github.com/zynax-io/zynax/issues/561)~~ | ~~Push service/adapter images to GHCR on every main merge~~ | S | ✅ Done |
 | ~~[#601](https://github.com/zynax-io/zynax/issues/601)~~ | ~~Fix Go builder base image 1.25→1.26.3-alpine in service Dockerfiles~~ | XS | ✅ Done |
-| ~~[#562](https://github.com/zynax-io/zynax/issues/562)~~ | ~~Make GHCR service/adapter images publicly readable~~ | XS | ✅ Done — all 5 service/adapter images public |
-| [#566](https://github.com/zynax-io/zynax/issues/566) | README packages section with GHCR image pull commands | S | ⬜ Unblocked — next |
+| ~~[#562](https://github.com/zynax-io/zynax/issues/562)~~ | ~~Make GHCR service/adapter images publicly readable~~ | XS | ✅ Done — 5 service/adapter images public; zynax/tools deleted (see below) |
+| (admin) | **Confirm zynax/tools published** — tools-image.yml workflow_dispatch triggered 2026-05-20; wait for run to succeed | — | 🔄 In progress — run queued |
+| (admin) | **Set zynax/tools to public** — org visibility policy now allows it; same UI step as #562 | — | ⬜ Blocked on image publish |
+| [#563](https://github.com/zynax-io/zynax/issues/563) | Deduplicate tools image — remove tools-publish.yml + delete old zynax-tools package | XS | ⬜ After zynax/tools is public |
+| [#566](https://github.com/zynax-io/zynax/issues/566) | README packages section with GHCR image pull commands | S | ⬜ After #563 (so tools pull command is accurate) |
 
 ---
 
@@ -100,7 +103,9 @@ Canvas aligned. Ordered delivery: #526 → #527 → #528 → #481.
 
 ## Known Blockers
 
-- **#566 (README pull commands)** — unblocked; start next.
+- **zynax/tools image** — deleted during #562 UI work; tools-image.yml workflow_dispatch triggered 2026-05-20, run in progress. Once published, set package to public (org visibility policy now allows it).
+- **#563 (deduplicate tools)** — remove tools-publish.yml + delete old zynax-tools package; start after zynax/tools is public.
+- **#566 (README pull commands)** — start after #563 so the tools image pull command is accurate and zynax-tools is gone.
 - **agent-registry (#480)** — BDD trim (#526) must merge before domain (#527) begins (ADR-016).
 - **compose wiring (#481)** — depends on #528 (agent-registry gRPC wiring) landing first.
 - **adapter implementations** — wait for #481 (compose wiring) so adapters have a live registry.


### PR DESCRIPTION
## Summary

- Corrects the BATCH 1 execution order to account for `zynax/tools` being deleted during the #562 visibility UI work.
- Promotes #563 (deduplicate tools image) from P2 → P1.
- Records the `tools-image.yml` `workflow_dispatch` triggered 2026-05-20.

## Why

`zynax/tools` was accidentally deleted when navigating the GitHub package visibility settings for #562. The plan now captures the correct sequence:

1. `tools-image.yml` rebuild (triggered manually 2026-05-20) → `zynax/tools` recreated
2. Set `zynax/tools` to public (admin, org visibility policy now allows it — same procedure as #562)
3. #563 — remove `tools-publish.yml` + delete old `zynax-tools` package
4. #566 — README packages section (all images public and clean before documenting)

Also updates the M5.F.R cross-links: #358 is superseded by #563.

## State files updated

- `docs/milestones/M5-plan.md`: BATCH 1 table updated, #563 promoted to P1, cross-links revised, rev 20
- `state/current-milestone.md`: IMMEDIATE section updated with correct order and blockers

## Architecture gaps addressed

—

## Test plan

### Local pre-flight
- [x] (N/A — docs-only PR)

### Acceptance
- [x] BATCH 1 order correctly reflects: tools-publish → tools-public → #563 → #566
- [x] #563 marked P1 (was P2) in M5-plan.md
- [x] tools-image.yml trigger recorded in current-milestone.md

### Engineering hygiene
- [x] Branched from fresh `origin/main` (rebased after #604 merge)
- [x] PR ≤ 900 lines — 2 docs files only
- [x] Every commit: `Signed-off-by:` + `Assisted-by: Claude/claude-sonnet-4-6`
- [x] No `Co-Authored-By:` for AI
- [x] No mTLS/SBOM/cosign claims added
- [x] Gap scan done (N/A)
- [x] State files updated (M5-plan ✅, current-milestone ✅)
- [x] No out-of-scope edits
