### PR TITLE
docs(agents/sdk): update SDK docs to reflect delivered Agent base class

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -410,7 +410,7 @@ TypeScript API adapter are all equal participants in Layer 3. They implement the
 |-----------|-----------------------------------|
 | Go platform services (internal) | Import from `gen/go/zynax/v1/` via `go.work` workspace |
 | External Go consumers | Import `github.com/zynax-io/zynax/gen/go/zynax/v1` via `go.mod` |
-| Python SDK agents | `zynax-sdk` wraps `protos/generated/python/` — proto is abstracted |
+| Python SDK agents | `zynax-sdk` `Agent` base class + `@capability` routing; uses `protos/generated/python/` |
 | Python raw-stub callers | Import directly from `protos/generated/python/` |
 | Other languages | Run `buf generate` against `protos/zynax/v1/` source |
 | Future BSR consumers | Import from the Buf Schema Registry (planned for M1) |
@@ -430,12 +430,13 @@ eliminate because Go gRPC clients are already minimal. There is no framework
 integration to abstract because Go developers building capabilities implement the
 `AgentService` interface directly — that is the idiomatic Go approach.
 
-The Python SDK exists because the Python gRPC boilerplate for a server-role agent
-(registration, heartbeat, streaming lifecycle, context injection) is meaningful
-friction for developers whose primary skill is AI framework usage, not gRPC server
-implementation. The SDK eliminates that friction. Go developers do not have the same
-friction because implementing a gRPC server interface in Go is already straightforward
-and idiomatic.
+The Python SDK exists because the Python gRPC boilerplate for implementing the
+`AgentService` server contract — routing by capability name, constructing streaming
+`TaskEvent` responses — is meaningful friction for developers whose primary skill is
+AI framework usage, not gRPC server implementation. The SDK eliminates that friction
+through the `Agent` base class and `@capability` decorator. Go developers do not have
+the same friction because implementing a gRPC server interface in Go is already
+straightforward and idiomatic.
 
 ### Interoperability in Practice
 

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Layer 3 — Platform Services (Go, gRPC-only cross-service)
          │  gRPC: AgentService contract (protos/zynax/v1/agent.proto)
          ▼
 Layer 4 — Agents / SDK (Python execution adapters)
-    agents/sdk/          zynax-sdk — gRPC stub wrapper + base adapter
+    agents/sdk/          zynax-sdk — Agent base class + @capability routing
     agents/examples/     reference agent implementations
 ```
 

--- a/agents/sdk/AGENTS.md
+++ b/agents/sdk/AGENTS.md
@@ -1,22 +1,29 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 # agents/sdk — AGENTS.md
 
-> The Zynax Python SDK (`zynax-sdk`). Framework-agnostic core.
+> The Zynax Python SDK (`zynax-sdk`). Minimal `Agent` base class for capability providers.
 > Inherits all rules from root `AGENTS.md` and `agents/AGENTS.md`.
-> Full implementation patterns: `docs/patterns/python-agent-guide.md`.
 
 ---
 
 ## Purpose
 
-The SDK is the **platform adapter layer** for Python agents. It handles:
-- Agent registration and heartbeat with `agent-registry`.
-- Task reception and routing from `task-broker`.
-- Streaming `TaskEvent` updates back to the broker.
-- `AgentContext` construction and injection.
-- Structured logging, OTel tracing, Prometheus metrics bootstrap.
-- Graceful shutdown on `SIGTERM`.
+The SDK provides the **`Agent` base class** — an abstract gRPC servicer that handles
+capability routing and `TaskEvent` streaming, so adapter authors focus on business
+logic rather than gRPC plumbing.
 
-**The SDK never implements task execution logic** — that is the `AgentRuntime`'s job.
+What the SDK handles:
+- Routing incoming `ExecuteCapability` requests to the matching `@capability` handler.
+- Streaming `TaskEvent` responses (`PROGRESS`, `COMPLETED`, `FAILED`) back to the caller.
+- Input validation (`capability_name`, `task_id`, `input_payload` JSON check).
+- `GetCapabilitySchema` stub — returns metadata for a registered capability.
+
+What the SDK does **not** handle (M6+):
+- Agent registration and heartbeat with `agent-registry`.
+- Prometheus metrics, OTel tracing, structured logging bootstrap.
+- Graceful shutdown on `SIGTERM`.
+- Health probes, Dockerfile, or docker-compose wiring.
 
 ---
 
@@ -24,19 +31,76 @@ The SDK is the **platform adapter layer** for Python agents. It handles:
 
 ```
 agents/sdk/src/zynax_sdk/
