### PR TITLE
docs: add Docker Images section to README with GHCR pull commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,35 @@ make TOOLS_IMAGE=ghcr.io/zynax-io/zynax/tools:main-<sha> lint
 
 ---
 
+## Docker Images
+
+All service and adapter images are published to GitHub Container Registry (GHCR) and are publicly readable. No authentication required to pull.
+
+| Image | Description |
+|-------|-------------|
+| `ghcr.io/zynax-io/zynax/api-gateway` | REST gateway — receives `zynax apply` requests |
+| `ghcr.io/zynax-io/zynax/workflow-compiler` | YAML → WorkflowIR compiler |
+| `ghcr.io/zynax-io/zynax/engine-adapter` | Temporal execution adapter |
+| `ghcr.io/zynax-io/zynax/task-broker` | In-memory capability dispatcher |
+| `ghcr.io/zynax-io/zynax/http-adapter` | HTTP REST capability adapter |
+| `ghcr.io/zynax-io/zynax/tools` | Dev toolchain image (Go + Python + proto tools) |
+
+Images are rebuilt on every merge to `main` (`:main` tag) and on every versioned release (`:v<version>` and `:latest` tags).
+
+**Pull the latest main build:**
+```bash
+docker pull ghcr.io/zynax-io/zynax/api-gateway:main
+```
+
+**Pull a specific version:**
+```bash
+docker pull ghcr.io/zynax-io/zynax/api-gateway:v0.4.0
+```
+
+Replace `api-gateway` with any image name from the table above.
+
+---
+
 ## Key Principles
 
 **Declarative-first** — workflows are YAML manifests, not code. Versionable, diffable, GitOps-ready.

--- a/agents/sdk/pyproject.toml
+++ b/agents/sdk/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "opentelemetry-api>=1.25.0",
     "opentelemetry-sdk>=1.25.0",
     "opentelemetry-instrumentation-grpc>=0.46b0",
+    "idna>=3.15",  # CVE-2026-45409 — pin floor via transitive requests dep
 ]
 
 

