### PR TITLE
fix(infra): add agent-registry to .dockerignore allowlist

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -63,6 +63,7 @@ infra/k8s/
 !services/engine-adapter/
 !services/workflow-compiler/
 !services/task-broker/
+!services/agent-registry/
 
 # ── Adapter build allowlist (negations for agents/adapters/*/Dockerfile) ──────
 # Adapter Dockerfiles are built from repo root and need their module source

--- a/docs/milestones/M5-plan.md
+++ b/docs/milestones/M5-plan.md
@@ -6,7 +6,7 @@
 **GitHub Milestone:** [Adapter Library (M5)](https://github.com/zynax-io/zynax/milestone/5)
 **Parent epic:** [#377](https://github.com/zynax-io/zynax/issues/377)
 **Status:** In Progress
-**Last updated:** 2026-05-21 (rev 37 — #481 compose wiring ✅; M5.C dispatch chain complete)
+**Last updated:** 2026-05-21 (rev 38 — #567 ✅ #568 ✅; .dockerignore agent-registry allowlist fixed)
 
 ---
 
@@ -196,8 +196,8 @@ These issues address the security gaps identified in the 2026-05-20 principal ar
 
 | Issue | Title | Size | Why |
 |-------|-------|------|-----|
-| [#567](https://github.com/zynax-io/zynax/issues/567) | Bearer token constant-time compare | XS | Timing-attack exposure in `auth.go` (G1 from review) |
-| [#568](https://github.com/zynax-io/zynax/issues/568) | ReadHeaderTimeout + MaxBytesReader on HTTP server | XS | Slow-read DoS vector (G2 from review) |
+| [#567](https://github.com/zynax-io/zynax/issues/567) | Bearer token constant-time compare | XS | ✅ Done — timing-attack exposure in `auth.go` (G1) |
+| [#568](https://github.com/zynax-io/zynax/issues/568) | ReadHeaderTimeout + MaxBytesReader on HTTP server | XS | ✅ Done — slow-read DoS vector (G2) |
 | [#622](https://github.com/zynax-io/zynax/issues/622) | Add `context.WithTimeout` to all outgoing gRPC calls | S | Cascading hang risk across all services (NEW-1 from review) |
 | [#623](https://github.com/zynax-io/zynax/issues/623) | Refuse to start without `ZYNAX_GW_API_KEY` in production | XS | Silent auth bypass on misconfiguration (NEW-4 from review) |
 

--- a/state/current-milestone.md
+++ b/state/current-milestone.md
@@ -118,16 +118,18 @@ Priority gaps to file immediately:
 
 | Gap | Severity |
 |-----|----------|
-| G1: constant-time bearer compare in api-gateway | High |
-| G4: no RetryPolicy on Temporal Activities | Medium |
-| G16: background-context goroutines in task-broker | Medium |
-| G19: competitive positioning doc (Kagent/Dapr) | High |
-| G17: stub services in SERVICE_LIST | Low |
+| ~~G1: constant-time bearer compare~~ | ✅ fixed #567 |
+| ~~G2: ReadHeaderTimeout + MaxBytesReader~~ | ✅ fixed #568 |
+| G4: no RetryPolicy on Temporal Activities (#569) | Medium |
+| G16: background-context goroutines in task-broker (#570) | Medium |
+| G19: competitive positioning doc (Kagent/Dapr) (#575) | High |
+| G17: stub services in SERVICE_LIST (#574) | Low |
 
 ---
 
 ## Recently Closed
 
+- **#567** — Bearer constant-time compare (G1 fix) ✅. **#568** — ReadHeaderTimeout + MaxBytesReader (G2 fix) ✅.
 - **#461 M5.D** — Control Plane Security Baseline: all 5 child issues merged (#482–#486).
 - **#462 M5.E** — Developer Experience Polish: all child issues merged (#485–#486).
 - **#442** — Fully Containerized Makefile: all 4 child issues merged (#443–#446).
@@ -140,8 +142,8 @@ Priority gaps to file immediately:
 
 | Priority | Issue | Title | Note |
 |----------|-------|-------|------|
-| P1 | [#567](https://github.com/zynax-io/zynax/issues/567) | Bearer constant-time compare (G1) | XS, fix, api-gateway |
-| P1 | [#568](https://github.com/zynax-io/zynax/issues/568) | ReadHeaderTimeout + MaxBytesReader (G2) | XS, fix, api-gateway |
+| P1 | [#623](https://github.com/zynax-io/zynax/issues/623) | Refuse to start without ZYNAX_API_KEY (NEW-4) | XS, fix, api-gateway |
+| P1 | [#622](https://github.com/zynax-io/zynax/issues/622) | context.WithTimeout on all gRPC calls (NEW-1) | S, fix, 4 services |
 | P2 | [#642](https://github.com/zynax-io/zynax/issues/642) | Distroless + `-s -w` (S) | Independent — 5 Dockerfile edits |
 | P2 | [#641](https://github.com/zynax-io/zynax/issues/641) | Per-service image rebuild filtering (M) | After #642 |
 | P2 | [#549](https://github.com/zynax-io/zynax/issues/549) | Per-service change detection (CI test lanes) | Independent |


### PR DESCRIPTION
## Summary

- `.dockerignore` excludes all of `services/` for build context isolation, then uses negation rules to re-allow individual service directories
- PR #649 added `agent-registry` to the release image matrix, but never added `!services/agent-registry/` to the negation allowlist
- Every `main` push since #649 merges fails with: `failed to calculate checksum of ref ...: "/services/agent-registry": not found`

## Why

Failing run: https://github.com/zynax-io/zynax/actions/runs/26249369356/job/77256128942  
Root cause: the `services/agent-registry/Dockerfile` was added in #646, wired into `release.yml` in #649, but `.dockerignore` was never updated.

## Cluster

Single-issue cluster — no siblings.

## State files updated

- `docs/milestones/M5-plan.md` rev 38: #567 ✅ #568 ✅ (BATCH 6 reconciliation)
- `state/current-milestone.md`: Next Session Queue updated to #622/#623; Architecture Gaps table updated

## Architecture gaps addressed

None — pure CI build fix.

## Test plan

### Local pre-flight
- [x] `make lint-fix` — (N/A — no source file changes)
- [x] `make lint-go` — (N/A — no Go changes)
- [x] `make lint-protos` — (N/A — no proto changes)
- [x] `make lint-agents` — (N/A — no Python changes)
- [x] `GOWORK=off go test ./... -race` — (N/A — no Go changes)
- [x] `make test-coverage` — (N/A — no Go changes)
- [x] `make test-coverage-adapters` — (N/A)
- [x] `make test-bdd` — (N/A — no contract changes)
- [x] `make security` — (N/A — .dockerignore is not scanned by govulncheck/bandit/gitleaks)
- [x] `make validate-spec` — (N/A — no spec changes)

### Acceptance
- [x] `.dockerignore` now includes `!services/agent-registry/` in the service allowlist section
- [x] Docker build for `agent-registry` will resolve `services/agent-registry/` in the build context — verified by inspecting the negation pattern matches the existing Dockerfile COPY paths

### Engineering hygiene
- [x] Branched from fresh `origin/main`
- [x] PR ≤ 900 lines (1 line changed in `.dockerignore`)
- [x] Every commit: `Signed-off-by:` + `Assisted-by: Claude/claude-sonnet-4-6`
- [x] No `Co-Authored-By:` for AI
- [x] No `panic` in prod paths; no silent `_ = err` (N/A — no source changes)
- [x] No mTLS/SBOM/cosign claims added to docs
- [x] Gap scan done (G1/G4/G7/G16) — not applicable (no service code touched)
- [x] 4 state files updated: M5-plan.md ✅, current-milestone.md ✅, canvas N/A (fix type), AGENTS.md N/A (no new capability)
- [x] `.feature` committed before impl (N/A — no public boundary change)
- [x] No out-of-scope / drive-by edits

## Out of scope

- Per-service change detection for the release workflow (#641) — separate issue
- Distroless image migration (#642) — separate issue