### PR TITLE
test(task-broker): add handler unit tests for all 5 gRPC methods (#532)

### DIFF
--- a/services/task-broker/internal/api/handler_test.go
+++ b/services/task-broker/internal/api/handler_test.go
@@ -1,0 +1,337 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package api_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"sync"
+	"testing"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
+
+	zynaxv1 "github.com/zynax-io/zynax/protos/generated/go/zynax/v1"
+	"github.com/zynax-io/zynax/services/task-broker/internal/api"
+	"github.com/zynax-io/zynax/services/task-broker/internal/domain"
+)
+
+const bufSize = 1024 * 1024
+
+// ── fakes ──────────────────────────────────────────────────────────────────
+
+type fakeRepo struct {
+	mu    sync.Mutex
+	tasks map[string]*domain.Task
+}
+
+func newFakeRepo() *fakeRepo { return &fakeRepo{tasks: make(map[string]*domain.Task)} }
+
+func (r *fakeRepo) Save(_ context.Context, t *domain.Task) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	c := *t
+	r.tasks[c.TaskID] = &c
+	return nil
+}
+
+func (r *fakeRepo) GetByID(_ context.Context, id string) (*domain.Task, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	t, ok := r.tasks[id]
+	if !ok {
+		return nil, fmt.Errorf("%w: %q", domain.ErrTaskNotFound, id)
+	}
+	c := *t
+	return &c, nil
+}
+
+func (r *fakeRepo) Update(_ context.Context, t *domain.Task) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	c := *t
+	r.tasks[t.TaskID] = &c
+	return nil
+}
+
+func (r *fakeRepo) List(_ context.Context, _ domain.ListFilter) (domain.ListResult, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var out []*domain.Task
+	for _, t := range r.tasks {
+		c := *t
+		out = append(out, &c)
+	}
+	return domain.ListResult{Tasks: out}, nil
+}
+
+type fakeFinder struct{ agents map[string][]domain.AgentInfo }
+
+func (f *fakeFinder) FindByCapability(_ context.Context, capName string) ([]domain.AgentInfo, error) {
+	return f.agents[capName], nil
+}
+
+type errorFinder struct{ err error }
+
+func (f *errorFinder) FindByCapability(_ context.Context, _ string) ([]domain.AgentInfo, error) {
+	return nil, f.err
+}
+
+type fakeExecutor struct{}
+
+func (e *fakeExecutor) Execute(_ context.Context, _ domain.AgentInfo, _ *domain.Task) ([]byte, *domain.TaskError, error) {
+	return []byte(`{"result":"ok"}`), nil, nil
+}
+
+// blockingExecutor blocks in Execute until released, letting tests control task lifecycle.
+type blockingExecutor struct {
+	ready   chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func newBlockingExecutor() *blockingExecutor {
+	return &blockingExecutor{ready: make(chan struct{}), release: make(chan struct{})}
+}
+
+func (e *blockingExecutor) Execute(_ context.Context, _ domain.AgentInfo, _ *domain.Task) ([]byte, *domain.TaskError, error) {
+	e.once.Do(func() { close(e.ready) })
+	<-e.release
+	return []byte(`{"result":"ok"}`), nil, nil
+}
+
+// ── server helper ───────────────────────────────────────────────────────────
+
+type testEnv struct {
+	client zynaxv1.TaskBrokerServiceClient
+	svc    *domain.TaskService
+}
+
+func newTestEnv(t *testing.T, finder domain.AgentFinder, exec domain.CapabilityExecutor) *testEnv {
+	t.Helper()
+	repo := newFakeRepo()
+	svc := domain.NewTaskService(repo, finder, exec)
+	h := api.NewHandler(svc)
+
+	lis := bufconn.Listen(bufSize)
+	srv := grpc.NewServer()
+	zynaxv1.RegisterTaskBrokerServiceServer(srv, h)
+	t.Cleanup(func() { srv.GracefulStop() })
+	go func() { _ = srv.Serve(lis) }()
+
+	conn, err := grpc.NewClient("passthrough:///bufnet",
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+			return lis.DialContext(ctx)
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		t.Fatalf("bufconn dial: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	return &testEnv{client: zynaxv1.NewTaskBrokerServiceClient(conn), svc: svc}
+}
+
+func agentsWith(capability string) domain.AgentFinder {
+	return &fakeFinder{agents: map[string][]domain.AgentInfo{
+		capability: {{AgentID: "agent-1", Endpoint: "localhost:9000"}},
+	}}
+}
+
+func validDispatchReq(workflowID, capName string) *zynaxv1.DispatchTaskRequest {
+	return &zynaxv1.DispatchTaskRequest{
+		Task: &zynaxv1.WorkflowTask{
+			WorkflowId:     workflowID,
+			CapabilityName: capName,
+			InputPayload:   []byte(`{}`),
+		},
+	}
+}
+
+// ── DispatchTask ────────────────────────────────────────────────────────────
+
+func TestDispatchTask_HappyPath(t *testing.T) {
+	env := newTestEnv(t, agentsWith("summarize"), &fakeExecutor{})
+
+	resp, err := env.client.DispatchTask(context.Background(), validDispatchReq("wf-1", "summarize"))
+	if err != nil {
+		t.Fatalf("DispatchTask: %v", err)
+	}
+	if resp.TaskId == "" {
+		t.Error("want non-empty task_id")
+	}
+	if resp.CreatedAt == nil {
+		t.Error("want non-nil created_at")
+	}
+}
+
+func TestDispatchTask_MissingWorkflowID_InvalidArgument(t *testing.T) {
+	env := newTestEnv(t, agentsWith("summarize"), &fakeExecutor{})
+
+	_, err := env.client.DispatchTask(context.Background(), &zynaxv1.DispatchTaskRequest{
+		Task: &zynaxv1.WorkflowTask{CapabilityName: "summarize", InputPayload: []byte(`{}`)},
+	})
+	if code := status.Code(err); code != codes.InvalidArgument {
+		t.Errorf("want InvalidArgument, got %v", code)
+	}
+}
+
+func TestDispatchTask_NoEligibleAgent_NotFound(t *testing.T) {
+	env := newTestEnv(t, &fakeFinder{agents: map[string][]domain.AgentInfo{}}, &fakeExecutor{})
+
+	_, err := env.client.DispatchTask(context.Background(), validDispatchReq("wf-2", "unknown-cap"))
+	if code := status.Code(err); code != codes.NotFound {
+		t.Errorf("want NotFound, got %v", code)
+	}
+}
+
+func TestDispatchTask_FinderError_Internal(t *testing.T) {
+	env := newTestEnv(t, &errorFinder{err: errors.New("db connection refused")}, &fakeExecutor{})
+
+	_, err := env.client.DispatchTask(context.Background(), validDispatchReq("wf-3", "any-cap"))
+	if code := status.Code(err); code != codes.Internal {
+		t.Errorf("want Internal, got %v", code)
+	}
+}
+
+// ── AcknowledgeTask ─────────────────────────────────────────────────────────
+
+func TestAcknowledgeTask_WithTaskError(t *testing.T) {
+	blocker := newBlockingExecutor()
+	t.Cleanup(func() { close(blocker.release) })
+
+	env := newTestEnv(t, agentsWith("summarize"), blocker)
+
+	disp, err := env.client.DispatchTask(context.Background(), validDispatchReq("wf-ack-err", "summarize"))
+	if err != nil {
+		t.Fatalf("DispatchTask: %v", err)
+	}
+	<-blocker.ready
+
+	resp, err := env.client.AcknowledgeTask(context.Background(), &zynaxv1.AcknowledgeTaskRequest{
+		TaskId: disp.TaskId,
+		Status: zynaxv1.TaskStatus_TASK_STATUS_FAILED,
+		Error: &zynaxv1.TaskError{
+			Code:    "EXEC_ERROR",
+			Message: "something went wrong",
+		},
+	})
+	if err != nil {
+		t.Fatalf("AcknowledgeTask: %v", err)
+	}
+	if resp.ResultingStatus != zynaxv1.TaskStatus_TASK_STATUS_FAILED {
+		t.Errorf("want FAILED, got %v", resp.ResultingStatus)
+	}
+}
+
+func TestAcknowledgeTask_HappyPath(t *testing.T) {
+	blocker := newBlockingExecutor()
+	t.Cleanup(func() { close(blocker.release) })
+
+	env := newTestEnv(t, agentsWith("summarize"), blocker)
+
+	disp, err := env.client.DispatchTask(context.Background(), validDispatchReq("wf-ack", "summarize"))
+	if err != nil {
+		t.Fatalf("DispatchTask: %v", err)
+	}
+	<-blocker.ready // task is DISPATCHED; goroutine is blocked in Execute
+
+	resp, err := env.client.AcknowledgeTask(context.Background(), &zynaxv1.AcknowledgeTaskRequest{
+		TaskId:        disp.TaskId,
+		Status:        zynaxv1.TaskStatus_TASK_STATUS_COMPLETED,
+		ResultPayload: []byte(`{"ok":true}`),
+	})
+	if err != nil {
+		t.Fatalf("AcknowledgeTask: %v", err)
+	}
+	if resp.ResultingStatus != zynaxv1.TaskStatus_TASK_STATUS_COMPLETED {
+		t.Errorf("want COMPLETED, got %v", resp.ResultingStatus)
+	}
+}
+
+// ── GetTask ──────────────────────────────────────────────────────────────────
+
+func TestGetTask_HappyPath(t *testing.T) {
+	env := newTestEnv(t, agentsWith("summarize"), &fakeExecutor{})
+
+	disp, err := env.client.DispatchTask(context.Background(), validDispatchReq("wf-get", "summarize"))
+	if err != nil {
+		t.Fatalf("DispatchTask: %v", err)
+	}
+
+	got, err := env.client.GetTask(context.Background(), &zynaxv1.GetTaskRequest{TaskId: disp.TaskId})
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if got.TaskId != disp.TaskId {
+		t.Errorf("task_id mismatch: want %q, got %q", disp.TaskId, got.TaskId)
+	}
+}
+
+func TestGetTask_UnknownID_NotFound(t *testing.T) {
+	env := newTestEnv(t, agentsWith("summarize"), &fakeExecutor{})
+
+	_, err := env.client.GetTask(context.Background(), &zynaxv1.GetTaskRequest{TaskId: "task-does-not-exist"})
+	if code := status.Code(err); code != codes.NotFound {
+		t.Errorf("want NotFound, got %v", code)
+	}
+}
+
+// ── ListTasks ────────────────────────────────────────────────────────────────
+
+func TestListTasks_EmptyReturnsOK(t *testing.T) {
+	env := newTestEnv(t, agentsWith("summarize"), &fakeExecutor{})
+
+	resp, err := env.client.ListTasks(context.Background(), &zynaxv1.ListTasksRequest{})
+	if err != nil {
+		t.Fatalf("ListTasks: %v", err)
+	}
+	if len(resp.Tasks) != 0 {
+		t.Errorf("want empty list, got %d tasks", len(resp.Tasks))
+	}
+}
+
+// ── CancelTask ────────────────────────────────────────────────────────────────
+
+func TestCancelTask_HappyPath(t *testing.T) {
+	blocker := newBlockingExecutor()
+	t.Cleanup(func() { close(blocker.release) })
+
+	env := newTestEnv(t, agentsWith("summarize"), blocker)
+
+	disp, err := env.client.DispatchTask(context.Background(), validDispatchReq("wf-cancel", "summarize"))
+	if err != nil {
+		t.Fatalf("DispatchTask: %v", err)
+	}
+	<-blocker.ready // task is DISPATCHED; goroutine is blocked
+
+	resp, err := env.client.CancelTask(context.Background(), &zynaxv1.CancelTaskRequest{TaskId: disp.TaskId})
+	if err != nil {
+		t.Fatalf("CancelTask: %v", err)
+	}
+	if resp.CancelledAt == nil {
+		t.Error("want non-nil cancelled_at")
+	}
+}
+
+func TestCancelTask_TerminalTask_FailedPrecondition(t *testing.T) {
+	env := newTestEnv(t, agentsWith("summarize"), &fakeExecutor{})
+
+	disp, err := env.client.DispatchTask(context.Background(), validDispatchReq("wf-cancel-terminal", "summarize"))
+	if err != nil {
+		t.Fatalf("DispatchTask: %v", err)
+	}
+	// Wait for background execution to finish → task is COMPLETED (terminal).
+	env.svc.WaitBackground()
+
+	_, err = env.client.CancelTask(context.Background(), &zynaxv1.CancelTaskRequest{TaskId: disp.TaskId})
+	if code := status.Code(err); code != codes.FailedPrecondition {
+		t.Errorf("want FailedPrecondition, got %v", code)
+	}
+}


### PR DESCRIPTION
## Summary

- Add `services/task-broker/internal/api/handler_test.go` (337 lines)
- bufconn-based gRPC test server — no real network ports
- Covers all 5 gRPC handlers: `DispatchTask`, `AcknowledgeTask`, `GetTask`, `ListTasks`, `CancelTask`
- Covers all 4 `grpcErr` mappings + Internal fallthrough path
- api package: 84.9% coverage; domain package: 92.7% (unchanged)

## Why

The `internal/api/` handler layer had zero test coverage. The `grpcErr` mapping (domain errors → gRPC status codes) was entirely untested — a mismatch here silently breaks every task-broker client.

Closes #532

## Cluster

Cluster (BATCH 4 + 5, independent siblings): #636 (#526) · #532 (this PR) · #554
Merge order: any (independent).

## State files updated

- canvas: N/A (test: issue, exempt from SPDD)
- AGENTS.md: N/A (no new capability)
- M5-plan.md / current-milestone.md: updated after merge

## Architecture gaps addressed

None — test code only, no production code changed.

## Test plan

### Local pre-flight
- [x] `make lint-fix` — N/A (Docker-based; pre-commit hooks ran on commit)
- [x] `make lint-go` — golangci-lint passed (pre-commit hook)
- [x] `make lint-protos` — N/A (no proto changes)
- [x] `make lint-agents` — N/A (no Python changes)
- [x] `GOWORK=off go test ./... -race` — all 4 packages pass, race detector clean
  ```
  ok  github.com/zynax-io/zynax/services/task-broker/internal/api    1.032s
  ok  github.com/zynax-io/zynax/services/task-broker/internal/domain 1.008s
  ok  github.com/zynax-io/zynax/services/task-broker/tests           1.036s
  ```
- [x] `make test-coverage` — api: 84.9%, domain: 92.7% ≥ 80% combined
- [x] `make test-coverage-adapters` — N/A
- [x] `make test-bdd` — N/A (no new BDD scenarios)
- [x] `make security` — N/A (Docker-based; test code only)
- [x] `make validate-spec` — N/A

### Acceptance (from issue body)
- [x] `handler_test.go` uses `bufconn` — no real network ports
- [x] `DispatchTask`: happy path returns non-empty `task_id` (`TestDispatchTask_HappyPath`)
- [x] `AcknowledgeTask`: happy path transitions to acknowledged state (`TestAcknowledgeTask_HappyPath`)
- [x] `GetTask`: happy path returns task; unknown id → `codes.NotFound` (`TestGetTask_HappyPath`, `TestGetTask_UnknownID_NotFound`)
- [x] `ListTasks`: empty list (not error) when no tasks (`TestListTasks_EmptyReturnsOK`)
- [x] `CancelTask`: happy path cancels; terminal task → `codes.FailedPrecondition` (`TestCancelTask_HappyPath`, `TestCancelTask_TerminalTask_FailedPrecondition`)
- [x] `grpcErr` mapping: `ErrTaskNotFound`→`NotFound` · `ErrNoEligibleAgent`→`NotFound` · `ErrTaskTerminal`→`FailedPrecondition` · `ErrInvalidArgument`→`InvalidArgument` — all verified
- [x] `GOWORK=off go test ./internal/api/... -race -cover` passes — api: 84.9%
- [x] `GOWORK=off go test ./... -race` combined coverage: api 84.9%, domain 92.7% ≥ 80%

### Engineering hygiene
- [x] Branched from fresh `origin/main`
- [x] PR ≤ 900 lines (337 lines, new file)
- [x] Every commit: `Signed-off-by:` + `Assisted-by: Claude/claude-sonnet-4-6`
- [x] No `Co-Authored-By:` for AI
- [x] No `panic` in prod paths; no silent `_ = err`
- [x] No mTLS/SBOM/cosign claims added to docs
- [x] Gap scan done: G1 (N/A test), G4 (N/A test), G7 (N/A test), G16 (N/A test)
- [x] 4 state files: M5-plan + current-milestone updated after merge; canvas N/A; AGENTS.md N/A
- [x] `.feature` committed before impl — N/A (test code only; no new public boundary)
- [x] No out-of-scope / drive-by edits

## Out of scope

- Integration tests against a real gRPC port
- Testing the domain service logic (already covered in domain tests at 92.7%)