### PR TITLE
docs: add #641 #642 to M5 plan and update next-session queue

### DIFF
--- a/docs/milestones/M5-plan.md
+++ b/docs/milestones/M5-plan.md
@@ -6,7 +6,7 @@
 **GitHub Milestone:** [Adapter Library (M5)](https://github.com/zynax-io/zynax/milestone/5)
 **Parent epic:** [#377](https://github.com/zynax-io/zynax/issues/377)
 **Status:** In Progress
-**Last updated:** 2026-05-21 (rev 33 — #526 ✅ BDD trim; #532 ✅ handler tests; #554 ✅ force-full-pipeline; #527 unblocked)
+**Last updated:** 2026-05-21 (rev 34 — #640 PR open: centralize coverage gates; #641 filed: per-service image rebuild; #642 filed: distroless + -s -w)
 
 ---
 
@@ -179,6 +179,13 @@ of tooling at run time. The image is rebuilt and published to
 | [#563](https://github.com/zynax-io/zynax/issues/563) | Deduplicate tools image — remove tools-publish.yml | XS | ✅ Done | — |
 | [#564](https://github.com/zynax-io/zynax/issues/564) | Pin action digests + add linux/arm64 to zynax-ci | XS | After #552 | P2 |
 | [#565](https://github.com/zynax-io/zynax/issues/565) | Add trivy container scan gate before GHCR push | S | After #552 | P2 |
+| [#641](https://github.com/zynax-io/zynax/issues/641) | Per-service change detection for image builds in release.yml | M | After #552 | P2 |
+| [#642](https://github.com/zynax-io/zynax/issues/642) | Switch service Dockerfiles to distroless/static:nonroot + `-ldflags "-s -w"` | S | None | P2 |
+
+**Notes on #641 and #642:**
+- **#641** adds a `changes` job to `release.yml` with per-service path filters (including `protos/generated/go/` as a shared dep), a `resolve-matrix` job that emits only the services that changed, a weekly scheduled rebuild, and a `rebuild_all` workflow_dispatch input. Version tag pushes always build all images unconditionally. See issue body for the `fromJson` matrix pattern. Savings: ~80% fewer image builds on non-release main pushes.
+- **#642** replaces `alpine:3.20/3.21` runtime stages with `gcr.io/distroless/static:nonroot` and adds `-ldflags "-s -w"` to the builder `go build` commands in all 5 service Dockerfiles. No code changes needed — fully static `CGO_ENABLED=0` binaries are drop-in compatible. Removes `adduser`/`addgroup`/`USER zynax` (distroless ships UID 65532). Estimated savings: ≥40% compressed image size per service. `tools` and `ci-runner` images remain Alpine.
+- Both can be done in the same session; #642 (#S) before #641 (#M) since it has no dependency.
 
 **Engineer profile:** DevOps / GitHub Actions specialist with Docker/Alpine experience.
 
@@ -334,6 +341,8 @@ without rewriting the graph).
 | [#564](https://github.com/zynax-io/zynax/issues/564) | Pin action digests + add linux/arm64 | XS | P2 |
 | [#565](https://github.com/zynax-io/zynax/issues/565) | Add trivy container scan gate before GHCR push | S | P2 |
 | [#566](https://github.com/zynax-io/zynax/issues/566) | README Docker Images section with pull commands | S | ✅ Done |
+| [#641](https://github.com/zynax-io/zynax/issues/641) | Per-service change detection for image builds — skip unchanged images on main push | M | P2 |
+| [#642](https://github.com/zynax-io/zynax/issues/642) | Switch service Dockerfiles to distroless/static:nonroot + add `-ldflags "-s -w"` | S | P2 |
 
 **Cross-links:**
 - #601 → #562 → tools-public → #563 → #566: Full chain — service Dockerfiles fixed → images made public → zynax/tools rebuilt and made public → old zynax-tools removed → README documented.

--- a/state/current-milestone.md
+++ b/state/current-milestone.md
@@ -31,7 +31,7 @@ M5 is structured into seven tracks. See full execution plan: **[docs/milestones/
 | Track | Epic | Status |
 |-------|------|--------|
 | **M5.F CI Sprint** | [#542](https://github.com/zynax-io/zynax/issues/542) | 🟡 In Progress — #551 ✅ #552 ✅ #554 ✅ force-full-pipeline; next: **#549** per-service change-detection |
-| **M5.F.R Release Pipeline** | [#556](https://github.com/zynax-io/zynax/issues/556) | 🟢 BATCH 1 complete — #566 ✅ Docker Images in README; GHCR image refs in docker-compose |
+| **M5.F.R Release Pipeline** | [#556](https://github.com/zynax-io/zynax/issues/556) | 🟢 BATCH 1 complete; #641 #642 filed (image rebuild filtering + distroless) |
 | M5.A Truth Pass | [#458](https://github.com/zynax-io/zynax/issues/458) | In Progress — 2/3 children done; #474 open |
 | M5.B Engine Correctness | [#459](https://github.com/zynax-io/zynax/issues/459) | In Progress — #538 ✅ #539 ✅ #540 ✅; #476 parent open |
 | M5.C Capability Dispatch | [#460](https://github.com/zynax-io/zynax/issues/460) | In Progress — task-broker code merged; agent-registry pending |
@@ -42,7 +42,7 @@ M5 is structured into seven tracks. See full execution plan: **[docs/milestones/
 
 ---
 
-## IMMEDIATE — #527 agent-registry domain layer (P0, unblocked by #526 ✅)
+## IMMEDIATE — #527 agent-registry domain layer (P0, unblocked by #526 ✅) · #640 coverage gates PR (merge when CI green)
 
 ### BATCH 0 — ✅ All done
 ~~#547 #544 #548 #545 #589 #546 #557 #558 #559 #560~~
@@ -103,7 +103,8 @@ Canvas aligned. Ordered delivery: #526 → #527 → #528 → #481.
 
 ## Known Blockers
 
-- **#551 (Dockerfile.ci-runner) → #552 (switch all jobs)** — highest CI priority. Image must bake in every tool (Go 1.26.3, golangci-lint, govulncheck, buf, Python+uv, ruff, mypy, bandit, pip-audit, gitleaks, zynax-ci, etc.) so no CI step downloads tooling at run time. Reference: `infra/docker/Dockerfile.tools`. Publish to `ghcr.io/zynax-io/zynax/ci-runner:latest` on every Dockerfile change.
+- **#552 ✅ done** — all jobs now run in ci-runner container mode.
+- **#640 PR open** — centralize coverage gates in `tools/coverage-gates.env`; fixes false ❌ for `cmd/zynax` at 79.9%. Merge when CI green.
 - **agent-registry (#480)** — BDD trim (#526) must merge before domain (#527) begins (ADR-016).
 - **compose wiring (#481)** — depends on #528 (agent-registry gRPC wiring) landing first.
 - **adapter implementations** — wait for #481 (compose wiring) so adapters have a live registry.
@@ -135,4 +136,17 @@ Priority gaps to file immediately:
 - **#442** — Fully Containerized Makefile: all 4 child issues merged (#443–#446).
 - **#529** — docs(agent-registry): REASONS Canvas for #480.
 - **#533** — docs(task-broker): REASONS Canvas for #479.
+- **#526** — BDD trim (agent-registry), **#532** — handler unit tests (task-broker), **#554** — force-full-pipeline trigger.
 - **SECURITY.md** — false mTLS/SBOM/cosign claims removed (2026-05-20, part of M5.A truth pass).
+
+## Next Session Queue (priority order)
+
+| Priority | Issue | Title | Note |
+|----------|-------|-------|------|
+| P0 | [#527](https://github.com/zynax-io/zynax/issues/527) | agent-registry domain layer | Read `docs/spdd/480-agent-registry/canvas.md` first |
+| P0 | [#640](https://github.com/zynax-io/zynax/issues/640) | Merge coverage gates PR | Wait for CI green |
+| P1 | [#528](https://github.com/zynax-io/zynax/issues/528) | agent-registry gRPC wiring | After #527 |
+| P1 | [#481](https://github.com/zynax-io/zynax/issues/481) | Compose wiring | After #528 |
+| P2 | [#642](https://github.com/zynax-io/zynax/issues/642) | Distroless + `-s -w` (S) | Independent — 5 Dockerfile edits |
+| P2 | [#641](https://github.com/zynax-io/zynax/issues/641) | Per-service image rebuild filtering (M) | After #642 |
+| P2 | [#549](https://github.com/zynax-io/zynax/issues/549) | Per-service change detection (CI test lanes) | Parallel with #641 |


### PR DESCRIPTION
## Summary

- Files two new M5.F.R P2 issues in the plan: **#641** (per-service image rebuild filtering) and **#642** (distroless + `-ldflags "-s -w"`)
- Adds both to BATCH 5 with full implementation notes including the `fromJson` matrix pattern and size analysis
- Updates `state/current-milestone.md` with a **Next Session Queue** table (priority-ordered) and corrects the Known Blockers section (#552 done, #640 PR open)

## Next session priorities encoded in this PR

| Priority | Issue | Title |
|----------|-------|-------|
| P0 | #527 | agent-registry domain layer |
| P0 | #640 | Merge coverage gates PR |
| P1 | #528 | agent-registry gRPC wiring |
| P1 | #481 | Compose wiring |
| P2 | #642 | Distroless + `-s -w` |
| P2 | #641 | Per-service image rebuild filtering |
| P2 | #549 | Per-service change detection (CI test lanes) |

## Test plan

- [ ] Plan and state files render correctly (markdown tables)
- [ ] Issue links (#641, #642) resolve to the newly filed issues