### PR TITLE
docs: add Go, Python, and Dockerfile engineering best practices

### DIFF
--- a/docs/engineering/best-practices/dockerfiles.md
+++ b/docs/engineering/best-practices/dockerfiles.md
@@ -1,0 +1,171 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Dockerfile Best Practices — Zynax
+
+> Scope: `infra/docker/Dockerfile.*`, service Dockerfiles  
+> Enforcement: `trivy` scan in release pipeline (#565); reviewed in PR
+
+---
+
+## Multi-stage Build Template (Go service)
+
+```dockerfile
+# ─── Stage 1: Build ─────────────────────────────────────────────────────────
+FROM golang:1.26.3-alpine AS builder
+
+# Use build cache mounts — dramatically speeds up rebuilds
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/go/pkg/mod \
+    true
+
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN --mount=type=cache,target=/go/pkg/mod go mod download
+
+COPY . .
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/go/pkg/mod \
+    CGO_ENABLED=0 GOOS=linux go build \
+      -trimpath \
+      -ldflags="-s -w -X main.version=${VERSION}" \
+      -o /out/service ./cmd/service/
+
+# ─── Stage 2: Runtime ────────────────────────────────────────────────────────
+FROM gcr.io/distroless/static-debian12:nonroot
+
+# OCI image labels (SLSA provenance when cosign is added)
+LABEL org.opencontainers.image.title="zynax-<service>"
+LABEL org.opencontainers.image.source="https://github.com/zynax-io/zynax"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+
+COPY --from=builder /out/service /service
+
+# Non-root user (nonroot = uid 65532 on distroless)
+USER nonroot:nonroot
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD ["/service", "--healthcheck"]
+
+EXPOSE 50051
+
+ENTRYPOINT ["/service"]
+```
+
+**Key rules:**
+1. **Multi-stage** — build stage discarded; only binary in final image
+2. **Pin base image by tag** (1.26.3-alpine) — Renovate keeps this updated
+3. **`CGO_ENABLED=0 -trimpath`** — reproducible static binary
+4. **Distroless or Alpine final** — no shell, no package manager in production image
+5. **Non-root user** — `nonroot` on distroless, `zynax` (uid 1001) on Alpine variants
+6. **HEALTHCHECK** — required for container orchestrators (#463)
+7. **OCI labels** — machine-readable metadata for SBOM and provenance
+
+---
+
+## Current Pattern (Alpine final)
+
+The current service Dockerfiles use Alpine as the final stage (not distroless) with a
+dedicated `zynax` user:
+
+```dockerfile
+FROM alpine:3.21 AS runtime
+RUN addgroup -S zynax && adduser -S zynax -G zynax
+USER zynax
+```
+
+This is acceptable for now. The distroless migration is recommended for M6 when SBOM
+and cosign are added (smaller attack surface, no package manager).
+
+---
+
+## .dockerignore
+
+```
+.git/
+docs/
+*.md
+*.yaml        # include only what the Dockerfile COPYs
+infra/
+spec/
+tools/
+```
+
+A tight `.dockerignore` prevents the build context from including unnecessary files,
+reducing build time and preventing accidental secret leakage from `.env` files.
+
+---
+
+## No Secrets in Layers
+
+```dockerfile
+# ❌ NEVER — secret baked into layer history
+ENV AWS_SECRET_ACCESS_KEY=abc123
+
+# ✅ Inject secrets at runtime via environment variables or secrets mounts
+RUN --mount=type=secret,id=api_key cat /run/secrets/api_key
+```
+
+Trivy and gitleaks scan for secrets in image layers. Any hardcoded secret in a layer
+fails the release pipeline.
+
+---
+
+## Go Builder Toolchain Alignment
+
+The Go builder stage must use the same Go version as `go.work`:
+
+```
+go.work: go 1.26.3          (source of truth)
+Dockerfile: golang:1.26.3-alpine   (must match)
+```
+
+Mismatches cause `GOTOOLCHAIN=local` errors and silent build failures (#601 fixed this).
+
+---
+
+## HEALTHCHECK
+
+Every service Dockerfile must include a HEALTHCHECK. Current services are missing this
+(tracked by #463 / canvas `docs/spdd/463-health-probes/canvas.md`).
+
+```dockerfile
+# For gRPC services, use grpc_health_probe (available in ci-runner and tools images)
+HEALTHCHECK --interval=15s --timeout=5s --start-period=15s \
+    CMD ["/usr/local/bin/grpc_health_probe", "-addr=:50051"] || exit 1
+
+# For HTTP services, curl or wget
+HEALTHCHECK --interval=15s --timeout=5s \
+    CMD wget -qO- http://localhost:7080/healthz || exit 1
+```
+
+---
+
+## Pinning Tool Versions in Dockerfile.tools
+
+`infra/docker/Dockerfile.tools` must pin every tool version:
+
+```dockerfile
+ARG GOLANGCI_LINT_VERSION=1.62.2
+ARG BUF_VERSION=1.47.2
+ARG GOVULNCHECK_VERSION=v1.1.3
+
+RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCI_LINT_VERSION}
+```
+
+- Never use `@latest` — Renovate manages version bumps via PR
+- Renovate's `regexManagers` watches these ARG lines for update PRs
+
+---
+
+## Anti-patterns
+
+| Anti-pattern | Correct approach |
+|---|---|
+| `RUN apt-get install …` in final stage | Use multi-stage; install in builder only |
+| `ADD` instead of `COPY` for local files | Use `COPY` unless you need URL fetch or auto-extract |
+| Single-stage build | Always multi-stage for Go/Python services |
+| No `.dockerignore` | Always have `.dockerignore` that excludes `.git`, `docs/`, local dev files |
+| `golang:1.22-alpine` with `go 1.26.3` in go.mod | Pin base image to match `go.work` toolchain version |
+| GOPATH `/root/go/bin/` on Alpine | Use `/go/bin/` — Alpine GOPATH is `/go`, not `/root/go` |
+| `USER root` in final stage | Use dedicated non-root user |
+| No HEALTHCHECK | All services must have HEALTHCHECK for Compose + K8s probes |

--- a/docs/engineering/best-practices/go.md
+++ b/docs/engineering/best-practices/go.md
@@ -1,0 +1,210 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Go Best Practices — Zynax Platform Services
+
+> Scope: `services/*/`, `cmd/zynax/`, `cmd/zynax-ci/`  
+> Enforcement: `golangci-lint` (`.golangci.yml`), `make lint test`
+
+---
+
+## Service Layout
+
+Every service follows the hexagonal structure:
+```
+services/<service>/
+  internal/
+    api/           ← gRPC handler (delegates to domain; no business logic)
+    domain/        ← business logic (ZERO proto/gRPC/Temporal imports)
+    infrastructure/ ← concrete adapters (DB, gRPC clients, Temporal SDK)
+  cmd/<service>/   ← main.go: wire dependencies and start server
+```
+
+**Rule:** `internal/domain/` must have zero imports from `google.golang.org/grpc`,
+`go.temporal.io/`, or any `proto` package. The `layer-boundaries` CI gate enforces this.
+
+---
+
+## Context Propagation
+
+```go
+// ✅ Always thread context through the call stack
+func (s *Service) Dispatch(ctx context.Context, req *Request) (*Response, error) {
+    ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+    defer cancel()
+    return s.repo.FindByCapability(ctx, req.Capability)
+}
+
+// ❌ Never use context.Background() for request-scoped work
+go func() {
+    s.executeAsync(context.Background(), task) // loses request-ID, tracing, cancellation
+}()
+```
+
+For long-running goroutines spawned from a request context, derive a detached context with
+a fresh cancel — do not carry the HTTP/gRPC deadline, but DO carry the request-ID via
+`metadata.NewOutgoingContext` or similar. See #570.
+
+---
+
+## Error Handling
+
+```go
+// ✅ Wrap errors with %w so callers can inspect
+if err := s.store.Save(ctx, ir); err != nil {
+    return nil, fmt.Errorf("save workflow IR %s: %w", ir.WorkflowId, err)
+}
+
+// ✅ Use typed sentinel errors at domain boundaries
+var ErrNotFound = errors.New("not found")
+
+// ❌ Never discard errors
+_ = conn.Close()          // ❌
+defer conn.Close()         // ✅ (log if error matters)
+```
+
+Map domain errors to gRPC status codes in the `api/` layer only — never in `domain/`.
+
+---
+
+## gRPC Service Implementation
+
+```go
+// ✅ Return codes, not panics
+func (s *Server) GetWorkflowStatus(ctx context.Context, req *pb.GetWorkflowStatusRequest) (*pb.GetWorkflowStatusResponse, error) {
+    if req.WorkflowId == "" {
+        return nil, status.Error(codes.InvalidArgument, "workflow_id required")
+    }
+    state, err := s.engine.GetWorkflowStatus(ctx, domain.ExecutionID(req.WorkflowId))
+    if errors.Is(err, domain.ErrNotFound) {
+        return nil, status.Error(codes.NotFound, "workflow not found")
+    }
+    if err != nil {
+        return nil, status.Errorf(codes.Internal, "get status: %v", err)
+    }
+    return mapToProto(state), nil
+}
+```
+
+---
+
+## Constant-Time Secret Comparison
+
+```go
+// ✅ Use crypto/subtle for all bearer-token comparisons
+import "crypto/subtle"
+
+want := []byte("Bearer " + key)
+got  := []byte(r.Header.Get("Authorization"))
+if subtle.ConstantTimeCompare(want, got) != 1 {
+    writeError(w, http.StatusUnauthorized, "unauthorized", "UNAUTHORIZED")
+    return
+}
+```
+
+See #567. Never use `==` or `!=` for secret comparison.
+
+---
+
+## HTTP Server Hardening
+
+```go
+// ✅ Always set ReadHeaderTimeout to prevent Slowloris attacks
+srv := &http.Server{
+    Addr:              addr,
+    Handler:           mux,
+    ReadHeaderTimeout: 5 * time.Second,
+    ReadTimeout:       30 * time.Second,
+    WriteTimeout:      60 * time.Second,
+    IdleTimeout:       120 * time.Second,
+}
+```
+
+See #568. Without `ReadHeaderTimeout`, the server is vulnerable to Slowloris.
+
+---
+
+## Logging
+
+```go
+// ✅ Use log/slog with structured fields
+slog.InfoContext(ctx, "workflow submitted",
+    slog.String("workflow_id", id),
+    slog.String("engine",      engine),
+)
+
+// ❌ No fmt.Println, no log.Printf in production code
+// ❌ Never log secrets, tokens, or PII
+```
+
+---
+
+## Table-Driven Tests + Race Detector
+
+```go
+func TestDispatch(t *testing.T) {
+    tests := []struct {
+        name       string
+        capability string
+        wantErr    bool
+    }{
+        {"found", "summarize", false},
+        {"not found", "nonexistent", true},
+    }
+    for _, tc := range tests {
+        t.Run(tc.name, func(t *testing.T) {
+            // ...
+        })
+    }
+}
+```
+
+Always run `GOWORK=off go test ./... -race -timeout 60s` in service directories.
+The `-race` flag is required; CI enforces it.
+
+---
+
+## gRPC Client Deadlines
+
+```go
+// ✅ Always set a deadline on outgoing gRPC calls
+ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+defer cancel()
+resp, err := client.CompileWorkflow(ctx, req)
+```
+
+No `context.Background()` without a timeout on any outgoing gRPC call.
+
+---
+
+## Shared Interceptors
+
+gRPC interceptor boilerplate (logging, tracing, recovery) is copy-pasted across services today.
+**When extracting a shared helper:**
+- Put it in `pkg/grpcmw/` (internal to this module, not exported)
+- ADR-008 "no shared DB" does not prohibit shared utility packages — the rule is about
+  data stores and domain types, not helpers
+
+Tracked by Phase 5 standards / review §5.2.
+
+---
+
+## Generated Code
+
+Generated code lives in `gen/go/zynax/v1/` and `protos/generated/python/`.
+- **Never edit generated files by hand.** Run `make generate-protos`.
+- Generated files are committed to the repository.
+- CI verifies freshness via the `stubs-freshness` gate.
+
+---
+
+## Key linter rules (`.golangci.yml`)
+
+| Linter | Rule |
+|---|---|
+| `errcheck` | Every error must be checked |
+| `govet` | All vet checks |
+| `staticcheck` | SA + ST checks |
+| `gosec` | Security-focused checks (hardcoded secrets, weak crypto) |
+| `goconst` | Repeated strings ≥ 3 occurrences must be constants |
+| `funlen` | Functions ≤ 60 lines (suppress with `//nolint:funlen // reason`) |
+| `goconst` | Suppressed in test files via `ignore-tests: true` |

--- a/docs/engineering/best-practices/python.md
+++ b/docs/engineering/best-practices/python.md
@@ -1,0 +1,194 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Python Best Practices — Zynax Adapters and SDK
+
+> Scope: `agents/sdk/`, `agents/adapters/`  
+> Enforcement: `ruff` (lint+format), `mypy --strict`, `bandit` (SAST), `pip-audit`
+> Run via `make lint security` (all inside Docker)
+
+---
+
+## Project Setup
+
+All Python projects use `uv` (ADR-003). Each adapter has its own `pyproject.toml` and
+`uv.lock`.
+
+```toml
+# pyproject.toml
+[project]
+name = "zynax-llm-adapter"
+requires-python = ">=3.12"
+dependencies = [
+    "grpcio>=1.63",
+    "grpcio-tools>=1.63",
+    "pydantic-settings>=2.0",
+    "openai>=1.0",          # example: llm-adapter
+]
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "S", "B", "ANN"]
+
+[tool.mypy]
+strict = true
+```
+
+---
+
+## Type Hints (mypy --strict)
+
+```python
+# ✅ Full type hints on all public functions
+from typing import AsyncIterator
+import grpc
+
+async def execute(
+    self,
+    request: TaskRequest,
+    context: grpc.aio.ServicerContext,
+) -> AsyncIterator[TaskEvent]:
+    ...
+
+# ❌ Bare Any or missing annotations will fail mypy --strict
+```
+
+---
+
+## Agent Base Class (zynax-sdk)
+
+Use the `Agent` base class from `agents/sdk/` for all Python adapters:
+
+```python
+from zynax_sdk import Agent, capability
+
+class LLMAdapter(Agent):
+    @capability("chat_completion")
+    async def chat(self, request: CapabilityRequest) -> AsyncIterator[TaskEvent]:
+        # Implementation
+        yield TaskEvent(type=TaskEventType.PROGRESS, ...)
+        yield TaskEvent(type=TaskEventType.COMPLETED, result=result)
+```
+
+The `@capability` decorator registers the handler with the gRPC `AgentService`.
+Use `async` generators for streaming responses — `PROGRESS` events during generation,
+`COMPLETED` on finish.
+
+---
+
+## Configuration (Pydantic Settings — ADR-007)
+
+```python
+from pydantic_settings import BaseSettings
+
+class LLMConfig(BaseSettings):
+    api_key: str                    # required — no default, fails fast if missing
+    model: str = "gpt-4o"           # overridable via LLM_MODEL env var
+    registry_addr: str = "agent-registry:50057"
+
+    model_config = {"env_prefix": "LLM_"}
+
+# Usage: config = LLMConfig()  # reads from environment
+```
+
+**Rules:**
+- Never hardcode API keys, model names, or service addresses
+- All config from environment variables (12-Factor)
+- Use `env_prefix` to namespace vars per adapter
+- Fail fast at startup if required vars are missing
+
+---
+
+## gRPC Patterns
+
+```python
+# ✅ Always use async gRPC (grpc.aio)
+import grpc.aio
+
+async def run() -> None:
+    server = grpc.aio.server()
+    add_AgentServiceServicer_to_server(adapter, server)
+    server.add_insecure_port(f"[::]:{config.grpc_port}")
+    await server.start()
+    await server.wait_for_termination()
+
+# ✅ Use context managers for gRPC channels
+async with grpc.aio.insecure_channel(registry_addr) as channel:
+    stub = AgentRegistryStub(channel)
+    await stub.RegisterAgent(request)
+```
+
+Never call platform services via HTTP — always use gRPC stubs from
+`protos/generated/python/`. See ADR-001.
+
+---
+
+## Security (bandit)
+
+```python
+# ✅ Never log secrets
+logger.info("registered adapter", extra={"capability": cap_name})
+# ❌ Never: logger.info(f"API key: {config.api_key}")
+
+# ✅ Use subprocess with explicit args list (not shell=True)
+result = subprocess.run(["git", "clone", url], capture_output=True)
+
+# ✅ Validate URLs before making requests (SSRF prevention)
+from urllib.parse import urlparse
+parsed = urlparse(url)
+if parsed.scheme not in ("https",):
+    raise ValueError(f"unsafe URL scheme: {parsed.scheme}")
+```
+
+Run `bandit -r agents/` (via `make security`) to catch SAST issues.
+
+---
+
+## I/O Resource Management
+
+```python
+# ✅ Use context managers or try/finally
+async with aiofiles.open(path) as f:
+    content = await f.read()
+
+# ✅ Clean up gRPC channels
+try:
+    async with grpc.aio.insecure_channel(addr) as channel:
+        ...
+finally:
+    # channel closed automatically
+    pass
+```
+
+---
+
+## Testing
+
+```python
+# ✅ Use pytest + pytest-asyncio for async tests
+import pytest
+
+@pytest.mark.asyncio
+async def test_chat_capability() -> None:
+    adapter = LLMAdapter(config=MockConfig())
+    events = [e async for e in adapter.chat(mock_request)]
+    assert events[-1].type == TaskEventType.COMPLETED
+
+# ✅ Mock external API calls, not gRPC stubs
+@pytest.fixture
+def mock_openai(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("openai.AsyncOpenAI", MockOpenAI)
+```
+
+Coverage target: ≥ 85% for adapters (same spirit as Go's 90% domain target).
+
+---
+
+## Key tool versions (pinned in ci-runner image)
+
+| Tool | Purpose | Pin |
+|---|---|---|
+| `ruff` | Lint + format | via `pyproject.toml` |
+| `mypy` | Static type checking | via `pyproject.toml` |
+| `bandit` | SAST security scanner | via CI |
+| `pip-audit` | Dependency CVE check | via CI |
+| `pytest` + `pytest-asyncio` | Test runner | via `pyproject.toml` |
+| `uv` | Package manager (ADR-003) | Pinned in `Dockerfile.ci-runner` |


### PR DESCRIPTION
## Summary

Adds three engineering best-practices reference files under
`docs/engineering/best-practices/`. These canonicalise the implicit standards
already followed in the codebase so that both human contributors and AI
assistants have an authoritative reference, reducing review churn.

**PR series context:**
| PR | Branch | What |
|----|--------|------|
| #627 | `ci/fix-lint-proto-ai-context-step` | CI fix — must merge first |
| #628 | `docs/truth-pass-core-docs` | Core truth pass |
| #629 | `docs/review-inventory-ledger` | Review 1/4 |
| #630 | `docs/review-reality-gaps` | Review 2/4 |
| #631 | `docs/review-action-plan-m5` | Review 3/4 |
| **This PR** | `docs/best-practices-go-python-docker` | **Best practices 1/2 — Go/Python/Docker** |
| Next | `docs/best-practices-ci-arch-kb` | Best practices 2/2 |
| Next | `docs/adr-020-021-pending` | ADR-020 (mTLS) + ADR-021 (Postgres) |

## Files changed (3 files, ~575 lines)

- **`docs/engineering/best-practices/go.md`** — Go service patterns: hexagonal layout, error wrapping, context propagation, function size limits (≤30 lines), no `panic` in production, `GOWORK=off` enforcement, testing tiers
- **`docs/engineering/best-practices/python.md`** — Python agent patterns: Pydantic settings, gRPC-only platform calls, no hardcoded LLM model names, context managers, BDD steps
- **`docs/engineering/best-practices/dockerfiles.md`** — Dockerfile standards: multi-stage builds, distroless base images, non-root UIDs, COPY paths on Alpine (`/go/bin/` not `/root/go/bin/`), layer caching, health-check conventions

## Why now

The 2026-05-20 external architecture review (`docs/reviews/04-architecture-gaps.md`)
identified the absence of written engineering standards as gap G18. These files
close that gap and are linked from `AGENTS.md` knowledge-base index (PR #632 adds
the links alongside `CLAUDE.md` updates).

## Related issues

Related: #624 (arch overhaul tracking issue)

## Test plan

- [ ] All three files render correctly as Markdown
- [ ] No placeholder or TODO content left in files
- [ ] `AGENTS.md` knowledge-base index will reference these files (in follow-up PR)