### PR TITLE
ci: guard lint-proto AI context detection against git diff exit 128

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,17 +224,23 @@ jobs:
       - name: Detect AI context file changes
         id: ai-detect
         run: |
-          changed=$(git diff --name-only origin/main...HEAD -- \
+          if ! files=$(git diff --name-only origin/main...HEAD -- \
             'CLAUDE.md' '*/AGENTS.md' 'AGENTS.md' \
-            'docs/ai-assistant-setup.md' '.ai/' '.claude/' 2>/dev/null | wc -l)
-          echo "has_changes=$changed" >> "$GITHUB_OUTPUT"
+            'docs/ai-assistant-setup.md' '.ai/' '.claude/' \
+            2>/tmp/ai-diff-err.txt); then
+            echo "⚠️  git diff failed for AI context scan — enabling scan as fail-safe"
+            cat /tmp/ai-diff-err.txt || true
+            echo "has_changes=1" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "has_changes=$(echo "$files" | grep -c . || echo 0)" >> "$GITHUB_OUTPUT"
 
       - name: Scan AI context files for secrets and PII
         if: steps.ai-detect.outputs.has_changes != '0'
         run: |
           files=$(git diff --name-only origin/main...HEAD -- \
             'CLAUDE.md' '*/AGENTS.md' 'AGENTS.md' \
-            'docs/ai-assistant-setup.md' '.ai/' '.claude/')
+            'docs/ai-assistant-setup.md' '.ai/' '.claude/' 2>/dev/null || true)
           echo "── scanning AI context files for secrets / PII / local paths"
           echo "$files"
           gitleaks detect --no-git --source . \


### PR DESCRIPTION
## Problem

The `lint-proto` job's **Detect AI context file changes** step ran:

\`\`\`bash
changed=$(git diff --name-only origin/main...HEAD -- 'CLAUDE.md' '*/AGENTS.md' ... | wc -l)
\`\`\`

With `pipefail` enabled in the CI shell, if `git diff` exits 128 (origin/main not available in shallow-clone containers), the pipe fails before `wc` runs — causing the step to error even though no proto or AI context check was actually needed.

This blocked every PR that touches `AGENTS.md` or `CLAUDE.md`.

## Fix

Apply the same fail-safe pattern used by the `changes` job (from `ci/549-change-detection-fail-safe`):

- Capture `git diff` output with explicit error handling (`if !`)  
- Log the git error for debugging  
- Fall back to enabling the scan (conservative: scan runs, never skipped silently)

Also fix the `Scan AI context files` step to use `|| true` so a failed git diff doesn't skip the scan body.

## Test plan

- [ ] Open a PR that modifies `AGENTS.md` — `lint-proto` should pass (AI context scan runs, gitleaks passes)
- [ ] `Conventional Commit title` check passes (title is 60 chars)

## Related

- Part of `ci/549-change-detection-fail-safe` work (#549)
- Unblocks: `docs/best-practices-ci-arch-kb` PR (touches AGENTS.md + CLAUDE.md)
- See also: `docs/reviews/04-architecture-gaps.md` (tooling note)

> ⚠️ **Merge this first** before the docs PR that touches AGENTS.md/CLAUDE.md.