### PR TITLE
docs(task-broker): rewrite AGENTS.md to reflect M5 implementation

### DIFF
--- a/docs/milestones/M5-plan.md
+++ b/docs/milestones/M5-plan.md
@@ -6,7 +6,7 @@
 **GitHub Milestone:** [Adapter Library (M5)](https://github.com/zynax-io/zynax/milestone/5)
 **Parent epic:** [#377](https://github.com/zynax-io/zynax/issues/377)
 **Status:** In Progress
-**Last updated:** 2026-05-21 (rev 28 — #537 ✅ docs update SDK; BATCH 3 M5.A complete)
+**Last updated:** 2026-05-21 (rev 29 — #530 ✅ task-broker AGENTS.md rewrite)
 
 ---
 
@@ -137,7 +137,7 @@ These must be done strictly in order. Each step is blocked by the previous.
 
 | Issue | Title | Size | Dependency | Engineer profile |
 |-------|-------|------|------------|-----------------|
-| [#530](https://github.com/zynax-io/zynax/issues/530) | Update task-broker AGENTS.md | XS | None (ready) | Any — docs only |
+| [#530](https://github.com/zynax-io/zynax/issues/530) | Update task-broker AGENTS.md | XS | None (ready) | ✅ Done |
 | [#531](https://github.com/zynax-io/zynax/issues/531) | Align task-broker BDD + godog steps | S | None (ready) | Go + godog |
 | [#532](https://github.com/zynax-io/zynax/issues/532) | Handler unit tests for all 5 gRPC methods | S | None (ready) | Go engineer |
 | [#526](https://github.com/zynax-io/zynax/issues/526) | Trim agent-registry BDD to proto scope | XS | None (ready) | Go + godog |
@@ -385,7 +385,7 @@ Implementation merged: PRs #520, #522, #523. Domain coverage: 92.7%.
 
 | Issue | Canvas step | Title | Status |
 |-------|-------------|-------|--------|
-| [#530](https://github.com/zynax-io/zynax/issues/530) | O6 | Update AGENTS.md | ⬜ Open |
+| [#530](https://github.com/zynax-io/zynax/issues/530) | O6 | Update AGENTS.md | ✅ Done |
 | [#531](https://github.com/zynax-io/zynax/issues/531) | O7 | Align service BDD + godog steps | ⬜ Open |
 | [#532](https://github.com/zynax-io/zynax/issues/532) | O8 | Handler unit tests (grpcErr coverage) | ⬜ Open |
 

--- a/services/task-broker/AGENTS.md
+++ b/services/task-broker/AGENTS.md
@@ -1,7 +1,8 @@
 # services/task-broker — AGENTS.md
 
-> Go 1.22+. Inherits rules from root `AGENTS.md` and `services/AGENTS.md`.
-> **Status: M4+ (not yet implemented).** BDD contract tests exist in `protos/tests/`. gRPC contract called by engine-adapter `DispatchCapabilityActivity` in M3.
+> Go 1.26.3+. Inherits rules from root `AGENTS.md` and `services/AGENTS.md`.
+> **Status: M5 Implemented — quality cleanup in progress (#531, #532).**
+> Implementation merged in PRs #520, #522, #523. BDD contract tests in `protos/tests/task_broker_service/`.
 
 ---
 
@@ -9,16 +10,45 @@
 
 The Task Broker is the **work scheduler** of the mesh.
 
-- Accepts task submissions (async — returns `task_id` immediately).
-- Discovers eligible agents from `agent-registry` via gRPC.
-- Assigns tasks using a pluggable `AssignmentStrategy`.
-- Manages state machine: `PENDING → ASSIGNED → RUNNING → SUCCEEDED | FAILED | TIMED_OUT | CANCELLED`.
-- Retries failed tasks with exponential backoff + jitter.
-- Enforces per-task timeouts via a background watchdog goroutine.
-- Fan-out real-time `WatchTask` state updates to concurrent server-streaming subscribers.
-- Publishes task lifecycle events to `event-bus`.
+- Accepts `DispatchTask` calls from `engine-adapter`; returns a broker-assigned `task_id` immediately (async execution).
+- Discovers eligible agents from `agent-registry` via gRPC (`AgentFinder` port).
+- Assigns tasks to agents using atomic round-robin selection.
+- Drives the task lifecycle state machine: `PENDING → DISPATCHED → COMPLETED | FAILED | CANCELLED`. Failed tasks with remaining retries transition to `RETRYING` before re-dispatching.
+- Executes capability invocations via `CapabilityExecutor` (HTTP-based agent call).
+- Exposes `AcknowledgeTask` for agents to report outcomes; applies retry logic in the domain layer.
+- Exposes `ListTasks` for filtered, paginated queries (by workflow, status, or agent).
 
-Does NOT: execute tasks · store results · authenticate callers.
+Does NOT: execute tasks directly · store results permanently · authenticate callers.
+
+---
+
+## gRPC API
+
+**Service:** `zynax.v1.TaskBrokerService`
+**Port:** `50053` (env: `ZYNAX_BROKER_GRPC_PORT`)
+
+| RPC | Request | Response | Description |
+|-----|---------|----------|-------------|
+| `DispatchTask` | `DispatchTaskRequest` | `DispatchTaskResponse` | Submit a task; returns `task_id` + `created_at` |
+| `AcknowledgeTask` | `AcknowledgeTaskRequest` | `AcknowledgeTaskResponse` | Agent reports outcome (COMPLETED/FAILED/CANCELLED); triggers retry logic |
+| `GetTask` | `GetTaskRequest` | `WorkflowTask` | Fetch current task state by ID |
+| `ListTasks` | `ListTasksRequest` | `ListTasksResponse` | Paginated list filtered by workflow, status, or agent |
+| `CancelTask` | `CancelTaskRequest` | `CancelTaskResponse` | Transition a non-terminal task to CANCELLED |
+
+---
+
+## TaskStatus Enum
+
+| Value | Ordinal | Description |
+|-------|---------|-------------|
+| `PENDING` | 1 | Task accepted; waiting for agent dispatch |
+| `DISPATCHED` | 2 | Routed to an agent; execution in progress |
+| `RETRYING` | 3 | Agent reported failure; retry budget remaining |
+| `COMPLETED` | 4 | Terminal — successful execution |
+| `FAILED` | 5 | Terminal — retries exhausted |
+| `CANCELLED` | 6 | Terminal — explicitly cancelled via `CancelTask` |
+
+Ordinal values are stable and must never be reordered or reassigned (ADR-001).
 
 ---
 
@@ -26,28 +56,55 @@ Does NOT: execute tasks · store results · authenticate callers.
 
 ```
 services/task-broker/
-├── cmd/task-broker/main.go
+├── cmd/task-broker/main.go          ← wires repo + finder + executor + gRPC server
 ├── internal/
 │   ├── api/
-│   │   └── handler.go          ← SubmitTask, GetTask, CancelTask, WatchTask, ListTasks
+│   │   └── handler.go               ← gRPC handler: DispatchTask, AcknowledgeTask, GetTask, ListTasks, CancelTask
 │   ├── domain/
-│   │   ├── model.go            ← TaskID, Task, TaskState, TaskPriority
-│   │   ├── service.go          ← TaskScheduler (Submit, Assign, Transition)
-│   │   ├── repository.go       ← TaskRepository interface
-│   │   ├── strategy.go         ← AssignmentStrategy: RoundRobin, LeastLoaded
-│   │   ├── watcher.go          ← WatcherRegistry: fan-out state changes
-│   │   └── errors.go           ← ErrTaskNotFound, ErrNoEligibleAgent
+│   │   ├── model.go                 ← TaskStatus, Task, TaskError, AgentInfo, ListFilter, ListResult
+│   │   ├── ports.go                 ← TaskRepository, AgentFinder, CapabilityExecutor interfaces
+│   │   ├── service.go               ← TaskService: core dispatch, acknowledge, cancel, list logic
+│   │   ├── errors.go                ← ErrTaskNotFound, ErrNoEligibleAgent, ErrTaskTerminal, ErrInvalidArgument
+│   │   └── service_test.go
 │   └── infrastructure/
-│       ├── postgres.go         ← PostgresTaskRepository
-│       ├── redis_lock.go       ← distributed lock (prevent double-assignment)
-│       ├── registry_client.go  ← gRPC client for agent-registry
-│       ├── nats_events.go      ← publish task lifecycle events
-│       └── watchdog.go         ← background goroutine: enforce timeouts
+│       ├── memory_repo.go           ← in-memory TaskRepository (M5; Postgres in M6)
+│       ├── agent_executor.go        ← CapabilityExecutor: HTTP invocation of agent endpoints
+│       └── registry_client.go       ← AgentFinder: gRPC client for agent-registry
+├── tests/
+│   └── features/task_broker.feature ← BDD contract scenarios
 ├── go.mod
+├── go.sum
 └── Dockerfile
 ```
 
-Config env prefix: `ZYNAX_BROKER_` · gRPC port: 50052
+**Hexagonal layout invariants:**
+- `internal/domain/` — pure business logic; zero imports from `api` or `infrastructure`.
+- `internal/api/` — gRPC handler; imports `domain` types only; translates proto ↔ domain.
+- `internal/infrastructure/` — port implementations; imports `domain` interfaces; never imported by `api`.
+
+---
+
+## Configuration
+
+| Env var | Default | Description |
+|---------|---------|-------------|
+| `ZYNAX_BROKER_GRPC_PORT` | `50053` | gRPC listen port |
+| `ZYNAX_BROKER_REGISTRY_ADDR` | `localhost:50052` | agent-registry gRPC address |
+| `ZYNAX_BROKER_LOG_LEVEL` | `info` | Log level: `debug`, `info`, `warn`, `error` |
+
+---
+
+## Error Mapping
+
+| Domain error | gRPC code |
+|---|---|
+| `ErrTaskNotFound` | `NOT_FOUND` |
+| `ErrNoEligibleAgent` | `NOT_FOUND` |
+| `ErrTaskTerminal` | `FAILED_PRECONDITION` |
+| `ErrInvalidArgument` | `INVALID_ARGUMENT` |
+| `context.Canceled` | `CANCELED` |
+| `context.DeadlineExceeded` | `DEADLINE_EXCEEDED` |
+| all other errors | `INTERNAL` |
 
 ---
 
@@ -61,3 +118,5 @@ GOWORK=off go test ./... -race -timeout 60s
 cd protos/tests
 GOWORK=off go test ./task_broker_service/... -v -timeout 60s
 ```
+
+Coverage gate: `internal/domain/` ≥ 90% (ADR-016). Current: 92.7%.

--- a/state/current-milestone.md
+++ b/state/current-milestone.md
@@ -71,7 +71,7 @@ Implementation PRs #520, #522, #523 merged. Domain coverage: 92.7%.
 
 | Issue | Step | Status |
 |-------|------|--------|
-| [#530](https://github.com/zynax-io/zynax/issues/530) | Update AGENTS.md | ready |
+| [#530](https://github.com/zynax-io/zynax/issues/530) | Update AGENTS.md | ✅ Done |
 | [#531](https://github.com/zynax-io/zynax/issues/531) | Align service BDD + godog steps | ready |
 | [#532](https://github.com/zynax-io/zynax/issues/532) | Handler unit tests | ready |
 


### PR DESCRIPTION
## Summary

- Rewrites `services/task-broker/AGENTS.md` from the pre-implementation spec to match the code merged in PRs #520, #522, #523
- Corrects RPCs (5 actual), `TaskStatus` enum (6 values), infrastructure files (3 actual), and gRPC port (50053)
- Adds hexagonal layout diagram, error-to-gRPC mapping table, and configuration env vars

## Why

The pre-implementation AGENTS.md described phantom files (`postgres.go`, `redis_lock.go`, `nats_events.go`), wrong RPCs (`SubmitTask`, `WatchTask`), wrong status values (`ASSIGNED`, `RUNNING`, `SUCCEEDED`, `TIMED_OUT`), and wrong port (50052). Any AI assistant or new contributor reading it would be misled. Closes #530.

## State files updated

- `docs/milestones/M5-plan.md`: #530 ⬜→✅ (BATCH 4 task-broker row)
- `state/current-milestone.md`: #530 ready→✅

## Architecture gaps addressed

- Truth pass (M5.A) — eliminates a documentation lie that could cause cross-layer coupling through misunderstanding.

## Test plan

### Local pre-flight
- [x] `make lint-fix` — N/A (docs only; no code changed)
- [x] `make lint-go` — N/A (no Go files changed)
- [x] `make lint-protos` — N/A (no proto files changed)
- [x] `make lint-agents` — N/A (no Python files changed)
- [x] `GOWORK=off go test ./... -race` — N/A (no code changed)
- [x] `make test-coverage` — N/A (no domain code changed)
- [x] `make test-coverage-adapters` — N/A
- [x] `make test-bdd` — N/A (no feature files changed)
- [x] `make security` — N/A (docs only; no secrets/code changed)
- [x] `make validate-spec` — N/A (no spec/ changes)

### Acceptance (from issue #530)
- [x] Lists all 5 actual RPCs: `DispatchTask`, `AcknowledgeTask`, `GetTask`, `ListTasks`, `CancelTask` — verified against `internal/api/handler.go` methods
- [x] Lists correct `TaskStatus` values: `PENDING=1`, `DISPATCHED=2`, `RETRYING=3`, `COMPLETED=4`, `FAILED=5`, `CANCELLED=6` — verified against `internal/domain/model.go` constants
- [x] Lists actual infrastructure files only: `memory_repo.go`, `agent_executor.go`, `registry_client.go` — verified via `find services/task-broker/internal/infrastructure/`
- [x] States gRPC port `50053` (env: `ZYNAX_BROKER_GRPC_PORT`) — verified against `cmd/task-broker/main.go` config struct
- [x] States status: "M5 Implemented — quality cleanup in progress (#531, #532)" — in AGENTS.md header
- [x] No mention of `postgres.go`, `redis_lock.go`, `nats_events.go`, `watchdog.go`, `SubmitTask`, `WatchTask`, `ASSIGNED`, `RUNNING`, `SUCCEEDED`, `TIMED_OUT` — confirmed by reading final file
- [x] Describes hexagonal layout: `internal/domain/` (pure), `internal/api/` (gRPC handler), `internal/infrastructure/` (repo + executor + registry) — included in layout section
- [x] PR type: `docs:` — ✅

### Engineering hygiene
- [x] Branched from fresh `origin/main` (32b5fb8)
- [x] PR ≤ 900 lines (88 additions, 29 deletions — XS)
- [x] Every commit: `Signed-off-by: Oscar Gómez Manresa <ogomezmanresa@gmail.com>` + `Assisted-by: Claude/claude-sonnet-4-6`
- [x] No `Co-Authored-By:` for AI
- [x] No `panic` in prod paths; no silent `_ = err` — N/A (docs only)
- [x] No mTLS/SBOM/cosign claims added to docs
- [x] Gap scan done (G1/G4/G7/G16) — N/A (touching only AGENTS.md)
- [x] 4 state files updated: M5-plan.md ✅, current-milestone.md ✅, canvas N/A (docs type), AGENTS.md is the target file
- [x] `.feature` committed before impl — N/A (docs type)
- [x] No out-of-scope / drive-by edits

## Out of scope

Code changes, proto files, BDD scenarios — addressed in #531 and #532.

Closes #530
