### PR TITLE
fix(api-gateway): use constant-time compare for bearer token (G1)

### DIFF
--- a/services/api-gateway/internal/api/auth.go
+++ b/services/api-gateway/internal/api/auth.go
@@ -2,7 +2,10 @@
 
 package api
 
-import "net/http"
+import (
+	"crypto/subtle"
+	"net/http"
+)
 
 // requireBearer wraps next with bearer-token authentication when key is non-empty.
 // If key is empty the gate is disabled and all requests pass through unchanged.
@@ -11,9 +14,10 @@ func requireBearer(key string, next http.HandlerFunc) http.HandlerFunc {
 	if key == "" {
 		return next
 	}
-	want := "Bearer " + key
+	want := []byte("Bearer " + key)
 	return func(w http.ResponseWriter, r *http.Request) {
-		if r.Header.Get("Authorization") != want {
+		got := []byte(r.Header.Get("Authorization"))
+		if subtle.ConstantTimeCompare(got, want) != 1 {
 			writeError(w, http.StatusUnauthorized, "unauthorized", "UNAUTHORIZED")
 			return
 		}


### PR DESCRIPTION
## Summary

- Replace `r.Header.Get("Authorization") != want` with `crypto/subtle.ConstantTimeCompare` in `services/api-gateway/internal/api/auth.go`
- Eliminates CWE-208 timing side-channel: an attacker can no longer measure response-time deltas to brute-force the API key character by character

## Why

Closes #567. Identified in `docs/architecture/2026-05-20-principal-architect-review.md §7` (G1). Part of M5 security hardening (BATCH 6).

## Cluster

- #649 — compose wiring (independent, opened in parallel)
- **This PR** (#567) — bearer constant-time compare
- #568 — HTTP server hardening (independent, opened in parallel)
- Merge order: any (all independent)

## State files updated

- N/A — `fix:` PR, no canvas or state file update required

## Architecture gaps addressed

- **G1**: constant-time bearer token comparison

## Test plan

### Local pre-flight
- [x] `make lint-fix` — N/A (no format changes)
- [x] `make lint-go` — exit 0 (golangci-lint passed in pre-commit hook)
- [x] `make lint-protos` — N/A
- [x] `make lint-agents` — N/A
- [x] `GOWORK=off go test ./internal/api/... -race -timeout 60s` — PASS (all 9 TestHandler_Auth_* tests pass, including CorrectKey/MissingKey/WrongKey/EmptyKey/DeleteWithKey/GetNotProtected)
- [x] `make test-coverage` — N/A (no domain/ change)
- [x] `make test-coverage-adapters` — N/A
- [x] `make test-bdd` — N/A
- [x] `make security` — N/A (single-file fix; pre-commit gitleaks passed)
- [x] `make validate-spec` — N/A

### Acceptance (from issue body)
- [x] `auth.go` uses `crypto/subtle.ConstantTimeCompare` for bearer token validation — verified in diff
- [x] No other string equality comparisons against secrets in `auth.go` — only one comparison function, now constant-time
- [x] Existing auth tests pass — `TestHandler_Auth_CorrectKey_Passes`, `TestHandler_Auth_WrongKey_Returns401`, `TestHandler_Auth_MissingKey_Returns401`, `TestHandler_Auth_EmptyAPIKey_DisablesGate` all PASS

### Engineering hygiene
- [x] Branched from fresh `origin/main`
- [x] PR ≤ 900 lines — 1 file, 7 lines net change (XS)
- [x] Every commit: `Signed-off-by:` + `Assisted-by: Claude/claude-sonnet-4-6`
- [x] No `Co-Authored-By:` for AI
- [x] No `panic` in prod paths; no silent `_ = err`
- [x] No mTLS/SBOM/cosign claims added to docs
- [x] Gap scan done — G1 addressed by this PR
- [x] 4 state files updated — N/A for fix: PR
- [x] `.feature` committed before impl — N/A (no proto boundary)
- [x] No out-of-scope / drive-by edits

## Out of scope

- G2 (ReadHeaderTimeout) — covered by #568

Closes #567