### PR TITLE
docs: prioritize #551/#552 Alpine ci-runner as P0 next work

### DIFF
--- a/docs/milestones/M5-plan.md
+++ b/docs/milestones/M5-plan.md
@@ -6,7 +6,7 @@
 **GitHub Milestone:** [Adapter Library (M5)](https://github.com/zynax-io/zynax/milestone/5)
 **Parent epic:** [#377](https://github.com/zynax-io/zynax/issues/377)
 **Status:** In Progress
-**Last updated:** 2026-05-20 (rev 22 — #566 ✅; Docker Images section added to README, GHCR image refs in docker-compose; BATCH 1 complete)
+**Last updated:** 2026-05-20 (rev 23 — #566 ✅ BATCH 1 complete; #551/#552 promoted to P0 next; self-contained ci-runner requirement added; BATCH 5 reordered)
 
 ---
 
@@ -155,21 +155,34 @@ implement `AgentRepository` port (in-memory backing for M5; Postgres in M6), `Ag
 application service with round-robin health tracking, and heartbeat timeout logic (mark unhealthy
 after 2 min without ping). Reference: `services/task-broker/internal/domain/` for the pattern.
 
-### BATCH 5 — CI DX improvements (P1 · M5.F Group B/C/E, after BATCH 0)
+### BATCH 5 — CI DX improvements (P0 first pair · then P1 · M5.F Group B/C/E, after BATCH 0)
 
-| Issue | Title | Size | Dependency |
-|-------|-------|------|------------|
-| [#554](https://github.com/zynax-io/zynax/issues/554) | Force-full-pipeline trigger (dispatch, label, `[full-ci]`) | S | After #546 |
-| [#549](https://github.com/zynax-io/zynax/issues/549) | Extend changes job per-service module granularity | M | After #546 |
-| [#550](https://github.com/zynax-io/zynax/issues/550) | Scope govulncheck to changed services only | M | After #549 |
-| [#551](https://github.com/zynax-io/zynax/issues/551) | Create Dockerfile.ci-runner (Alpine, minimal) | S | None |
-| [#552](https://github.com/zynax-io/zynax/issues/552) | Switch GH Actions jobs to ci-runner container mode | M | After #551 |
-| [#555](https://github.com/zynax-io/zynax/issues/555) | DRY/KISS refactor — reusable workflows, composite actions | L | After #552 |
-| [#563](https://github.com/zynax-io/zynax/issues/563) | Deduplicate tools image — remove tools-publish.yml | XS | ✅ Done |
-| [#564](https://github.com/zynax-io/zynax/issues/564) | Pin action digests + add linux/arm64 to zynax-ci | XS | None |
-| [#565](https://github.com/zynax-io/zynax/issues/565) | Add trivy container scan gate before GHCR push | S | After #561 |
+**Do #551 → #552 first.** Every subsequent PR pays the ubuntu-24.04 cold-start tax until these
+land. Once #552 merges, all jobs run inside the pre-baked Alpine ci-runner container and no CI
+step downloads packages from the internet (other than code-level dependency installs such as
+`go mod download` or `uv sync`).
 
-**Engineer profile:** DevOps / GitHub Actions specialist.
+**Self-contained requirement for #551:** `Dockerfile.ci-runner` must bake in every tool the CI
+pipeline calls — Go 1.26.3, golangci-lint, govulncheck, godog, mockery, buf,
+protoc-gen-go, protoc-gen-go-grpc, Python + uv, ruff, mypy, bandit, pip-audit, pytest,
+gitleaks, wget, and the `zynax-ci` binary. No `apt-get install`, `go install`, or `pip install`
+of tooling at run time. The image is rebuilt and published to
+`ghcr.io/zynax-io/zynax/ci-runner:latest` on every change to its Dockerfile (same pattern as
+`tools-image.yml`). Reference: `infra/docker/Dockerfile.tools` for the current tool list.
+
+| Issue | Title | Size | Dependency | Priority |
+|-------|-------|------|------------|----------|
+| [#551](https://github.com/zynax-io/zynax/issues/551) | Create Dockerfile.ci-runner — self-contained Alpine image | S | None | **P0 — do next** |
+| [#552](https://github.com/zynax-io/zynax/issues/552) | Switch all GH Actions jobs to ci-runner container mode | M | After #551 | **P0 — do after #551** |
+| [#554](https://github.com/zynax-io/zynax/issues/554) | Force-full-pipeline trigger (dispatch, label, `[full-ci]`) | S | After #552 | P1 |
+| [#549](https://github.com/zynax-io/zynax/issues/549) | Extend changes job per-service module granularity | M | After #552 | P1 |
+| [#550](https://github.com/zynax-io/zynax/issues/550) | Scope govulncheck to changed services only | M | After #549 | P1 |
+| [#555](https://github.com/zynax-io/zynax/issues/555) | DRY/KISS refactor — reusable workflows, composite actions | L | After #552 | P2 |
+| [#563](https://github.com/zynax-io/zynax/issues/563) | Deduplicate tools image — remove tools-publish.yml | XS | ✅ Done | — |
+| [#564](https://github.com/zynax-io/zynax/issues/564) | Pin action digests + add linux/arm64 to zynax-ci | XS | After #552 | P2 |
+| [#565](https://github.com/zynax-io/zynax/issues/565) | Add trivy container scan gate before GHCR push | S | After #552 | P2 |
+
+**Engineer profile:** DevOps / GitHub Actions specialist with Docker/Alpine experience.
 
 ### BATCH 6 — Adapter implementations (P2 · #377, after M5.C complete)
 

--- a/state/current-milestone.md
+++ b/state/current-milestone.md
@@ -30,7 +30,7 @@ M5 is structured into seven tracks. See full execution plan: **[docs/milestones/
 
 | Track | Epic | Status |
 |-------|------|--------|
-| **M5.F CI Sprint** | [#542](https://github.com/zynax-io/zynax/issues/542) | 🟡 In Progress — BATCH 1 complete; next: BATCH 5 CI DX (#554, #549, …) |
+| **M5.F CI Sprint** | [#542](https://github.com/zynax-io/zynax/issues/542) | 🔴 **Next: #551 ci-runner Dockerfile → #552 switch all jobs** — every PR pays ubuntu cold-start until these land |
 | **M5.F.R Release Pipeline** | [#556](https://github.com/zynax-io/zynax/issues/556) | 🟢 BATCH 1 complete — #566 ✅ Docker Images in README; GHCR image refs in docker-compose |
 | M5.A Truth Pass | [#458](https://github.com/zynax-io/zynax/issues/458) | In Progress — 2/3 children done; #474 open |
 | M5.B Engine Correctness | [#459](https://github.com/zynax-io/zynax/issues/459) | In Progress — #538 ✅ #539 ✅ #540 ✅; #476 parent open |
@@ -42,7 +42,7 @@ M5 is structured into seven tracks. See full execution plan: **[docs/milestones/
 
 ---
 
-## IMMEDIATE — BATCH 5 CI DX improvements (next after BATCH 1 complete)
+## IMMEDIATE — Alpine ci-runner (#551 → #552) — P0, do before all other BATCH 5 work
 
 ### BATCH 0 — ✅ All done
 ~~#547 #544 #548 #545 #589 #546 #557 #558 #559 #560~~
@@ -102,7 +102,7 @@ Canvas aligned. Ordered delivery: #526 → #527 → #528 → #481.
 
 ## Known Blockers
 
-- **BATCH 1 complete** — all release pipeline issues done; next focus is BATCH 5 CI DX and BATCH 4 capability dispatch.
+- **#551 (Dockerfile.ci-runner) → #552 (switch all jobs)** — highest CI priority. Image must bake in every tool (Go 1.26.3, golangci-lint, govulncheck, buf, Python+uv, ruff, mypy, bandit, pip-audit, gitleaks, zynax-ci, etc.) so no CI step downloads tooling at run time. Reference: `infra/docker/Dockerfile.tools`. Publish to `ghcr.io/zynax-io/zynax/ci-runner:latest` on every Dockerfile change.
 - **agent-registry (#480)** — BDD trim (#526) must merge before domain (#527) begins (ADR-016).
 - **compose wiring (#481)** — depends on #528 (agent-registry gRPC wiring) landing first.
 - **adapter implementations** — wait for #481 (compose wiring) so adapters have a live registry.


### PR DESCRIPTION
## Summary

- Promote #551 (`Dockerfile.ci-runner`) and #552 (switch all GH Actions jobs) to **P0** at the top of BATCH 5 — every subsequent PR pays the ubuntu-24.04 cold-start tax until these land.
- Add **self-contained requirement** to #551: the ci-runner image must bake in all CI tooling (Go 1.26.3, golangci-lint, govulncheck, buf, Python+uv, ruff, mypy, bandit, pip-audit, gitleaks, zynax-ci, etc.) — no CI step downloads tooling at run time. Reference: `infra/docker/Dockerfile.tools`.
- Reorder remaining BATCH 5 items (#554, #549, #550, #555, #564, #565) behind #551→#552.
- Update `state/current-milestone.md` IMMEDIATE section and M5.F track status to reflect the new priority.

## Why

CI jobs currently run on `ubuntu-24.04` and download tools on every run. Shipping a self-contained Alpine ci-runner first means all future PRs (BATCH 4 capability dispatch, BATCH 6 adapters) run faster and don't depend on external package availability.

## State files updated

- `docs/milestones/M5-plan.md`: BATCH 5 reordered, self-contained requirement added, rev 23
- `state/current-milestone.md`: IMMEDIATE updated to #551→#552, M5.F track status updated, Known Blockers updated

## Test plan

- [x] `make lint-fix` — (N/A — docs-only, no code changed)
- [x] `make security` — (N/A — docs-only)
- [x] Branched from fresh `origin/main` (843f70d9)
- [x] PR ≤ 900 lines (34 insertions, 21 deletions)
- [x] Every commit: `Signed-off-by` + `Assisted-by: Claude/claude-sonnet-4-6`
- [x] No `Co-Authored-By:` for AI
- [x] No mTLS/SBOM/cosign claims added
- [x] No out-of-scope edits

## Out of scope

Implementing #551 or #552 — this PR only updates the execution plan.