### PR TITLE
fix(api-gateway): correct COMPILER_ADDR default (50051 → 50054)

### DIFF
--- a/docs/milestones/M5-plan.md
+++ b/docs/milestones/M5-plan.md
@@ -345,8 +345,13 @@ all are XS, and none require a SPDD canvas (`fix:` / `chore:` / `docs:` types).
 
 | Issue | Title | Size | Why |
 |-------|-------|------|-----|
+<<<<<<< HEAD
 | [#661](https://github.com/zynax-io/zynax/issues/661) | Fix stale `COMPILER_ADDR` default (`50051` → `50054`) | XS | Latent connection failure outside compose (PE-1) |
 | [#662](https://github.com/zynax-io/zynax/issues/662) | Repair `sbom` + `scan-image` Makefile targets | XS | ✅ Done |
+=======
+| [#661](https://github.com/zynax-io/zynax/issues/661) | Fix stale `COMPILER_ADDR` default (`50051` → `50054`) | XS | ✅ Done |
+| [#662](https://github.com/zynax-io/zynax/issues/662) | Repair `sbom` + `scan-image` Makefile targets | XS | Both targets always fail — wrong build context (PE-2) |
+>>>>>>> 9e034b8 (fix(api-gateway): correct COMPILER_ADDR default (50051 → 50054))
 | [#665](https://github.com/zynax-io/zynax/issues/665) | Fix http-adapter `registry_endpoint` port (`9091` → `50052`) | XS | Dev compose profile wires adapter to a port nothing listens on (PE-5) |
 | [#663](https://github.com/zynax-io/zynax/issues/663) | Derive `GO_SERVICES` from `go.work` | XS | Hardcoded list includes unimplemented stubs (PE-3) |
 | [#666](https://github.com/zynax-io/zynax/issues/666) | Align `ZYNAX_ENGINE_ACTIVE_ENGINE` to full-prefix convention | XS | Off-grammar env var invisible in `env \| grep ZYNAX_ENGINE_ADAPTER_` (PE-6) |

--- a/services/api-gateway/cmd/api-gateway/main.go
+++ b/services/api-gateway/cmd/api-gateway/main.go
@@ -24,7 +24,7 @@ import (
 
 type config struct {
 	HTTPPort     int    `envconfig:"HTTP_PORT" default:"8080"`
-	CompilerAddr string `envconfig:"COMPILER_ADDR" default:"localhost:50051"`
+	CompilerAddr string `envconfig:"COMPILER_ADDR" default:"localhost:50054"`
 	EngineAddr   string `envconfig:"ENGINE_ADDR" default:"localhost:50055"`
 	RegistryAddr string `envconfig:"REGISTRY_ADDR" default:"localhost:50052"`
 	LogLevel     string `envconfig:"LOG_LEVEL" default:"info"`


### PR DESCRIPTION
## Summary

- Change compiled-in `COMPILER_ADDR` default from `localhost:50051` to `localhost:50054`
- `workflow-compiler` binds on port 50054 (`ZYNAX_WC_PORT` default); the old default caused silent connection failure outside compose

## Why

Closes #661 — identified in the 2026-05-22 platform-engineering review (PE-1). Anyone running api-gateway without an explicit `ZYNAX_GW_COMPILER_ADDR` override (debugger, bare K8s pod, CI smoke test) would silently fail to connect.

## Cluster

BATCH 5B quick wins — independent siblings, no merge order required:
- This PR: #661 fix(api-gateway) ← this PR
- #662 fix(infra): Makefile repo-root context
- #665 fix(agents): http-adapter registry port

## State files updated

- `docs/milestones/M5-plan.md`: #661 → ✅ (bundled in commit)
- `state/current-milestone.md`: update done in session end
- canvas: N/A (`fix:` type, SPDD exempt)
- `services/api-gateway/AGENTS.md`: no new capability added

## Architecture gaps addressed

None directly. Reduces silent connection failures outside compose (PE-1 finding).

## Test plan

### Local pre-flight
- [x] `make lint-fix` — (N/A — no Python changes)
- [x] `make lint-go` — exit 0 (pre-commit golangci-lint hook passed on commit)
- [x] `make lint-protos` — (N/A — no proto changes)
- [x] `make lint-agents` — (N/A — no Python changes)
- [x] `GOWORK=off go test ./... -race` — PASS [services/api-gateway/: ok cmd/api-gateway (cached), ok internal/api (cached), ok internal/domain (cached)]
- [x] `make test-coverage` — (N/A — `cmd/` change only; no domain coverage impact)
- [x] `make test-coverage-adapters` — (N/A — no adapter changes)
- [x] `make test-bdd` — (N/A — no .feature changes)
- [x] `make security` — (N/A — no security-relevant code path changed)
- [x] `make validate-spec` — (N/A — no spec changes)

### Acceptance (from issue body)
- [x] `default:"localhost:50054"` in api-gateway config struct [services/api-gateway/cmd/api-gateway/main.go:27]
- [x] `GOWORK=off go test ./... -race` passes in `services/api-gateway/` [evidence above]

### Engineering hygiene
- [x] Branched from fresh `origin/main` (831559b)
- [x] PR ≤ 900 lines (2 files, 6 lines changed)
- [x] Every commit: `Signed-off-by: Oscar Gómez Manresa <ogomezmanresa@gmail.com>` + `Assisted-by: Claude/claude-sonnet-4-6`
- [x] No `Co-Authored-By:` for AI
- [x] No `panic` in prod paths; no silent `_ = err`
- [x] No mTLS/SBOM/cosign claims added to docs
- [x] Gap scan done (G1/G4/G7/G16); none found in changed files
- [x] 4 state files updated (M5-plan bundled in commit; current-milestone updated at session end)
- [x] `.feature` committed before impl (N/A — no new gRPC boundary)
- [x] No out-of-scope / drive-by edits

## Out of scope

- Verifying other services' `_ADDR` defaults — separate issue if any are stale