### PR TITLE
chore(infra): update ci-runner digest after #610 merge

### DIFF
--- a/config/ci-runner-digest.txt
+++ b/config/ci-runner-digest.txt
@@ -8,4 +8,4 @@
 #     image: ghcr.io/zynax-io/zynax/ci-runner@<digest>
 #
 # Digest from last build (update after each tools-image.yml run):
-sha256:e12f828693f89e27fe91c3d9bff0fa862cae2e805da0ea21a39632d5389c1462
+sha256:b0653d255e0b8b7133b8c7537a8885431f68367bb74ba7851f73e58a3d675d0f


### PR DESCRIPTION
Updates `config/ci-runner-digest.txt` with the digest from the tools-image.yml build triggered by merging #610 (commit b058b10).

**New digest:** `sha256:b0653d255e0b8b7133b8c7537a8885431f68367bb74ba7851f73e58a3d675d0f`

Post-merge acceptance checks — see also the comment on #610 for full evidence.