### PR TITLE
ci: fix grep-c pipefail in change-detect steps on main push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,7 +233,11 @@ jobs:
             echo "has_changes=1" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          echo "has_changes=$(echo "$files" | grep -c . || echo 0)" >> "$GITHUB_OUTPUT"
+          if [ -n "$files" ]; then
+            echo "has_changes=1" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changes=0" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Scan AI context files for secrets and PII
         if: steps.ai-detect.outputs.has_changes != '0'
@@ -266,10 +270,10 @@ jobs:
             exit 0
           fi
           # Only run buf checks when proto/gen files actually changed in this PR
-          changed=$(git diff --name-only origin/main...HEAD -- \
+          changed_protos=$(git diff --name-only origin/main...HEAD -- \
             'protos/' 2>/dev/null \
-            | grep -cE '\.proto$|buf\.(yaml|gen\.yaml)$' || echo 0)
-          if [ "$changed" -gt 0 ]; then
+            | grep -E '\.proto$|buf\.(yaml|gen\.yaml)$' || true)
+          if [ -n "$changed_protos" ]; then
             echo "has_protos=1" >> "$GITHUB_OUTPUT"
           else
             echo "has_protos=0" >> "$GITHUB_OUTPUT"
@@ -332,9 +336,9 @@ jobs:
             exit 0
           fi
           # Only validate spec when spec files actually changed in this PR
-          changed=$(git diff --name-only origin/main...HEAD -- \
-            'spec/' 2>/dev/null | grep -c . || echo 0)
-          if [ "$changed" -gt 0 ]; then
+          changed_spec=$(git diff --name-only origin/main...HEAD -- \
+            'spec/' 2>/dev/null | grep . || true)
+          if [ -n "$changed_spec" ]; then
             echo "has_spec=1" >> "$GITHUB_OUTPUT"
           else
             echo "has_spec=0" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

- Fix `CI: completed/failure` on every push to `main` — `lint-proto` job, `Detect AI context file changes` step
- Root cause: `$(echo "$files" | grep -c . || echo 0)` embedded in `echo "key=..." >> $GITHUB_OUTPUT` — with `-o pipefail`, Alpine bash propagates the pipe's exit-1 even when `|| echo 0` fires, writing bare `0` to `$GITHUB_OUTPUT` and triggering `Invalid format '0'`
- Same pattern also present in two new steps added by #633: `Detect proto workspace` and `Detect spec files`

## Why

`grep -c .` exits 1 when there are 0 matches (correct POSIX behaviour). On a push-to-main trigger `git diff origin/main...HEAD` produces empty output (HEAD == origin/main), making `grep -c .` always fail. The `|| echo 0` fallback inside a command substitution embedded in an `echo "key=..."` argument is unreliable in Alpine bash with `set -o pipefail`.

Fix: use `|| true` so the grep pipeline always exits 0, capture filtered lines into a variable, then check `[ -n "$var" ]`. No subprocess exit-code risk.

Regressed by: #633. Original fix: #627.

## Changes

| Step | Before | After |
|------|--------|-------|
| `Detect AI context file changes` | `echo "has_changes=$(... \| grep -c . \|\| echo 0)"` | `if [ -n "$files" ]; then echo "has_changes=1"; else echo "has_changes=0"; fi` |
| `Detect proto workspace` | `changed=$(... \| grep -cE ... \|\| echo 0)` + `[ "$changed" -gt 0 ]` | `changed_protos=$(... \| grep -E ... \|\| true)` + `[ -n "$changed_protos" ]` |
| `Detect spec files` | `changed=$(... \| grep -c . \|\| echo 0)` + `[ "$changed" -gt 0 ]` | `changed_spec=$(... \| grep . \|\| true)` + `[ -n "$changed_spec" ]` |

## Test plan

### Local pre-flight
- [x] `make lint-fix` — N/A (CI YAML only, no Go/Python)
- [x] `make lint-go` — N/A
- [x] `make lint-protos` — N/A
- [x] `make lint-agents` — N/A
- [x] `GOWORK=off go test ./... -race` — N/A (no code changes)
- [x] `make test-coverage` — N/A
- [x] `make test-bdd` — N/A
- [x] `make security` — N/A
- [x] `make validate-spec` — N/A

### Acceptance
- [x] `|| true` replaces `|| echo 0` in all three grep pipelines — verified in diff
- [x] `[ -n "$var" ]` check replaces `[ "$changed" -gt 0 ]` — pure bash, no exit-code risk
- [x] `has_changes`, `has_protos`, `has_spec` still write `0` or `1` to `$GITHUB_OUTPUT` — explicit if/else confirmed
- [x] On PR push (non-empty diff): grep finds matches → variable non-empty → `has_X=1`
- [x] On main push (empty diff): grep finds nothing → `|| true` exits 0, variable empty → `has_X=0`

### Engineering hygiene
- [x] Branched from fresh `origin/main`
- [x] PR ≤ 900 lines — 18 lines changed
- [x] Every commit: `Signed-off-by:` + `Assisted-by: Claude/claude-sonnet-4-6`
- [x] No `Co-Authored-By:` for AI
- [x] No panic in prod paths; no silent `_ = err` — N/A
- [x] No mTLS/SBOM/cosign claims added to docs
- [x] Gap scan done — N/A (CI YAML only)
- [x] State files: no change needed (ci fix, not a feature)
- [x] No out-of-scope / drive-by edits

## Out of scope

- Fixing the `changes` job (uses a different, already-safe pattern with the fail-safe from #621)
- Adding a test for this exact failure mode (CI integration test — tracked in #553)
