### PR TITLE
chore(infra): switch service Dockerfiles to distroless + -ldflags

### DIFF
--- a/agents/adapters/http/Dockerfile
+++ b/agents/adapters/http/Dockerfile
@@ -11,15 +11,9 @@ RUN cd agents/adapters/http && GOWORK=off go mod download
 COPY protos/generated/go/ ./protos/generated/go/
 COPY agents/adapters/http/ ./agents/adapters/http/
 RUN cd agents/adapters/http && CGO_ENABLED=0 GOWORK=off \
-    go build -trimpath -o /http-adapter ./cmd/http-adapter/
+    go build -trimpath -ldflags "-s -w" -o /http-adapter ./cmd/http-adapter/
 
-FROM alpine:3.21
-
-RUN apk add --no-cache ca-certificates \
-    && addgroup -S zynax && adduser -S zynax -G zynax
-
+# renovate: datasource=docker depName=gcr.io/distroless/static
+FROM gcr.io/distroless/static:nonroot
 COPY --from=builder /http-adapter /http-adapter
-
-USER zynax
-
 ENTRYPOINT ["/http-adapter"]

--- a/docs/milestones/M5-plan.md
+++ b/docs/milestones/M5-plan.md
@@ -6,7 +6,7 @@
 **GitHub Milestone:** [Adapter Library (M5)](https://github.com/zynax-io/zynax/milestone/5)
 **Parent epic:** [#377](https://github.com/zynax-io/zynax/issues/377)
 **Status:** In Progress
-**Last updated:** 2026-05-21 (rev 38 — #567 ✅ #568 ✅; .dockerignore agent-registry allowlist fixed)
+**Last updated:** 2026-05-21 (rev 39 — #642 ✅ distroless Dockerfiles + -ldflags "-s -w")
 
 ---
 
@@ -180,7 +180,7 @@ of tooling at run time. The image is rebuilt and published to
 | [#564](https://github.com/zynax-io/zynax/issues/564) | Pin action digests + add linux/arm64 to zynax-ci | XS | After #552 | P2 |
 | [#565](https://github.com/zynax-io/zynax/issues/565) | Add trivy container scan gate before GHCR push | S | After #552 | P2 |
 | [#641](https://github.com/zynax-io/zynax/issues/641) | Per-service change detection for image builds in release.yml | M | After #552 | P2 |
-| [#642](https://github.com/zynax-io/zynax/issues/642) | Switch service Dockerfiles to distroless/static:nonroot + `-ldflags "-s -w"` | S | None | P2 |
+| [#642](https://github.com/zynax-io/zynax/issues/642) | Switch service Dockerfiles to distroless/static:nonroot + `-ldflags "-s -w"` | S | None | ✅ Done |
 
 **Notes on #641 and #642:**
 - **#641** adds a `changes` job to `release.yml` with per-service path filters (including `protos/generated/go/` as a shared dep), a `resolve-matrix` job that emits only the services that changed, a weekly scheduled rebuild, and a `rebuild_all` workflow_dispatch input. Version tag pushes always build all images unconditionally. See issue body for the `fromJson` matrix pattern. Savings: ~80% fewer image builds on non-release main pushes.

--- a/services/AGENTS.md
+++ b/services/AGENTS.md
@@ -116,3 +116,4 @@ Never connect to a shared or external service from within a build-tagged test.
 | Integration tests reaching a real DB without `testcontainers` | Use `testcontainers-go` for real DB (ADR-016) |
 | Returning raw `error` from a gRPC handler | `return nil, status.Errorf(codes.InvalidArgument, "…")` |
 | Makefile target that calls `go` or `python` directly on host | Wrap in `$(TOOLS_RUN) sh -c "…"` |
+| Using `distroless/static:nonroot` for a service with `CGO_ENABLED=1` | Only `CGO_ENABLED=0` (fully static) binaries are compatible; use `distroless/cc` or Alpine if CGO is required |

--- a/services/agent-registry/Dockerfile
+++ b/services/agent-registry/Dockerfile
@@ -8,11 +8,9 @@ RUN cd services/agent-registry && GOWORK=off go mod download
 COPY protos/generated/go/ ./protos/generated/go/
 COPY services/agent-registry/ ./services/agent-registry/
 RUN cd services/agent-registry && CGO_ENABLED=0 GOWORK=off \
-    go build -trimpath -o /agent-registry ./cmd/agent-registry/
+    go build -trimpath -ldflags "-s -w" -o /agent-registry ./cmd/agent-registry/
 
-FROM alpine:3.20
-RUN apk add --no-cache ca-certificates \
-    && addgroup -S zynax && adduser -S zynax -G zynax
-USER zynax
+# renovate: datasource=docker depName=gcr.io/distroless/static
+FROM gcr.io/distroless/static:nonroot
 COPY --from=builder /agent-registry /agent-registry
 ENTRYPOINT ["/agent-registry"]

--- a/services/api-gateway/Dockerfile
+++ b/services/api-gateway/Dockerfile
@@ -8,11 +8,9 @@ RUN cd services/api-gateway && GOWORK=off go mod download
 COPY protos/generated/go/ ./protos/generated/go/
 COPY services/api-gateway/ ./services/api-gateway/
 RUN cd services/api-gateway && CGO_ENABLED=0 GOWORK=off \
-    go build -trimpath -o /api-gateway ./cmd/api-gateway/
+    go build -trimpath -ldflags "-s -w" -o /api-gateway ./cmd/api-gateway/
 
-FROM alpine:3.20
-RUN apk add --no-cache ca-certificates \
-    && addgroup -S zynax && adduser -S zynax -G zynax
-USER zynax
+# renovate: datasource=docker depName=gcr.io/distroless/static
+FROM gcr.io/distroless/static:nonroot
 COPY --from=builder /api-gateway /api-gateway
 ENTRYPOINT ["/api-gateway"]

--- a/services/engine-adapter/Dockerfile
+++ b/services/engine-adapter/Dockerfile
@@ -8,11 +8,9 @@ RUN cd services/engine-adapter && GOWORK=off go mod download
 COPY protos/generated/go/ ./protos/generated/go/
 COPY services/engine-adapter/ ./services/engine-adapter/
 RUN cd services/engine-adapter && CGO_ENABLED=0 GOWORK=off \
-    go build -trimpath -o /engine-adapter ./cmd/engine-adapter/
+    go build -trimpath -ldflags "-s -w" -o /engine-adapter ./cmd/engine-adapter/
 
-FROM alpine:3.20
-RUN apk add --no-cache ca-certificates \
-    && addgroup -S zynax && adduser -S zynax -G zynax
-USER zynax
+# renovate: datasource=docker depName=gcr.io/distroless/static
+FROM gcr.io/distroless/static:nonroot
 COPY --from=builder /engine-adapter /engine-adapter
 ENTRYPOINT ["/engine-adapter"]

--- a/services/task-broker/Dockerfile
+++ b/services/task-broker/Dockerfile
@@ -8,11 +8,9 @@ RUN cd services/task-broker && GOWORK=off go mod download
 COPY protos/generated/go/ ./protos/generated/go/
 COPY services/task-broker/ ./services/task-broker/
 RUN cd services/task-broker && CGO_ENABLED=0 GOWORK=off \
-    go build -trimpath -o /task-broker ./cmd/task-broker/
+    go build -trimpath -ldflags "-s -w" -o /task-broker ./cmd/task-broker/
 
-FROM alpine:3.20
-RUN apk add --no-cache ca-certificates \
-    && addgroup -S zynax && adduser -S zynax -G zynax
-USER zynax
+# renovate: datasource=docker depName=gcr.io/distroless/static
+FROM gcr.io/distroless/static:nonroot
 COPY --from=builder /task-broker /task-broker
 ENTRYPOINT ["/task-broker"]

--- a/services/workflow-compiler/Dockerfile
+++ b/services/workflow-compiler/Dockerfile
@@ -8,11 +8,9 @@ RUN cd services/workflow-compiler && GOWORK=off go mod download
 COPY protos/generated/go/ ./protos/generated/go/
 COPY services/workflow-compiler/ ./services/workflow-compiler/
 RUN cd services/workflow-compiler && CGO_ENABLED=0 GOWORK=off \
-    go build -trimpath -o /workflow-compiler ./cmd/workflow-compiler/
+    go build -trimpath -ldflags "-s -w" -o /workflow-compiler ./cmd/workflow-compiler/
 
-FROM alpine:3.20
-RUN apk add --no-cache ca-certificates \
-    && addgroup -S zynax && adduser -S zynax -G zynax
-USER zynax
+# renovate: datasource=docker depName=gcr.io/distroless/static
+FROM gcr.io/distroless/static:nonroot
 COPY --from=builder /workflow-compiler /workflow-compiler
 ENTRYPOINT ["/workflow-compiler"]

--- a/state/current-milestone.md
+++ b/state/current-milestone.md
@@ -31,7 +31,7 @@ M5 is structured into seven tracks. See full execution plan: **[docs/milestones/
 | Track | Epic | Status |
 |-------|------|--------|
 | **M5.F CI Sprint** | [#542](https://github.com/zynax-io/zynax/issues/542) | 🟡 In Progress — #551 ✅ #552 ✅ #554 ✅ force-full-pipeline; next: **#549** per-service change-detection |
-| **M5.F.R Release Pipeline** | [#556](https://github.com/zynax-io/zynax/issues/556) | 🟢 BATCH 1 complete; #641 #642 filed (image rebuild filtering + distroless) |
+| **M5.F.R Release Pipeline** | [#556](https://github.com/zynax-io/zynax/issues/556) | 🟢 BATCH 1 complete; #642 ✅ distroless; #641 open (image rebuild filtering) |
 | M5.A Truth Pass | [#458](https://github.com/zynax-io/zynax/issues/458) | In Progress — 2/3 children done; #474 open |
 | M5.B Engine Correctness | [#459](https://github.com/zynax-io/zynax/issues/459) | In Progress — #538 ✅ #539 ✅ #540 ✅; #476 parent open |
 | M5.C Capability Dispatch | [#460](https://github.com/zynax-io/zynax/issues/460) | ✅ Compose wired — all 3 services in stack; E2E dispatch pending adapters |
@@ -144,6 +144,6 @@ Priority gaps to file immediately:
 |----------|-------|-------|------|
 | P1 | [#623](https://github.com/zynax-io/zynax/issues/623) | Refuse to start without ZYNAX_API_KEY (NEW-4) | XS, fix, api-gateway |
 | P1 | [#622](https://github.com/zynax-io/zynax/issues/622) | context.WithTimeout on all gRPC calls (NEW-1) | S, fix, 4 services |
-| P2 | [#642](https://github.com/zynax-io/zynax/issues/642) | Distroless + `-s -w` (S) | Independent — 5 Dockerfile edits |
-| P2 | [#641](https://github.com/zynax-io/zynax/issues/641) | Per-service image rebuild filtering (M) | After #642 |
+| ~~P2~~ | ~~[#642](https://github.com/zynax-io/zynax/issues/642)~~ | ~~Distroless + `-s -w`~~ | ✅ Done |
+| P2 | [#641](https://github.com/zynax-io/zynax/issues/641) | Per-service image rebuild filtering (M) | Ready (unblocked by #642) |
 | P2 | [#549](https://github.com/zynax-io/zynax/issues/549) | Per-service change detection (CI test lanes) | Independent |


### PR DESCRIPTION
## Summary

- Replace `alpine:3.20/3.21` runtime stages with `gcr.io/distroless/static:nonroot` in all 6 service Dockerfiles (api-gateway, engine-adapter, workflow-compiler, task-broker, agent-registry, http-adapter)
- Add `-ldflags "-s -w"` to each `go build` command — strips DWARF debug info and Go symbol table (~30% binary size reduction)
- Remove `apk add ca-certificates`, `addgroup`, `adduser`, `USER zynax` — distroless:nonroot ships UID 65532 + ca-certificates
- Add Renovate comment per Dockerfile for base image tracking
- Document the CGO_ENABLED=0 constraint in `services/AGENTS.md`

## Why

All services use `CGO_ENABLED=0` producing fully static binaries with no libc dependency — the ideal fit for `distroless/static`. Alpine adds ~8 MB of musl libc, busybox, apk metadata, and a POSIX shell, none of which the Go binaries use at runtime. Estimated savings: ≥35% compressed image size per service.

Closes #642

## Cluster

- **#642** (this PR) → **#641** (per-service image filter in release.yml, stacked on this branch)
- Merge order: #642 first, then #641
- Dependency: #641 branches from `chore/642-distroless-dockerfiles`; after #642 merges, #641 will be retargeted to main

## State files updated

- `docs/milestones/M5-plan.md`: #642 ⬜→✅ (rev 39→40)
- `state/current-milestone.md`: M5.F.R track row updated; Next Session Queue row struck through
- `services/AGENTS.md`: CGO distroless constraint documented

## Architecture gaps addressed

None directly — `tools` and `ci-runner` images intentionally remain Alpine.

## Test plan

### Local pre-flight
- [x] `make lint-fix` — N/A (Dockerfile + AGENTS.md only, no Go/Python changes)
- [x] `make lint-go` — N/A (no Go source changes)
- [x] `make lint-protos` — N/A
- [x] `make lint-agents` — N/A
- [x] `GOWORK=off go test ./... -race` — N/A (no source changes)
- [x] `make test-coverage` — N/A
- [x] `make test-coverage-adapters` — N/A
- [x] `make test-bdd` — N/A
- [x] `make security` — N/A (Dockerfile edits, no secret exposure)
- [x] `make validate-spec` — N/A

### Acceptance (from issue #642)
- [x] All 6 service Dockerfiles use `FROM gcr.io/distroless/static:nonroot` — verified by inspection
- [x] All 6 `go build` commands include `-ldflags "-s -w"` — verified by inspection
- [x] `RUN apk add`, `addgroup`, `adduser`, `USER zynax` removed from all 6 runtime stages — verified by inspection
- [x] `# renovate: datasource=docker depName=gcr.io/distroless/static` comment present in each Dockerfile — verified by inspection
- [x] `tools` and `ci-runner` images not changed — verified: only service Dockerfiles edited
- [x] `distroless/static:nonroot` used (not `:debug`, not `distroless/cc`) — verified by inspection
- [x] CGO constraint documented in `services/AGENTS.md` — added row to AI Anti-patterns table

### Engineering hygiene
- [x] Branched from fresh `origin/main`
- [x] PR ≤ 900 lines (6 Dockerfiles + AGENTS.md + state: net -16 lines on Dockerfiles)
- [x] Every commit: `Signed-off-by: Oscar Gómez Manresa <ogomezmanresa@gmail.com>` + `Assisted-by: Claude/claude-sonnet-4-6`
- [x] No `Co-Authored-By:` for AI
- [x] No `panic` in prod paths; no silent `_ = err` — N/A (Dockerfile + docs only)
- [x] No mTLS/SBOM/cosign claims added to docs
- [x] Gap scan done (G1/G4/G7/G16) — none in Dockerfiles
- [x] 4 state files updated (M5-plan ✅, current-milestone ✅, canvas N/A, AGENTS.md ✅)
- [x] `.feature` committed before impl — N/A (chore, no public boundary)
- [x] No out-of-scope / drive-by edits

## Out of scope

- `tools` and `ci-runner` images (remain Alpine — they need a shell)
- Multi-arch test in CI (handled by existing `linux/amd64,linux/arm64` build matrix in release.yml)
- Image size measurement (CI will show compressed sizes post-push)

Closes #642