### PR TITLE
ci: add conflict-marker check to pr-checks workflow

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -316,6 +316,51 @@ jobs:
             zynax-ci validate canvas docs/spdd/
           fi
 
+# ── Git Conflict Marker Check ─────────────────────────────────────────────────
+# Scans every file changed in the PR for leftover git conflict markers
+# (<<<<<<<, =======, >>>>>>>). These are invisible to golangci-lint, ruff,
+# and gitleaks but produce broken docs/configs if merged.
+  conflict-markers:
+    name: No conflict markers
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-24.04
+    container:
+      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:6dd8e55d433324656bdbbd2a46541c361498230f866f15be67863ac89ae81af1
+      options: --user root
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Scan changed files for conflict markers
+        run: |
+          BASE="${{ github.event.pull_request.base.sha }}"
+          HEAD="${{ github.event.pull_request.head.sha }}"
+
+          changed=$(git diff --name-only "${BASE}..${HEAD}" | grep -v "^$" || true)
+          if [ -z "$changed" ]; then
+            echo "✅ No changed files"
+            exit 0
+          fi
+
+          found=0
+          while IFS= read -r f; do
+            [ -f "$f" ] || continue
+            # Binary files return non-zero from grep -I; skip them
+            if grep -IqE '^(<{7} |={7}$|>{7} )' "$f" 2>/dev/null; then
+              echo "❌ Conflict markers in: $f"
+              grep -InE '^(<{7} |={7}$|>{7} )' "$f" | head -5
+              found=1
+            fi
+          done <<< "$changed"
+
+          if [ "$found" -eq 1 ]; then
+            echo ""
+            echo "Fix: resolve the conflict, remove the markers, and push again."
+            exit 1
+          fi
+          echo "✅ No conflict markers found"
+
 # ── Secret Scan (gitleaks) ────────────────────────────────────────────────────
 # Scans every commit in the PR range — including commits that were later amended
 # or squashed — so secrets deleted before merge are still caught.


### PR DESCRIPTION
## Summary

- Add a new `conflict-markers` job to `pr-checks.yml` that scans every changed file in a PR for leftover git conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`)
- Fast: runs `grep` on changed files only, skips binaries
- Fires on every `pull_request` event alongside existing checks

## Why

During the BATCH 5B cluster (2026-05-23), a three-way rebase conflict in `docs/milestones/M5-plan.md` was only partially resolved. The `<<<<<<<`/`=======`/`>>>>>>>` markers in the BATCH 5B table went undetected and were squash-merged to `main` (fixed by PR #680). `golangci-lint`, `ruff`, `gitleaks`, and `actionlint` all scan for their specific domains and don't catch plain-text conflict markers in any file type.

## Post-merge action required

After this merges, add **"No conflict markers"** to the repository's required status checks in branch protection settings (Settings → Branches → main → Require status checks → search "No conflict markers"). This makes the check a hard gate rather than informational.

## Implementation notes

- Pattern: `^(<{7} |={7}$|>{7} )` — `<<<<<<<` and `>>>>>>>` always have a trailing space (branch name); `=======` never does, so it matches end-of-line
- Binary files skipped via `grep -I` (exits non-zero for binaries)
- Shows the first 5 matching lines per file for fast debugging
- Only runs on PRs (skipped on push to main, where it's too late)

## Test plan

### Local pre-flight
- [x] `make lint-fix` — N/A (no Python changes)
- [x] `make lint-go` — N/A (no Go changes)
- [x] `make lint-protos` — N/A
- [x] `make lint-agents` — N/A
- [x] `GOWORK=off go test ./... -race` — N/A (no Go changes)
- [x] `make test-coverage` — N/A
- [x] `make test-bdd` — N/A
- [x] `make security` — N/A
- [x] `make validate-spec` — N/A
- [x] `actionlint` — will run in CI on this PR

### Acceptance
- [x] New `conflict-markers` job appears in the PR check list for this PR
- [x] The job passes on this PR (no conflict markers in `pr-checks.yml`)

### Engineering hygiene
- [x] Branched from fresh `origin/main`
- [x] PR ≤ 900 lines (1 file, 45 lines added)
- [x] Every commit: `Signed-off-by:` + `Assisted-by: Claude/claude-sonnet-4-6`
- [x] No `Co-Authored-By:` for AI
- [x] No mTLS/SBOM/cosign claims
- [x] No out-of-scope edits
- [x] Gap scan done (G1/G4/G7/G16); none found in changed files

## Out of scope

- Adding the check as a required status check in branch protection (requires admin; noted above as post-merge action)