### PR TITLE
docs: remove conflict markers from M5-plan BATCH 5B table

### DIFF
--- a/docs/milestones/M5-plan.md
+++ b/docs/milestones/M5-plan.md
@@ -345,22 +345,13 @@ all are XS, and none require a SPDD canvas (`fix:` / `chore:` / `docs:` types).
 
 | Issue | Title | Size | Why |
 |-------|-------|------|-----|
-<<<<<<< HEAD
-| [#661](https://github.com/zynax-io/zynax/issues/661) | Fix stale `COMPILER_ADDR` default (`50051` → `50054`) | XS | Latent connection failure outside compose (PE-1) |
-<<<<<<< HEAD
-| [#662](https://github.com/zynax-io/zynax/issues/662) | Repair `sbom` + `scan-image` Makefile targets | XS | ✅ Done |
-=======
 | [#661](https://github.com/zynax-io/zynax/issues/661) | Fix stale `COMPILER_ADDR` default (`50051` → `50054`) | XS | ✅ Done |
-| [#662](https://github.com/zynax-io/zynax/issues/662) | Repair `sbom` + `scan-image` Makefile targets | XS | Both targets always fail — wrong build context (PE-2) |
->>>>>>> 9e034b8 (fix(api-gateway): correct COMPILER_ADDR default (50051 → 50054))
-| [#665](https://github.com/zynax-io/zynax/issues/665) | Fix http-adapter `registry_endpoint` port (`9091` → `50052`) | XS | Dev compose profile wires adapter to a port nothing listens on (PE-5) |
-=======
-| [#662](https://github.com/zynax-io/zynax/issues/662) | Repair `sbom` + `scan-image` Makefile targets | XS | Both targets always fail — wrong build context (PE-2) |
+| [#662](https://github.com/zynax-io/zynax/issues/662) | Repair `sbom` + `scan-image` Makefile targets | XS | ✅ Done |
 | [#665](https://github.com/zynax-io/zynax/issues/665) | Fix http-adapter `registry_endpoint` port (`9091` → `50052`) | XS | ✅ Done |
->>>>>>> 9ea07ed (fix(agents): correct registry_endpoint port in http-adapter example)
 | [#663](https://github.com/zynax-io/zynax/issues/663) | Derive `GO_SERVICES` from `go.work` | XS | Hardcoded list includes unimplemented stubs (PE-3) |
 | [#666](https://github.com/zynax-io/zynax/issues/666) | Align `ZYNAX_ENGINE_ACTIVE_ENGINE` to full-prefix convention | XS | Off-grammar env var invisible in `env \| grep ZYNAX_ENGINE_ADAPTER_` (PE-6) |
 | [#664](https://github.com/zynax-io/zynax/issues/664) | Correct Go 1.25+ claim and Helm chart claim in README | XS | Doc/reality drifts erode operator trust (PE-4) |
+| [#679](https://github.com/zynax-io/zynax/issues/679) | Translate Temporal NotFound → domain.ErrExecutionNotFound | S | GetStatus/Signal/Cancel return INTERNAL instead of NOT_FOUND |
 
 **Engineer profile:** any Go engineer. Work in priority order (top to bottom) — #661 and #662
 are most impactful. Each is a standalone PR with no dependencies on the others.

--- a/state/current-milestone.md
+++ b/state/current-milestone.md
@@ -153,5 +153,6 @@ Priority gaps to file immediately:
 | P1 | [#663](https://github.com/zynax-io/zynax/issues/663) | Derive GO_SERVICES from go.work | XS, chore — hardcoded list includes stubs |
 | P1 | [#666](https://github.com/zynax-io/zynax/issues/666) | Align ZYNAX_ENGINE_ACTIVE_ENGINE to full-prefix | XS, fix |
 | P1 | [#664](https://github.com/zynax-io/zynax/issues/664) | Correct Go 1.25+ / Helm chart claims in README | XS, docs |
+| P1 | [#679](https://github.com/zynax-io/zynax/issues/679) | Translate Temporal NotFound → domain.ErrExecutionNotFound | S, fix — GetStatus/Signal/Cancel return INTERNAL instead of NOT_FOUND |
 | P2 | [#549](https://github.com/zynax-io/zynax/issues/549) | Per-service change detection (CI test lanes) | M, ci |
 | M6 prep | [#656](https://github.com/zynax-io/zynax/issues/656) | gRPC Health Checking Protocol in all services | L, deferred |


### PR DESCRIPTION
## Summary

- Remove git conflict markers accidentally committed to `docs/milestones/M5-plan.md` during the BATCH 5B rebase sequence (PRs #675 / #677)
- Correct BATCH 5B table: #661 ✅ #662 ✅ #665 ✅, remaining issues open
- Add #679 (TemporalEngine NotFound translation) to both state files

## Why

During the rebase of fix/661 and fix/665 branches onto the new main (after #676 merged), only the "Last updated" line conflict was resolved. The BATCH 5B table had a second conflict that went unnoticed and was squash-merged with the markers intact. CI's `gitleaks`/`golangci-lint`/`Secret scan` checks don't scan Markdown for git conflict syntax.

## Test plan

### Local pre-flight
- [x] All local checks N/A — docs-only change
- [x] `grep -n "<<<<<<\|>>>>>>>" docs/milestones/M5-plan.md` — no matches

### Acceptance
- [x] BATCH 5B table renders correctly with #661 ✅ #662 ✅ #665 ✅ and #663/#664/#666/#679 open
- [x] No conflict markers anywhere in the file

### Engineering hygiene
- [x] Branched from fresh `origin/main`
- [x] PR ≤ 900 lines (2 files, ~14 lines changed)
- [x] Every commit: `Signed-off-by:` + `Assisted-by: Claude/claude-sonnet-4-6`
- [x] No `Co-Authored-By:` for AI
- [x] No mTLS/SBOM/cosign claims
- [x] No out-of-scope edits