### PR TITLE
ci: tighten code change detection — skip test-unit on non-code paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,7 @@ jobs:
 # ── Change Detection ──────────────────────────────────────────────────────────
 # Detects which path groups changed so downstream lanes can be skipped.
 # Outputs:
-#   code   — true when any file outside docs/ or root *.md changes; gates test-unit
+#   code   — true when services/, agents/, cmd/, protos/, or go.work change; gates test-unit
 #   proto  — true when protos/, spec/, or AI context files change
 #   go     — true when any Go code changes (services/, cmd/, Go adapters)
 #   python — true when Python agents change
@@ -202,9 +202,9 @@ jobs:
           while IFS= read -r f; do
             [ -z "$f" ] && continue
 
-            # code=true for anything that is not pure documentation or root metadata.
-            # Docs-only paths: docs/ directory and root-level *.md / LICENSE / CODEOWNERS.
-            if ! echo "$f" | grep -qE '^(docs/|[^/]+\.md$|LICENSE$|CODEOWNERS$)'; then
+            # code=true only for paths that have tests in test-unit.
+            # Everything else (docs, state, infra, .github, tools, spec) skips the test job.
+            if echo "$f" | grep -qE '^(services/|agents/|cmd/|protos/|go\.work(\.sum)?$)'; then
               code=true
             fi
 


### PR DESCRIPTION
## Problem

The `code` output in the `changes` job used a **negative** filter: anything outside `docs/` and root-level `*.md` files set `code=true`. This caused `test-unit` to run on every push that touched `state/`, `infra/`, `.github/`, `tools/`, or `spec/` — none of which have tests.

Examples of unnecessary test-unit runs:
- `tools/coverage-gates.env` changed in #640 → test-unit triggered on both the PR branch and the main merge
- `state/current-milestone.md` changed → test-unit triggered
- `.github/workflows/ci.yml` changed → test-unit triggered

## Fix

Replace the negative filter with an explicit **positive filter**. `code=true` is now set only for paths that actually have tests in `test-unit`:

```
services/**   — Go platform services
agents/**     — Python SDK, example agents, Go adapters
cmd/**        — CLI tools (zynax, zynax-ci)
protos/**     — proto contracts + generated stubs + BDD contract tests
go.work       — workspace file (changes affect all Go module resolution)
go.work.sum   — workspace checksum
```

All other paths (`docs/`, `state/`, `infra/`, `.github/`, `tools/`, `spec/`, root files) produce `code=false` → `test-unit` is skipped.

## Verification

A PR that only touches `tools/coverage-gates.env` or `state/current-milestone.md` or `docs/**` should show:
```
changes job: code=false  lint-proto=false  lint-go=false  lint-python=false
test-unit: skipped
```

Related: M5.F CI Sprint (#542)