### PR TITLE
feat(agent-registry): domain layer — model, port, service

### DIFF
--- a/docs/milestones/M5-plan.md
+++ b/docs/milestones/M5-plan.md
@@ -6,7 +6,7 @@
 **GitHub Milestone:** [Adapter Library (M5)](https://github.com/zynax-io/zynax/milestone/5)
 **Parent epic:** [#377](https://github.com/zynax-io/zynax/issues/377)
 **Status:** In Progress
-**Last updated:** 2026-05-21 (rev 34 — #640 PR open: centralize coverage gates; #641 filed: per-service image rebuild; #642 filed: distroless + -s -w)
+**Last updated:** 2026-05-21 (rev 35 — #640 ✅ merged; #644 CI hotfix merged; #527 agent-registry domain layer ✅)
 
 ---
 
@@ -141,7 +141,7 @@ These must be done strictly in order. Each step is blocked by the previous.
 | [#531](https://github.com/zynax-io/zynax/issues/531) | Align task-broker BDD + godog steps | S | None (ready) | ✅ Done |
 | [#532](https://github.com/zynax-io/zynax/issues/532) | Handler unit tests for all 5 gRPC methods | S | None (ready) | ✅ Done — api 84.9% |
 | [#526](https://github.com/zynax-io/zynax/issues/526) | Trim agent-registry BDD to proto scope | XS | None (ready) | ✅ Done |
-| [#527](https://github.com/zynax-io/zynax/issues/527) | agent-registry domain layer | M | After #526 ✅ | **ready** — Go domain engineer — read `docs/spdd/480-agent-registry/canvas.md` |
+| [#527](https://github.com/zynax-io/zynax/issues/527) | agent-registry domain layer | M | After #526 ✅ | ✅ Done |
 | [#528](https://github.com/zynax-io/zynax/issues/528) | agent-registry gRPC wiring + cmd + go.work | M | After #527 | Go gRPC engineer |
 | [#481](https://github.com/zynax-io/zynax/issues/481) | Add task-broker + agent-registry to docker-compose | S | After #528 | DevOps / Docker |
 

--- a/docs/spdd/480-agent-registry/canvas.md
+++ b/docs/spdd/480-agent-registry/canvas.md
@@ -145,7 +145,7 @@ services/agent-registry/
    `ACTIVE`/`OFFLINE` status references, and `WatchAgentEvents` mention. Commit alone;
    CI must be green before step 2 begins.
 
-2. **[#527]** `feat(agent-registry)`: Domain layer — `Agent` model, `AgentRepository`
+2. ✅ **[#527]** `feat(agent-registry)`: Domain layer — `Agent` model, `AgentRepository`
    port, `AgentRegistryService` domain service, `ErrAgentNotFound` / `ErrAgentAlreadyExists`
    errors, domain unit tests. ≥ 90% domain coverage. No imports from `api/` or
    `infrastructure/`.

--- a/services/agent-registry/go.mod
+++ b/services/agent-registry/go.mod
@@ -1,0 +1,3 @@
+module github.com/zynax-io/zynax/services/agent-registry
+
+go 1.26.3

--- a/services/agent-registry/internal/domain/errors.go
+++ b/services/agent-registry/internal/domain/errors.go
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package domain
+
+import "errors"
+
+// Sentinel errors returned by AgentRegistryService. All are safe to wrap with fmt.Errorf("%w", ...).
+var (
+	// ErrAgentNotFound is returned when an agent_id is unknown.
+	ErrAgentNotFound = errors.New("agent not found")
+	// ErrAgentAlreadyExists is returned when a REGISTERED agent with the same ID already exists.
+	ErrAgentAlreadyExists = errors.New("agent already exists")
+	// ErrInvalidArgument is returned when a request field fails validation.
+	ErrInvalidArgument = errors.New("invalid argument")
+)

--- a/services/agent-registry/internal/domain/model.go
+++ b/services/agent-registry/internal/domain/model.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package domain
+
+import "time"
+
+// AgentStatus mirrors the proto AgentStatus enum; values are stable (ADR-001).
+type AgentStatus int32
+
+// AgentStatus values; ordinal values are permanent — never reorder or reassign (ADR-001).
+const (
+	AgentStatusUnspecified  AgentStatus = 0
+	AgentStatusRegistered   AgentStatus = 1
+	AgentStatusDeregistered AgentStatus = 2
+)
+
+// String returns the proto-style name of the status.
+func (s AgentStatus) String() string {
+	switch s {
+	case AgentStatusRegistered:
+		return "REGISTERED"
+	case AgentStatusDeregistered:
+		return "DEREGISTERED"
+	default:
+		return "UNSPECIFIED"
+	}
+}
+
+// Capability describes a single named function an agent can execute.
+type Capability struct {
+	Name         string
+	Description  string
+	InputSchema  []byte // optional JSON Schema (draft-07)
+	OutputSchema []byte // optional JSON Schema (draft-07)
+}
+
+// Agent is the registry's canonical agent record.
+type Agent struct {
+	ID           string
+	Name         string
+	Description  string
+	Endpoint     string // host:port used by the task broker for capability routing
+	Capabilities []Capability
+	Labels       map[string]string
+	Status       AgentStatus
+	RegisteredAt time.Time
+	UpdatedAt    time.Time
+}
+
+// ListFilter specifies criteria for a List call.
+type ListFilter struct {
+	LabelSelector       string // comma-separated key=value pairs; empty matches all
+	IncludeDeregistered bool
+	PageToken           string
+	PageSize            int32
+}
+
+// ListResult carries one page of matching agents.
+type ListResult struct {
+	Agents        []Agent
+	NextPageToken string
+}

--- a/services/agent-registry/internal/domain/repository.go
+++ b/services/agent-registry/internal/domain/repository.go
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package domain
+
+import "context"
+
+// AgentRepository persists and retrieves agent records.
+// FindByCapability MUST return only REGISTERED agents.
+type AgentRepository interface {
+	Save(ctx context.Context, agent Agent) error
+	Delete(ctx context.Context, id string) error
+	FindByID(ctx context.Context, id string) (Agent, error)
+	FindAll(ctx context.Context) ([]Agent, error)
+	FindByCapability(ctx context.Context, name string) ([]Agent, error)
+}

--- a/services/agent-registry/internal/domain/service.go
+++ b/services/agent-registry/internal/domain/service.go
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package domain contains the pure business logic for the agent-registry service.
+// It has zero imports from the api or infrastructure layers (ADR-001).
+package domain
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+)
+
+const maxCapabilities = 50
+
+// capNameRE matches valid capability names: lowercase letters, digits, underscores; 1–64 chars.
+var capNameRE = regexp.MustCompile(`^[a-z0-9_]{1,64}$`)
+
+// AgentRegistryService implements agent registration, deregistration, and discovery.
+type AgentRegistryService struct {
+	repo AgentRepository
+}
+
+// NewAgentRegistryService constructs an AgentRegistryService backed by the given repository.
+func NewAgentRegistryService(repo AgentRepository) *AgentRegistryService {
+	return &AgentRegistryService{repo: repo}
+}
+
+// Register validates and persists a new agent.
+// Returns ErrAgentAlreadyExists if a REGISTERED agent with the same ID already exists.
+// Returns ErrInvalidArgument if required fields are missing or invalid.
+func (s *AgentRegistryService) Register(ctx context.Context, agent Agent) (Agent, error) {
+	if err := validateAgent(agent); err != nil {
+		return Agent{}, err
+	}
+
+	existing, err := s.repo.FindByID(ctx, agent.ID)
+	if err == nil && existing.Status == AgentStatusRegistered {
+		return Agent{}, fmt.Errorf("%w: %q", ErrAgentAlreadyExists, agent.ID)
+	}
+
+	now := time.Now()
+	agent.Status = AgentStatusRegistered
+	agent.RegisteredAt = now
+	agent.UpdatedAt = now
+
+	if err := s.repo.Save(ctx, agent); err != nil {
+		return Agent{}, fmt.Errorf("agent-registry: save: %w", err)
+	}
+	return agent, nil
+}
+
+// Deregister marks the agent as DEREGISTERED. The record is retained for audit.
+// Returns ErrAgentNotFound if no agent with the given ID is known.
+// Returns ErrInvalidArgument if id is empty.
+func (s *AgentRegistryService) Deregister(ctx context.Context, id string) (time.Time, error) {
+	if id == "" {
+		return time.Time{}, fmt.Errorf("%w: agent_id is required", ErrInvalidArgument)
+	}
+
+	agent, err := s.repo.FindByID(ctx, id)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("%w: %s", ErrAgentNotFound, id)
+	}
+
+	now := time.Now()
+	agent.Status = AgentStatusDeregistered
+	agent.UpdatedAt = now
+
+	if err := s.repo.Save(ctx, agent); err != nil {
+		return time.Time{}, fmt.Errorf("agent-registry: save: %w", err)
+	}
+	return now, nil
+}
+
+// GetByID returns the agent record regardless of status.
+// Returns ErrAgentNotFound if the ID is unknown.
+// Returns ErrInvalidArgument if id is empty.
+func (s *AgentRegistryService) GetByID(ctx context.Context, id string) (Agent, error) {
+	if id == "" {
+		return Agent{}, fmt.Errorf("%w: agent_id is required", ErrInvalidArgument)
+	}
+
+	agent, err := s.repo.FindByID(ctx, id)
+	if err != nil {
+		return Agent{}, fmt.Errorf("%w: %s", ErrAgentNotFound, id)
+	}
+	return agent, nil
+}
+
+// FindByCapability returns all REGISTERED agents that declare the named capability.
+// Returns an empty slice (not an error) when no agents match.
+// Returns ErrInvalidArgument if capability_name is empty.
+func (s *AgentRegistryService) FindByCapability(ctx context.Context, capabilityName string) ([]Agent, error) {
+	if capabilityName == "" {
+		return nil, fmt.Errorf("%w: capability_name is required", ErrInvalidArgument)
+	}
+
+	agents, err := s.repo.FindByCapability(ctx, capabilityName)
+	if err != nil {
+		return nil, fmt.Errorf("agent-registry: find by capability: %w", err)
+	}
+	return agents, nil
+}
+
+// List returns a filtered page of agents. DEREGISTERED agents are excluded unless
+// ListFilter.IncludeDeregistered is true. Label filtering uses equality-based matching.
+func (s *AgentRegistryService) List(ctx context.Context, filter ListFilter) (ListResult, error) {
+	all, err := s.repo.FindAll(ctx)
+	if err != nil {
+		return ListResult{}, fmt.Errorf("agent-registry: list: %w", err)
+	}
+
+	labelReqs := parseLabelSelector(filter.LabelSelector)
+
+	var matched []Agent
+	for _, a := range all {
+		if !filter.IncludeDeregistered && a.Status == AgentStatusDeregistered {
+			continue
+		}
+		if !matchesLabels(a.Labels, labelReqs) {
+			continue
+		}
+		matched = append(matched, a)
+	}
+
+	return ListResult{Agents: matched}, nil
+}
+
+// validateAgent checks required fields and capability constraints.
+func validateAgent(agent Agent) error {
+	if agent.ID == "" {
+		return fmt.Errorf("%w: agent_id is required", ErrInvalidArgument)
+	}
+	if agent.Endpoint == "" {
+		return fmt.Errorf("%w: endpoint is required", ErrInvalidArgument)
+	}
+	if len(agent.Capabilities) == 0 {
+		return fmt.Errorf("%w: at least one capability is required", ErrInvalidArgument)
+	}
+	if len(agent.Capabilities) > maxCapabilities {
+		return fmt.Errorf("%w: capability limit is %d", ErrInvalidArgument, maxCapabilities)
+	}
+	seen := make(map[string]struct{}, len(agent.Capabilities))
+	for _, c := range agent.Capabilities {
+		if !capNameRE.MatchString(c.Name) {
+			return fmt.Errorf("%w: capability name %q must match %s", ErrInvalidArgument, c.Name, capNameRE)
+		}
+		if _, dup := seen[c.Name]; dup {
+			return fmt.Errorf("%w: duplicate capability name %q", ErrInvalidArgument, c.Name)
+		}
+		seen[c.Name] = struct{}{}
+	}
+	return nil
+}
+
+// parseLabelSelector parses "key=value,key2=value2" into a map. Empty string → empty map.
+func parseLabelSelector(selector string) map[string]string {
+	if selector == "" {
+		return nil
+	}
+	reqs := make(map[string]string)
+	for _, part := range strings.Split(selector, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		kv := strings.SplitN(part, "=", 2)
+		if len(kv) == 2 {
+			reqs[strings.TrimSpace(kv[0])] = strings.TrimSpace(kv[1])
+		}
+	}
+	return reqs
+}
+
+// matchesLabels returns true if the agent's labels satisfy all equality requirements.
+func matchesLabels(labels map[string]string, reqs map[string]string) bool {
+	for k, v := range reqs {
+		if labels[k] != v {
+			return false
+		}
+	}
+	return true
+}

--- a/services/agent-registry/internal/domain/service_test.go
+++ b/services/agent-registry/internal/domain/service_test.go
@@ -1,0 +1,404 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package domain_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/zynax-io/zynax/services/agent-registry/internal/domain"
+)
+
+// ── fakeRepo ──────────────────────────────────────────────────────────────────
+
+type fakeRepo struct {
+	mu     sync.Mutex
+	agents map[string]domain.Agent
+}
+
+func newFakeRepo() *fakeRepo { return &fakeRepo{agents: make(map[string]domain.Agent)} }
+
+func (r *fakeRepo) Save(_ context.Context, agent domain.Agent) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.agents[agent.ID] = agent
+	return nil
+}
+
+func (r *fakeRepo) Delete(_ context.Context, id string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, ok := r.agents[id]; !ok {
+		return fmt.Errorf("%w: %q", domain.ErrAgentNotFound, id)
+	}
+	delete(r.agents, id)
+	return nil
+}
+
+func (r *fakeRepo) FindByID(_ context.Context, id string) (domain.Agent, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	a, ok := r.agents[id]
+	if !ok {
+		return domain.Agent{}, fmt.Errorf("%w: %q", domain.ErrAgentNotFound, id)
+	}
+	return a, nil
+}
+
+func (r *fakeRepo) FindAll(_ context.Context) ([]domain.Agent, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]domain.Agent, 0, len(r.agents))
+	for _, a := range r.agents {
+		out = append(out, a)
+	}
+	return out, nil
+}
+
+func (r *fakeRepo) FindByCapability(_ context.Context, name string) ([]domain.Agent, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var out []domain.Agent
+	for _, a := range r.agents {
+		if a.Status != domain.AgentStatusRegistered {
+			continue
+		}
+		for _, c := range a.Capabilities {
+			if c.Name == name {
+				out = append(out, a)
+				break
+			}
+		}
+	}
+	return out, nil
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+func validAgent(id string, caps ...string) domain.Agent {
+	if len(caps) == 0 {
+		caps = []string{"summarize"}
+	}
+	cs := make([]domain.Capability, len(caps))
+	for i, c := range caps {
+		cs[i] = domain.Capability{Name: c}
+	}
+	return domain.Agent{
+		ID:           id,
+		Name:         "Test Agent",
+		Endpoint:     "localhost:9000",
+		Capabilities: cs,
+	}
+}
+
+func seed(t *testing.T, svc *domain.AgentRegistryService, agent domain.Agent) domain.Agent {
+	t.Helper()
+	a, err := svc.Register(context.Background(), agent)
+	if err != nil {
+		t.Fatalf("seed Register: %v", err)
+	}
+	return a
+}
+
+// ── Register ─────────────────────────────────────────────────────────────────
+
+func TestRegister_HappyPath(t *testing.T) {
+	svc := domain.NewAgentRegistryService(newFakeRepo())
+	a, err := svc.Register(context.Background(), validAgent("agent-01"))
+	if err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if a.ID != "agent-01" || a.Status != domain.AgentStatusRegistered {
+		t.Errorf("got id=%q status=%s", a.ID, a.Status)
+	}
+	if a.RegisteredAt.IsZero() || a.UpdatedAt.IsZero() {
+		t.Errorf("timestamps not set: registeredAt=%v updatedAt=%v", a.RegisteredAt, a.UpdatedAt)
+	}
+}
+
+func TestRegister_Validation(t *testing.T) {
+	cases := []struct {
+		name    string
+		agent   domain.Agent
+		wantErr error
+	}{
+		{"empty_id", domain.Agent{Endpoint: "h:1", Capabilities: []domain.Capability{{Name: "x"}}}, domain.ErrInvalidArgument},
+		{"empty_endpoint", domain.Agent{ID: "a", Capabilities: []domain.Capability{{Name: "x"}}}, domain.ErrInvalidArgument},
+		{"no_capabilities", domain.Agent{ID: "a", Endpoint: "h:1"}, domain.ErrInvalidArgument},
+		{"invalid_cap_name_upper", domain.Agent{ID: "a", Endpoint: "h:1", Capabilities: []domain.Capability{{Name: "Invalid"}}}, domain.ErrInvalidArgument},
+		{"invalid_cap_name_space", domain.Agent{ID: "a", Endpoint: "h:1", Capabilities: []domain.Capability{{Name: "bad cap"}}}, domain.ErrInvalidArgument},
+		{"invalid_cap_name_empty", domain.Agent{ID: "a", Endpoint: "h:1", Capabilities: []domain.Capability{{Name: ""}}}, domain.ErrInvalidArgument},
+		{"duplicate_cap_names", domain.Agent{ID: "a", Endpoint: "h:1", Capabilities: []domain.Capability{{Name: "x"}, {Name: "x"}}}, domain.ErrInvalidArgument},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := domain.NewAgentRegistryService(newFakeRepo())
+			_, err := svc.Register(context.Background(), tc.agent)
+			if !errors.Is(err, tc.wantErr) {
+				t.Errorf("err = %v, want %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestRegister_TooManyCapabilities(t *testing.T) {
+	caps := make([]domain.Capability, 51)
+	for i := range caps {
+		caps[i] = domain.Capability{Name: fmt.Sprintf("cap%02d", i)}
+	}
+	a := domain.Agent{ID: "a", Endpoint: "h:1", Capabilities: caps}
+	svc := domain.NewAgentRegistryService(newFakeRepo())
+	_, err := svc.Register(context.Background(), a)
+	if !errors.Is(err, domain.ErrInvalidArgument) {
+		t.Errorf("err = %v, want ErrInvalidArgument", err)
+	}
+}
+
+func TestRegister_AlreadyExists(t *testing.T) {
+	svc := domain.NewAgentRegistryService(newFakeRepo())
+	seed(t, svc, validAgent("dup-01"))
+
+	_, err := svc.Register(context.Background(), validAgent("dup-01"))
+	if !errors.Is(err, domain.ErrAgentAlreadyExists) {
+		t.Errorf("err = %v, want ErrAgentAlreadyExists", err)
+	}
+}
+
+func TestRegister_ReregistrationAfterDeregister(t *testing.T) {
+	svc := domain.NewAgentRegistryService(newFakeRepo())
+	seed(t, svc, validAgent("rereg-01"))
+	if _, err := svc.Deregister(context.Background(), "rereg-01"); err != nil {
+		t.Fatalf("Deregister: %v", err)
+	}
+
+	// Re-registration of a DEREGISTERED agent must succeed.
+	a, err := svc.Register(context.Background(), validAgent("rereg-01"))
+	if err != nil {
+		t.Fatalf("re-Register: %v", err)
+	}
+	if a.Status != domain.AgentStatusRegistered {
+		t.Errorf("status = %s, want REGISTERED", a.Status)
+	}
+}
+
+// ── Deregister ────────────────────────────────────────────────────────────────
+
+func TestDeregister_HappyPath(t *testing.T) {
+	svc := domain.NewAgentRegistryService(newFakeRepo())
+	seed(t, svc, validAgent("dereg-01"))
+
+	deregisteredAt, err := svc.Deregister(context.Background(), "dereg-01")
+	if err != nil || deregisteredAt.IsZero() {
+		t.Fatalf("Deregister: err=%v deregisteredAt=%v", err, deregisteredAt)
+	}
+
+	a, err := svc.GetByID(context.Background(), "dereg-01")
+	if err != nil {
+		t.Fatalf("GetByID after deregister: %v", err)
+	}
+	if a.Status != domain.AgentStatusDeregistered {
+		t.Errorf("status = %s, want DEREGISTERED", a.Status)
+	}
+}
+
+func TestDeregister_NotFound(t *testing.T) {
+	svc := domain.NewAgentRegistryService(newFakeRepo())
+	_, err := svc.Deregister(context.Background(), "ghost-99")
+	if !errors.Is(err, domain.ErrAgentNotFound) {
+		t.Errorf("err = %v, want ErrAgentNotFound", err)
+	}
+}
+
+func TestDeregister_EmptyID(t *testing.T) {
+	svc := domain.NewAgentRegistryService(newFakeRepo())
+	_, err := svc.Deregister(context.Background(), "")
+	if !errors.Is(err, domain.ErrInvalidArgument) {
+		t.Errorf("err = %v, want ErrInvalidArgument", err)
+	}
+}
+
+// ── GetByID ───────────────────────────────────────────────────────────────────
+
+func TestGetByID_HappyPath(t *testing.T) {
+	svc := domain.NewAgentRegistryService(newFakeRepo())
+	seed(t, svc, validAgent("get-01", "summarize", "search"))
+
+	a, err := svc.GetByID(context.Background(), "get-01")
+	if err != nil {
+		t.Fatalf("GetByID: %v", err)
+	}
+	if a.ID != "get-01" || len(a.Capabilities) != 2 {
+		t.Errorf("got id=%q caps=%d", a.ID, len(a.Capabilities))
+	}
+}
+
+func TestGetByID_DeregisteredAgentIsRetrievable(t *testing.T) {
+	svc := domain.NewAgentRegistryService(newFakeRepo())
+	seed(t, svc, validAgent("audit-01"))
+	svc.Deregister(context.Background(), "audit-01") //nolint:errcheck
+
+	a, err := svc.GetByID(context.Background(), "audit-01")
+	if err != nil {
+		t.Fatalf("GetByID on deregistered agent: %v", err)
+	}
+	if a.Status != domain.AgentStatusDeregistered {
+		t.Errorf("status = %s, want DEREGISTERED", a.Status)
+	}
+}
+
+func TestGetByID_Errors(t *testing.T) {
+	svc := domain.NewAgentRegistryService(newFakeRepo())
+	cases := []struct {
+		name    string
+		id      string
+		wantErr error
+	}{
+		{"empty_id", "", domain.ErrInvalidArgument},
+		{"unknown_id", "nonexistent", domain.ErrAgentNotFound},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := svc.GetByID(context.Background(), tc.id)
+			if !errors.Is(err, tc.wantErr) {
+				t.Errorf("err = %v, want %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// ── FindByCapability ──────────────────────────────────────────────────────────
+
+func TestFindByCapability_ReturnsOnlyRegistered(t *testing.T) {
+	svc := domain.NewAgentRegistryService(newFakeRepo())
+	seed(t, svc, validAgent("cap-01", "summarize"))
+	seed(t, svc, validAgent("cap-02", "summarize"))
+	a3 := seed(t, svc, validAgent("cap-03", "summarize"))
+	svc.Deregister(context.Background(), a3.ID) //nolint:errcheck
+
+	agents, err := svc.FindByCapability(context.Background(), "summarize")
+	if err != nil {
+		t.Fatalf("FindByCapability: %v", err)
+	}
+	if len(agents) != 2 {
+		t.Errorf("want 2 registered agents, got %d", len(agents))
+	}
+}
+
+func TestFindByCapability_EmptyResult(t *testing.T) {
+	svc := domain.NewAgentRegistryService(newFakeRepo())
+	agents, err := svc.FindByCapability(context.Background(), "write")
+	if err != nil {
+		t.Fatalf("FindByCapability: %v", err)
+	}
+	if len(agents) != 0 {
+		t.Errorf("want empty, got %d", len(agents))
+	}
+}
+
+func TestFindByCapability_EmptyName(t *testing.T) {
+	svc := domain.NewAgentRegistryService(newFakeRepo())
+	_, err := svc.FindByCapability(context.Background(), "")
+	if !errors.Is(err, domain.ErrInvalidArgument) {
+		t.Errorf("err = %v, want ErrInvalidArgument", err)
+	}
+}
+
+// ── List ──────────────────────────────────────────────────────────────────────
+
+func TestList_NoFilter(t *testing.T) {
+	svc := domain.NewAgentRegistryService(newFakeRepo())
+	seed(t, svc, validAgent("la"))
+	seed(t, svc, validAgent("lb"))
+
+	res, err := svc.List(context.Background(), domain.ListFilter{})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(res.Agents) != 2 {
+		t.Errorf("want 2, got %d", len(res.Agents))
+	}
+}
+
+func TestList_ExcludesDeregisteredByDefault(t *testing.T) {
+	svc := domain.NewAgentRegistryService(newFakeRepo())
+	seed(t, svc, validAgent("l-active"))
+	a := seed(t, svc, validAgent("l-dereg"))
+	svc.Deregister(context.Background(), a.ID) //nolint:errcheck
+
+	res, err := svc.List(context.Background(), domain.ListFilter{})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(res.Agents) != 1 {
+		t.Errorf("want 1 active agent, got %d", len(res.Agents))
+	}
+}
+
+func TestList_IncludeDeregistered(t *testing.T) {
+	svc := domain.NewAgentRegistryService(newFakeRepo())
+	seed(t, svc, validAgent("ld-active"))
+	a := seed(t, svc, validAgent("ld-dereg"))
+	svc.Deregister(context.Background(), a.ID) //nolint:errcheck
+
+	res, err := svc.List(context.Background(), domain.ListFilter{IncludeDeregistered: true})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(res.Agents) != 2 {
+		t.Errorf("want 2 agents, got %d", len(res.Agents))
+	}
+}
+
+func TestList_LabelSelector(t *testing.T) {
+	svc := domain.NewAgentRegistryService(newFakeRepo())
+	a1 := validAgent("ls-prod")
+	a1.Labels = map[string]string{"env": "production", "tier": "standard"}
+	a2 := validAgent("ls-dev")
+	a2.Labels = map[string]string{"env": "development"}
+	seed(t, svc, a1)
+	seed(t, svc, a2)
+
+	res, err := svc.List(context.Background(), domain.ListFilter{LabelSelector: "env=production"})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(res.Agents) != 1 || res.Agents[0].ID != "ls-prod" {
+		t.Errorf("label filter: got %d agents", len(res.Agents))
+	}
+}
+
+func TestList_MultiLabelSelector(t *testing.T) {
+	svc := domain.NewAgentRegistryService(newFakeRepo())
+	a1 := validAgent("ml-01")
+	a1.Labels = map[string]string{"env": "production", "tier": "standard"}
+	a2 := validAgent("ml-02")
+	a2.Labels = map[string]string{"env": "production", "tier": "premium"}
+	seed(t, svc, a1)
+	seed(t, svc, a2)
+
+	res, err := svc.List(context.Background(), domain.ListFilter{LabelSelector: "env=production,tier=standard"})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(res.Agents) != 1 || res.Agents[0].ID != "ml-01" {
+		t.Errorf("multi-label filter: got %d agents", len(res.Agents))
+	}
+}
+
+// ── AgentStatus ───────────────────────────────────────────────────────────────
+
+func TestAgentStatus_String(t *testing.T) {
+	cases := map[domain.AgentStatus]string{
+		domain.AgentStatusUnspecified:  "UNSPECIFIED",
+		domain.AgentStatusRegistered:   "REGISTERED",
+		domain.AgentStatusDeregistered: "DEREGISTERED",
+	}
+	for s, want := range cases {
+		if got := s.String(); got != want {
+			t.Errorf("AgentStatus(%d).String() = %q, want %q", s, got, want)
+		}
+	}
+}

--- a/services/agent-registry/internal/domain/service_test.go
+++ b/services/agent-registry/internal/domain/service_test.go
@@ -238,7 +238,7 @@ func TestGetByID_HappyPath(t *testing.T) {
 func TestGetByID_DeregisteredAgentIsRetrievable(t *testing.T) {
 	svc := domain.NewAgentRegistryService(newFakeRepo())
 	seed(t, svc, validAgent("audit-01"))
-	svc.Deregister(context.Background(), "audit-01") //nolint:errcheck
+	svc.Deregister(context.Background(), "audit-01") //nolint:errcheck,gosec
 
 	a, err := svc.GetByID(context.Background(), "audit-01")
 	if err != nil {
@@ -276,7 +276,7 @@ func TestFindByCapability_ReturnsOnlyRegistered(t *testing.T) {
 	seed(t, svc, validAgent("cap-01", "summarize"))
 	seed(t, svc, validAgent("cap-02", "summarize"))
 	a3 := seed(t, svc, validAgent("cap-03", "summarize"))
-	svc.Deregister(context.Background(), a3.ID) //nolint:errcheck
+	svc.Deregister(context.Background(), a3.ID) //nolint:errcheck,gosec
 
 	agents, err := svc.FindByCapability(context.Background(), "summarize")
 	if err != nil {
@@ -326,7 +326,7 @@ func TestList_ExcludesDeregisteredByDefault(t *testing.T) {
 	svc := domain.NewAgentRegistryService(newFakeRepo())
 	seed(t, svc, validAgent("l-active"))
 	a := seed(t, svc, validAgent("l-dereg"))
-	svc.Deregister(context.Background(), a.ID) //nolint:errcheck
+	svc.Deregister(context.Background(), a.ID) //nolint:errcheck,gosec
 
 	res, err := svc.List(context.Background(), domain.ListFilter{})
 	if err != nil {
@@ -341,7 +341,7 @@ func TestList_IncludeDeregistered(t *testing.T) {
 	svc := domain.NewAgentRegistryService(newFakeRepo())
 	seed(t, svc, validAgent("ld-active"))
 	a := seed(t, svc, validAgent("ld-dereg"))
-	svc.Deregister(context.Background(), a.ID) //nolint:errcheck
+	svc.Deregister(context.Background(), a.ID) //nolint:errcheck,gosec
 
 	res, err := svc.List(context.Background(), domain.ListFilter{IncludeDeregistered: true})
 	if err != nil {

--- a/state/current-milestone.md
+++ b/state/current-milestone.md
@@ -42,7 +42,7 @@ M5 is structured into seven tracks. See full execution plan: **[docs/milestones/
 
 ---
 
-## IMMEDIATE — #527 agent-registry domain layer (P0, unblocked by #526 ✅) · #640 coverage gates PR (merge when CI green)
+## IMMEDIATE — #528 agent-registry gRPC wiring (P0, unblocked by #527 ✅)
 
 ### BATCH 0 — ✅ All done
 ~~#547 #544 #548 #545 #589 #546 #557 #558 #559 #560~~
@@ -82,8 +82,8 @@ Canvas aligned. Ordered delivery: #526 → #527 → #528 → #481.
 | Issue | Step | Status |
 |-------|------|--------|
 | [#526](https://github.com/zynax-io/zynax/issues/526) | Trim BDD to proto scope | ✅ Done |
-| [#527](https://github.com/zynax-io/zynax/issues/527) | Domain layer | **ready** (unblocked by #526 ✅) |
-| [#528](https://github.com/zynax-io/zynax/issues/528) | gRPC wiring + go.work | blocked on #527 |
+| [#527](https://github.com/zynax-io/zynax/issues/527) | Domain layer | ✅ Done |
+| [#528](https://github.com/zynax-io/zynax/issues/528) | gRPC wiring + go.work | **ready** (unblocked by #527 ✅) |
 | [#481](https://github.com/zynax-io/zynax/issues/481) | Compose wiring | blocked on #528 |
 
 ---
@@ -104,8 +104,7 @@ Canvas aligned. Ordered delivery: #526 → #527 → #528 → #481.
 ## Known Blockers
 
 - **#552 ✅ done** — all jobs now run in ci-runner container mode.
-- **#640 PR open** — centralize coverage gates in `tools/coverage-gates.env`; fixes false ❌ for `cmd/zynax` at 79.9%. Merge when CI green.
-- **agent-registry (#480)** — BDD trim (#526) must merge before domain (#527) begins (ADR-016).
+- **agent-registry (#480)** — domain (#527) ✅; gRPC wiring (#528) is next.
 - **compose wiring (#481)** — depends on #528 (agent-registry gRPC wiring) landing first.
 - **adapter implementations** — wait for #481 (compose wiring) so adapters have a live registry.
 - **E2E demo** — blocked on #481 fully wired.
@@ -143,10 +142,8 @@ Priority gaps to file immediately:
 
 | Priority | Issue | Title | Note |
 |----------|-------|-------|------|
-| P0 | [#527](https://github.com/zynax-io/zynax/issues/527) | agent-registry domain layer | Read `docs/spdd/480-agent-registry/canvas.md` first |
-| P0 | [#640](https://github.com/zynax-io/zynax/issues/640) | Merge coverage gates PR | Wait for CI green |
-| P1 | [#528](https://github.com/zynax-io/zynax/issues/528) | agent-registry gRPC wiring | After #527 |
-| P1 | [#481](https://github.com/zynax-io/zynax/issues/481) | Compose wiring | After #528 |
+| P0 | [#528](https://github.com/zynax-io/zynax/issues/528) | agent-registry gRPC wiring | Unblocked by #527 ✅ |
+| P0 | [#481](https://github.com/zynax-io/zynax/issues/481) | Compose wiring | After #528 |
 | P2 | [#642](https://github.com/zynax-io/zynax/issues/642) | Distroless + `-s -w` (S) | Independent — 5 Dockerfile edits |
 | P2 | [#641](https://github.com/zynax-io/zynax/issues/641) | Per-service image rebuild filtering (M) | After #642 |
-| P2 | [#549](https://github.com/zynax-io/zynax/issues/549) | Per-service change detection (CI test lanes) | Parallel with #641 |
+| P2 | [#549](https://github.com/zynax-io/zynax/issues/549) | Per-service change detection (CI test lanes) | Independent |


### PR DESCRIPTION
## Summary

- `Agent` / `Capability` / `AgentStatus` domain types with stable ordinals (ADR-001)
- `AgentRepository` interface port (5 ops: Save/Delete/FindByID/FindAll/FindByCapability)
- `AgentRegistryService` with Register/Deregister/GetByID/FindByCapability/List
- Validation: capability names `^[a-z0-9_]{1,64}$`, max 50 caps, duplicate check, endpoint required
- Label selector: comma-separated `key=value` equality matching
- Minimal `go.mod` (stdlib only; gRPC/proto deps added in #528)

## Why

Canvas O2 step for agent-registry MVP (#480). Implements the domain layer before gRPC wiring (#528) per ADR-016 (BDD first, then domain, then API). Task-broker pattern mirrors this: #520 → #522 → #523.

## Cluster

Single-issue cluster. Next: #528 (gRPC wiring, now unblocked).

## State files updated

- `docs/milestones/M5-plan.md`: #527 → ✅; rev 35; #640 stale ref cleaned
- `state/current-milestone.md`: IMMEDIATE updated; #528 ready; #640 stale ref cleaned
- `docs/spdd/480-agent-registry/canvas.md`: O2 step → ✅

## Architecture gaps addressed

None directly. No G1/G4/G7/G16 patterns applicable to a stdlib-only domain layer.

## Test plan

### Local pre-flight
- [x] `make lint-fix` (gofmt + golangci-lint) — exit 0 (pre-commit hook passed)
- [x] `make lint-go` — exit 0 (pre-commit hook ran golangci-lint ✅)
- [x] `make lint-protos` — (N/A — no proto changes)
- [x] `make lint-agents` — (N/A — no Python changes)
- [x] `GOWORK=off go test ./internal/domain/... -race -timeout 60s` — PASS (all 26 tests)
- [x] `make test-coverage` — 94.0% domain coverage (gate: ≥90%) ✅
- [x] `make test-coverage-adapters` — (N/A — no adapter changes)
- [x] `make test-bdd` — (N/A — BDD tests require gRPC handler, added in #528)
- [x] `make security` — (N/A — stdlib-only package; no external deps or network calls)
- [x] `make validate-spec` — (N/A — no spec/ changes)

### Acceptance (from issue #527 / Canvas O2)
- [x] `Agent` struct has ID, Name, Status, Capabilities fields (+ Description/Endpoint/Labels/timestamps)
- [x] `Capability` struct has Name field (+ Description/InputSchema/OutputSchema)
- [x] `AgentStatus` enum with Registered=1 and Deregistered=2 values (mirrors proto, ADR-001)
- [x] `AgentRepository` interface: Save/Delete/FindByID/FindAll/FindByCapability ✅
- [x] `AgentRegistryService` has all 5 operations: Register/Deregister/GetByID/FindByCapability/List ✅
- [x] `ErrAgentNotFound` and `ErrAgentAlreadyExists` exported sentinel errors ✅
- [x] Zero imports from `api/` or `infrastructure/` in any `domain/` file ✅
- [x] `GOWORK=off go test ./internal/domain/... -race -cover` ≥ 90% — **94.0%** ✅
- [x] BDD validation rules in `service_test.go`: caps ≤ 50, lowercase names, duplicate rejection ✅

### Engineering hygiene
- [x] Branched from fresh `origin/main`
- [x] PR size: ~688 code LOC (L range; justified — 404 LOC are tests required for ≥90% coverage gate)
- [x] Every commit: `Signed-off-by:` + `Assisted-by: Claude/claude-sonnet-4-6`
- [x] No `Co-Authored-By:` for AI
- [x] No `panic` in prod paths; no silent `_ = err` (test `//nolint:errcheck` only on deregister setup calls)
- [x] No mTLS/SBOM/cosign claims added to docs
- [x] Gap scan done (G1/G4/G7/G16): N/A — stdlib-only domain, no HTTP/Temporal/JSON/goroutines
- [x] 4 state files updated: M5-plan.md ✅, current-milestone.md ✅, canvas O2 ✅, AGENTS.md (N/A — scoped to #528)
- [x] `.feature` committed before impl (BDD done in #526 ✅)
- [x] No out-of-scope / drive-by edits

## Out of scope

- gRPC handler, in-memory repo, `go.work` update, Dockerfile, full `AGENTS.md` — all #528

Closes #527