### PR TITLE
fix(api-gateway): refuse to start without ZYNAX_GW_API_KEY

### DIFF
--- a/docs/milestones/M5-plan.md
+++ b/docs/milestones/M5-plan.md
@@ -6,7 +6,7 @@
 **GitHub Milestone:** [Adapter Library (M5)](https://github.com/zynax-io/zynax/milestone/5)
 **Parent epic:** [#377](https://github.com/zynax-io/zynax/issues/377)
 **Status:** In Progress
-**Last updated:** 2026-05-22 (rev 42 — #655 ✅ healthcheck binary merged; compose override removed)
+**Last updated:** 2026-05-22 (rev 43 — #655 ✅ #623 ✅)
 
 ---
 
@@ -347,7 +347,7 @@ These issues address the security gaps identified in the 2026-05-20 principal ar
 | [#567](https://github.com/zynax-io/zynax/issues/567) | Bearer token constant-time compare | XS | ✅ Done — timing-attack exposure in `auth.go` (G1) |
 | [#568](https://github.com/zynax-io/zynax/issues/568) | ReadHeaderTimeout + MaxBytesReader on HTTP server | XS | ✅ Done — slow-read DoS vector (G2) |
 | [#622](https://github.com/zynax-io/zynax/issues/622) | Add `context.WithTimeout` to all outgoing gRPC calls | S | Cascading hang risk across all services (NEW-1 from review) |
-| [#623](https://github.com/zynax-io/zynax/issues/623) | Refuse to start without `ZYNAX_GW_API_KEY` in production | XS | Silent auth bypass on misconfiguration (NEW-4 from review) |
+| ~~[#623](https://github.com/zynax-io/zynax/issues/623)~~ | ~~Refuse to start without `ZYNAX_GW_API_KEY` in production~~ | XS | ✅ Done |
 
 **Engineer profile:** Go engineer. All four changes are self-contained. Start with #567 and #568
 (smallest), then #623 (startup guard), then #622 (gRPC deadlines — touches 4 services).

--- a/services/api-gateway/cmd/api-gateway/main.go
+++ b/services/api-gateway/cmd/api-gateway/main.go
@@ -29,6 +29,19 @@ type config struct {
 	RegistryAddr string `envconfig:"REGISTRY_ADDR" default:"localhost:50052"`
 	LogLevel     string `envconfig:"LOG_LEVEL" default:"info"`
 	APIKey       string `envconfig:"API_KEY"`
+	DevInsecure  bool   `envconfig:"DEV_INSECURE"`
+}
+
+// validateConfig rejects an empty API key unless ZYNAX_GW_DEV_INSECURE=1 is set.
+// Keeps production deployments from silently accepting all requests on misconfiguration.
+func validateConfig(cfg config) error {
+	if cfg.APIKey == "" && !cfg.DevInsecure {
+		return fmt.Errorf(
+			"ZYNAX_GW_API_KEY is not set; refusing to start " +
+				"(set ZYNAX_GW_DEV_INSECURE=1 to allow an empty key in development)",
+		)
+	}
+	return nil
 }
 
 func main() {
@@ -40,6 +53,13 @@ func main() {
 	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
 		Level: parseLogLevel(cfg.LogLevel),
 	})))
+	if err := validateConfig(cfg); err != nil {
+		slog.Error("startup validation failed", "err", err)
+		os.Exit(1)
+	}
+	if cfg.APIKey == "" {
+		slog.Warn("ZYNAX_GW_API_KEY not set — auth disabled (dev-insecure mode)")
+	}
 	if err := run(cfg); err != nil {
 		slog.Error("fatal error", "err", err)
 		os.Exit(1)
@@ -53,10 +73,6 @@ func run(cfg config) error {
 		return fmt.Errorf("gateway clients: %w", err)
 	}
 	defer cleanup()
-
-	if cfg.APIKey == "" {
-		slog.Warn("api_key not set — auth disabled")
-	}
 
 	svc := domain.NewApplyService(clients, clients, clients)
 	handler := api.NewHandler(svc, cfg.APIKey)

--- a/services/api-gateway/cmd/api-gateway/main_test.go
+++ b/services/api-gateway/cmd/api-gateway/main_test.go
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import "testing"
+
+func TestValidateConfig_EmptyKey_ProductionMode_Fails(t *testing.T) {
+	err := validateConfig(config{})
+	if err == nil {
+		t.Fatal("expected error for empty API key in production mode, got nil")
+	}
+}
+
+func TestValidateConfig_EmptyKey_DevInsecure_OK(t *testing.T) {
+	err := validateConfig(config{DevInsecure: true})
+	if err != nil {
+		t.Fatalf("expected no error in dev-insecure mode, got: %v", err)
+	}
+}
+
+func TestValidateConfig_NonEmptyKey_OK(t *testing.T) {
+	err := validateConfig(config{APIKey: "test-secret"})
+	if err != nil {
+		t.Fatalf("expected no error with API key set, got: %v", err)
+	}
+}

--- a/state/current-milestone.md
+++ b/state/current-milestone.md
@@ -149,7 +149,7 @@ Priority gaps to file immediately:
 | Priority | Issue | Title | Note |
 |----------|-------|-------|------|
 | ~~**P0**~~ | ~~[#655](https://github.com/zynax-io/zynax/issues/655)~~ | ~~Add healthcheck binary to distroless images + fix compose~~ | ✅ Done |
-| P1 | [#623](https://github.com/zynax-io/zynax/issues/623) | Refuse to start without ZYNAX_API_KEY (NEW-4) | XS, fix, api-gateway |
+| ~~P1~~ | ~~[#623](https://github.com/zynax-io/zynax/issues/623)~~ | ~~Refuse to start without ZYNAX_API_KEY (NEW-4)~~ | ✅ Done |
 | P1 | [#622](https://github.com/zynax-io/zynax/issues/622) | context.WithTimeout on all gRPC calls (NEW-1) | S, fix, 4 services |
 | P2 | [#549](https://github.com/zynax-io/zynax/issues/549) | Per-service change detection (CI test lanes) | Independent |
 | M6 prep | [#656](https://github.com/zynax-io/zynax/issues/656) | gRPC Health Checking Protocol in all services | L, deferred — enables K8s native probes |


### PR DESCRIPTION
## Summary

- Adds `DevInsecure bool` config field (env: `ZYNAX_GW_DEV_INSECURE`)
- Extracts `validateConfig()` — returns an error if `ZYNAX_GW_API_KEY` is empty and dev-insecure mode is off
- Calls `validateConfig()` in `main()` before `run()` — exits 1 with a descriptive message on failure
- Logs `WARN` when `ZYNAX_GW_DEV_INSECURE=1` and key is empty
- Adds three unit tests covering all three acceptance paths

## Why

When `ZYNAX_GW_API_KEY` is unset the bearer check in `auth.go` silently passes all requests (`requireBearer` returns `next` unchanged for an empty key). A misconfigured production deployment would silently have auth disabled. This is gap NEW-4 from the 2026-05-20 principal architect review.

Closes #623

## Cluster

- **#655**: P0 — distroless healthcheck fix (independent sibling, merges first)
- **This PR** (#623): P1 — startup guard for empty API key

Merge order: #655 first, then this PR.

## State files updated

- `docs/milestones/M5-plan.md`: #623 ✅ (rev 42)
- `state/current-milestone.md`: #623 moved to done in Next Session Queue

## Architecture gaps addressed

- **NEW-4** (from `docs/reviews/04-architecture-gaps.md`) — silent auth bypass on empty API key

## Test plan

### Local pre-flight
- [x] `make lint-fix` — clean (gofmt, golangci-lint passed in pre-commit hook)
- [x] `make lint-go` — exit 0 (golangci-lint passed in pre-commit hook)
- [x] `make lint-protos` — (N/A — no proto changes)
- [x] `make lint-agents` — (N/A — no Python changes)
- [x] `GOWORK=off go test ./... -race` — PASS [all 4 packages: cmd/api-gateway ok, internal/api ok, internal/domain ok, internal/infrastructure N/A]
- [x] `make test-coverage` — (N/A — no `internal/domain/` changes; new tests are in `cmd/`, not domain)
- [x] `make test-coverage-adapters` — (N/A — no adapter changes)
- [x] `make test-bdd` — (N/A — no feature file changes; auth gate is middleware, not a gRPC boundary)
- [x] `make security` — (N/A — tool not available locally; gitleaks pre-commit hook passed)
- [x] `make validate-spec` — (N/A — no spec changes)

### Acceptance (from issue #623 acceptance criteria)
- [x] Empty key + no `ZYNAX_GW_DEV_INSECURE` → `validateConfig` returns error — confirmed: `TestValidateConfig_EmptyKey_ProductionMode_Fails` PASS
- [x] Empty key + `ZYNAX_GW_DEV_INSECURE=1` → `validateConfig` returns nil — confirmed: `TestValidateConfig_EmptyKey_DevInsecure_OK` PASS
- [x] Non-empty key → `validateConfig` returns nil — confirmed: `TestValidateConfig_NonEmptyKey_OK` PASS
- [x] Old `slog.Warn("api_key not set — auth disabled")` in `run()` removed — confirmed: no longer in main.go

### Engineering hygiene
- [x] Branched from fresh `origin/main` (`a92685c`)
- [x] PR ≤ 900 lines — diff: 49 additions, 7 deletions
- [x] Every commit: `Signed-off-by: Oscar Gómez Manresa <ogomezmanresa@gmail.com>` + `Assisted-by: Claude/claude-sonnet-4-6`
- [x] No `Co-Authored-By:` for AI
- [x] No `panic` in prod paths; no silent `_ = err`
- [x] No mTLS/SBOM/cosign claims added to docs
- [x] Gap scan done (G1/G4/G7/G16) — not present in changed files; NEW-4 addressed
- [x] 4 state files updated: M5-plan.md ✅, current-milestone.md ✅, canvas N/A (fix type), AGENTS.md N/A (no new public endpoint)
- [x] `.feature` committed before impl — N/A (startup guard is internal; no gRPC boundary change)
- [x] No out-of-scope / drive-by edits

## Out of scope

- Implementing the `ZYNAX_GW_DEV_INSECURE` flag in docker-compose.yml (operator decision)
- Auth changes for other services (each service owns its own auth)
