### PR TITLE
docs: correct Go version (1.25+ → 1.26.3) and Helm claim in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Download from the [latest GitHub Release](https://github.com/zynax-io/zynax/rele
 | Linux (amd64) | `curl -fsSL https://github.com/zynax-io/zynax/releases/latest/download/zynax_linux_amd64.tar.gz \| tar xz && sudo mv zynax /usr/local/bin/` |
 | Linux (arm64) | `curl -fsSL https://github.com/zynax-io/zynax/releases/latest/download/zynax_linux_arm64.tar.gz \| tar xz && sudo mv zynax /usr/local/bin/` |
 
-**From source** (requires Go 1.25+): `cd cmd/zynax && GOWORK=off go build -o ~/bin/zynax .`
+**From source** (requires Go 1.26.3): `cd cmd/zynax && GOWORK=off go build -o ~/bin/zynax .`
 **Makefile shortcut:** `make install-cli`
 
 Verify: `zynax --version`
@@ -124,7 +124,7 @@ curl -fsSL https://github.com/zynax-io/zynax/releases/latest/download/zynax-ci-d
   -o ~/bin/zynax-ci && chmod +x ~/bin/zynax-ci
 ```
 
-**From source** (requires Go 1.25+): `cd cmd/zynax-ci && GOWORK=off go build -o ~/bin/zynax-ci .`
+**From source** (requires Go 1.26.3): `cd cmd/zynax-ci && GOWORK=off go build -o ~/bin/zynax-ci .`
 **Makefile shortcut:** `make install-ci-tools`
 
 ---
@@ -420,7 +420,7 @@ cmd/zynax-ci/        zynax-ci CI toolchain — validate canvas/schema/manifests,
 agents/              Python execution adapters + zynax-sdk
 protos/              gRPC contracts (Go + Python stubs generated)
 protos/tests/        BDD contract test suites (godog)
-infra/               Docker-first dev environment + Helm charts
+infra/               Docker-first dev environment · Helm charts (planned, #241)
 docs/adr/            Architecture Decision Records (ADR-001 – ADR-019)
 docs/milestones/     Per-milestone engineering reviews and release notes
 docs/spdd/           REASONS Canvas artifacts — one canvas.md per feat: issue

--- a/docs/milestones/M5-plan.md
+++ b/docs/milestones/M5-plan.md
@@ -6,7 +6,7 @@
 **GitHub Milestone:** [Adapter Library (M5)](https://github.com/zynax-io/zynax/milestone/5)
 **Parent epic:** [#377](https://github.com/zynax-io/zynax/issues/377)
 **Status:** In Progress
-**Last updated:** 2026-05-23 (rev 46 — BATCH 5B: #661 ✅ #662 ✅ #665 ✅ #663 ✅)
+**Last updated:** 2026-05-23 (rev 47 — BATCH 5B: #661 ✅ #662 ✅ #665 ✅ #663 ✅ #664 ✅)
 
 ---
 
@@ -350,7 +350,7 @@ all are XS, and none require a SPDD canvas (`fix:` / `chore:` / `docs:` types).
 | [#665](https://github.com/zynax-io/zynax/issues/665) | Fix http-adapter `registry_endpoint` port (`9091` → `50052`) | XS | ✅ Done |
 | [#663](https://github.com/zynax-io/zynax/issues/663) | Derive `GO_SERVICES` from `go.work` | XS | ✅ Done |
 | [#666](https://github.com/zynax-io/zynax/issues/666) | Align `ZYNAX_ENGINE_ACTIVE_ENGINE` to full-prefix convention | XS | Off-grammar env var invisible in `env \| grep ZYNAX_ENGINE_ADAPTER_` (PE-6) |
-| [#664](https://github.com/zynax-io/zynax/issues/664) | Correct Go 1.25+ claim and Helm chart claim in README | XS | Doc/reality drifts erode operator trust (PE-4) |
+| [#664](https://github.com/zynax-io/zynax/issues/664) | Correct Go 1.25+ claim and Helm chart claim in README | XS | ✅ Done |
 | [#679](https://github.com/zynax-io/zynax/issues/679) | Translate Temporal NotFound → domain.ErrExecutionNotFound | S | GetStatus/Signal/Cancel return INTERNAL instead of NOT_FOUND |
 
 **Engineer profile:** any Go engineer. Work in priority order (top to bottom) — #661 and #662

--- a/state/current-milestone.md
+++ b/state/current-milestone.md
@@ -152,7 +152,7 @@ Priority gaps to file immediately:
 | P1 | [#622](https://github.com/zynax-io/zynax/issues/622) | context.WithTimeout on all gRPC calls (NEW-1) | S, fix, 4 services |
 | ~~P1~~ | ~~[#663](https://github.com/zynax-io/zynax/issues/663)~~ | ~~Derive GO_SERVICES from go.work~~ | ✅ Done |
 | P1 | [#666](https://github.com/zynax-io/zynax/issues/666) | Align ZYNAX_ENGINE_ACTIVE_ENGINE to full-prefix | XS, fix |
-| P1 | [#664](https://github.com/zynax-io/zynax/issues/664) | Correct Go 1.25+ / Helm chart claims in README | XS, docs |
+| ~~P1~~ | ~~[#664](https://github.com/zynax-io/zynax/issues/664)~~ | ~~Correct Go 1.25+ / Helm chart claims in README~~ | ✅ Done |
 | P1 | [#679](https://github.com/zynax-io/zynax/issues/679) | Translate Temporal NotFound → domain.ErrExecutionNotFound | S, fix — GetStatus/Signal/Cancel return INTERNAL instead of NOT_FOUND |
 | P2 | [#549](https://github.com/zynax-io/zynax/issues/549) | Per-service change detection (CI test lanes) | M, ci |
 | M6 prep | [#656](https://github.com/zynax-io/zynax/issues/656) | gRPC Health Checking Protocol in all services | L, deferred |


### PR DESCRIPTION
## Summary

- Corrects two `requires Go 1.25+` occurrences in README (lines 98, 127) to `requires Go 1.26.3` — every `go.mod` and `go.work` in the repo pins `go 1.26.3`; Go 1.25 cannot build from source.
- Corrects the `infra/` directory description to note Helm charts are planned, not present (`infra/               Docker-first dev environment · Helm charts (planned, #241)`).
- `tools/healthcheck/go.mod` was already at `1.26.3` — no change needed.

## Why

Closes #664 — PE-4 from the 2026-05-22 platform-engineering review. Documentation inaccuracies erode operator trust and cause confusing build failures for new contributors.

## Cluster

BATCH 5B — Platform Engineering Quick Wins (independent siblings, any merge order):
- PR for #663 — `chore(infra)`: derive GO_SERVICES from go.work
- PR for #666 — `fix(engine-adapter)`: align ACTIVE_ENGINE env var to full prefix
- **This PR** — #664 `docs`: correct Go version and Helm claim in README

## State files updated

- `docs/milestones/M5-plan.md`: #664 → ✅ Done
- `state/current-milestone.md`: #664 removed from Next Session Queue

## Architecture gaps addressed

G2 (doc/reality drift) — two README inaccuracies resolved.

## Test plan

### Local pre-flight
- [x] `make lint-fix` — (N/A — no Python changes)
- [x] `make lint-go` — (N/A — no Go source changes)
- [x] `make lint-protos` — (N/A — no proto changes)
- [x] `make lint-agents` — (N/A — no Python changes)
- [x] `GOWORK=off go test ./... -race` — (N/A — no Go source changes)
- [x] `make test-coverage` — (N/A — no domain changes)
- [x] `make test-coverage-adapters` — (N/A — no adapter changes)
- [x] `make test-bdd` — (N/A — no feature files changed)
- [x] `make security` — (N/A — no source changes)
- [x] `make validate-spec` — (N/A — no spec changes)

### Acceptance (from issue #664)
- [x] `grep -r "Go 1.25" README.md` returns nothing — evidence: both occurrences replaced with `Go 1.26.3`
- [x] `grep "1.26.3" tools/healthcheck/go.mod` returns a match — evidence: file was already at `1.26.3` (pre-condition satisfied, no change needed)
- [x] README `infra/` description references `(planned, #241)` — evidence: line 423 now reads `Docker-first dev environment · Helm charts (planned, #241)`

### Engineering hygiene
- [x] Branched from fresh `origin/main`
- [x] PR ≤ 900 lines (3 files, 12 lines changed)
- [x] Every commit: `Signed-off-by:` + `Assisted-by: Claude/claude-sonnet-4-6`
- [x] No `Co-Authored-By:` for AI
- [x] No `panic` in prod paths; no silent `_ = err` — (N/A — docs only)
- [x] No mTLS/SBOM/cosign claims added to docs
- [x] Gap scan done (G1/G4/G7/G16 — N/A, docs-only PR)
- [x] 4 state files updated (M5-plan ✅, current-milestone ✅, canvas N/A, AGENTS.md N/A)
- [x] `.feature` committed before impl — (N/A — docs only)
- [x] No out-of-scope / drive-by edits (Makefile `requires Go 1.25` comments left for a separate `chore:` PR)

## Out of scope

- Makefile help-target comments that also say "requires Go 1.25" — left for a separate cleanup; issue scope is README only.

Closes #664
