### PR TITLE
docs: add ADR-020 (mTLS) and ADR-021 (Postgres repositories)

### DIFF
--- a/docs/adr/ADR-020-zero-trust-auth.md
+++ b/docs/adr/ADR-020-zero-trust-auth.md
@@ -1,0 +1,143 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# ADR-020: mTLS with cert-manager for Inter-Service gRPC Authentication
+
+**Status:** Accepted  **Date:** 2026-05-21  
+**Related:** ADR-001 (gRPC-first), ADR-009 (Go services), ADR-016 (Layered Testing)  
+**Issues:** [#240](https://github.com/zynax-io/zynax/issues/240) (ADR authoring) · [#488](https://github.com/zynax-io/zynax/issues/488) (implementation)  
+**Milestone:** M6 — K8s Production-Ready
+
+---
+
+## Context
+
+Today, all inter-service gRPC communication in Zynax is **unauthenticated**. Any process
+co-located in the same Docker network (or Kubernetes namespace) can call any service's
+gRPC endpoint without presenting credentials. This is acceptable for local development
+but is a critical gap for production K8s deployment (M6).
+
+The 2026-05-20 principal architect review rated this as gap **H3** (High) in
+`docs/reviews/04-architecture-gaps.md`. The gap was elevated to a blocking concern
+for M6 because:
+
+1. Zynax will run in a shared K8s cluster where other pods could call platform services.
+2. api-gateway bearer-token auth protects the external boundary but not the internal mesh.
+3. CNCF Sandbox submission (M8) requires documented inter-service authentication.
+
+Three options were considered:
+- **Option A — mTLS with cert-manager** (selected)
+- **Option B — SPIFFE/SPIRE workload identity**
+- **Option C — Shared API key / service-account tokens**
+
+---
+
+## Decision
+
+**Adopt mutual TLS (mTLS) for all inter-service gRPC calls in Kubernetes, managed by cert-manager.**
+
+### What mTLS provides
+
+- Each service presents a certificate during the TLS handshake; the peer verifies it.
+- Certificates are issued by cert-manager's `ClusterIssuer` (self-signed CA for M6;
+  Let's Encrypt or Vault for M7+).
+- Per-service identity is encoded in certificate SANs (e.g. `workflow-compiler.zynax.svc`).
+- No additional API call or token rotation needed — TLS handles authentication.
+
+### Scope
+
+| Environment | Authentication |
+|-------------|----------------|
+| Kubernetes (M6+) | mTLS enforced on all inter-service gRPC |
+| Docker Compose (local dev) | Insecure gRPC (no TLS) — dev convenience |
+| CI/test environment | Insecure gRPC with bufconn in-process transport |
+
+### Implementation approach
+
+```go
+// Each service loads TLS credentials from cert-manager-issued files:
+creds, err := credentials.NewClientTLSFromFile(cfg.TLSCertPath, "")
+conn, err := grpc.Dial(addr, grpc.WithTransportCredentials(creds))
+
+// Server-side:
+creds, err := credentials.NewServerTLSFromFile(cfg.TLSCertPath, cfg.TLSKeyPath)
+server := grpc.NewServer(grpc.Creds(creds))
+```
+
+Configuration via environment variables:
+- `ZYNAX_TLS_CERT_PATH` — path to service certificate (PEM)
+- `ZYNAX_TLS_KEY_PATH` — path to private key (PEM)
+- `ZYNAX_TLS_CA_PATH` — path to CA certificate for peer verification
+- `ZYNAX_TLS_ENABLED` — `true` in K8s, unset/`false` in Docker Compose
+
+### cert-manager setup
+
+```yaml
+# ClusterIssuer (self-signed for M6)
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: zynax-internal-ca
+spec:
+  selfSigned: {}
+
+# Certificate per service (example: workflow-compiler)
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: workflow-compiler-tls
+  namespace: zynax
+spec:
+  secretName: workflow-compiler-tls
+  issuerRef:
+    name: zynax-internal-ca
+    kind: ClusterIssuer
+  dnsNames:
+    - workflow-compiler.<namespace>.svc  # short-form in-cluster DNS
+```
+
+---
+
+## Consequences
+
+### Positive
+- Per-service identity without shared secrets or token rotation
+- cert-manager handles certificate renewal automatically
+- Standard K8s pattern — any platform engineer can operate it
+- Compatible with service mesh (Istio/Linkerd) if adopted in M8
+
+### Negative / Trade-offs
+- cert-manager is a new cluster dependency (Helm chart required)
+- Local Docker Compose stays insecure — developers must be aware of this gap
+- Integration tests must stub TLS credentials or use bufconn (no network TLS)
+
+### Deferred
+- SPIFFE/SPIRE: deferred until CNCF Sandbox (M8). mTLS with cert-manager satisfies
+  the M6 security requirement. SPIFFE adds workload federation across clusters,
+  which is only relevant post-Sandbox.
+- Let's Encrypt / Vault CA: upgrade from self-signed in M7 when external clients
+  need to verify service certificates.
+
+---
+
+## Rejected Alternatives
+
+### Option B — SPIFFE/SPIRE workload identity
+
+SPIFFE provides platform-independent workload identity (SVIDs), which are useful when
+services run across multiple clusters or clouds. However:
+- Adds SPIRE server + node agents as K8s dependencies
+- Adds ~2–3 weeks of implementation + operational complexity
+- Not necessary for M6 (single-cluster deployment)
+
+Deferred to M8 CNCF Sandbox evaluation.
+
+### Option C — Shared API key / service-account tokens
+
+Shared secrets do not provide per-service identity. Key rotation is manual.
+A compromised service exposes all others. Not acceptable for a platform targeting
+production workloads. Suitable only as a stepping stone (already done for external
+auth via ZYNAX_GW_API_KEY).
+
+---
+
+*See also: `docs/reviews/04-architecture-gaps.md §H3` · `docs/reviews/DECISIONS-NEEDED.md §D2`*

--- a/docs/adr/ADR-021-horizontal-scale.md
+++ b/docs/adr/ADR-021-horizontal-scale.md
@@ -1,0 +1,164 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# ADR-021: Postgres-Backed Repositories for Horizontal Scaling (M6)
+
+**Status:** Accepted  **Date:** 2026-05-21  
+**Related:** ADR-001 (gRPC-first), ADR-009 (Go services), ADR-016 (Layered Testing)  
+**Issues:** [#578](https://github.com/zynax-io/zynax/issues/578) (ADR authoring) · [#626](https://github.com/zynax-io/zynax/issues/626) (M6.H epic)  
+**Milestone:** M6 — K8s Production-Ready
+
+---
+
+## Context
+
+Zynax's task-broker and agent-registry use **in-memory repositories** for M5. Each service
+holds state in a Go struct with a mutex. This is acceptable for a single-replica MVP but
+blocks horizontal scaling:
+
+- Multiple replicas of task-broker would each hold a disjoint view of tasks.
+- Multiple replicas of agent-registry would each hold a disjoint agent list.
+- A replica restart loses all in-flight state.
+
+The 2026-05-20 principal architect review rated this as risk **R4** (High) and
+gap **H1** in `docs/reviews/04-architecture-gaps.md`.
+
+Three options were considered for M6:
+- **Option A — Single replica, defer persistence** (acceptable for M5, not M6)
+- **Option B — Redis-backed repositories**
+- **Option C — Postgres-backed repositories** (selected)
+
+The decision was made 2026-05-21 (`docs/reviews/DECISIONS-NEEDED.md §D3`).
+
+---
+
+## Decision
+
+**Switch task-broker and agent-registry from in-memory to Postgres-backed repositories in M6.**
+
+### Rationale
+
+1. **ACID guarantees** — task state transitions require atomicity (claim a task,
+   update status). Postgres transactions provide this; Redis requires Lua scripts.
+2. **Queryable history** — completed tasks and agent heartbeat history are queryable
+   for debugging and analytics. Redis has limited query capabilities.
+3. **Front-loaded work** — Postgres is required before CNCF Sandbox (M8) regardless.
+   Shipping in M6 alongside K8s deployment avoids a mid-Sandbox migration.
+4. **Existing patterns** — Zynax uses Temporal (Postgres-backed) and NATS JetStream
+   (file-backed) already. Adding Postgres is an operational pattern engineers already
+   manage.
+
+### Hexagonal architecture (ports & adapters)
+
+The repository port is **unchanged**. Only the infrastructure adapter changes:
+
+```
+services/<service>/internal/
+  domain/
+    repository.go          ← port interface (unchanged)
+  infrastructure/
+    memory/
+      repository.go        ← retained as test double (not removed)
+    postgres/
+      repository.go        ← NEW — implements domain port via pgx/v5
+      migrations/
+        001_initial.sql    ← schema
+```
+
+**The domain layer has zero knowledge of Postgres.** The adapter is injected at startup:
+
+```go
+// main.go (simplified)
+var repo domain.TaskRepository
+if cfg.DBEnabled {
+    repo = postgres.NewTaskRepository(db)
+} else {
+    repo = memory.NewTaskRepository() // test / local mode
+}
+```
+
+### Services affected
+
+| Service | Repository | Table |
+|---------|-----------|-------|
+| task-broker | `TaskRepository` | `tasks` |
+| agent-registry | `AgentRepository` | `agents`, `heartbeats` |
+
+### Postgres provisioning
+
+**Docker Compose:** Add `postgres:16-alpine` container alongside Temporal/NATS.
+**Kubernetes:** Bitnami Postgres Helm chart (M6); migrate to Postgres Operator (M7+).
+
+Environment variables:
+- `ZYNAX_DB_DSN` — Postgres connection string (e.g. `postgres://zynax:pwd@localhost:5432/zynax`)
+- `ZYNAX_DB_ENABLED` — `true` in K8s and compose, unset/`false` in unit tests
+
+### Migration strategy
+
+Migrations run at service startup via `golang-migrate/migrate` (same tool Temporal uses).
+Each service owns its own schema — no shared tables (ADR-001).
+
+```go
+// Startup migration (each service)
+m, _ := migrate.NewWithDatabaseInstance("file://migrations", "postgres", driver)
+if err := m.Up(); err != nil && err != migrate.ErrNoChange {
+    log.Fatal("migration failed", err)
+}
+```
+
+### Testing
+
+- **Unit tests:** inject `memory.TaskRepository` — no DB required (existing pattern)
+- **Integration tests:** spin up Postgres via `testcontainers-go` with `//go:build integration` tag
+- **CI:** integration tests run in `test-integration` job (already exists, currently skipped — see #227)
+
+---
+
+## Consequences
+
+### Positive
+- Horizontal scaling: task-broker and agent-registry can run N replicas
+- Durable state across restarts (no lost in-flight tasks)
+- Queryable task history for debugging
+- Satisfies CNCF Sandbox data durability requirement
+- In-memory adapter retained as fast test double
+
+### Negative / Trade-offs
+- Postgres is a new runtime dependency (docker-compose and K8s Helm chart)
+- Migration management adds ~50 LoC per service
+- Integration test infrastructure requires testcontainers (Docker in CI)
+- Adds ~4–5 weeks to M6 scope
+
+### Scale target (M6)
+
+| Service | M6 replicas | Horizontal scale? |
+|---------|-------------|-------------------|
+| api-gateway | 2+ | ✅ Stateless already |
+| workflow-compiler | 2+ | ✅ After #466 (stateless compiler) |
+| engine-adapter | 1 | ⚠ Temporal handles fan-out |
+| task-broker | 2+ | ✅ With Postgres repo |
+| agent-registry | 2+ | ✅ With Postgres repo |
+
+---
+
+## Rejected Alternatives
+
+### Option A — Single replica, defer persistence (M7)
+
+Deferred persistence would block horizontal scaling until M7, adding risk to CNCF
+Sandbox (M8). In-memory state under load is risk R4 from the 2026-05-20 review.
+Acceptable for M5 (already shipped); not acceptable for a production K8s release.
+
+### Option B — Redis-backed repositories
+
+Redis provides fast key-value storage with TTL support. However:
+- No ACID transactions without Lua scripts (error-prone for task state machines)
+- Limited query capability for task history
+- Adds a second caching layer alongside the in-memory adapter (confusing to operators)
+- Postgres is required in M8 regardless; Redis would be a stepping stone only
+
+Redis remains an option for **caching** (e.g. compiled workflow IR cache in
+workflow-compiler — see #466) but not for primary task/agent state.
+
+---
+
+*See also: `docs/reviews/04-architecture-gaps.md §H1/R4` · `docs/reviews/DECISIONS-NEEDED.md §D3`*

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -30,6 +30,8 @@ a PR against `docs/adr/`.
 | [ADR-017](ADR-017-contract-test-isolation.md) | Contract test isolation — GOWORK=off | Accepted | 2026-04-21 | `protos/tests/`, `services/*/` — all `go test` invocations |
 | [ADR-018](ADR-018-ai-kb-authorization-model.md) | AI knowledge base authorization model | Accepted | 2026-04-24 | `CLAUDE.md`, `AGENTS.md`, `.ai/`, `.claude/` — KB paths |
 | [ADR-019](ADR-019-spdd-prompt-governance.md) | Structured Prompt-Driven Development (SPDD) | Accepted | 2026-04-30 | `feat:` PRs — Canvas before code, `docs/spdd/`, slash commands |
+| [ADR-020](ADR-020-zero-trust-auth.md) | mTLS with cert-manager for inter-service gRPC auth | Accepted | 2026-05-21 | All inter-service gRPC in K8s — #240 #488 |
+| [ADR-021](ADR-021-horizontal-scale.md) | Postgres-backed repositories for horizontal scaling | Accepted | 2026-05-21 | task-broker + agent-registry repos — #578 #626 |
 
 ---
 


### PR DESCRIPTION
## Summary

Records two architectural decisions made during the 2026-05-20 principal
architect review as formal ADRs. Both are accepted and binding for M6. Both
were resolved via interactive decision process documented in
`docs/reviews/DECISIONS-NEEDED.md` (D2 and D3).

## Decisions recorded

### ADR-020 — mTLS with cert-manager for inter-service gRPC (D2)

Closes gap **H3** from `docs/reviews/04-architecture-gaps.md`: all inter-service
gRPC is currently unauthenticated. Decision: enforce mutual TLS in Kubernetes
via cert-manager `ClusterIssuer`; Docker Compose and CI remain on insecure gRPC
(developer convenience + bufconn test transport).

- Env vars: `ZYNAX_TLS_CERT_PATH`, `ZYNAX_TLS_KEY_PATH`, `ZYNAX_TLS_CA_PATH`, `ZYNAX_TLS_ENABLED`
- cert-manager Certificate example using short-form in-cluster DNS (`<svc>.<ns>.svc`)
- M6: self-signed CA; M7+: Let's Encrypt or Vault
- Rejected: SPIFFE/SPIRE (deferred M8), shared API keys (no per-service identity)
- Related issues: [#240](https://github.com/zynax-io/zynax/issues/240) (ADR authoring) · [#488](https://github.com/zynax-io/zynax/issues/488) (implementation)

### ADR-021 — Postgres-backed repositories for horizontal scaling (D3)

Closes risk **R4/H1** from `docs/reviews/04-architecture-gaps.md`: in-memory
repositories in task-broker and agent-registry block horizontal scaling and lose
state on restart. Decision: implement hexagonal `infrastructure/postgres/`
adapters using pgx/v5; in-memory adapter retained as test double.

- Env vars: `ZYNAX_DB_DSN`, `ZYNAX_DB_ENABLED`
- Migrations via `golang-migrate/migrate` at service startup
- Integration tests via `testcontainers-go` with `//go:build integration` tag
- Rejected: Redis (no ACID transactions), single-replica deferral (R4 risk)
- Related issues: [#578](https://github.com/zynax-io/zynax/issues/578) (ADR authoring) · [#626](https://github.com/zynax-io/zynax/issues/626) (M6.H epic)

## Files changed (3 files, ~309 lines)

- **`docs/adr/ADR-020-zero-trust-auth.md`** — New ADR (Status: Accepted)
- **`docs/adr/ADR-021-horizontal-scale.md`** — New ADR (Status: Accepted)
- **`docs/adr/INDEX.md`** — Two new entries added (ADR-020, ADR-021)

## Relationship to other PRs

This PR is **independent** — it can merge in any order relative to #628–#633.
It does not modify any implementation files, only documentation.

## Related issues

Closes #240  
Closes #578  
Related: #488 #626 #624

## Test plan

- [ ] ADR-020 and ADR-021 render correctly in GitHub Markdown
- [ ] `docs/adr/INDEX.md` shows both new entries with correct links and dates
- [ ] No `.cluster.local` or other internal hostnames in the ADR text (gitleaks rule)
- [ ] All env vars documented in both ADRs match the env var conventions in `AGENTS.md`
- [ ] `docs/reviews/DECISIONS-NEEDED.md` D2 and D3 entries reference these ADRs (in PR #631)