### PR TITLE
fix(engine-adapter): align ACTIVE_ENGINE env var to full prefix

### DIFF
--- a/docs/adr/ADR-015-pluggable-workflow-engines.md
+++ b/docs/adr/ADR-015-pluggable-workflow-engines.md
@@ -21,7 +21,7 @@ The `WorkflowEngine` interface abstracts this complexity:
 - LangGraph is secondary (M5) — best for pure Python agent workflows
 - Argo is tertiary (M6) — best for K8s-native deployments
 
-Engine selected via config (`ZYNAX_ENGINE_ACTIVE_ENGINE`).
+Engine selected via config (`ZYNAX_ENGINE_ADAPTER_ACTIVE_ENGINE`).
 No code change required to swap engines.
 
 ## What Zynax Owns vs Engines

--- a/docs/milestones/M5-plan.md
+++ b/docs/milestones/M5-plan.md
@@ -6,7 +6,7 @@
 **GitHub Milestone:** [Adapter Library (M5)](https://github.com/zynax-io/zynax/milestone/5)
 **Parent epic:** [#377](https://github.com/zynax-io/zynax/issues/377)
 **Status:** In Progress
-**Last updated:** 2026-05-23 (rev 47 — BATCH 5B: #661 ✅ #662 ✅ #665 ✅ #663 ✅ #664 ✅)
+**Last updated:** 2026-05-23 (rev 48 — BATCH 5B: #661 ✅ #662 ✅ #665 ✅ #663 ✅ #664 ✅ #666 ✅)
 
 ---
 
@@ -349,7 +349,7 @@ all are XS, and none require a SPDD canvas (`fix:` / `chore:` / `docs:` types).
 | [#662](https://github.com/zynax-io/zynax/issues/662) | Repair `sbom` + `scan-image` Makefile targets | XS | ✅ Done |
 | [#665](https://github.com/zynax-io/zynax/issues/665) | Fix http-adapter `registry_endpoint` port (`9091` → `50052`) | XS | ✅ Done |
 | [#663](https://github.com/zynax-io/zynax/issues/663) | Derive `GO_SERVICES` from `go.work` | XS | ✅ Done |
-| [#666](https://github.com/zynax-io/zynax/issues/666) | Align `ZYNAX_ENGINE_ACTIVE_ENGINE` to full-prefix convention | XS | Off-grammar env var invisible in `env \| grep ZYNAX_ENGINE_ADAPTER_` (PE-6) |
+| [#666](https://github.com/zynax-io/zynax/issues/666) | Align `ZYNAX_ENGINE_ACTIVE_ENGINE` to full-prefix convention | XS | ✅ Done |
 | [#664](https://github.com/zynax-io/zynax/issues/664) | Correct Go 1.25+ claim and Helm chart claim in README | XS | ✅ Done |
 | [#679](https://github.com/zynax-io/zynax/issues/679) | Translate Temporal NotFound → domain.ErrExecutionNotFound | S | GetStatus/Signal/Cancel return INTERNAL instead of NOT_FOUND |
 

--- a/infra/docker-compose/docker-compose.yml
+++ b/infra/docker-compose/docker-compose.yml
@@ -152,7 +152,7 @@ services:
       ZYNAX_ENGINE_ADAPTER_TEMPORAL_NAMESPACE: default
       ZYNAX_ENGINE_ADAPTER_TEMPORAL_TASK_QUEUE: engine-adapter
       ZYNAX_ENGINE_ADAPTER_TASK_BROKER_ADDR: "task-broker:50053"
-      ZYNAX_ENGINE_ACTIVE_ENGINE: temporal
+      ZYNAX_ENGINE_ADAPTER_ACTIVE_ENGINE: temporal
     depends_on:
       temporal:
         condition: service_healthy

--- a/services/engine-adapter/AGENTS.md
+++ b/services/engine-adapter/AGENTS.md
@@ -17,8 +17,7 @@ selectable at deploy time.
 - `DispatchCapabilityActivity` (Temporal activity) calls `TaskBrokerService.DispatchTask` gRPC.
 - Publishes `zynax.workflow.state.entered/exited/completed/failed` CloudEvents.
 - Streams execution state via `WatchWorkflow` gRPC server-streaming.
-- Active engine selected via `ZYNAX_ENGINE_ACTIVE_ENGINE` env var (default: `temporal`).
-  **Note:** this name breaks the full-prefix convention; tracked in [#666](https://github.com/zynax-io/zynax/issues/666) for rename to `ZYNAX_ENGINE_ADAPTER_ACTIVE_ENGINE`.
+- Active engine selected via `ZYNAX_ENGINE_ADAPTER_ACTIVE_ENGINE` env var (default: `temporal`).
 
 Does NOT: compile YAML (workflow-compiler) · route capabilities (task-broker) · decide which engine to use (workflow-compiler).
 

--- a/services/engine-adapter/cmd/engine-adapter/main.go
+++ b/services/engine-adapter/cmd/engine-adapter/main.go
@@ -52,7 +52,7 @@ func loadConfig() config {
 		TemporalNamespace: getEnv("ZYNAX_ENGINE_ADAPTER_TEMPORAL_NAMESPACE", "default"),
 		TemporalTaskQueue: getEnv("ZYNAX_ENGINE_ADAPTER_TEMPORAL_TASK_QUEUE", "engine-adapter"),
 		TaskBrokerAddr:    getEnv("ZYNAX_ENGINE_ADAPTER_TASK_BROKER_ADDR", "localhost:50053"),
-		ActiveEngine:      getEnv("ZYNAX_ENGINE_ACTIVE_ENGINE", "temporal"),
+		ActiveEngine:      getEnv("ZYNAX_ENGINE_ADAPTER_ACTIVE_ENGINE", "temporal"),
 	}
 }
 

--- a/services/engine-adapter/internal/domain/engine.go
+++ b/services/engine-adapter/internal/domain/engine.go
@@ -13,7 +13,7 @@ import (
 // WorkflowEngine is the port that every execution backend must satisfy.
 // The gRPC handler injects a concrete engine at startup; all other domain
 // code depends only on this interface — never on engine-specific packages.
-// Engine selection is process-wide via ZYNAX_ENGINE_ACTIVE_ENGINE (ADR-015).
+// Engine selection is process-wide via ZYNAX_ENGINE_ADAPTER_ACTIVE_ENGINE (ADR-015).
 type WorkflowEngine interface {
 	// Submit starts execution of a compiled workflow and returns the
 	// adapter-assigned run identifier. The caller must not supply a run_id.

--- a/services/engine-adapter/internal/infrastructure/temporal.go
+++ b/services/engine-adapter/internal/infrastructure/temporal.go
@@ -34,7 +34,7 @@ type temporalClient interface {
 }
 
 // TemporalEngine implements domain.WorkflowEngine backed by the Temporal Go SDK.
-// Selected when ZYNAX_ENGINE_ACTIVE_ENGINE=temporal (ADR-015).
+// Selected when ZYNAX_ENGINE_ADAPTER_ACTIVE_ENGINE=temporal (ADR-015).
 type TemporalEngine struct {
 	client       temporalClient
 	taskQueue    string

--- a/state/current-milestone.md
+++ b/state/current-milestone.md
@@ -151,7 +151,7 @@ Priority gaps to file immediately:
 |----------|-------|-------|------|
 | P1 | [#622](https://github.com/zynax-io/zynax/issues/622) | context.WithTimeout on all gRPC calls (NEW-1) | S, fix, 4 services |
 | ~~P1~~ | ~~[#663](https://github.com/zynax-io/zynax/issues/663)~~ | ~~Derive GO_SERVICES from go.work~~ | ✅ Done |
-| P1 | [#666](https://github.com/zynax-io/zynax/issues/666) | Align ZYNAX_ENGINE_ACTIVE_ENGINE to full-prefix | XS, fix |
+| ~~P1~~ | ~~[#666](https://github.com/zynax-io/zynax/issues/666)~~ | ~~Align ZYNAX_ENGINE_ACTIVE_ENGINE to full-prefix~~ | ✅ Done |
 | ~~P1~~ | ~~[#664](https://github.com/zynax-io/zynax/issues/664)~~ | ~~Correct Go 1.25+ / Helm chart claims in README~~ | ✅ Done |
 | P1 | [#679](https://github.com/zynax-io/zynax/issues/679) | Translate Temporal NotFound → domain.ErrExecutionNotFound | S, fix — GetStatus/Signal/Cancel return INTERNAL instead of NOT_FOUND |
 | P2 | [#549](https://github.com/zynax-io/zynax/issues/549) | Per-service change detection (CI test lanes) | M, ci |


### PR DESCRIPTION
## Summary

- Renames `ZYNAX_ENGINE_ACTIVE_ENGINE` → `ZYNAX_ENGINE_ADAPTER_ACTIVE_ENGINE` in all locations: `main.go`, `docker-compose.yml`, `AGENTS.md`, `ADR-015`, and two internal code comments.
- All engine-adapter env vars now consistently share the `ZYNAX_ENGINE_ADAPTER_*` prefix, making them discoverable via `env | grep ZYNAX_ENGINE_ADAPTER_`.
- Clean rename (no deprecation shim): `docker-compose.yml` is updated in the same PR and no external consumers exist.

## Why

Closes #666 — PE-6 from the 2026-05-22 platform-engineering review. `ZYNAX_ENGINE_ACTIVE_ENGINE` was the only engine-adapter config variable missing the `_ADAPTER_` infix, breaking `env | grep ZYNAX_ENGINE_ADAPTER_` discovery for operators.

## Cluster

BATCH 5B — Platform Engineering Quick Wins (independent siblings, any merge order):
- PR for #663 — `chore(infra)`: derive GO_SERVICES from go.work
- **This PR** — #666 `fix(engine-adapter)`: align ACTIVE_ENGINE env var to full prefix
- PR for #664 — `docs`: correct Go version and Helm claim in README

## State files updated

- `docs/milestones/M5-plan.md`: #666 → ✅ Done
- `state/current-milestone.md`: #666 removed from Next Session Queue
- `services/engine-adapter/AGENTS.md`: updated env var name + removed tracking note
- `docs/adr/ADR-015-pluggable-workflow-engines.md`: updated env var reference

## Architecture gaps addressed

None directly. Env-var naming correctness (PE-6).

## Test plan

### Local pre-flight
- [x] `make lint-fix` — (N/A — no Python changes)
- [x] `make lint-go` — pre-commit `golangci-lint` hook passed on commit [evidence: `golangci-lint....Passed`]
- [x] `make lint-protos` — (N/A — no proto changes)
- [x] `make lint-agents` — (N/A — no Python changes)
- [x] `GOWORK=off go test ./... -race` — (N/A locally — Docker-only; change is a string constant rename with no logic change; golangci-lint passed)
- [x] `make test-coverage` — (N/A — no domain logic changes)
- [x] `make test-coverage-adapters` — (N/A — no adapter changes)
- [x] `make test-bdd` — (N/A — no feature files changed)
- [x] `make security` — (N/A — no security-sensitive logic changed)
- [x] `make validate-spec` — (N/A — no spec changes)

### Acceptance (from issue #666)
- [x] `ZYNAX_ENGINE_ADAPTER_ACTIVE_ENGINE` controls the active engine — evidence: `main.go:55` now reads `getEnv("ZYNAX_ENGINE_ADAPTER_ACTIVE_ENGINE", "temporal")`
- [x] Old name `ZYNAX_ENGINE_ACTIVE_ENGINE` removed from all runtime paths — evidence: `grep -rn ZYNAX_ENGINE_ACTIVE_ENGINE services/ infra/` returns only historical canvas (M3) and review docs
- [x] `docker-compose.yml` updated — evidence: `infra/docker-compose/docker-compose.yml:155` now `ZYNAX_ENGINE_ADAPTER_ACTIVE_ENGINE: temporal`

### Engineering hygiene
- [x] Branched from fresh `origin/main`
- [x] PR ≤ 900 lines (8 files, 19 lines changed)
- [x] Every commit: `Signed-off-by:` + `Assisted-by: Claude/claude-sonnet-4-6`
- [x] No `Co-Authored-By:` for AI
- [x] No `panic` in prod paths; no silent `_ = err`
- [x] No mTLS/SBOM/cosign claims added to docs
- [x] Gap scan done (G1/G4/G7/G16 — none present in touched files)
- [x] 4 state files updated (M5-plan ✅, current-milestone ✅, canvas N/A — fix type, AGENTS.md ✅ updated)
- [x] `.feature` committed before impl — (N/A — no new public boundary; env var rename only)
- [x] No out-of-scope / drive-by edits

## Out of scope

- Historical canvas `docs/spdd/214-temporal-execution/canvas.md` (documents M3 implementation context — intentionally unchanged)
- Deprecation fallback (not needed — docker-compose updated in same PR; no external consumers)

Closes #666
