### PR TITLE
ci: raise ai-context total budget from 2000 to 2200 lines

### DIFF
--- a/cmd/zynax-ci/check/context.go
+++ b/cmd/zynax-ci/check/context.go
@@ -34,7 +34,7 @@ var (
 	thresholdRootAgents = 300
 	thresholdAISetup    = 150
 	thresholdDirAgents  = 150
-	thresholdTotal      = 2000
+	thresholdTotal      = 2200
 )
 
 // Context scans repoRoot for CLAUDE.md, AGENTS.md files, and

--- a/cmd/zynax-ci/check/context_test.go
+++ b/cmd/zynax-ci/check/context_test.go
@@ -80,12 +80,12 @@ func TestContext_TotalExceedsLimit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if report.Total <= 2000 {
+	if report.Total <= 2200 {
 		t.Logf("total=%d — test may not be exercising total threshold, skipping", report.Total)
 		return
 	}
 	if report.Warnings == 0 {
-		t.Error("expected warnings when total exceeds 2000")
+		t.Error("expected warnings when total exceeds 2200")
 	}
 }
 

--- a/cmd/zynax-ci/cmd/check_ai_context.go
+++ b/cmd/zynax-ci/cmd/check_ai_context.go
@@ -22,7 +22,7 @@ Thresholds:
   AGENTS.md (root)          300 lines
   docs/ai-assistant-setup.md 150 lines
   per-directory AGENTS.md   150 lines
-  TOTAL                    2000 lines
+  TOTAL                    2200 lines
 
 Exceeding a threshold emits a WARN but never causes a non-zero exit code.
 This check is advisory only.`,


### PR DESCRIPTION
## Summary

- Raises `thresholdTotal` from 2000 → 2200 in `cmd/zynax-ci/check/context.go`
- Updates the matching test guard and the `--help` docstring

## Why

After #646 (agent-registry gRPC wiring), the repo now has 18 subdir `AGENTS.md` files. The aggregate AI context budget hit 2077 lines — 77 lines over the previous 2000 threshold — even though every individual file is within its own per-file limit (≤ 150 lines per subdir `AGENTS.md`). This produces a spurious WARN on every CI run.

All individual-file thresholds are unchanged. The 2200 ceiling gives headroom for ~8 more services before hitting the aggregate limit again.

## Test plan

- [x] `GOWORK=off go test ./... -race` in repo root — all 3 zynax-ci packages pass
- [x] `TestContext_TotalExceedsLimit` still triggers the warning path (fixture writes 2570 lines > 2200)
- [x] 4-line diff; no logic change

🤖 Generated with [Claude Code](https://claude.com/claude-code)