### PR TITLE
docs: align Go version to 1.26.3 in Makefile and local-dev docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,11 +93,11 @@ stop-local: ## Stop and remove local stack containers
 logs-local: ## Tail all local stack logs
 	$(COMPOSE) logs -f
 
-install-cli: ## Build and install zynax CLI to ~/bin/zynax (requires Go 1.25)
+install-cli: ## Build and install zynax CLI to ~/bin/zynax (requires Go 1.26.3)
 	cd cmd/zynax && GOWORK=off go build -trimpath -o ~/bin/zynax .
 	@echo "✅ zynax installed → ~/bin/zynax  (ensure ~/bin is on your PATH)"
 
-install-ci-tools: ## Build and install zynax-ci toolchain to ~/bin/zynax-ci (requires Go 1.25)
+install-ci-tools: ## Build and install zynax-ci toolchain to ~/bin/zynax-ci (requires Go 1.26.3)
 	cd cmd/zynax-ci && GOWORK=off go build -trimpath -o ~/bin/zynax-ci .
 	@echo "✅ zynax-ci installed → ~/bin/zynax-ci  (ensure ~/bin is on your PATH)"
 

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -17,7 +17,7 @@ sudo mv zynax /usr/local/bin/
 curl -L https://github.com/zynax-io/zynax/releases/latest/download/zynax_linux_amd64.tar.gz | tar xz
 sudo mv zynax /usr/local/bin/
 
-# Or build from source (requires Go 1.25 installed locally):
+# Or build from source (requires Go 1.26.3 installed locally):
 cd cmd/zynax && GOWORK=off go build -o ~/bin/zynax .
 # or: make install-cli
 ```

--- a/services/workflow-compiler/AGENTS.md
+++ b/services/workflow-compiler/AGENTS.md
@@ -1,6 +1,6 @@
 # services/workflow-compiler — AGENTS.md
 
-> Go 1.25+. Inherits rules from root `AGENTS.md` and `services/AGENTS.md`.
+> Go 1.26.3. Inherits rules from root `AGENTS.md` and `services/AGENTS.md`.
 > **Status: M2 Complete.** Fully implemented — one of two complete platform services (M3 adds engine-adapter).
 
 ---


### PR DESCRIPTION
## Summary

- Fixes three operator-facing locations that still said \`Go 1.25\` after #683 corrected the README:
  - \`Makefile:96\` — \`make help\` comment for \`install-cli\`
  - \`Makefile:100\` — \`make help\` comment for \`install-ci-tools\`
  - \`docs/local-dev.md:20\` — build-from-source note
  - \`services/workflow-compiler/AGENTS.md:3\` — service header line

## Why

Found during post-merge verification of #683. All \`go.mod\` and \`go.work\` files pin \`go 1.26.3\`; Go 1.25 cannot build from source due to the \`toolchain\` directive. Stale \`make help\` output is the first thing a new contributor reads.

## State files updated

- No state files changed (no issue number — found during verification).

## Test plan

### Local pre-flight
- [x] \`make lint-fix\` — N/A (no Python)
- [x] \`make lint-go\` — N/A (no Go source)
- [x] \`make lint-protos\` — N/A
- [x] \`make lint-agents\` — N/A
- [x] \`GOWORK=off go test ./... -race\` — N/A (docs only)
- [x] \`make test-coverage\` — N/A
- [x] \`make test-coverage-adapters\` — N/A
- [x] \`make test-bdd\` — N/A
- [x] \`make security\` — N/A
- [x] \`make validate-spec\` — N/A

### Acceptance
- [x] \`grep -rn "Go 1.25" Makefile docs/local-dev.md services/workflow-compiler/AGENTS.md\` returns nothing — confirmed locally
- [x] \`grep -n "1.26.3" Makefile\` shows both install targets — confirmed
- [x] Historical review docs, state files, and CLAUDE.md retain the old name for context — confirmed, untouched

### Engineering hygiene
- [x] Branched from fresh \`origin/main\`
- [x] PR ≤ 900 lines (3 files, 8 lines changed)
- [x] Every commit: \`Signed-off-by:\` + \`Assisted-by: Claude/claude-sonnet-4-6\`
- [x] No \`Co-Authored-By:\` for AI
- [x] No mTLS/SBOM/cosign claims added
- [x] Gap scan done (G2 — doc/reality drift; this closes the remaining instances)
- [x] No out-of-scope edits