### PR TITLE
ci(release): per-service change detection for image builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,11 +24,17 @@ on:
     paths-ignore:
       - '**.md'
       - 'docs/**'
+  schedule:
+    - cron: '0 3 * * 1'    # Monday 03:00 UTC — weekly base-image CVE safety net
   workflow_dispatch:
     inputs:
       tag:
         description: 'Version tag (e.g. v0.4.0)'
-        required: true
+        required: false
+      rebuild_all:
+        description: 'Force rebuild all service images regardless of changes'
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -148,21 +154,107 @@ jobs:
           path: cmd/zynax-ci/zynax-ci-${{ matrix.suffix }}
           retention-days: 7
 
+# ── Per-service change detection ─────────────────────────────────────────────
+# On branch pushes: detect which services changed (git diff HEAD^1..HEAD).
+# On tag push, schedule, or workflow_dispatch: resolve-matrix forces all services.
+
+  changes:
+    name: Detect changed services
+    runs-on: ubuntu-24.04
+    outputs:
+      api_gateway:       ${{ steps.detect.outputs.api_gateway }}
+      engine_adapter:    ${{ steps.detect.outputs.engine_adapter }}
+      workflow_compiler: ${{ steps.detect.outputs.workflow_compiler }}
+      task_broker:       ${{ steps.detect.outputs.task_broker }}
+      agent_registry:    ${{ steps.detect.outputs.agent_registry }}
+      http_adapter:      ${{ steps.detect.outputs.http_adapter }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 2
+
+      - name: Detect per-service file changes
+        id: detect
+        run: |
+          api_gateway=false engine_adapter=false workflow_compiler=false
+          task_broker=false agent_registry=false http_adapter=false
+
+          if [ "${{ github.event_name }}" = "push" ] && [ "${{ github.ref_type }}" = "branch" ]; then
+            if ! FILES=$(git diff --name-only HEAD^1...HEAD 2>/tmp/git-diff-err.txt); then
+              echo "⚠️  git diff failed — enabling all services as fail-safe"
+              cat /tmp/git-diff-err.txt
+              api_gateway=true engine_adapter=true workflow_compiler=true
+              task_broker=true agent_registry=true http_adapter=true
+            else
+              while IFS= read -r f; do
+                [ -z "$f" ] && continue
+                echo "$f" | grep -qE '^(services/api-gateway/|protos/generated/go/)'      && api_gateway=true
+                echo "$f" | grep -qE '^(services/engine-adapter/|protos/generated/go/)'   && engine_adapter=true
+                echo "$f" | grep -qE '^(services/workflow-compiler/|protos/generated/go/)' && workflow_compiler=true
+                echo "$f" | grep -qE '^(services/task-broker/|protos/generated/go/)'      && task_broker=true
+                echo "$f" | grep -qE '^(services/agent-registry/|protos/generated/go/)'   && agent_registry=true
+                echo "$f" | grep -qE '^(agents/adapters/http/|protos/generated/go/)'      && http_adapter=true
+              done <<< "$FILES"
+            fi
+          else
+            echo "ℹ️  event='${{ github.event_name }}' ref_type='${{ github.ref_type }}' — resolve-matrix will decide"
+          fi
+
+          {
+            echo "api_gateway=$api_gateway"
+            echo "engine_adapter=$engine_adapter"
+            echo "workflow_compiler=$workflow_compiler"
+            echo "task_broker=$task_broker"
+            echo "agent_registry=$agent_registry"
+            echo "http_adapter=$http_adapter"
+          } >> "$GITHUB_OUTPUT"
+
+  resolve-matrix:
+    name: Resolve image build matrix
+    needs: [changes]
+    runs-on: ubuntu-24.04
+    outputs:
+      matrix: ${{ steps.build.outputs.matrix }}
+      any:    ${{ steps.build.outputs.any }}
+    steps:
+      - id: build
+        run: |
+          force="false"
+          [[ "${{ github.ref_type }}" == "tag" ]]                     && force="true"
+          [[ "${{ github.event_name }}" == "schedule" ]]              && force="true"
+          [[ "${{ github.event_name }}" == "workflow_dispatch" ]]     && force="true"
+          [[ "${{ inputs.rebuild_all }}" == "true" ]]                 && force="true"
+
+          svc() { printf '{"service":"%s","dockerfile":"%s"}' "$1" "$2"; }
+          entries=()
+          [[ "$force" == "true" || "${{ needs.changes.outputs.api_gateway }}"       == "true" ]] && entries+=("$(svc api-gateway services/api-gateway/Dockerfile)")
+          [[ "$force" == "true" || "${{ needs.changes.outputs.engine_adapter }}"    == "true" ]] && entries+=("$(svc engine-adapter services/engine-adapter/Dockerfile)")
+          [[ "$force" == "true" || "${{ needs.changes.outputs.workflow_compiler }}" == "true" ]] && entries+=("$(svc workflow-compiler services/workflow-compiler/Dockerfile)")
+          [[ "$force" == "true" || "${{ needs.changes.outputs.task_broker }}"       == "true" ]] && entries+=("$(svc task-broker services/task-broker/Dockerfile)")
+          [[ "$force" == "true" || "${{ needs.changes.outputs.agent_registry }}"    == "true" ]] && entries+=("$(svc agent-registry services/agent-registry/Dockerfile)")
+          [[ "$force" == "true" || "${{ needs.changes.outputs.http_adapter }}"      == "true" ]] && entries+=("$(svc http-adapter agents/adapters/http/Dockerfile)")
+
+          if [[ ${#entries[@]} -eq 0 ]]; then
+            echo 'matrix={"include":[]}' >> "$GITHUB_OUTPUT"
+            echo 'any=false' >> "$GITHUB_OUTPUT"
+            echo "ℹ️  No service images changed — build skipped."
+          else
+            printf -v joined '%s,' "${entries[@]}"
+            echo "matrix={\"include\":[${joined%,}]}" >> "$GITHUB_OUTPUT"
+            echo 'any=true' >> "$GITHUB_OUTPUT"
+            echo "✓ Building ${#entries[@]} service(s)"
+          fi
+
 # ── Service images + CycloneDX SBOMs ─────────────────────────────────────────
 
   build-push-images:
     name: Image & SBOM — ${{ matrix.service }}
+    needs: [resolve-matrix]
+    if: needs.resolve-matrix.outputs.any == 'true'
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - { service: api-gateway,       dockerfile: services/api-gateway/Dockerfile }
-          - { service: engine-adapter,    dockerfile: services/engine-adapter/Dockerfile }
-          - { service: workflow-compiler, dockerfile: services/workflow-compiler/Dockerfile }
-          - { service: task-broker,       dockerfile: services/task-broker/Dockerfile }
-          - { service: agent-registry,    dockerfile: services/agent-registry/Dockerfile }
-          - { service: http-adapter,      dockerfile: agents/adapters/http/Dockerfile }
+      matrix: ${{ fromJson(needs.resolve-matrix.outputs.matrix) }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 

--- a/docs/milestones/M5-plan.md
+++ b/docs/milestones/M5-plan.md
@@ -6,7 +6,7 @@
 **GitHub Milestone:** [Adapter Library (M5)](https://github.com/zynax-io/zynax/milestone/5)
 **Parent epic:** [#377](https://github.com/zynax-io/zynax/issues/377)
 **Status:** In Progress
-**Last updated:** 2026-05-21 (rev 39 — #642 ✅ distroless Dockerfiles + -ldflags "-s -w")
+**Last updated:** 2026-05-21 (rev 40 — #642 ✅ #641 ✅ distroless + per-service image filter)
 
 ---
 
@@ -179,7 +179,7 @@ of tooling at run time. The image is rebuilt and published to
 | [#563](https://github.com/zynax-io/zynax/issues/563) | Deduplicate tools image — remove tools-publish.yml | XS | ✅ Done | — |
 | [#564](https://github.com/zynax-io/zynax/issues/564) | Pin action digests + add linux/arm64 to zynax-ci | XS | After #552 | P2 |
 | [#565](https://github.com/zynax-io/zynax/issues/565) | Add trivy container scan gate before GHCR push | S | After #552 | P2 |
-| [#641](https://github.com/zynax-io/zynax/issues/641) | Per-service change detection for image builds in release.yml | M | After #552 | P2 |
+| [#641](https://github.com/zynax-io/zynax/issues/641) | Per-service change detection for image builds in release.yml | M | After #552 | ✅ Done |
 | [#642](https://github.com/zynax-io/zynax/issues/642) | Switch service Dockerfiles to distroless/static:nonroot + `-ldflags "-s -w"` | S | None | ✅ Done |
 
 **Notes on #641 and #642:**

--- a/state/current-milestone.md
+++ b/state/current-milestone.md
@@ -31,7 +31,7 @@ M5 is structured into seven tracks. See full execution plan: **[docs/milestones/
 | Track | Epic | Status |
 |-------|------|--------|
 | **M5.F CI Sprint** | [#542](https://github.com/zynax-io/zynax/issues/542) | 🟡 In Progress — #551 ✅ #552 ✅ #554 ✅ force-full-pipeline; next: **#549** per-service change-detection |
-| **M5.F.R Release Pipeline** | [#556](https://github.com/zynax-io/zynax/issues/556) | 🟢 BATCH 1 complete; #642 ✅ distroless; #641 open (image rebuild filtering) |
+| **M5.F.R Release Pipeline** | [#556](https://github.com/zynax-io/zynax/issues/556) | 🟢 BATCH 1 complete; #642 ✅ #641 ✅ distroless + per-service filter |
 | M5.A Truth Pass | [#458](https://github.com/zynax-io/zynax/issues/458) | In Progress — 2/3 children done; #474 open |
 | M5.B Engine Correctness | [#459](https://github.com/zynax-io/zynax/issues/459) | In Progress — #538 ✅ #539 ✅ #540 ✅; #476 parent open |
 | M5.C Capability Dispatch | [#460](https://github.com/zynax-io/zynax/issues/460) | ✅ Compose wired — all 3 services in stack; E2E dispatch pending adapters |
@@ -145,5 +145,5 @@ Priority gaps to file immediately:
 | P1 | [#623](https://github.com/zynax-io/zynax/issues/623) | Refuse to start without ZYNAX_API_KEY (NEW-4) | XS, fix, api-gateway |
 | P1 | [#622](https://github.com/zynax-io/zynax/issues/622) | context.WithTimeout on all gRPC calls (NEW-1) | S, fix, 4 services |
 | ~~P2~~ | ~~[#642](https://github.com/zynax-io/zynax/issues/642)~~ | ~~Distroless + `-s -w`~~ | ✅ Done |
-| P2 | [#641](https://github.com/zynax-io/zynax/issues/641) | Per-service image rebuild filtering (M) | Ready (unblocked by #642) |
+| ~~P2~~ | ~~[#641](https://github.com/zynax-io/zynax/issues/641)~~ | ~~Per-service image rebuild filtering~~ | ✅ Done |
 | P2 | [#549](https://github.com/zynax-io/zynax/issues/549) | Per-service change detection (CI test lanes) | Independent |


### PR DESCRIPTION
## Summary

- Add a `changes` job to `release.yml` (bash git diff, same approach as `ci.yml`) to detect which services changed on main branch pushes
- Add a `resolve-matrix` job that emits a dynamic `fromJson` matrix: only changed services on branch pushes; all services on tag push, weekly schedule, or workflow_dispatch
- `build-push-images` now consumes `fromJson(needs.resolve-matrix.outputs.matrix)` instead of a hardcoded matrix
- Add weekly schedule trigger (Monday 03:00 UTC) as a base-image CVE safety net
- Add `rebuild_all: boolean` input to `workflow_dispatch`; relax `tag` input to `required: false`

## Why

Every main branch push currently rebuilds all 6 service images (~12 min, 6× `go build` + `docker push`), even when only one service changed. The `:main-<sha>` tag misleads consumers — it implies "this service changed at this commit." Estimated savings: ~80% fewer image builds on non-release main pushes.

Closes #641

## Cluster

- **#642** (PR #653 — base) → **#641** (this PR, stacked on `chore/642-distroless-dockerfiles`)
- Merge order: #642 first, then #641
- After #653 merges, this PR will be retargeted to main and rebased

## State files updated

- `docs/milestones/M5-plan.md`: #641 ⬜→✅ (rev 40)
- `state/current-milestone.md`: M5.F.R track row updated; Next Session Queue #641 struck through

## Architecture gaps addressed

None directly — this is CI pipeline housekeeping.

## Test plan

### Local pre-flight
- [x] `make lint-fix` — N/A (YAML + state files only)
- [x] `make lint-go` — N/A
- [x] `make lint-protos` — N/A
- [x] `make lint-agents` — N/A
- [x] `GOWORK=off go test ./... -race` — N/A
- [x] `make test-coverage` — N/A
- [x] `make test-coverage-adapters` — N/A
- [x] `make test-bdd` — N/A
- [x] `make security` — N/A
- [x] `make validate-spec` — N/A

### Acceptance (from issue #641)
- [x] `changes` job detects per-service file changes via bash git diff — implemented and inspected
- [x] On branch push touching only `services/task-broker/`: only task-broker entry emitted — path filter verified by inspection (`'^(services/task-broker/|protos/generated/go/)'`)
- [x] Touching `protos/generated/go/`: all 6 services included — pattern match covers all services
- [x] `workflow_dispatch` with `rebuild_all: true` builds all 6 — force=true path in resolve-matrix
- [x] Weekly schedule (Monday 03:00 UTC) rebuilds all 6 — `event_name == schedule` → force=true
- [x] Version tag push builds all 6 unconditionally — `ref_type == tag` → force=true
- [x] Fail-safe: git diff error → all services enabled — implemented with stderr capture
- [x] Existing `tag` input preserved (relaxed to `required: false`) — verified in YAML
- [x] `agent-registry` placeholder preserved in matrix — included as 6th service entry

### Engineering hygiene
- [x] Branched from `chore/642-distroless-dockerfiles` (stacked dependency chain)
- [x] PR ≤ 900 lines (release.yml: 101 additions — M size)
- [x] Every commit: `Signed-off-by: Oscar Gómez Manresa <ogomezmanresa@gmail.com>` + `Assisted-by: Claude/claude-sonnet-4-6`
- [x] No `Co-Authored-By:` for AI
- [x] No `panic` in prod paths — N/A (CI YAML only)
- [x] No mTLS/SBOM/cosign claims added
- [x] Gap scan done (G1/G4/G7/G16) — none applicable to CI YAML
- [x] 4 state files updated (M5-plan ✅, current-milestone ✅, canvas N/A, AGENTS.md N/A)
- [x] `.feature` committed before impl — N/A (ci type)
- [x] No out-of-scope / drive-by edits

## Out of scope

- CI test lanes per-service (#549 — separate issue, different workflow)
- `govulncheck` scoping (#550 — after #549)
- cosign signing on images (#239 — M6+)

Closes #641