### PR TITLE
docs(infra): plan distroless healthcheck regression fix (#655 #656)

### DIFF
--- a/docs/milestones/M5-plan.md
+++ b/docs/milestones/M5-plan.md
@@ -6,7 +6,7 @@
 **GitHub Milestone:** [Adapter Library (M5)](https://github.com/zynax-io/zynax/milestone/5)
 **Parent epic:** [#377](https://github.com/zynax-io/zynax/issues/377)
 **Status:** In Progress
-**Last updated:** 2026-05-21 (rev 40 — #642 ✅ #641 ✅ distroless + per-service image filter)
+**Last updated:** 2026-05-22 (rev 41 — distroless regression documented; #655 #656 filed; compose override added)
 
 ---
 
@@ -188,6 +188,162 @@ of tooling at run time. The image is rebuilt and published to
 - Both can be done in the same session; #642 (#S) before #641 (#M) since it has no dependency.
 
 **Engineer profile:** DevOps / GitHub Actions specialist with Docker/Alpine experience.
+
+### BATCH 5 — Addendum: Distroless healthcheck regression (P0 · fix before anything else)
+
+> **⚠️ Regression introduced by #642 / PR #653 (merged 2026-05-21)**
+>
+> `docker-compose.yml` healthchecks use `wget` and `nc` which are not present in
+> `gcr.io/distroless/static:nonroot`. Both `make run-local` and `docker compose up --no-build`
+> are broken — api-gateway never starts because the cascade of `service_healthy` dependencies
+> fails. A temporary override (`infra/docker-compose/docker-compose.override.yml`) exists as a
+> workaround until #655 is merged.
+
+| Issue | Title | Size | Dependency |
+|-------|-------|------|------------|
+| [#655](https://github.com/zynax-io/zynax/issues/655) | Add static healthcheck binary to distroless Dockerfiles + fix compose | M | **P0 — do first** |
+| [#656](https://github.com/zynax-io/zynax/issues/656) | Implement gRPC Health Checking Protocol in all platform services | L | After #655 · M6 prep |
+
+**Temporary workaround** (until #655 merges):
+```bash
+docker compose \
+  -f infra/docker-compose/docker-compose.yml \
+  -f infra/docker-compose/docker-compose.override.yml \
+  up -d --no-build
+```
+
+---
+
+#### Architecture decision: how to add health probes to distroless images
+
+Docker `HEALTHCHECK` instructions execute **inside the container**. `distroless/static` has no
+shell (`sh`/`bash`), no POSIX utilities (`wget`, `nc`, `curl`). This section documents the
+options evaluated, their trade-offs, and the chosen approach.
+
+##### Option A — Custom static Go health-probe binary ✅ CHOSEN FOR #655
+
+Build a minimal Go binary (`tools/healthcheck/`) in the existing builder stage. No new
+Go dependencies — uses `net/http` and `net` from the stdlib. Binary is ~3–4 MB compressed.
+Handles two URL schemes:
+
+```
+/healthcheck http://localhost:8080/healthz   → HTTP GET; exits 0 if 2xx
+/healthcheck tcp://localhost:50052           → TCP dial; exits 0 if port accepts
+```
+
+**Pros:**
+- Zero external dependencies — same Go toolchain, same builder stage, no new pinned SHAs
+- ~3 MB binary (vs ~13 MB for grpc-health-probe)
+- Works for all 5 service types (HTTP `/healthz` + bare TCP gRPC) without application code changes
+- 100% auditable — < 80 lines of stdlib Go
+- Handles both `docker-compose` and future `kubectl exec` debugging
+
+**Cons:**
+- Not the CNCF-standard approach (grpc-health-probe is more widely recognised in the ecosystem)
+- We own the ~80-line binary (very low maintenance burden)
+- TCP probe verifies port is open, not that gRPC service is _serving_ — acceptable for M5,
+  superseded by Option D in M6 when services implement gRPC Health Checking Protocol
+
+**Trade-off verdict:** Correct for M5. Fastest path to unblocking `make run-local` without
+requiring application code changes or external binaries in the build.
+
+##### Option B — grpc-health-probe (CNCF standard, v0.4.50 as of May 2026)
+
+Download the pre-built static binary (~13 MB) from `ghcr.io/grpc-ecosystem/grpc-health-probe`.
+Requires services to implement `grpc.health.v1.Health/Check`.
+
+**Pros:** Battle-tested, multi-arch, maintained by grpc-ecosystem (CNCF), supports TLS/mTLS.
+Standard tooling for CNCF-style projects.
+
+**Cons:**
+- +13 MB per image (vs +3 MB for custom binary)
+- Requires `grpc_health_v1.RegisterHealthServer` in all 5 services — **not implemented today**
+- External binary to download in `docker build` — fragile (network dependency, SHA rotation)
+- Still needs a separate HTTP probe for api-gateway, workflow-compiler, engine-adapter `/healthz`
+- Blocks on #656 (application code changes) before it can be used
+
+**Trade-off verdict:** Right for M6+ once #656 lands. Not suitable for the immediate regression
+fix because it requires application-level changes across all services.
+
+##### Option C — Revert services to Alpine for local dev
+
+Use `ARG BASE=gcr.io/distroless/static:nonroot` with `--build-arg BASE=alpine:3.21` locally.
+
+**Pros:** No Dockerfile complexity; wget and nc are available in Alpine.
+
+**Cons:**
+- Production (GHCR) and local dev run **different runtimes** — bugs reproducible in only one
+  environment; defeats the purpose of distroless. Local-prod parity is non-negotiable.
+
+**Trade-off verdict:** Rejected.
+
+##### Option D — Kubernetes-native gRPC probes (K8s 1.24+) · Deferred to #656
+
+Implement `grpc.health.v1` in each service; Kubernetes uses `livenessProbe.grpc` natively.
+No binary in the image, no exec probe. Correct long-term production approach.
+
+**Cons:** Does nothing for `docker-compose` (K8s probes don't run inside containers).
+Tracked by #656, deferred to M6+.
+
+##### Option E — Disable healthchecks + restart: on-failure (current workaround)
+
+No code changes; compose retries crashed containers.
+
+**Cons:** No health signal; startup ordering is non-deterministic; poor developer experience.
+Workaround only — `docker-compose.override.yml` is committed for this purpose.
+
+---
+
+#### Implementation plan for #655
+
+```
+tools/healthcheck/
+├── go.mod    (module github.com/zynax-io/zynax/tools/healthcheck; go 1.26; no deps)
+└── main.go   (~70 lines; CGO_ENABLED=0; HTTP GET + TCP dial; 5s timeout)
+```
+
+**Each Dockerfile change (6 files):**
+
+In builder stage, after the service binary is built:
+```dockerfile
+COPY tools/healthcheck/ ./tools/healthcheck/
+RUN cd tools/healthcheck && CGO_ENABLED=0 GOWORK=off \
+    go build -trimpath -ldflags "-s -w" -o /healthcheck .
+```
+
+In runtime stage, before ENTRYPOINT:
+```dockerfile
+COPY --from=builder /healthcheck /healthcheck
+```
+
+**docker-compose.yml healthcheck replacement (per service):**
+
+| Service | Before | After |
+|---------|--------|-------|
+| agent-registry | `nc -z localhost 50052` | `CMD ["/healthcheck", "tcp://localhost:50052"]` |
+| task-broker | `nc -z localhost 50053` | `CMD ["/healthcheck", "tcp://localhost:50053"]` |
+| workflow-compiler | `wget .../healthz (9094)` | `CMD ["/healthcheck", "http://localhost:9094/healthz"]` |
+| engine-adapter | `wget .../healthz (9095)` | `CMD ["/healthcheck", "http://localhost:9095/healthz"]` |
+| api-gateway | `wget .../healthz (8080)` | `CMD ["/healthcheck", "http://localhost:8080/healthz"]` |
+
+All use exec form (`CMD`, not `CMD-SHELL`) — no shell required.
+
+---
+
+#### Future path: #656 (M6)
+
+Once #656 lands (gRPC Health Checking Protocol in all services), the gRPC service
+healthchecks (agent-registry, task-broker) can optionally switch to `grpc-health-probe`
+for richer semantic checking. The custom HTTP binary is retained for HTTP services.
+In M6, Kubernetes Helm chart probes will use `livenessProbe.grpc` natively — no binary needed.
+
+**Engineer profile for #655:** Go engineer. Read `agents/adapters/http/` as a reference
+Go module and `services/api-gateway/Dockerfile` for the builder pattern.
+
+**Engineer profile for #656:** Go engineer familiar with gRPC interceptors. Read
+`google.golang.org/grpc/health/grpc_health_v1` — the implementation is ~5 lines per service.
+
+---
 
 ### BATCH 6 — Security Hardening (P1 · independent, can be done in any order)
 

--- a/infra/docker-compose/docker-compose.override.yml
+++ b/infra/docker-compose/docker-compose.override.yml
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# TEMPORARY WORKAROUND for distroless healthcheck regression (#655).
+#
+# Problem: docker-compose.yml healthchecks use wget/nc which do not exist
+# in gcr.io/distroless/static:nonroot — services stay UNHEALTHY and the
+# startup cascade fails (api-gateway never starts).
+#
+# Usage:
+#   docker compose \
+#     -f infra/docker-compose/docker-compose.yml \
+#     -f infra/docker-compose/docker-compose.override.yml \
+#     up -d --no-build
+#
+# This override:
+#   - Disables healthchecks on the 5 platform service containers
+#   - Downgrades depends_on conditions from service_healthy → service_started
+#   - Adds restart: on-failure so services retry if a dependency isn't ready yet
+#
+# Remove this file once #655 is merged (healthcheck binary added to images).
+
+services:
+  agent-registry:
+    healthcheck:
+      disable: true
+    restart: on-failure
+
+  task-broker:
+    healthcheck:
+      disable: true
+    restart: on-failure
+    depends_on:
+      agent-registry:
+        condition: service_started
+
+  workflow-compiler:
+    healthcheck:
+      disable: true
+    restart: on-failure
+
+  engine-adapter:
+    healthcheck:
+      disable: true
+    restart: on-failure
+    depends_on:
+      temporal:
+        condition: service_healthy
+      task-broker:
+        condition: service_started
+
+  api-gateway:
+    healthcheck:
+      disable: true
+    restart: on-failure
+    depends_on:
+      workflow-compiler:
+        condition: service_started
+      engine-adapter:
+        condition: service_started
+      agent-registry:
+        condition: service_started

--- a/services/AGENTS.md
+++ b/services/AGENTS.md
@@ -117,3 +117,5 @@ Never connect to a shared or external service from within a build-tagged test.
 | Returning raw `error` from a gRPC handler | `return nil, status.Errorf(codes.InvalidArgument, "…")` |
 | Makefile target that calls `go` or `python` directly on host | Wrap in `$(TOOLS_RUN) sh -c "…"` |
 | Using `distroless/static:nonroot` for a service with `CGO_ENABLED=1` | Only `CGO_ENABLED=0` (fully static) binaries are compatible; use `distroless/cc` or Alpine if CGO is required |
+| Adding `wget`/`nc`/`curl` healthchecks to distroless Dockerfile or compose | Distroless has no shell tools — use `CMD ["/healthcheck", "url"]` with the static probe binary from `tools/healthcheck/` (built in the builder stage, COPY'd to runtime); see #655 |
+| Implementing gRPC server without `grpc_health_v1.RegisterHealthServer` | Register the gRPC Health Checking Protocol on every gRPC server for Kubernetes-native probes and grpc-health-probe compatibility; see #656 |

--- a/state/current-milestone.md
+++ b/state/current-milestone.md
@@ -31,7 +31,7 @@ M5 is structured into seven tracks. See full execution plan: **[docs/milestones/
 | Track | Epic | Status |
 |-------|------|--------|
 | **M5.F CI Sprint** | [#542](https://github.com/zynax-io/zynax/issues/542) | 🟡 In Progress — #551 ✅ #552 ✅ #554 ✅ force-full-pipeline; next: **#549** per-service change-detection |
-| **M5.F.R Release Pipeline** | [#556](https://github.com/zynax-io/zynax/issues/556) | 🟢 BATCH 1 complete; #642 ✅ #641 ✅ distroless + per-service filter |
+| **M5.F.R Release Pipeline** | [#556](https://github.com/zynax-io/zynax/issues/556) | 🔴 **REGRESSION** — #642 ✅ #641 ✅ but distroless broke compose healthchecks; **#655 P0** |
 | M5.A Truth Pass | [#458](https://github.com/zynax-io/zynax/issues/458) | In Progress — 2/3 children done; #474 open |
 | M5.B Engine Correctness | [#459](https://github.com/zynax-io/zynax/issues/459) | In Progress — #538 ✅ #539 ✅ #540 ✅; #476 parent open |
 | M5.C Capability Dispatch | [#460](https://github.com/zynax-io/zynax/issues/460) | ✅ Compose wired — all 3 services in stack; E2E dispatch pending adapters |
@@ -103,6 +103,7 @@ Canvas aligned. Ordered delivery: #526 → #527 → #528 → #481.
 
 ## Known Blockers
 
+- **🔴 #655 REGRESSION** — `make run-local` and `docker compose up --no-build` are broken: distroless images have no `wget`/`nc` so compose healthchecks always fail → api-gateway never starts. **Workaround:** `docker-compose.override.yml` (committed). Fix in #655 (P0, do next session).
 - **#552 ✅ done** — all jobs now run in ci-runner container mode.
 - **adapter implementations** (#400–#418) — unblocked by #481 ✅; adapters need a live registry to register against.
 - **E2E demo** — compose wired (#481 ✅); needs an adapter registered for capability dispatch.
@@ -138,12 +139,17 @@ Priority gaps to file immediately:
 - **#526** — BDD trim (agent-registry), **#532** — handler unit tests (task-broker), **#554** — force-full-pipeline trigger.
 - **SECURITY.md** — false mTLS/SBOM/cosign claims removed (2026-05-20, part of M5.A truth pass).
 
+## Recently Closed (this session)
+
+- **#642** — distroless Dockerfiles + `-ldflags "-s -w"` (PR #653 ✅)
+- **#641** — per-service change detection in release.yml (PR #654 ✅)
+
 ## Next Session Queue (priority order)
 
 | Priority | Issue | Title | Note |
 |----------|-------|-------|------|
+| **P0** | [#655](https://github.com/zynax-io/zynax/issues/655) | Add healthcheck binary to distroless images + fix compose | M, fix — **regression from #642, do first** |
 | P1 | [#623](https://github.com/zynax-io/zynax/issues/623) | Refuse to start without ZYNAX_API_KEY (NEW-4) | XS, fix, api-gateway |
 | P1 | [#622](https://github.com/zynax-io/zynax/issues/622) | context.WithTimeout on all gRPC calls (NEW-1) | S, fix, 4 services |
-| ~~P2~~ | ~~[#642](https://github.com/zynax-io/zynax/issues/642)~~ | ~~Distroless + `-s -w`~~ | ✅ Done |
-| ~~P2~~ | ~~[#641](https://github.com/zynax-io/zynax/issues/641)~~ | ~~Per-service image rebuild filtering~~ | ✅ Done |
 | P2 | [#549](https://github.com/zynax-io/zynax/issues/549) | Per-service change detection (CI test lanes) | Independent |
+| M6 prep | [#656](https://github.com/zynax-io/zynax/issues/656) | gRPC Health Checking Protocol in all services | L, deferred — enables K8s native probes |


### PR DESCRIPTION
## Summary

- **Regression triage:** Documents the P0 regression introduced by #642 (PR #653) — `make run-local` and `docker compose up --no-build` are both broken because distroless images have no `wget`/`nc`, so all five compose healthchecks fail and api-gateway never starts
- **Temporary workaround:** Adds `infra/docker-compose/docker-compose.override.yml` so engineers can run the stack right now (disables healthchecks, adds `restart: on-failure`)
- **Architecture decision record:** Full options analysis in `M5-plan.md` — 5 approaches evaluated with trade-offs from the perspective of a principal engineer preparing for CNCF open-source and Kubernetes production
- **Two new GitHub issues:** #655 (P0 fix, next session) and #656 (M6 prep: gRPC Health Checking Protocol)
- **Updated state files:** `current-milestone.md` surfaced as P0 blocker; `services/AGENTS.md` new anti-pattern rows

## Why

The distroless migration (#642) was correct for image size and security posture but missed a critical constraint: Docker `HEALTHCHECK` runs **inside the container**, and `distroless/static:nonroot` ships with zero shell utilities. This PR makes that failure mode explicit, provides a working workaround, and blueprints the proper fix so the next engineer can implement it in one focused session with full context.

## Architecture decision — recommended approach for #655

**Chosen:** Custom static Go health-probe binary (`tools/healthcheck/`) built in the existing builder stage. ~70 lines of stdlib Go (`net/http` + `net`), zero external dependencies, ~3 MB compressed, handles both HTTP `/healthz` endpoints and bare TCP gRPC ports. Covers all 5 service types without requiring application code changes.

**Rejected alternatives:**
- `grpc-health-probe` (+13 MB, requires implementing gRPC Health Protocol in all services — blocked on #656)
- Revert to Alpine for local dev (breaks local-prod parity — non-negotiable)
- Disable healthchecks permanently (poor developer experience, non-deterministic startup)

Full trade-off analysis with suitability matrix: `docs/milestones/M5-plan.md §BATCH 5 Addendum`

## Future path — #656

Once #655 lands, #656 adds `grpc_health_v1.RegisterHealthServer` to all 5 services (~5 lines each). This enables Kubernetes 1.24+ native gRPC probes (`livenessProbe.grpc`) without any binary in the image — the correct long-term production pattern for a CNCF-style platform.

## State files updated

- `docs/milestones/M5-plan.md`: BATCH 5 Addendum added with full analysis (rev 41)
- `state/current-milestone.md`: #655 flagged as P0; Next Session Queue reordered
- `services/AGENTS.md`: Two new AI anti-pattern rows (distroless healthchecks + gRPC health registration)
- `infra/docker-compose/docker-compose.override.yml`: Temporary workaround (new file, remove after #655 merges)

## Test plan

### Local pre-flight
- [x] `make lint-fix` — N/A (docs + YAML only)
- [x] `make lint-go` — N/A
- [x] `make lint-protos` — N/A
- [x] `make lint-agents` — N/A
- [x] `GOWORK=off go test ./... -race` — N/A
- [x] `make security` — N/A
- [x] `make validate-spec` — N/A

### Acceptance
- [x] `infra/docker-compose/docker-compose.override.yml` exists and uses `disable: true` healthchecks + `restart: on-failure`
- [x] `M5-plan.md §BATCH 5 Addendum` contains: problem statement, 5 options with trade-offs, chosen approach with rationale, implementation plan table, future path
- [x] Issues #655 and #656 created on GitHub with full SPDD-style stories, linked to M5 milestone
- [x] `current-milestone.md` shows #655 as P0 in Known Blockers and as first item in Next Session Queue
- [x] `services/AGENTS.md` has rows for healthcheck and gRPC health registration anti-patterns

### Engineering hygiene
- [x] Branched from fresh `origin/main`
- [x] PR ≤ 900 lines (229 insertions — S/M size)
- [x] Every commit: `Signed-off-by:` + `Assisted-by: Claude/claude-sonnet-4-6`
- [x] No `Co-Authored-By:` for AI
- [x] No mTLS/SBOM/cosign claims added
- [x] Gap scan done — no code changes, N/A
- [x] 4 state files updated

## Out of scope

- The actual implementation of the healthcheck binary (tracked in #655 — next session)
- gRPC Health Checking Protocol implementation (tracked in #656 — M6)
- Removing the override file (happens when #655 is merged)

Refs #655 #656
Closes nothing — this is a planning/workaround PR only