-├── runtime.py         ← AgentRuntime Protocol, Task, TaskEvent (do not modify)
-├── context.py         ← AgentContext (injected — never constructed by agent)
-├── capability.py      ← @capability decorator
-├── contract.py        ← gRPC service implementation (do not edit)
-├── server.py          ← AgentServer: wires contract → sdk → runtime
-├── platform.py        ← MemoryClient, RegistryClient, BrokerClient
-├── observability.py   ← structlog + OTel + Prometheus bootstrap
-└── runtimes/
-    ├── direct.py      ← DirectRuntime: plain async generator
-    ├── langgraph.py   ← LangGraphRuntime (extras: zynax-sdk[langgraph])
-    ├── autogen.py     ← AutoGenRuntime  (extras: zynax-sdk[autogen])
-    └── crewai.py      ← CrewAIRuntime   (extras: zynax-sdk[crewai])
+├── agent.py       ← Agent base class, @capability decorator, report_* helpers
+└── __init__.py    ← Exports: Agent, capability, __version__
 ```
+
+---
+
+## Quickstart
+
+```python
+from zynax_sdk import Agent, capability
+
+class Summarizer(Agent):
+    @capability("summarize")
+    async def summarize(self, request, context):
+        # request.task_id, request.capability_name, request.input_payload
+        yield self.report_progress(request.task_id, {"step": 1, "status": "processing"})
+        yield self.report_completed(request.task_id, {"summary": "done"})
+```
+
+Then wire `Summarizer` into a `grpc.server`:
+
+```python
+import grpc
+from concurrent import futures
+from zynax.v1 import agent_pb2_grpc
+
+server = grpc.server(futures.ThreadPoolExecutor(max_workers=10))
+agent_pb2_grpc.add_AgentServiceServicer_to_server(Summarizer(), server)
+server.add_insecure_port("[::]:50051")
+server.start()
+```
+
+---
+
+## API Reference
+
+### `@capability(name: str)`
+
+Decorator. Registers an `async def` method as a named capability handler.
+The decorated method must be an async generator yielding `TaskEvent` objects:
+
+```python
+@capability("my_cap")
+async def my_cap(self, request, context):
+    yield self.report_progress(request.task_id, {...})
+    yield self.report_completed(request.task_id, {...})
+```
+
+### `Agent.report_progress(task_id, payload) -> TaskEvent`
+
+Creates a `TASK_EVENT_TYPE_PROGRESS` event. `payload` is a `dict[str, Any]` serialised to JSON bytes.
+
+### `Agent.report_completed(task_id, payload) -> TaskEvent`
+
+Creates a `TASK_EVENT_TYPE_COMPLETED` terminal event.
+
+### `Agent.report_failed(task_id, code, message) -> TaskEvent`
+
+Creates a `TASK_EVENT_TYPE_FAILED` terminal event with a structured `CapabilityError`.
+
+### `Agent.ExecuteCapability(request, context) -> Generator[TaskEvent]`
+
+gRPC handler (called by the gRPC framework). Routes the request to the registered handler.
+Aborts with `INVALID_ARGUMENT` if `capability_name` or `task_id` is empty, or if
+`input_payload` is not valid JSON. Yields `report_failed` if no handler is registered.
+
+### `Agent.GetCapabilitySchema(request, context) -> GetCapabilitySchemaResponse`
+
+gRPC handler. Returns basic schema metadata for a registered capability. Aborts with
+`NOT_FOUND` if the capability is not registered.
 
 ---
 

--- a/agents/sdk/pyproject.toml
+++ b/agents/sdk/pyproject.toml
@@ -9,7 +9,7 @@ packages = ["src/zynax_sdk"]
 [project]
 name = "zynax-sdk"
 version = "0.1.0"
-description = "Zynax Python SDK — Agent base class for building gRPC capability providers"
+description = "Minimal Python SDK for Zynax capability adapters — Agent base class and capability routing"
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }
 

--- a/agents/sdk/tests/test_package.py
+++ b/agents/sdk/tests/test_package.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Smoke test — verifies the package is importable and version is set.
-# Full BDD test suite is added in M2 alongside the SDK implementation.
+# Unit tests for Agent base class and capability routing live in test_agent.py.
 import zynax_sdk
 
 

--- a/docs/milestones/M5-plan.md
+++ b/docs/milestones/M5-plan.md
@@ -6,7 +6,7 @@
 **GitHub Milestone:** [Adapter Library (M5)](https://github.com/zynax-io/zynax/milestone/5)
 **Parent epic:** [#377](https://github.com/zynax-io/zynax/issues/377)
 **Status:** In Progress
-**Last updated:** 2026-05-21 (rev 27 — #536 ✅ Agent base class unit tests; 100% coverage)
+**Last updated:** 2026-05-21 (rev 28 — #537 ✅ docs update SDK; BATCH 3 M5.A complete)
 
 ---
 
@@ -123,14 +123,13 @@ These can run in parallel with BATCH 0/1.
 
 | Issue | Title | Size | Dependency |
 |-------|-------|------|------------|
-| [#535](https://github.com/zynax-io/zynax/issues/535) | Implement Agent base class (Python SDK) | M | None |
+| [#535](https://github.com/zynax-io/zynax/issues/535) | Implement Agent base class (Python SDK) | M | None | ✅ Done |
 | [#536](https://github.com/zynax-io/zynax/issues/536) | Python SDK unit tests (≥ 85% coverage) | S | After #535 | ✅ Done |
-| [#537](https://github.com/zynax-io/zynax/issues/537) | Docs update — README, ARCHITECTURE.md, AGENTS.md | XS | After #535+#536 |
+| [#537](https://github.com/zynax-io/zynax/issues/537) | Docs update — README, ARCHITECTURE.md, AGENTS.md | XS | After #535+#536 | ✅ Done |
 
 **Engineer profile:** Python engineer with gRPC experience. Read `docs/spdd/474-python-sdk/canvas.md`
 for the full design. Option A (minimal `Agent` base class, no framework lock-in) is the
-chosen approach. The existing `agents/sdk/src/zynax_sdk/__init__.py` is a 3-line placeholder
-that must be replaced with a real implementation following the `AgentRuntime` protocol.
+chosen approach. All three child issues are complete.
 
 ### BATCH 4 — Capability Dispatch E2E (P0 · M5.C, hardest dependency chain)
 
@@ -334,7 +333,7 @@ without rewriting the graph).
 |-------|-------|--------|
 | [#472](https://github.com/zynax-io/zynax/issues/472) | Remove CNCF badge + update milestone status | ✅ Done |
 | [#473](https://github.com/zynax-io/zynax/issues/473) | Audit CHANGELOG for phantom entries | ✅ Done |
-| [#474](https://github.com/zynax-io/zynax/issues/474) | Python SDK decision → implement minimal Agent base class | ⬜ Epic (see BATCH 3) |
+| [#474](https://github.com/zynax-io/zynax/issues/474) | Python SDK decision → implement minimal Agent base class | ✅ Epic complete (BATCH 3) |
 | **NEW** | Fix SECURITY.md — remove mTLS/SBOM/cosign false claims | ✅ Done (2026-05-20) |
 | **NEW** | Add per-service status table to README | ⬜ Open (file as child of #458) |
 
@@ -346,8 +345,8 @@ without rewriting the graph).
 | Issue | Step | Title | Status |
 |-------|------|-------|--------|
 | [#535](https://github.com/zynax-io/zynax/issues/535) | O1 | Implement Agent base class | ✅ Done |
-| [#536](https://github.com/zynax-io/zynax/issues/536) | O2 | Unit tests (≥ 85% coverage) | ⬜ Open (blocked on #535) |
-| [#537](https://github.com/zynax-io/zynax/issues/537) | O3 | Docs update | ⬜ Open (blocked on #535+#536) |
+| [#536](https://github.com/zynax-io/zynax/issues/536) | O2 | Unit tests (≥ 85% coverage) | ✅ Done |
+| [#537](https://github.com/zynax-io/zynax/issues/537) | O3 | Docs update | ✅ Done |
 
 ---
 

--- a/docs/spdd/474-python-sdk/canvas.md
+++ b/docs/spdd/474-python-sdk/canvas.md
@@ -104,7 +104,7 @@ docs/ (modified files)
 
 2. ✅ **[#536]** `test(agents/sdk)`: Unit tests for `Agent` base class — routing, event emission, error propagation, `timeout_seconds` cancellation. ≥ 85% coverage on `agents/sdk/`.
 
-3. **[#537]** `docs(agents/sdk)`: Update SDK status — rewrite `agents/sdk/AGENTS.md`; update SDK sections in README and ARCHITECTURE.md to describe the delivered `Agent` base class. Remove placeholder language.
+3. ✅ **[#537]** `docs(agents/sdk)`: Update SDK status — rewrite `agents/sdk/AGENTS.md`; update SDK sections in README and ARCHITECTURE.md to describe the delivered `Agent` base class. Remove placeholder language.
 
 ---
 

--- a/state/current-milestone.md
+++ b/state/current-milestone.md
@@ -92,7 +92,7 @@ Canvas aligned. Ordered delivery: #526 → #527 → #528 → #481.
 
 | Issue | Track | Title | Status |
 |-------|-------|-------|--------|
-| [#474](https://github.com/zynax-io/zynax/issues/474) | M5.A | Python SDK Agent base class | in progress — #535 ✅ impl done; #536 ✅ tests done (100% cov); #537 docs pending |
+| [#474](https://github.com/zynax-io/zynax/issues/474) | M5.A | Python SDK Agent base class | ✅ Complete — #535 ✅ #536 ✅ #537 ✅; BATCH 3 done |
 | [#476](https://github.com/zynax-io/zynax/issues/476) | M5.B | Guard parser (cel-go) | ✅ closed — all 3 children merged |
 | [#381](https://github.com/zynax-io/zynax/issues/381) | Adapters | git-adapter impl | open (#399 BDD done; #400+ pending, wait for #481) |
 | [#382](https://github.com/zynax-io/zynax/issues/382) | Adapters | ci-adapter impl | open (#404 BDD done; #405+ pending, wait for #481) |


### PR DESCRIPTION
## Summary

- Rewrite `agents/sdk/AGENTS.md` to describe the delivered `Agent` base class, `@capability` decorator, and `report_*` helpers — with a quickstart example and API reference
- Remove phantom module structure from AGENTS.md (`runtime.py`, `context.py`, `server.py`, `platform.py`, etc. — these are M6+ targets, not shipped)
- Update `README.md` Layer 4 description from "gRPC stub wrapper + base adapter" to "Agent base class + @capability routing"
- Update `ARCHITECTURE.md` SDK paragraph to accurately describe delivered functionality (routing + streaming events, not registration/heartbeat/context injection)
- Update `pyproject.toml` description to match AC requirement
- Fix stale M2 comment in `test_package.py`
- State files: flip #535/#536/#537 to ✅ Done in M5-plan.md; mark #474 epic complete; canvas O3 ✅

## Why

Closes the M5.A truth-pass gap: README, ARCHITECTURE.md, and AGENTS.md previously described a complex SDK that doesn't exist (M6+ features), making it impossible for developers to understand what `zynax-sdk` actually provides today. This is the final child issue of the Python SDK epic (#474). Closes #537.

## State files updated

- `docs/milestones/M5-plan.md` — #535 #536 #537 flipped to ✅; #474 epic marked complete; rev 28
- `state/current-milestone.md` — #474 row updated to ✅ Complete; BATCH 3 done
- `docs/spdd/474-python-sdk/canvas.md` — O3 step ✅
- `agents/sdk/AGENTS.md` — capability/purpose description updated (new capability documented)

## Architecture gaps addressed

- G21: Python SDK claims v0.1.0, was 3-line placeholder — now accurate documentation of the delivered `Agent` base class

## Test plan

### Local pre-flight
- [x] `make lint-fix` — clean (pre-commit: detect hardcoded secrets ✅, ruff ✅, ruff-format ✅)
- [x] `make lint-go` — (N/A — no Go changes)
- [x] `make lint-protos` — (N/A — no proto changes)
- [x] `make lint-agents` — pre-commit ruff + ruff-format passed on agents/sdk/ changes ✅
- [x] `GOWORK=off go test ./... -race` — (N/A — no Go changes)
- [x] `make test-coverage` — (N/A — no production Python code change; only docs + stale comment removal)
- [x] `make test-coverage-adapters` — (N/A — no adapter code change)
- [x] `make test-bdd` — (N/A — no feature file changes)
- [x] `make security` — pre-commit gitleaks/secrets check passed ✅
- [x] `make validate-spec` — (N/A — no spec/ changes)

### Acceptance (from issue #537 body)
- [x] `agents/sdk/AGENTS.md` rewritten: describes `Agent` base class, `@capability` decorator, `report_*` helpers; includes usage example with grpc.server wiring  [evidence: agents/sdk/AGENTS.md §Quickstart + §API Reference]
- [x] `README.md` Python SDK entry updated: no "placeholder/coming soon" language  [evidence: line 258 now "Agent base class + @capability routing"]
- [x] `ARCHITECTURE.md` SDK paragraph updated: accurately describes routing + streaming, not undelivered M6+ features  [evidence: ARCHITECTURE.md lines 433-439]
- [x] `pyproject.toml` description: `"Minimal Python SDK for Zynax capability adapters — Agent base class and capability routing"`  [evidence: agents/sdk/pyproject.toml line 12]
- [x] `git grep -rn "placeholder\|coming soon\|M2\|empty package" agents/sdk/ README.md ARCHITECTURE.md` — documentation occurrences removed; remaining "placeholder" strings in `test_agent_registry.py` (lines 79, 101) are test fixture values (`["placeholder"]` capability lists), not documentation claims — out of scope for this docs-only PR
- [x] `make gitleaks` passes — pre-commit secrets scan passed ✅

### Engineering hygiene
- [x] Branched from fresh `origin/main`
- [x] PR ≤ 900 lines (146 lines changed — XS)
- [x] Every commit: `Signed-off-by:` + `Assisted-by: Claude/claude-sonnet-4-6`
- [x] No `Co-Authored-By:` for AI
- [x] No `panic` in prod paths; no silent `_ = err` (N/A — docs only)
- [x] No mTLS/SBOM/cosign claims added to docs
- [x] Gap scan done (G1/G4/G7/G16 — N/A for docs-only; G21 addressed by this PR)
- [x] 4 state files updated (M5-plan ✅, current-milestone ✅, canvas O3 ✅, AGENTS.md ✅)
- [x] `.feature` committed before impl (N/A — docs: type, SPDD exempt)
- [x] No out-of-scope / drive-by edits

## Out of scope

- Renaming `["placeholder"]` test fixture in `test_agent_registry.py` — that's test logic, not docs
- SDK registration/heartbeat/observability (M6+)
- API reference generation (Sphinx/pdoc — M6+)
