### PR TITLE
fix(infra): set ZYNAX_GW_DEV_INSECURE in compose for local dev

### DIFF
--- a/infra/docker-compose/docker-compose.yml
+++ b/infra/docker-compose/docker-compose.yml
@@ -176,6 +176,7 @@ services:
       ZYNAX_GW_ENGINE_ADDR: engine-adapter:50055
       ZYNAX_GW_REGISTRY_ADDR: "agent-registry:50052"
       ZYNAX_GW_LOG_LEVEL: info
+      ZYNAX_GW_DEV_INSECURE: "1"
     ports:
       - "7080:8080"
     depends_on:


### PR DESCRIPTION
## Summary

Adds `ZYNAX_GW_DEV_INSECURE: "1"` to the api-gateway service in `docker-compose.yml`.

## Why

The startup guard merged in #623 (PR #658) exits 1 when `ZYNAX_GW_API_KEY` is empty and `ZYNAX_GW_DEV_INSECURE` is not set. The local dev compose stack has no API key configured, so api-gateway immediately exits and the stack never comes up. This is a regression from #623 — the compose file should have been updated at the same time.

Closes #660

## Test plan

- [x] Branched from fresh `origin/main`
- [x] PR ≤ 900 lines — 1 line changed
- [x] Every commit: `Signed-off-by` + `Assisted-by: Claude/claude-sonnet-4-6`
- [x] No `Co-Authored-By:` for AI
- [x] Gap scan (G1/G4/G7/G16) — N/A, compose-only change
- [x] No mTLS/SBOM/cosign claims added