### PR TITLE
docs: update M5 state after cluster #526 #532 #554

### DIFF
--- a/docs/milestones/M5-plan.md
+++ b/docs/milestones/M5-plan.md
@@ -6,7 +6,7 @@
 **GitHub Milestone:** [Adapter Library (M5)](https://github.com/zynax-io/zynax/milestone/5)
 **Parent epic:** [#377](https://github.com/zynax-io/zynax/issues/377)
 **Status:** In Progress
-**Last updated:** 2026-05-21 (rev 32 — decisions resolved: D1 #491 M7→M6; D3 #626 Postgres repos M6; D4/D5 spec on #622/#623; D6 #358 closed)
+**Last updated:** 2026-05-21 (rev 33 — #526 ✅ BDD trim; #532 ✅ handler tests; #554 ✅ force-full-pipeline; #527 unblocked)
 
 ---
 
@@ -139,9 +139,9 @@ These must be done strictly in order. Each step is blocked by the previous.
 |-------|-------|------|------------|-----------------|
 | [#530](https://github.com/zynax-io/zynax/issues/530) | Update task-broker AGENTS.md | XS | None (ready) | ✅ Done |
 | [#531](https://github.com/zynax-io/zynax/issues/531) | Align task-broker BDD + godog steps | S | None (ready) | ✅ Done |
-| [#532](https://github.com/zynax-io/zynax/issues/532) | Handler unit tests for all 5 gRPC methods | S | None (ready) | Go engineer |
-| [#526](https://github.com/zynax-io/zynax/issues/526) | Trim agent-registry BDD to proto scope | XS | None (ready) | Go + godog |
-| [#527](https://github.com/zynax-io/zynax/issues/527) | agent-registry domain layer | M | After #526 | Go domain engineer — read `docs/spdd/480-agent-registry/canvas.md` |
+| [#532](https://github.com/zynax-io/zynax/issues/532) | Handler unit tests for all 5 gRPC methods | S | None (ready) | ✅ Done — api 84.9% |
+| [#526](https://github.com/zynax-io/zynax/issues/526) | Trim agent-registry BDD to proto scope | XS | None (ready) | ✅ Done |
+| [#527](https://github.com/zynax-io/zynax/issues/527) | agent-registry domain layer | M | After #526 ✅ | **ready** — Go domain engineer — read `docs/spdd/480-agent-registry/canvas.md` |
 | [#528](https://github.com/zynax-io/zynax/issues/528) | agent-registry gRPC wiring + cmd + go.work | M | After #527 | Go gRPC engineer |
 | [#481](https://github.com/zynax-io/zynax/issues/481) | Add task-broker + agent-registry to docker-compose | S | After #528 | DevOps / Docker |
 
@@ -172,7 +172,7 @@ of tooling at run time. The image is rebuilt and published to
 |-------|-------|------|------------|----------|
 | [#551](https://github.com/zynax-io/zynax/issues/551) | Create Dockerfile.ci-runner — self-contained Alpine image | S | ✅ Done | — |
 | [#552](https://github.com/zynax-io/zynax/issues/552) | Switch all GH Actions jobs to ci-runner container mode | M | ✅ Done | **P0** |
-| [#554](https://github.com/zynax-io/zynax/issues/554) | Force-full-pipeline trigger (dispatch, label, `[full-ci]`) | S | After #552 | P1 |
+| [#554](https://github.com/zynax-io/zynax/issues/554) | Force-full-pipeline trigger (dispatch, label, `[full-ci]`) | S | After #552 ✅ | ✅ Done |
 | [#549](https://github.com/zynax-io/zynax/issues/549) | Extend changes job per-service module granularity | M | After #552 | P1 |
 | [#550](https://github.com/zynax-io/zynax/issues/550) | Scope govulncheck to changed services only | M | After #549 | P1 |
 | [#555](https://github.com/zynax-io/zynax/issues/555) | DRY/KISS refactor — reusable workflows, composite actions | L | After #552 | P2 |

--- a/state/current-milestone.md
+++ b/state/current-milestone.md
@@ -30,7 +30,7 @@ M5 is structured into seven tracks. See full execution plan: **[docs/milestones/
 
 | Track | Epic | Status |
 |-------|------|--------|
-| **M5.F CI Sprint** | [#542](https://github.com/zynax-io/zynax/issues/542) | 🟡 In Progress — #551 ✅ Dockerfile.ci-runner; #552 ✅ container-mode PR merged; next: **#554** force-full-pipeline trigger |
+| **M5.F CI Sprint** | [#542](https://github.com/zynax-io/zynax/issues/542) | 🟡 In Progress — #551 ✅ #552 ✅ #554 ✅ force-full-pipeline; next: **#549** per-service change-detection |
 | **M5.F.R Release Pipeline** | [#556](https://github.com/zynax-io/zynax/issues/556) | 🟢 BATCH 1 complete — #566 ✅ Docker Images in README; GHCR image refs in docker-compose |
 | M5.A Truth Pass | [#458](https://github.com/zynax-io/zynax/issues/458) | In Progress — 2/3 children done; #474 open |
 | M5.B Engine Correctness | [#459](https://github.com/zynax-io/zynax/issues/459) | In Progress — #538 ✅ #539 ✅ #540 ✅; #476 parent open |
@@ -42,7 +42,7 @@ M5 is structured into seven tracks. See full execution plan: **[docs/milestones/
 
 ---
 
-## IMMEDIATE — #554 force-full-pipeline trigger (P1, unblocked by #552 ✅)
+## IMMEDIATE — #527 agent-registry domain layer (P0, unblocked by #526 ✅)
 
 ### BATCH 0 — ✅ All done
 ~~#547 #544 #548 #545 #589 #546 #557 #558 #559 #560~~
@@ -73,7 +73,7 @@ Implementation PRs #520, #522, #523 merged. Domain coverage: 92.7%.
 |-------|------|--------|
 | [#530](https://github.com/zynax-io/zynax/issues/530) | Update AGENTS.md | ✅ Done |
 | [#531](https://github.com/zynax-io/zynax/issues/531) | Align service BDD + godog steps | ✅ Done |
-| [#532](https://github.com/zynax-io/zynax/issues/532) | Handler unit tests | ready |
+| [#532](https://github.com/zynax-io/zynax/issues/532) | Handler unit tests | ✅ Done — api 84.9%, domain 92.7% |
 
 ### agent-registry (#480) — pending implementation
 
@@ -81,8 +81,8 @@ Canvas aligned. Ordered delivery: #526 → #527 → #528 → #481.
 
 | Issue | Step | Status |
 |-------|------|--------|
-| [#526](https://github.com/zynax-io/zynax/issues/526) | Trim BDD to proto scope | ready (do first) |
-| [#527](https://github.com/zynax-io/zynax/issues/527) | Domain layer | blocked on #526 |
+| [#526](https://github.com/zynax-io/zynax/issues/526) | Trim BDD to proto scope | ✅ Done |
+| [#527](https://github.com/zynax-io/zynax/issues/527) | Domain layer | **ready** (unblocked by #526 ✅) |
 | [#528](https://github.com/zynax-io/zynax/issues/528) | gRPC wiring + go.work | blocked on #527 |
 | [#481](https://github.com/zynax-io/zynax/issues/481) | Compose wiring | blocked on #528 |
 


### PR DESCRIPTION
## Summary

- Mark #526 (BDD trim), #532 (handler tests), #554 (force-full-pipeline) as ✅ Done in M5-plan.md and current-milestone.md
- #527 (agent-registry domain layer) unblocked — status updated to **ready**
- IMMEDIATE pointer advanced from #554 → #527

## Why

State files are the session navigation aid. Keeping them accurate prevents picking already-done work next session.

## Test plan

- [x] Docs-only change — no code, no lint, no tests required
- [x] PR ≤ 900 lines (10 lines changed)
- [x] Every commit: `Signed-off-by:` + `Assisted-by: Claude/claude-sonnet-4-6`