### PR TITLE
fix(infra): use repo-root context in scan-image, sbom, build-svc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -251,12 +251,12 @@ lint-protos: ensure-tools ## buf lint + format check on all proto files
 security: security-go security-go-adapters security-agents ## Full security scan (govulncheck + bandit + pip-audit + trivy)
 
 scan-image: ## Scan one service container image for CVEs: make scan-image SVC=agent-registry
-	docker build -t zynax/$(SVC):scan services/$(SVC)/
+	docker build -f services/$(SVC)/Dockerfile -t zynax/$(SVC):scan .
 	trivy image --exit-code 1 --severity HIGH,CRITICAL --ignorefile .trivyignore zynax/$(SVC):scan
 	docker rmi zynax/$(SVC):scan
 
 sbom: ensure-tools ## Generate CycloneDX SBOM for one service image: make sbom SVC=api-gateway
-	docker build services/$(SVC) -t $(REGISTRY)/zynax-$(SVC):local
+	docker build -f services/$(SVC)/Dockerfile -t $(REGISTRY)/zynax-$(SVC):local .
 	docker run --rm \
 	  -v /var/run/docker.sock:/var/run/docker.sock \
 	  -v "$(CURDIR):/workspace" -w /workspace \
@@ -302,11 +302,11 @@ audit: ensure-tools ## Dependency vulnerability audit (govulncheck + pip-audit);
 # ── Build images ───────────────────────────────────────────────────────────
 .PHONY: build build-svc build-agent
 build: check-docker ## Build all Docker images
-	@for svc in $(GO_SERVICES); do docker build services/$$svc -t $(REGISTRY)/zynax-$$svc:local; done
+	@for svc in $(GO_SERVICES); do docker build -f services/$$svc/Dockerfile -t $(REGISTRY)/zynax-$$svc:local .; done
 	@for a in $(AGENTS); do [ -f "agents/examples/$$a/Dockerfile" ] && docker build agents/examples/$$a -t $(REGISTRY)/zynax-agent-$$a:local || true; done
 
 build-svc: ## Build one service image: make build-svc SVC=agent-registry
-	docker build services/$(SVC) -t $(REGISTRY)/zynax-$(SVC):local
+	docker build -f services/$(SVC)/Dockerfile -t $(REGISTRY)/zynax-$(SVC):local .
 
 build-agent: ## Build one agent image: make build-agent AGENT=summarizer
 	docker build agents/examples/$(AGENT) -t $(REGISTRY)/zynax-agent-$(AGENT):local

