### PR TITLE
ci: set UV_LINK_MODE=copy in test-unit and security jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -552,6 +552,8 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+    env:
+      UV_LINK_MODE: copy
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -1205,6 +1207,8 @@ jobs:
     needs: [dco, changes]
     # PRs: always run (satisfies required check). Push to main: skip on docs-only changes.
     if: github.event_name != 'push' || needs.changes.outputs.code == 'true'
+    env:
+      UV_LINK_MODE: copy
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 


### PR DESCRIPTION
## Summary

- Adds `UV_LINK_MODE: copy` job-level env var to `test-unit` and `security` jobs
- Eliminates the "Failed to hardlink files; falling back to full copy" warning that appears on every uv invocation inside the ci-runner Alpine container

## Why

uv tries to hardlink cached packages into the venv. Inside the ci-runner container the uv cache and the workspace mount are on different filesystems, so hardlinking always fails and uv silently falls back to full copy — but prints a warning on every call. Setting `UV_LINK_MODE=copy` up front tells uv to use copy mode directly, suppressing the noise. No behavioural change; copy was already the effective path.

## Test plan

- [x] `git commit` — pre-commit hooks pass (gitleaks, ruff, golangci-lint — N/A for YAML)
- [x] CI will confirm the warning no longer appears in `test-unit` (pytest-bdd step) and `security` (bandit + pip-audit step)
- [x] 4-line diff; no logic changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)