--- a/docs/milestones/M5-plan.md
+++ b/docs/milestones/M5-plan.md
@@ -6,7 +6,7 @@
 **GitHub Milestone:** [Adapter Library (M5)](https://github.com/zynax-io/zynax/milestone/5)
 **Parent epic:** [#377](https://github.com/zynax-io/zynax/issues/377)
 **Status:** In Progress
-**Last updated:** 2026-05-20 (rev 21 — #563 ✅; tools-publish.yml deleted, all zynax-tools refs updated; next: #566 README pull commands)
+**Last updated:** 2026-05-20 (rev 22 — #566 ✅; Docker Images section added to README, GHCR image refs in docker-compose; BATCH 1 complete)
 
 ---
 
@@ -165,7 +165,7 @@ after 2 min without ping). Reference: `services/task-broker/internal/domain/` fo
 | [#551](https://github.com/zynax-io/zynax/issues/551) | Create Dockerfile.ci-runner (Alpine, minimal) | S | None |
 | [#552](https://github.com/zynax-io/zynax/issues/552) | Switch GH Actions jobs to ci-runner container mode | M | After #551 |
 | [#555](https://github.com/zynax-io/zynax/issues/555) | DRY/KISS refactor — reusable workflows, composite actions | L | After #552 |
-| [#563](https://github.com/zynax-io/zynax/issues/563) | Deduplicate tools image — remove tools-publish.yml | XS | None |
+| [#563](https://github.com/zynax-io/zynax/issues/563) | Deduplicate tools image — remove tools-publish.yml | XS | ✅ Done |
 | [#564](https://github.com/zynax-io/zynax/issues/564) | Pin action digests + add linux/arm64 to zynax-ci | XS | None |
 | [#565](https://github.com/zynax-io/zynax/issues/565) | Add trivy container scan gate before GHCR push | S | After #561 |
 
@@ -303,7 +303,7 @@ without rewriting the graph).
 | [#563](https://github.com/zynax-io/zynax/issues/563) | Deduplicate tools image (remove tools-publish.yml) | XS | ✅ Done |
 | [#564](https://github.com/zynax-io/zynax/issues/564) | Pin action digests + add linux/arm64 | XS | P2 |
 | [#565](https://github.com/zynax-io/zynax/issues/565) | Add trivy container scan gate before GHCR push | S | P2 |
-| [#566](https://github.com/zynax-io/zynax/issues/566) | README Docker Images section with pull commands | S | P1 · ready (after #563) |
+| [#566](https://github.com/zynax-io/zynax/issues/566) | README Docker Images section with pull commands | S | ✅ Done |
 
 **Cross-links:**
 - #601 → #562 → tools-public → #563 → #566: Full chain — service Dockerfiles fixed → images made public → zynax/tools rebuilt and made public → old zynax-tools removed → README documented.

--- a/infra/docker-compose/docker-compose.services.yml
+++ b/infra/docker-compose/docker-compose.services.yml
@@ -43,6 +43,7 @@ services:
 
   http-adapter:
     profiles: [dev]
+    image: ghcr.io/zynax-io/zynax/http-adapter:main
     build:
       context: ../..
       dockerfile: agents/adapters/http/Dockerfile

--- a/infra/docker-compose/docker-compose.yml
+++ b/infra/docker-compose/docker-compose.yml
@@ -13,7 +13,7 @@
 #   7088  → Temporal Web UI        http://localhost:7088
 #   7422  → NATS client            (optional direct access)
 #
-# Not included yet (unimplemented stubs awaiting M5):
+# Not included yet (pending M5.C compose wiring #481):
 #   agent-registry, task-broker, memory-service, event-bus
 
 services:
@@ -87,6 +87,7 @@ services:
   # ── Platform services ───────────────────────────────────────────────────
 
   workflow-compiler:
+    image: ghcr.io/zynax-io/zynax/workflow-compiler:main
     build:
       context: ../..
       dockerfile: services/workflow-compiler/Dockerfile
@@ -102,6 +103,7 @@ services:
       start_period: 10s
 
   engine-adapter:
+    image: ghcr.io/zynax-io/zynax/engine-adapter:main
     build:
       context: ../..
       dockerfile: services/engine-adapter/Dockerfile
@@ -124,6 +126,7 @@ services:
       start_period: 15s
 
   api-gateway:
+    image: ghcr.io/zynax-io/zynax/api-gateway:main
     build:
       context: ../..
       dockerfile: services/api-gateway/Dockerfile

--- a/state/current-milestone.md
+++ b/state/current-milestone.md
@@ -30,8 +30,8 @@ M5 is structured into seven tracks. See full execution plan: **[docs/milestones/
 
 | Track | Epic | Status |
 |-------|------|--------|
-| **M5.F CI Sprint** | [#542](https://github.com/zynax-io/zynax/issues/542) | 🟡 In Progress — #563 ✅ tools deduplicated; next: #566 (README pull commands) |
-| **M5.F.R Release Pipeline** | [#556](https://github.com/zynax-io/zynax/issues/556) | 🟡 In Progress — **#563 ✅** tools-publish.yml removed; next: #566 (README) |
+| **M5.F CI Sprint** | [#542](https://github.com/zynax-io/zynax/issues/542) | 🟡 In Progress — BATCH 1 complete; next: BATCH 5 CI DX (#554, #549, …) |
+| **M5.F.R Release Pipeline** | [#556](https://github.com/zynax-io/zynax/issues/556) | 🟢 BATCH 1 complete — #566 ✅ Docker Images in README; GHCR image refs in docker-compose |
 | M5.A Truth Pass | [#458](https://github.com/zynax-io/zynax/issues/458) | In Progress — 2/3 children done; #474 open |
 | M5.B Engine Correctness | [#459](https://github.com/zynax-io/zynax/issues/459) | In Progress — #538 ✅ #539 ✅ #540 ✅; #476 parent open |
 | M5.C Capability Dispatch | [#460](https://github.com/zynax-io/zynax/issues/460) | In Progress — task-broker code merged; agent-registry pending |
@@ -42,7 +42,7 @@ M5 is structured into seven tracks. See full execution plan: **[docs/milestones/
 
 ---
 
-## IMMEDIATE — BATCH 1 completion (#566 README pull commands — last open item)
+## IMMEDIATE — BATCH 5 CI DX improvements (next after BATCH 1 complete)
 
 ### BATCH 0 — ✅ All done
 ~~#547 #544 #548 #545 #589 #546 #557 #558 #559 #560~~
@@ -56,7 +56,7 @@ M5 is structured into seven tracks. See full execution plan: **[docs/milestones/
 | ~~[#562](https://github.com/zynax-io/zynax/issues/562)~~ | ~~Make GHCR service/adapter images publicly readable~~ | XS | ✅ Done — 5 service/adapter images public; zynax/tools deleted (see below) |
 | (admin) | **Confirm zynax/tools published + set public** | — | ✅ Done — tools-image.yml succeeded 2026-05-20; package set public |
 | [#563](https://github.com/zynax-io/zynax/issues/563) | Deduplicate tools image — remove tools-publish.yml + delete old zynax-tools package | XS | ✅ Done |
-| [#566](https://github.com/zynax-io/zynax/issues/566) | README packages section with GHCR image pull commands | S | ⬜ Ready |
+| [#566](https://github.com/zynax-io/zynax/issues/566) | README packages section with GHCR image pull commands | S | ✅ Done |
 
 ---
 
@@ -102,7 +102,7 @@ Canvas aligned. Ordered delivery: #526 → #527 → #528 → #481.
 
 ## Known Blockers
 
-- **#566 (README pull commands)** — documents `ghcr.io/zynax-io/zynax/tools:latest` pull command; ready to start (no remaining blockers).
+- **BATCH 1 complete** — all release pipeline issues done; next focus is BATCH 5 CI DX and BATCH 4 capability dispatch.
 - **agent-registry (#480)** — BDD trim (#526) must merge before domain (#527) begins (ADR-016).
 - **compose wiring (#481)** — depends on #528 (agent-registry gRPC wiring) landing first.
 - **adapter implementations** — wait for #481 (compose wiring) so adapters have a live registry.


### PR DESCRIPTION
## Summary

- Add `## Docker Images` section to `README.md` listing all 6 published GHCR images (`api-gateway`, `workflow-compiler`, `engine-adapter`, `task-broker`, `http-adapter`, `tools`) with `docker pull` examples for `:main` and `:v0.4.0` tags.
- Wire `image: ghcr.io/zynax-io/zynax/<svc>:main` into `docker-compose.yml` (3 platform services) and `docker-compose.services.yml` (http-adapter) alongside existing `build:` fallback — `docker compose up` now pulls from GHCR by default.
- Fix `idna 3.13` → `>=3.15` in `agents/sdk/pyproject.toml` (CVE-2026-45409, CVSS 7.5) — `make security` now exits clean.
- Fix stale BATCH 5 `#563` row in `M5-plan.md` (closed since PR #606 merged).

## Why

Closes #566. BATCH 1 (`#556` release pipeline track) is now fully complete. The CVE fix was caught by `make security` during the docs pass and resolved in the same PR.

## State files updated

- `docs/milestones/M5-plan.md`: #566 ⬜→✅, #563 BATCH 5 row ✅, Last updated rev 22
- `state/current-milestone.md`: BATCH 1 complete, M5.F.R track updated, #566 ✅, Known Blockers updated
- `agents/sdk/pyproject.toml`: `idna>=3.15` floor constraint added

## Architecture gaps addressed

— (docs + infra + dependency bump; no architectural gaps)

## Test plan

### Local pre-flight
- [x] `make lint-fix` — exit 0  [evidence: `✅ Docker 29.4.1`; no Python/Go files changed]
- [x] `make lint-go` — (N/A — no Go source changes)
- [x] `make lint-protos` — (N/A — no .proto changes)
- [x] `make lint-agents` — (N/A — pyproject.toml constraint-only change; no src/ changes)
- [x] `GOWORK=off go test ./... -race` — (N/A — no Go source changes)
- [x] `make test-coverage` — (N/A — no domain/ changes)
- [x] `make test-coverage-adapters` — (N/A — no adapter changes)
- [x] `make test-bdd` — (N/A — no BDD/.feature changes)
- [x] `make security` — exit 0  [evidence: "No known vulnerabilities found"; idna CVE-2026-45409 resolved by idna 3.15 floor]
- [x] `make validate-spec` — (N/A — no spec/ changes)

### Acceptance (from issue #566)
- [x] `README.md` has `## Docker Images` section with table of all published images and pull commands  [evidence: README.md — 6 images in table]
- [x] All image URLs use correct GHCR namespace `ghcr.io/zynax-io/zynax/*`  [evidence: verified against `gh api /orgs/zynax-io/packages` — 6 matching packages exist]
- [x] No phantom image entries for adapters not yet shipped  [evidence: only api-gateway, workflow-compiler, engine-adapter, task-broker, http-adapter, tools listed; git/ci/llm/langgraph adapters absent]
- [x] `docker pull` commands in README use `:main` (available now) and `:v0.4.0` (on release)  [evidence: `gh api` confirmed `:main` tag exists on api-gateway]
- [x] `docker-compose.yml` + `docker-compose.services.yml` reference GHCR images with `build:` fallback  [evidence: `image: ghcr.io/zynax-io/zynax/<svc>:main` added alongside existing `build:` blocks]

### Engineering hygiene
- [x] Branched from fresh `origin/main` (843f70d9)
- [x] PR ≤ 900 lines (43 insertions, 9 deletions — size S)
- [x] Every commit: `Signed-off-by: Oscar Gómez Manresa <ogomezmanresa@gmail.com>` + `Assisted-by: Claude/claude-sonnet-4-6`
- [x] No `Co-Authored-By:` for AI
- [x] No `panic` in prod paths; no silent `_ = err` (N/A — docs/infra/dep-bump only)
- [x] No mTLS/SBOM/cosign claims added to docs
- [x] Gap scan done (G1/G4/G7/G16): no code touched; no gaps triggered
- [x] 4 state files updated (M5-plan.md ✅, current-milestone.md ✅, canvas N/A — docs type, AGENTS.md N/A — no new capability)
- [x] `.feature` committed before impl (N/A — docs type, no public boundary)
- [x] No out-of-scope / drive-by edits

## Out of scope

- Updating ARCHITECTURE.md or per-service AGENTS.md (separate docs issues).
- Publishing images (tracked in #561, already done).
- BATCH 5 CI DX improvements and BATCH 4 capability dispatch (separate issues).

Closes #566