--- a/docs/milestones/M5-plan.md
+++ b/docs/milestones/M5-plan.md
@@ -6,7 +6,7 @@
 **GitHub Milestone:** [Adapter Library (M5)](https://github.com/zynax-io/zynax/milestone/5)
 **Parent epic:** [#377](https://github.com/zynax-io/zynax/issues/377)
 **Status:** In Progress
-**Last updated:** 2026-05-22 (rev 44 — platform-engineering review: 9 issues filed #661–#669)
+**Last updated:** 2026-05-23 (rev 45 — BATCH 5B: #661 ✅ #662 ✅)
 
 ---
 
@@ -346,7 +346,7 @@ all are XS, and none require a SPDD canvas (`fix:` / `chore:` / `docs:` types).
 | Issue | Title | Size | Why |
 |-------|-------|------|-----|
 | [#661](https://github.com/zynax-io/zynax/issues/661) | Fix stale `COMPILER_ADDR` default (`50051` → `50054`) | XS | Latent connection failure outside compose (PE-1) |
-| [#662](https://github.com/zynax-io/zynax/issues/662) | Repair `sbom` + `scan-image` Makefile targets | XS | Both targets always fail — wrong build context (PE-2) |
+| [#662](https://github.com/zynax-io/zynax/issues/662) | Repair `sbom` + `scan-image` Makefile targets | XS | ✅ Done |
 | [#665](https://github.com/zynax-io/zynax/issues/665) | Fix http-adapter `registry_endpoint` port (`9091` → `50052`) | XS | Dev compose profile wires adapter to a port nothing listens on (PE-5) |
 | [#663](https://github.com/zynax-io/zynax/issues/663) | Derive `GO_SERVICES` from `go.work` | XS | Hardcoded list includes unimplemented stubs (PE-3) |
 | [#666](https://github.com/zynax-io/zynax/issues/666) | Align `ZYNAX_ENGINE_ACTIVE_ENGINE` to full-prefix convention | XS | Off-grammar env var invisible in `env \| grep ZYNAX_ENGINE_ADAPTER_` (PE-6) |


### PR DESCRIPTION
## Summary

- Fix `scan-image`, `sbom`, `build-svc`, and `build` Makefile targets to use repo-root build context (`-f services/<svc>/Dockerfile .`)
- Service Dockerfiles COPY from `protos/generated/go/` and `tools/healthcheck/` — neither exists under `services/<svc>/`; all four targets failed with `COPY failed: file not found`

## Why

Closes #662 — identified in the 2026-05-22 platform-engineering review (PE-2). Both `make sbom SVC=...` and `make scan-image SVC=...` have always failed with this repo-root context requirement.

## Cluster

BATCH 5B quick wins — independent siblings, no merge order required:
- #661 fix(api-gateway): COMPILER_ADDR default
- This PR: #662 fix(infra) ← this PR
- #665 fix(agents): http-adapter registry port

## State files updated

- `docs/milestones/M5-plan.md`: #662 → ✅ (bundled in commit)
- `state/current-milestone.md`: update done at session end
- canvas: N/A (`fix:` type, SPDD exempt)
- `AGENTS.md`: N/A — no new service capability

## Architecture gaps addressed

None directly. Unblocks SBOM and CVE scanning workflows (PE-2 finding).

## Test plan

### Local pre-flight
- [x] `make lint-fix` — (N/A — no Python changes)
- [x] `make lint-go` — (N/A — no Go changes)
- [x] `make lint-protos` — (N/A — no proto changes)
- [x] `make lint-agents` — (N/A — no Python changes)
- [x] `GOWORK=off go test ./... -race` — (N/A — Makefile-only change)
- [x] `make test-coverage` — (N/A)
- [x] `make test-coverage-adapters` — (N/A)
- [x] `make test-bdd` — (N/A)
- [x] `make security` — (N/A — no security-relevant code path; Makefile targets not run in CI)
- [x] `make validate-spec` — (N/A)

### Acceptance (from issue body)
- [x] `make scan-image SVC=api-gateway` uses repo-root build context [Makefile:254]
- [x] `make sbom SVC=api-gateway` uses repo-root build context [Makefile:259]
- [x] `make build-svc SVC=api-gateway` uses repo-root build context [Makefile:309]
- [x] `make build` loop uses repo-root build context [Makefile:305] — same pattern, fixed opportunistically per issue body note
- [x] `make lint` passes [pre-commit hook passed on commit]

### Engineering hygiene
- [x] Branched from fresh `origin/main` (831559b)
- [x] PR ≤ 900 lines (2 files, 12 lines changed)
- [x] Every commit: `Signed-off-by:` + `Assisted-by: Claude/claude-sonnet-4-6`
- [x] No `Co-Authored-By:` for AI
- [x] No `panic` in prod paths; no silent `_ = err`
- [x] No mTLS/SBOM/cosign claims added to docs
- [x] Gap scan done (G1/G4/G7/G16); none found in changed files
- [x] 4 state files updated (M5-plan bundled in commit)
- [x] `.feature` committed before impl (N/A — no new gRPC boundary)
- [x] No out-of-scope / drive-by edits

## Out of scope

- `build-agent` target uses the agent directory directly (correct — agent Dockerfiles have no cross-repo COPY dependencies)
- `docker-compose` build stanzas already use `context: ../..` (no change needed)