### PR TITLE
chore(infra): derive GO_SERVICES from go.work

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 
 .DEFAULT_GOAL := help
 SHELL         := /bin/bash
-GO_SERVICES   := agent-registry task-broker memory-service event-bus api-gateway workflow-compiler engine-adapter
+GO_SERVICES   := $(shell grep -E '^\s+\./services/' go.work | sed 's|.*services/||' | tr -d '\t ' | sort)
 # Auto-discovered from go.work — no manual update needed when adding a new adapter module under agents/adapters/.
 GO_ADAPTERS   := $(shell grep -E '^\s+\./agents/adapters/' go.work | sed 's|.*agents/adapters/||' | tr -d '\t ' | sort)
 # Auto-discovered from agents/examples/*/pyproject.toml — no manual update needed when adding a new agent.

--- a/docs/milestones/M5-plan.md
+++ b/docs/milestones/M5-plan.md
@@ -6,7 +6,7 @@
 **GitHub Milestone:** [Adapter Library (M5)](https://github.com/zynax-io/zynax/milestone/5)
 **Parent epic:** [#377](https://github.com/zynax-io/zynax/issues/377)
 **Status:** In Progress
-**Last updated:** 2026-05-23 (rev 45 — BATCH 5B: #661 ✅ #662 ✅ #665 ✅)
+**Last updated:** 2026-05-23 (rev 46 — BATCH 5B: #661 ✅ #662 ✅ #665 ✅ #663 ✅)
 
 ---
 
@@ -348,7 +348,7 @@ all are XS, and none require a SPDD canvas (`fix:` / `chore:` / `docs:` types).
 | [#661](https://github.com/zynax-io/zynax/issues/661) | Fix stale `COMPILER_ADDR` default (`50051` → `50054`) | XS | ✅ Done |
 | [#662](https://github.com/zynax-io/zynax/issues/662) | Repair `sbom` + `scan-image` Makefile targets | XS | ✅ Done |
 | [#665](https://github.com/zynax-io/zynax/issues/665) | Fix http-adapter `registry_endpoint` port (`9091` → `50052`) | XS | ✅ Done |
-| [#663](https://github.com/zynax-io/zynax/issues/663) | Derive `GO_SERVICES` from `go.work` | XS | Hardcoded list includes unimplemented stubs (PE-3) |
+| [#663](https://github.com/zynax-io/zynax/issues/663) | Derive `GO_SERVICES` from `go.work` | XS | ✅ Done |
 | [#666](https://github.com/zynax-io/zynax/issues/666) | Align `ZYNAX_ENGINE_ACTIVE_ENGINE` to full-prefix convention | XS | Off-grammar env var invisible in `env \| grep ZYNAX_ENGINE_ADAPTER_` (PE-6) |
 | [#664](https://github.com/zynax-io/zynax/issues/664) | Correct Go 1.25+ claim and Helm chart claim in README | XS | Doc/reality drifts erode operator trust (PE-4) |
 | [#679](https://github.com/zynax-io/zynax/issues/679) | Translate Temporal NotFound → domain.ErrExecutionNotFound | S | GetStatus/Signal/Cancel return INTERNAL instead of NOT_FOUND |

--- a/state/current-milestone.md
+++ b/state/current-milestone.md
@@ -150,7 +150,7 @@ Priority gaps to file immediately:
 | Priority | Issue | Title | Note |
 |----------|-------|-------|------|
 | P1 | [#622](https://github.com/zynax-io/zynax/issues/622) | context.WithTimeout on all gRPC calls (NEW-1) | S, fix, 4 services |
-| P1 | [#663](https://github.com/zynax-io/zynax/issues/663) | Derive GO_SERVICES from go.work | XS, chore — hardcoded list includes stubs |
+| ~~P1~~ | ~~[#663](https://github.com/zynax-io/zynax/issues/663)~~ | ~~Derive GO_SERVICES from go.work~~ | ✅ Done |
 | P1 | [#666](https://github.com/zynax-io/zynax/issues/666) | Align ZYNAX_ENGINE_ACTIVE_ENGINE to full-prefix | XS, fix |
 | P1 | [#664](https://github.com/zynax-io/zynax/issues/664) | Correct Go 1.25+ / Helm chart claims in README | XS, docs |
 | P1 | [#679](https://github.com/zynax-io/zynax/issues/679) | Translate Temporal NotFound → domain.ErrExecutionNotFound | S, fix — GetStatus/Signal/Cancel return INTERNAL instead of NOT_FOUND |


### PR DESCRIPTION
## Summary

- Replaces the hardcoded `GO_SERVICES` list in `Makefile:8` (which included `memory-service` and `event-bus` stub-only modules with no `go.mod`) with the same auto-discovery `$(shell grep ...)` pattern already used by `GO_ADAPTERS`.
- `memory-service` and `event-bus` are now correctly excluded from all build, lint, govulncheck, scan-image, and sbom targets.
- Any new service added to `go.work` automatically appears in all targets — no manual Makefile update required.

## Why

Closes #663 — PE-3 from the 2026-05-22 platform-engineering review. Hardcoded list included two stub-only services (no `go.mod`, no `main.go`, not in `go.work`), causing targets that iterate `GO_SERVICES` to fail or produce misleading output.

## Cluster

BATCH 5B — Platform Engineering Quick Wins (independent siblings, any merge order):
- **This PR** — #663 `chore(infra)`: derive GO_SERVICES from go.work
- PR for #666 — `fix(engine-adapter)`: align ACTIVE_ENGINE env var to full prefix
- PR for #664 — `docs`: correct Go version and Helm claim in README

## State files updated

- `docs/milestones/M5-plan.md`: #663 → ✅ Done
- `state/current-milestone.md`: #663 removed from Next Session Queue

## Architecture gaps addressed

G17 (stub services in SERVICE_LIST) — partially addressed. The Makefile `GO_SERVICES` no longer includes stubs. The remaining gap (stub entries in doc lists) is tracked in #574.

## Test plan

### Local pre-flight
- [x] `make lint-fix` — (N/A — no Python changes)
- [x] `make lint-go` — (N/A — no Go source changes; Makefile change is a variable definition only)
- [x] `make lint-protos` — (N/A — no proto changes)
- [x] `make lint-agents` — (N/A — no Python changes)
- [x] `GOWORK=off go test ./... -race` — (N/A — no Go source changes)
- [x] `make test-coverage` — (N/A — no domain code changes)
- [x] `make test-coverage-adapters` — (N/A — no adapter changes)
- [x] `make test-bdd` — (N/A — no feature files changed)
- [x] `make security` — (N/A — no Go source changes)
- [x] `make validate-spec` — (N/A — no spec changes)

### Acceptance (from issue #663)
- [x] `GO_SERVICES` is no longer hardcoded in `Makefile` — evidence: `grep -n "GO_SERVICES" Makefile | head -3` shows `$(shell grep -E ...)` pattern
- [x] `$(GO_SERVICES)` no longer includes `memory-service` or `event-bus` — evidence: `grep -E '^\s+\./services/' go.work` confirms only `agent-registry api-gateway engine-adapter task-broker workflow-compiler`
- [x] Adding a new service to `go.work` automatically includes it in all targets — by construction: the `$(shell grep ...)` reads `go.work` at make-eval time

### Engineering hygiene
- [x] Branched from fresh `origin/main`
- [x] PR ≤ 900 lines (3 files, 8 lines changed)
- [x] Every commit: `Signed-off-by:` + `Assisted-by: Claude/claude-sonnet-4-6`
- [x] No `Co-Authored-By:` for AI
- [x] No `panic` in prod paths; no silent `_ = err` — (N/A — no Go source)
- [x] No mTLS/SBOM/cosign claims added to docs
- [x] Gap scan done (G17 noted — stub list in Makefile fixed; #574 tracks the doc-level gap)
- [x] 4 state files updated (M5-plan ✅, current-milestone ✅, canvas N/A, AGENTS.md N/A)
- [x] `.feature` committed before impl — (N/A — no new public boundary)
- [x] No out-of-scope / drive-by edits

## Out of scope

- Stub service entries in doc lists (#574) — separate issue
- `GO_ADAPTERS` or `AGENTS` variable (already auto-discovered; no change needed)

Closes #663
