### PR TITLE
docs: add repo inventory and ADR decision ledger (review 1/4)

### DIFF
--- a/docs/reviews/00-inventory.md
+++ b/docs/reviews/00-inventory.md
@@ -1,0 +1,281 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# 00 — Repository Inventory
+
+**Date:** 2026-05-21  
+**Branch:** docs/architecture-overhaul-m5  
+**Purpose:** Phase 0 artifact — complete file/directory map, doc-artifact list,
+agent-context census, and AI-context-budget baseline.
+
+---
+
+## 1. Repository Facts (verified against HEAD)
+
+| Property | Value |
+|---|---|
+| Remote | `github.com/zynax-io/zynax` |
+| Default branch | `main` |
+| Working branch | `docs/architecture-overhaul-m5` |
+| License | Apache-2.0 |
+| Languages | Go (~68%), Gherkin/BDD (~17%), Python (~13%), Makefile |
+| Go version | 1.26.3 (go.work) |
+| Python version | 3.12 (ADR-002) |
+| Package manager (Python) | uv (ADR-003) |
+| Releases cut | v0.4.0 tag pending (CHANGELOG promoted, `git push origin v0.4.0` pending per state/current-milestone.md) |
+
+---
+
+## 2. Top-Level Directory Map
+
+```
+zynax/
+├── spec/                   Layer 1 — YAML manifests + JSON schemas + AsyncAPI
+│   ├── asyncapi/           AsyncAPI spec (11 event channels defined)
+│   ├── schemas/            JSON Schema files (Workflow, AgentDef, Policy)
+│   ├── tests/              Schema validation tests
+│   └── workflows/examples/ 5 example workflow YAML files
+│
+├── protos/                 Layer 2 — gRPC contracts (source of truth)
+│   ├── zynax/v1/           8 proto files (agent, workflow_compiler, engine_adapter,
+│   │                       task_broker, agent_registry, event_bus, memory_service, cloudevents)
+│   ├── buf.yaml / buf.gen.yaml
+│   ├── generated/          Python stubs (auto-generated, committed)
+│   ├── tests/              BDD contract test suites (godog, 140+ scenarios)
+│   └── AGENTS.md
+│
+├── services/               Layer 3 — Go platform services
+│   ├── workflow-compiler/  ✅ Implemented — YAML → WorkflowIR (go.mod, ~1390 LoC)
+│   ├── engine-adapter/     ✅ Implemented — IR → Temporal (go.mod, ~1143 LoC)
+│   ├── api-gateway/        ✅ Implemented — HTTP REST entry point (go.mod, ~1047 LoC)
+│   ├── task-broker/        🟡 In-memory MVP (go.mod, ~905 LoC); not in compose yet
+│   ├── agent-registry/     ❌ Stub — AGENTS.md + feature files only; no go.mod, 0 LoC
+│   ├── event-bus/          ❌ Stub — AGENTS.md only; no go.mod, 0 LoC
+│   ├── memory-service/     ❌ Stub — AGENTS.md only; no go.mod, 0 LoC
+│   └── AGENTS.md
+│
+├── agents/                 Layer 4 — Python execution adapters + SDK
+│   ├── sdk/                Python SDK — zynax-sdk (Agent base class, @capability routing)
+│   ├── adapters/
+│   │   └── http/           ✅ HTTP adapter — REST capability proxy
+│   ├── examples/           Reference feature files (summarizer, etc.)
+│   └── AGENTS.md
+│
+├── cmd/
+│   ├── zynax/              ✅ CLI — apply/get/delete/status/logs (go.mod, ~1470 LoC)
+│   └── zynax-ci/           ✅ CI toolchain — validate canvas/schema/manifests, check ai-context
+│
+├── infra/
+│   ├── docker/             Dockerfile.tools, Dockerfile.ci-runner
+│   └── docker-compose/     docker-compose.yml (canonical), overrides
+│
+├── gen/go/                 Go protobuf stubs (auto-generated, committed)
+├── docs/                   All documentation (see §4 below)
+├── state/                  current-milestone.md
+├── tools/                  Tool scripts
+├── .github/workflows/      14 CI workflow files
+├── .claude/commands/       8 SPDD slash-command definitions
+└── [root governance files] README.md ARCHITECTURE.md AGENTS.md CLAUDE.md
+                            CHANGELOG.md ROADMAP.md SECURITY.md GOVERNANCE.md
+                            CONTRIBUTING.md CODE_OF_CONDUCT.md LICENSE
+                            Makefile go.work .pre-commit-config.yaml renovate.json
+                            .trivyignore .dockerignore
+```
+
+---
+
+## 3. GitHub Actions Workflows (14 files)
+
+| File | Purpose | Size |
+|---|---|---|
+| `ci.yml` | Main CI — lint, test, coverage, BDD, security | 1,325 lines (⚠ oversized) |
+| `pr-checks.yml` | PR validation — conventional-commit, PR-size, canvas | ~600 lines |
+| `release.yml` | Unified tag-triggered release — CLI + zynax-ci + service images | ~550 lines |
+| `cli-release.yml` | CLI binary release (also called from release.yml) | ~220 lines |
+| `service-release.yml` | Service image release (also called from release.yml) | ~225 lines |
+| `zynax-ci-release.yml` | zynax-ci binary release | ~115 lines |
+| `tools-image.yml` | tools Docker image rebuild on Dockerfile.tools change | ~160 lines |
+| `proto-generate.yml` | Auto-regenerate stubs on .proto change, post-merge | ~115 lines |
+| `proto-stubs-publish.yml` | Publish proto stubs to BSR (Buf Schema Registry) | ~220 lines |
+| `pr-size.yml` | PR size gate | ~55 lines |
+| `ai-context-budget.yml` | Advisory AI context line count check | ~40 lines |
+| `kb-preview.yml` | Knowledge-base preview builds | ~165 lines |
+
+Required status checks (enforced): `CI / lint`, `CI / test-unit-go`, `CI / test-bdd`,
+`CI / coverage-gate`, `PR Checks / conventional-commit`, `PR Checks / pr-size`,
+`PR Checks / validate-canvas`.
+
+---
+
+## 4. Documentation Artifacts
+
+### Root governance
+
+| File | Purpose | State |
+|---|---|---|
+| `README.md` (449 lines) | Project overview, quickstart, milestone status | Mostly current (see §5) |
+| `ARCHITECTURE.md` (510 lines) | Architecture design and rationale | ⚠ **Severely stale** — milestone table shows M2 as "Next", M3 as "Planned" |
+| `AGENTS.md` (217 lines) | Engineering constitution for contributors + AI | Mostly current; 3 broken file links |
+| `CLAUDE.md` (195 lines) | Session bootstrap for AI coding assistants | Current |
+| `CHANGELOG.md` | Notable changes per milestone | Current (v0.4.0 accurate) |
+| `ROADMAP.md` | Narrative roadmap M1–M8 | Mostly current; M5 section needs completion state |
+| `SECURITY.md` | Security policy and controls | Truth-pass complete (2026-05-20) |
+| `GOVERNANCE.md` | Contributor governance, DCO, conflict resolution | Current |
+| `CONTRIBUTING.md` | Contribution guide | Current |
+| `CODE_OF_CONDUCT.md` | CNCF CoC | Current |
+
+### Architecture reviews (`docs/architecture/`)
+
+| File | Date | Summary |
+|---|---|---|
+| `2026-04-30-competitive-analysis.md` | 2026-04-30 | Competitive landscape (Temporal, Dapr, Argo, LangGraph) |
+| `2026-04-30-execution-architecture.md` | 2026-04-30 | Execution architecture deep-dive (M3 era) |
+| `2026-05-18-external-architectural-review.md` | 2026-05-18 | External review — pre-M5.F |
+| `2026-05-20-principal-architect-review.md` | 2026-05-20 | **Authoritative review** — 6.5/10 overall, G1-G24 gap list, 30-day plan |
+
+### ADRs (`docs/adr/`)
+
+| ADR | Title | Status |
+|---|---|---|
+| ADR-001 | gRPC as inter-service protocol | Accepted |
+| ADR-002 | Python 3.12 | Accepted |
+| ADR-003 | uv package manager | Accepted |
+| ADR-004 | BDD testing | **Superseded by ADR-016** |
+| ADR-005 | Apache 2.0 | Accepted |
+| ADR-006 | Monorepo | Accepted |
+| ADR-007 | Pydantic Settings | Accepted |
+| ADR-008 | No shared databases | Accepted |
+| ADR-009 | Language strategy (Go/Python) | Accepted |
+| ADR-010 | Pluggable agent runtime | Accepted |
+| ADR-011 | Declarative YAML control plane | Accepted |
+| ADR-012 | Workflow IR | Accepted |
+| ADR-013 | Adapter-first, no mandatory SDK | Accepted |
+| ADR-014 | Event-driven state machine model | Accepted |
+| ADR-015 | Pluggable workflow engines | Accepted |
+| ADR-016 | Layered testing strategy | Accepted |
+| ADR-017 | Contract test isolation (GOWORK=off) | Accepted |
+| ADR-018 | AI KB authorization model | Accepted |
+| ADR-019 | SPDD prompt governance | Accepted |
+| ADR-020 | Zero-trust intra-service security | **Not yet filed** (planned; issue #240) |
+| ADR-021 | Horizontal scale + multi-tenancy | **Not yet filed** (planned; issue #578) |
+
+### Milestone docs (`docs/milestones/`)
+
+| File | Purpose | State |
+|---|---|---|
+| `M1-engineering-review.md` | M1 engineering review | Complete |
+| `M1-release-notes.md` | M1 release notes | Complete |
+| `M5-plan.md` (494 lines) | M5 authoritative execution plan | Current (rev 30, 2026-05-21) |
+| M2–M4 reviews | Missing | ⚠ **Not yet created** |
+
+### SPDD Canvas artifacts (`docs/spdd/`)
+
+27 canvas directories. Notable ones:
+
+| Directory | Issue | Status |
+|---|---|---|
+| `214-temporal-execution/` | #214 | M3 epic |
+| `314-yaml-system-cli/` | #314 | M4 epic |
+| `377-adapter-library/` | #377 | M5 adapter library epic |
+| `380–384-*` | #380–384 | Adapter canvases (http ✅, git/ci/llm/langgraph BDD done) |
+| `458-truth-pass/` | #458 | M5.A truth pass |
+| `459-engine-correctness/` | #459 | M5.B engine correctness |
+| `460-capability-dispatch/` | #460 | M5.C capability dispatch E2E |
+| `461-security-baseline/` | #461 | M5.D security baseline ✅ |
+| `462-dx-polish/` | #462 | M5.E DX polish ✅ |
+| `474-python-sdk/` | #474 | Python SDK ✅ |
+| `476-guard-parser/` | #476 | cel-go guard ✅ |
+| `479-task-broker/` | #479 | task-broker MVP ✅ |
+| `480-agent-registry/` | #480 | agent-registry pending |
+
+### Engineering docs (`docs/engineering/`, `docs/patterns/`, `docs/decisions/`)
+
+| File | Purpose |
+|---|---|
+| `docs/engineering/dependency-strategy.md` | Dependency version policy |
+| `docs/engineering/renovate-fix-sop.md` | Renovate CI failure SOP |
+| `docs/patterns/bdd-contract-testing.md` | BDD contract testing guide |
+| `docs/patterns/go-service-patterns.md` | Go service code templates |
+| `docs/patterns/python-agent-guide.md` | Python agent patterns |
+| `docs/patterns/proto-interop.md` | Multi-language proto guide |
+| `docs/patterns/helm-charts.md` | Helm chart templates |
+| `docs/patterns/spdd-guide.md` | Full SPDD workflow guide |
+| `docs/decisions/001–004` | Minor scoped decisions |
+| `docs/reviews/` | **This task's audit trail** (being created) |
+
+---
+
+## 5. Agent-Context Files (AI Context Budget)
+
+The `zynax-ci check ai-context` command enforces advisory line-count budgets.
+
+| File | Limit | **Current** | Delta | Notes |
+|---|---|---|---|---|
+| `CLAUDE.md` | 200 | **195** | -5 | ✅ Within budget |
+| `AGENTS.md` (root) | 300 | **217** | -83 | ✅ Has 3 broken links (see §6) |
+| `docs/ai-assistant-setup.md` | 150 | **139** | -11 | ✅ Within budget |
+| `services/workflow-compiler/AGENTS.md` | 150 | **71** | -79 | ✅ |
+| `services/engine-adapter/AGENTS.md` | 150 | **98** | -52 | ✅ |
+| `services/api-gateway/AGENTS.md` | 150 | **70** | -80 | ✅ |
+| `services/task-broker/AGENTS.md` | 150 | **122** | -28 | ✅ |
+| `services/agent-registry/AGENTS.md` | 150 | **56** | -94 | ✅ |
+| `services/event-bus/AGENTS.md` | 150 | **57** | -93 | ✅ |
+| `services/memory-service/AGENTS.md` | 150 | **61** | -89 | ✅ |
+| `agents/sdk/AGENTS.md` | 150 | **126** | -24 | ✅ |
+| `agents/adapters/AGENTS.md` | 150 | **125** | -25 | ✅ |
+| `cmd/zynax/AGENTS.md` | 150 | **73** | -77 | ✅ |
+| `cmd/zynax-ci/AGENTS.md` | 150 | **81** | -69 | ✅ |
+| `protos/AGENTS.md` | 150 | **91** | -59 | ✅ |
+| `protos/tests/AGENTS.md` | 150 | **78** | -72 | ✅ |
+| `spec/AGENTS.md` | 150 | **67** | -83 | ✅ |
+| `infra/AGENTS.md` | 150 | **69** | -81 | ✅ |
+| **Total** | **2000** | **~1796** | **-204** | ✅ Under budget |
+
+---
+
+## 6. Known Issues Found During Inventory
+
+### Drift / Discrepancies
+
+| # | Location | Issue | Severity |
+|---|---|---|---|
+| D1 | `ARCHITECTURE.md` §Milestone Status | Shows M2 as "Next", M3 as "Planned" — stale by 4 milestones | **Critical** |
+| D2 | `ARCHITECTURE.md` §13 Milestones | Table still says M2 "Next" and M5 "Planned" | Critical |
+| D3 | `AGENTS.md` §Knowledge Base Index | References `docs/architecture/execution-architecture.md` (wrong path) | Medium |
+| D4 | `AGENTS.md` §Knowledge Base Index | References `docs/architecture/competitive-analysis-2026.md` (wrong path) | Medium |
+| D5 | `AGENTS.md` §Knowledge Base Index | References `docs/architecture/2026-05-external-architectural-review.md` (wrong path) | Medium |
+| D6 | `README.md` M4 description | Claims "kind: AgentDef routing via AgentRegistryService" — agent-registry doesn't exist | High |
+| D7 | `README.md` Quickstart | No caveat that first dispatch will fail (no agent-registry wired) | High |
+| D8 | `README.md` GHCR images table | Does not list agent-registry (no image exists — correct, but no explanation) | Low |
+| D9 | `docs/milestones/` | M2, M3, M4 engineering reviews missing (only M1 has review + release-notes) | Medium |
+| D10 | `AGENTS.md` | References `AGENTS.md §7` for security architecture — no §7 exists in AGENTS.md | Low |
+
+### Missing Docs
+
+- M2, M3, M4 engineering reviews and release notes
+- ADR-020 (zero-trust intra-service security — planned)
+- ADR-021 (horizontal scale + multi-tenancy — planned)
+- `docs/engineering/best-practices/` directory (all standards files missing)
+- `docs/reviews/DECISIONS-NEEDED.md` (created by this task)
+
+---
+
+## 7. CI Gates Summary
+
+| Gate | Enforced By | Description |
+|---|---|---|
+| `proto-breaking` | `pr-checks.yml` | `buf breaking` against main |
+| `stubs-freshness` | `pr-checks.yml` | Regenerate stubs and check no diff |
+| `layer-boundaries` | `pr-checks.yml` | `zynax-ci validate` layer isolation |
+| `conventional-commit` | `pr-checks.yml` | PR title format check |
+| `pr-size` | `pr-size.yml` | ≤ 900 LOC (with exclusions) |
+| `validate-canvas` | `pr-checks.yml` | `zynax-ci validate canvas` on docs/spdd/ |
+| `coverage-gate` | `ci.yml` | ≥ 90% on domain packages |
+| `ai-context-budget` | `ai-context-budget.yml` | Advisory (non-blocking); ≤ 2000 lines |
+| `trivy-scan` | `release.yml` | Container CVE scan before GHCR push (#565) |
+| `golangci-lint` | `ci.yml` | Go lint |
+| `ruff/mypy/bandit` | `ci.yml` | Python lint + SAST |
+
+---
+
+*This inventory was produced at phase boundary 0 on branch `docs/architecture-overhaul-m5`.
+Re-verify against HEAD before acting on specific file references.*

--- a/docs/reviews/01-decision-ledger.md
+++ b/docs/reviews/01-decision-ledger.md
@@ -1,0 +1,266 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# 01 — Decision Ledger
+
+**Date:** 2026-05-21  
+**Branch:** docs/architecture-overhaul-m5  
+**Purpose:** Phase 1 artifact — complete record of every architectural decision,
+its rationale, current status, and whether the code still reflects it.
+
+Each entry answers: What was decided? When? Why? Is it still in force?
+Does the code match? Evidence.
+
+---
+
+## Formal ADRs (docs/adr/)
+
+### ADR-001 — gRPC as inter-service protocol
+| Field | Value |
+|---|---|
+| Date | 2026-04-01 |
+| Status | **Accepted** |
+| Decision | All synchronous service-to-service communication uses gRPC + protobuf |
+| Why | Language-agnostic, strongly typed, `buf breaking` CI gate, generated stubs for Go + Python |
+| Code reflects? | ✅ Yes — all services use generated stubs from `gen/go/zynax/v1/`; no HTTP between services |
+| Still valid? | Yes — reinforced by the 2026-05-20 review which rates the contract layer highly |
+
+### ADR-002 — Python 3.12 as agent runtime
+| Field | Value |
+|---|---|
+| Date | 2026-04-01 |
+| Status | **Accepted** |
+| Decision | Python 3.12 for all agent/adapter code (`agents/`) |
+| Why | Latest stable with improved performance + typing |
+| Code reflects? | ✅ Yes — `agents/sdk/pyproject.toml` requires Python ≥ 3.12 |
+| Still valid? | Yes |
+
+### ADR-003 — uv as Python package manager
+| Field | Value |
+|---|---|
+| Date | 2026-04-01 |
+| Status | **Accepted** |
+| Decision | `uv` replaces `pip/poetry` for Python agent environments |
+| Why | 10–100× faster than pip; reproducible via `uv.lock` |
+| Code reflects? | ✅ Yes — `agents/sdk/uv.lock` exists; `pyproject.toml` uses uv conventions |
+| Still valid? | Yes |
+
+### ADR-004 — BDD as primary testing methodology
+| Field | Value |
+|---|---|
+| Date | 2026-04-01 |
+| Status | **Superseded by ADR-016** |
+| Decision | (original) BDD scenarios as primary test form |
+| Superseded because | ADR-016 introduces a tiered testing strategy (BDD at gRPC boundaries, unit ≥90% on domain, `buf breaking` as CI gate) — more precise scope than ADR-004 |
+| Code reflects? | ✅ Yes — ADR-016 governs; ADR-004 is informational history only |
+
+### ADR-005 — Apache 2.0 license
+| Field | Value |
+|---|---|
+| Date | 2026-04-01 |
+| Status | **Accepted** |
+| Decision | Apache-2.0 with SPDX headers on every source file |
+| Why | CNCF-compatible vendor-neutral license; DCO for copyright attribution |
+| Code reflects? | ✅ Yes — every .go/.py/.md/.proto file carries `<!-- SPDX-License-Identifier: Apache-2.0 -->` |
+| Still valid? | Yes |
+
+### ADR-006 — Monorepo structure
+| Field | Value |
+|---|---|
+| Date | 2026-04-01 |
+| Status | **Accepted** |
+| Decision | Single repo; `go.work` workspace; `buf.work.yaml`; GOWORK=off in service dirs |
+| Why | Atomic cross-service changes; single CI pipeline; all stubs co-located |
+| Code reflects? | ✅ Yes — `go.work` lists 6 modules |
+| Notes | `cmd/zynax` and `cmd/zynax-ci` are **not** in `go.work` — they are standalone modules (see docs/decisions/004-gowork-off-isolation.md) |
+
+### ADR-007 — Pydantic Settings for agent configuration
+| Field | Value |
+|---|---|
+| Date | 2026-04-01 |
+| Status | **Accepted** |
+| Decision | Pydantic `BaseSettings` for all Python agent config (env-var + `.env` file) |
+| Why | Type-safe config, 12-Factor compliance, `.env` for local dev |
+| Code reflects? | ✅ Yes — `agents/adapters/http/` uses Pydantic Settings |
+
+### ADR-008 — No shared databases
+| Field | Value |
+|---|---|
+| Date | 2026-04-01 |
+| Status | **Accepted** |
+| Decision | Each service owns its own schema/namespace; cross-service data flows via gRPC only |
+| Why | Prevent distributed monolith; each service can use the right store for its domain |
+| Code reflects? | ✅ Yes — no shared ORM models; `services/*/internal/infrastructure/` each manage their own |
+| Notes | task-broker uses in-memory store; agent-registry will use in-memory for MVP, Postgres in M6 |
+
+### ADR-009 — Language strategy (Go for services, Python for agents)
+| Field | Value |
+|---|---|
+| Date | 2026-04-01 |
+| Status | **Accepted** |
+| Decision | All platform services (`services/`, `cmd/`) in Go; all agents/adapters (`agents/`) in Python (or Go with gRPC contract) |
+| Why | Go for control plane performance/concurrency; Python for AI/ML ecosystem access |
+| Code reflects? | ✅ Yes — no Python in `services/`; no agent code in Go services |
+
+### ADR-010 — Pluggable agent runtime
+| Field | Value |
+|---|---|
+| Date | 2026-04-01 |
+| Status | **Accepted** |
+| Decision | Agents register capabilities via `AgentService.Register` gRPC; no SDK required |
+| Why | Zero lock-in; any language, any framework |
+| Code reflects? | ✅ Contractually — `AgentService` in proto; Python SDK provides optional ergonomic wrapper |
+
+### ADR-011 — Declarative YAML control plane
+| Field | Value |
+|---|---|
+| Date | 2026-04-01 |
+| Status | **Accepted** |
+| Decision | Workflows, AgentDefs, Policies are YAML. YAML is compiled to WorkflowIR — never imported by Go services |
+| Why | Kubernetes analogy; GitOps; no programming language required for intent expression |
+| Code reflects? | ✅ Yes — `spec/` never imported by `services/`; `layer-boundaries` CI gate enforces this |
+
+### ADR-012 — Workflow IR
+| Field | Value |
+|---|---|
+| Date | 2026-04-01 |
+| Status | **Accepted** |
+| Decision | `WorkflowIR` protobuf message is the canonical engine-agnostic representation |
+| Why | Decouple intent (YAML) from execution (Temporal/LangGraph/Argo) |
+| Code reflects? | ✅ Yes — `workflow_compiler.proto` has structured IR fields (M2 additions) |
+| Notes | `bytes ir_payload` field 4 kept for backward-compat alongside structured fields; review recommends removing by v1.0 (ADR-012 should be updated) |
+
+### ADR-013 — Adapter-first, no mandatory SDK
+| Field | Value |
+|---|---|
+| Date | 2026-04-01 |
+| Status | **Accepted** |
+| Decision | Any system can become a capability by implementing `AgentService` gRPC — no SDK required |
+| Why | Low adoption friction; language-neutral; Option A (minimal SDK) later chosen for Python ergonomics |
+| Code reflects? | ✅ Yes — Python SDK (`agents/sdk/`) is optional helper, not a requirement |
+| Notes | Python SDK Agent base class implemented in #535 (M5.A BATCH 3) |
+
+### ADR-014 — Event-driven state machine model
+| Field | Value |
+|---|---|
+| Date | 2026-04-01 |
+| Status | **Accepted** |
+| Decision | Workflows are finite state machines (states + events + transitions), NOT DAGs |
+| Why | Loops, human-in-the-loop, long-running async workflows are natural; DAGs force workarounds |
+| Code reflects? | ✅ Yes — `WorkflowIR` proto uses `StateIR` + `TransitionIR`; `IRInterpreterWorkflow` implements FSM |
+| Event classification | CloudEvents are **Event Notification** type (not sourcing); NATS is the dumb pipe (see §17 of review) |
+
+### ADR-015 — Pluggable workflow engines
+| Field | Value |
+|---|---|
+| Date | 2026-04-01 |
+| Status | **Accepted** |
+| Decision | `WorkflowEngine` Go interface (6 methods) decouples gRPC layer from any engine |
+| Why | Temporal is v0 default; swap in LangGraph/Argo without rewriting dispatch logic |
+| Code reflects? | ✅ Yes — `services/engine-adapter/internal/domain/engine.go` has the 6-method interface; `TemporalEngine` is only implementation |
+| Notes | The review calls the `WorkflowEngine` interface one of the "crown jewels" — preserve it |
+
+### ADR-016 — Layered testing strategy
+| Field | Value |
+|---|---|
+| Date | 2026-04-21 |
+| Status | **Accepted** (supersedes ADR-004) |
+| Decision | Three tiers: (1) BDD at gRPC boundaries (`protos/tests/`); (2) unit ≥90% on `internal/domain/`; (3) `buf breaking` as CI gate |
+| Code reflects? | ✅ Yes — all services hit ≥90% domain coverage; 140+ BDD scenarios pass |
+
+### ADR-017 — Contract test isolation (GOWORK=off)
+| Field | Value |
+|---|---|
+| Date | 2026-04-21 |
+| Status | **Accepted** |
+| Decision | All `go test` and `go` commands in `services/*/` and `protos/tests/` require `GOWORK=off` |
+| Why | `go.work` references modules that don't exist in early milestones; workspace causes resolution failures |
+| Code reflects? | ✅ Yes — CI enforces this; AGENTS.md and CLAUDE.md document it |
+
+### ADR-018 — AI KB authorization model
+| Field | Value |
+|---|---|
+| Date | 2026-04-24 |
+| Status | **Accepted** |
+| Decision | Context files are Tier 1 (public-safe only); sensitive context in `canvas.private.md` (gitignored) |
+| Code reflects? | ✅ Yes — enforced by ADR-019 SPDD process |
+
+### ADR-019 — SPDD prompt governance
+| Field | Value |
+|---|---|
+| Date | 2026-04-30 |
+| Status | **Accepted** |
+| Decision | Every `feat:` PR requires a REASONS Canvas committed before any implementation; CI validates canvas before code |
+| Code reflects? | ✅ Yes — `validate-canvas` CI gate; 27 canvas directories in `docs/spdd/` |
+| Scope | `feat:` PRs only — `fix:/refactor:/docs:/ci:/chore:` are exempt |
+
+---
+
+## Pending ADRs (decisions made in practice; not yet formalized)
+
+### ADR-020 — Zero-trust intra-service security [PROPOSED]
+| Field | Value |
+|---|---|
+| Linked issue | [#240](https://github.com/zynax-io/zynax/issues/240) + [#488](https://github.com/zynax-io/zynax/issues/488) |
+| Decision (proposed) | All inter-service gRPC uses TLS-by-default; `ZYNAX_DEV_INSECURE=1` gates plain-text in dev |
+| Current state | ❌ All services use `insecure.NewCredentials()` — no TLS anywhere |
+| Priority | High (review §7) |
+
+### ADR-021 — Horizontal scale + multi-tenancy [PROPOSED]
+| Field | Value |
+|---|---|
+| Linked issue | [#578](https://github.com/zynax-io/zynax/issues/578) |
+| Decision (proposed) | Document operating model as "one Zynax cluster per Kubernetes namespace per tenant" until v1.x |
+| Current state | No multi-tenancy; `namespace` field cosmetic |
+| Priority | High (review §8) |
+
+---
+
+## Significant Scoped Decisions (docs/decisions/)
+
+| File | Decision | Still valid? |
+|---|---|---|
+| `001-engine-adapter-test-split.md` | Engine-adapter tests split from main CI for parallel execution | ✅ Yes |
+| `002-pr-size-900-limit.md` | PR size limit 900 LOC (with exclusions); above 400 requires justification | ✅ Yes |
+| `003-bufconn-for-contract-tests.md` | All BDD contract tests use in-memory bufconn (no network ports) | ✅ Yes |
+| `004-gowork-off-isolation.md` | cmd/zynax and cmd/zynax-ci are not in go.work; standalone modules | ✅ Yes |
+
+---
+
+## Architectural Directions from Review (not yet ADRs)
+
+### §17.1 — Single-engine via env var (current) vs multi-engine per-workflow
+**Current:** `ZYNAX_ENGINE` env var selects one engine globally.  
+**Review recommendation:** Keep single-engine through v1.0; add `engine_hint` per-workflow in v1.x.  
+**Status:** Still current; no action needed until second engine ships.
+
+### §17.2 — IR transport: bytes+structured vs pure structured
+**Current:** `ir_payload` bytes (field 4) kept alongside structured fields (M2).  
+**Review recommendation:** Remove `ir_payload` field 4 by v1.0.  
+**Status:** Proposed; tracked as part of ADR-012 update.
+
+### §17.3 — Agent dispatch: push (planned) vs pull vs event-driven
+**Current:** Engine-adapter → task-broker → agent push model planned.  
+**Review recommendation:** Push for v0.x; pull mode for LLM/Bedrock adapters in alternate mode.  
+**Status:** Proposed; warrants a new ADR when second dispatch mode is designed.
+
+### §17.4 — Multi-tenancy model
+**Review recommendation:** "one Zynax cluster per Kubernetes namespace per tenant" until v1.x.  
+**Status:** To be formalized in ADR-021.
+
+---
+
+## Rejected / Not-merged Directions
+
+These are preserved from closed-unmerged PRs and issue threads to avoid re-litigating:
+
+| Direction | Why rejected | Evidence |
+|---|---|---|
+| CNCF Sandbox Candidate badge in README | Premature — no adopters, no community | PR #472 removed it |
+| Phantom CHANGELOG entries (Helm charts, Argo engine, working SDK) | Inflated claims removed in truth-pass | PR #473 removed them |
+| Merge queue + `strict: false` | Merge queue caused complexity; reverted to `allow_auto_merge + strict: true` | Issue #544, #589 |
+| Python SDK as separate published package | Not yet ready; minimal Agent base class approach chosen | ADR-013 + #474 Option A decision |
+
+---
+
+*All ADR source files are in `docs/adr/ADR-NNN-*.md`. Decisions in this ledger that trace
+to code should be re-verified against HEAD before acting on them.*


### PR DESCRIPTION
## Summary

Adds the first two review artifacts from the 2026-05-21 architecture overhaul: a complete repo inventory and an ADR decision ledger verified against HEAD.

**Tracking issue:** [#624](https://github.com/zynax-io/zynax/issues/624)  
**Source review:** `docs/architecture/2026-05-20-principal-architect-review.md`  
**Stacked on:** independent — no dependency on other PRs

---

## Files added (~547 lines)

### `docs/reviews/00-inventory.md` (281 lines)

Complete repo map covering:
- 7 platform services with build status (✅/🟡/❌)
- 5 adapters (1 merged, 4 pending compose wiring #481)
- 14 CI workflow files with triggers and purpose
- All doc artifacts with line counts
- AI context census: 948/2,000 lines total (within advisory budget)
- 10 known discrepancies (D1–D10) that drove the overhaul

### `docs/reviews/01-decision-ledger.md` (266 lines)

All 19 ADRs (ADR-001 through ADR-019) with:
- Status (Accepted / Superseded)
- Code-reflects: evidence verified against HEAD (`git grep`, file paths, function names)
- Key code examples for each ADR
- Rejected directions (merge queue experiment, phantom CHANGELOG entries)
- Pending: ADR-020 (mTLS+cert-manager — filed separately in `docs/adr-020-021-pending` PR) and ADR-021 (Postgres repos — same PR)

---

## Why these two files together

They are the "as-is" baseline artifacts: what exists in the repo and what decisions govern it. Reviewers reading the rest of the overhaul PRs start here.

## Test plan

- [ ] `docs/reviews/00-inventory.md` renders correctly in GitHub Markdown
- [ ] All issue links in `01-decision-ledger.md` resolve to open/closed issues
- [ ] CI passes (docs only — lint/test lanes skip)