### PR TITLE
chore(services): thread gRPC call timeout from config into infra

### DIFF
--- a/docs/milestones/M5-plan.md
+++ b/docs/milestones/M5-plan.md
@@ -6,7 +6,7 @@
 **GitHub Milestone:** [Adapter Library (M5)](https://github.com/zynax-io/zynax/milestone/5)
 **Parent epic:** [#377](https://github.com/zynax-io/zynax/issues/377)
 **Status:** In Progress
-**Last updated:** 2026-05-26 (rev 49 — BATCH 5B: #679 ✅; BATCH 6: #622 ✅)
+**Last updated:** 2026-05-26 (rev 50 — BATCH 5B: #679 ✅; BATCH 6: #622 ✅ #689 ✅)
 
 ---
 

--- a/services/api-gateway/cmd/api-gateway/main.go
+++ b/services/api-gateway/cmd/api-gateway/main.go
@@ -23,13 +23,14 @@ import (
 )
 
 type config struct {
-	HTTPPort     int    `envconfig:"HTTP_PORT" default:"8080"`
-	CompilerAddr string `envconfig:"COMPILER_ADDR" default:"localhost:50054"`
-	EngineAddr   string `envconfig:"ENGINE_ADDR" default:"localhost:50055"`
-	RegistryAddr string `envconfig:"REGISTRY_ADDR" default:"localhost:50052"`
-	LogLevel     string `envconfig:"LOG_LEVEL" default:"info"`
-	APIKey       string `envconfig:"API_KEY"`
-	DevInsecure  bool   `envconfig:"DEV_INSECURE"`
+	HTTPPort         int    `envconfig:"HTTP_PORT" default:"8080"`
+	CompilerAddr     string `envconfig:"COMPILER_ADDR" default:"localhost:50054"`
+	EngineAddr       string `envconfig:"ENGINE_ADDR" default:"localhost:50055"`
+	RegistryAddr     string `envconfig:"REGISTRY_ADDR" default:"localhost:50052"`
+	LogLevel         string `envconfig:"LOG_LEVEL" default:"info"`
+	APIKey           string `envconfig:"API_KEY"`
+	DevInsecure      bool   `envconfig:"DEV_INSECURE"`
+	GRPCCallTimeoutS int    `envconfig:"GRPC_CALL_TIMEOUT_S" default:"30"`
 }
 
 // validateConfig rejects an empty API key unless ZYNAX_GW_DEV_INSECURE=1 is set.
@@ -68,7 +69,8 @@ func main() {
 
 // run contains the service lifecycle. Deferred cleanups execute before returning.
 func run(cfg config) error {
-	clients, cleanup, err := infrastructure.NewGatewayClients(cfg.CompilerAddr, cfg.EngineAddr, cfg.RegistryAddr)
+	callTimeout := time.Duration(cfg.GRPCCallTimeoutS) * time.Second
+	clients, cleanup, err := infrastructure.NewGatewayClients(cfg.CompilerAddr, cfg.EngineAddr, cfg.RegistryAddr, callTimeout)
 	if err != nil {
 		return fmt.Errorf("gateway clients: %w", err)
 	}

--- a/services/api-gateway/internal/infrastructure/clients.go
+++ b/services/api-gateway/internal/infrastructure/clients.go
@@ -22,22 +22,19 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// grpcCallTimeout is the per-call deadline for all outgoing unary gRPC requests.
-// Streaming calls (WatchWorkflow) are excluded — they are bounded by the HTTP
-// request context instead.
-var grpcCallTimeout = 30 * time.Second
-
 // GatewayClients implements domain.CompilerPort, domain.EnginePort, and
 // domain.RegistryPort using gRPC connections to downstream services.
 type GatewayClients struct {
-	compiler zynaxv1.WorkflowCompilerServiceClient
-	engine   zynaxv1.EngineAdapterServiceClient
-	registry zynaxv1.AgentRegistryServiceClient
+	compiler    zynaxv1.WorkflowCompilerServiceClient
+	engine      zynaxv1.EngineAdapterServiceClient
+	registry    zynaxv1.AgentRegistryServiceClient
+	callTimeout time.Duration
 }
 
-// NewGatewayClients dials all three downstream gRPC services. The returned
-// cleanup function closes all connections and must be deferred by the caller.
-func NewGatewayClients(compilerAddr, engineAddr, registryAddr string) (*GatewayClients, func(), error) {
+// NewGatewayClients dials all three downstream gRPC services. callTimeout is
+// applied as a per-call deadline on every unary RPC (streaming Watch excluded).
+// The returned cleanup function closes all connections and must be deferred by the caller.
+func NewGatewayClients(compilerAddr, engineAddr, registryAddr string, callTimeout time.Duration) (*GatewayClients, func(), error) {
 	dialOpts := []grpc.DialOption{
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithUnaryInterceptor(requestIDUnaryInterceptor),
@@ -59,9 +56,10 @@ func NewGatewayClients(compilerAddr, engineAddr, registryAddr string) (*GatewayC
 		return nil, func() {}, fmt.Errorf("api-gateway: registry dial: %w", err)
 	}
 	c := &GatewayClients{
-		compiler: zynaxv1.NewWorkflowCompilerServiceClient(compConn),
-		engine:   zynaxv1.NewEngineAdapterServiceClient(engConn),
-		registry: zynaxv1.NewAgentRegistryServiceClient(regConn),
+		compiler:    zynaxv1.NewWorkflowCompilerServiceClient(compConn),
+		engine:      zynaxv1.NewEngineAdapterServiceClient(engConn),
+		registry:    zynaxv1.NewAgentRegistryServiceClient(regConn),
+		callTimeout: callTimeout,
 	}
 	cleanup := func() { _ = compConn.Close(); _ = engConn.Close(); _ = regConn.Close() }
 	return c, cleanup, nil
@@ -71,7 +69,7 @@ func NewGatewayClients(compilerAddr, engineAddr, registryAddr string) (*GatewayC
 // When the compiler returns codes.InvalidArgument the gRPC error message is
 // surfaced as a CompileError so the handler can return a structured 422.
 func (c *GatewayClients) CompileWorkflow(ctx context.Context, manifestYAML []byte, namespace string, dryRun bool) (domain.CompileResult, error) {
-	callCtx, cancel := context.WithTimeout(ctx, grpcCallTimeout)
+	callCtx, cancel := context.WithTimeout(ctx, c.callTimeout)
 	defer cancel()
 	resp, err := c.compiler.CompileWorkflow(callCtx, &zynaxv1.CompileWorkflowRequest{
 		ManifestYaml: manifestYAML,
@@ -93,7 +91,7 @@ func (c *GatewayClients) SubmitWorkflow(ctx context.Context, irBytes []byte, eng
 		return "", fmt.Errorf("api-gateway: unmarshal IR: %w", err)
 	}
 	ir.WorkflowId = workflowID
-	callCtx, cancel := context.WithTimeout(ctx, grpcCallTimeout)
+	callCtx, cancel := context.WithTimeout(ctx, c.callTimeout)
 	defer cancel()
 	resp, err := c.engine.SubmitWorkflow(callCtx, &zynaxv1.SubmitWorkflowRequest{
 		WorkflowIr: ir,
@@ -107,7 +105,7 @@ func (c *GatewayClients) SubmitWorkflow(ctx context.Context, irBytes []byte, eng
 
 // GetWorkflowStatus implements domain.EnginePort.
 func (c *GatewayClients) GetWorkflowStatus(ctx context.Context, runID string) (domain.WorkflowRunSummary, error) {
-	callCtx, cancel := context.WithTimeout(ctx, grpcCallTimeout)
+	callCtx, cancel := context.WithTimeout(ctx, c.callTimeout)
 	defer cancel()
 	run, err := c.engine.GetWorkflowStatus(callCtx, &zynaxv1.GetWorkflowStatusRequest{RunId: runID})
 	if err != nil {
@@ -123,7 +121,7 @@ func (c *GatewayClients) GetWorkflowStatus(ctx context.Context, runID string) (d
 
 // CancelWorkflow implements domain.EnginePort.
 func (c *GatewayClients) CancelWorkflow(ctx context.Context, runID string) error {
-	callCtx, cancel := context.WithTimeout(ctx, grpcCallTimeout)
+	callCtx, cancel := context.WithTimeout(ctx, c.callTimeout)
 	defer cancel()
 	_, err := c.engine.CancelWorkflow(callCtx, &zynaxv1.CancelWorkflowRequest{RunId: runID})
 	if err != nil {
@@ -185,7 +183,7 @@ func (c *GatewayClients) RegisterAgent(ctx context.Context, manifestYAML []byte,
 			Labels:       m.Metadata.Labels,
 		},
 	}
-	callCtx, cancel := context.WithTimeout(ctx, grpcCallTimeout)
+	callCtx, cancel := context.WithTimeout(ctx, c.callTimeout)
 	defer cancel()
 	resp, err := c.registry.RegisterAgent(callCtx, req)
 	if err != nil {

--- a/services/api-gateway/internal/infrastructure/clients_test.go
+++ b/services/api-gateway/internal/infrastructure/clients_test.go
@@ -28,16 +28,12 @@ func (b *blockingCompiler) GetCompiledWorkflow(_ context.Context, _ *zynaxv1.Get
 	return nil, nil
 }
 
-func newTestGatewayClients(compiler zynaxv1.WorkflowCompilerServiceClient) *GatewayClients {
-	return &GatewayClients{compiler: compiler}
+func newTestGatewayClients(compiler zynaxv1.WorkflowCompilerServiceClient, callTimeout time.Duration) *GatewayClients {
+	return &GatewayClients{compiler: compiler, callTimeout: callTimeout}
 }
 
 func TestCompileWorkflow_DeadlineExceeded(t *testing.T) {
-	old := grpcCallTimeout
-	grpcCallTimeout = 50 * time.Millisecond
-	defer func() { grpcCallTimeout = old }()
-
-	c := newTestGatewayClients(&blockingCompiler{})
+	c := newTestGatewayClients(&blockingCompiler{}, 50*time.Millisecond)
 	_, err := c.CompileWorkflow(context.Background(), []byte("manifest: {}"), "default", false)
 	if err == nil {
 		t.Fatal("expected error when compiler hangs past deadline")

--- a/services/engine-adapter/cmd/engine-adapter/main.go
+++ b/services/engine-adapter/cmd/engine-adapter/main.go
@@ -41,6 +41,7 @@ type config struct {
 	TemporalTaskQueue string
 	TaskBrokerAddr    string
 	ActiveEngine      string
+	GRPCCallTimeoutS  int
 }
 
 func loadConfig() config {
@@ -53,6 +54,7 @@ func loadConfig() config {
 		TemporalTaskQueue: getEnv("ZYNAX_ENGINE_ADAPTER_TEMPORAL_TASK_QUEUE", "engine-adapter"),
 		TaskBrokerAddr:    getEnv("ZYNAX_ENGINE_ADAPTER_TASK_BROKER_ADDR", "localhost:50053"),
 		ActiveEngine:      getEnv("ZYNAX_ENGINE_ADAPTER_ACTIVE_ENGINE", "temporal"),
+		GRPCCallTimeoutS:  getEnvInt("ZYNAX_ENGINE_ADAPTER_GRPC_CALL_TIMEOUT_S", 30),
 	}
 }
 
@@ -129,7 +131,8 @@ func buildEngine(cfg config) (domain.WorkflowEngine, func(), error) {
 		return nil, func() {}, fmt.Errorf("task-broker dial: %w", err)
 	}
 
-	dispatcher := domain.NewCapabilityDispatcher(zynaxv1.NewTaskBrokerServiceClient(brokerConn))
+	callTimeout := time.Duration(cfg.GRPCCallTimeoutS) * time.Second
+	dispatcher := domain.NewCapabilityDispatcher(zynaxv1.NewTaskBrokerServiceClient(brokerConn), callTimeout)
 
 	w := worker.New(tc, cfg.TemporalTaskQueue, worker.Options{})
 	w.RegisterWorkflow(infrastructure.IRInterpreterWorkflow)

--- a/services/engine-adapter/internal/domain/activity.go
+++ b/services/engine-adapter/internal/domain/activity.go
@@ -27,20 +27,19 @@ type ActivityResult struct {
 	Payload   []byte
 }
 
-// grpcCallTimeout is the per-call deadline for outgoing gRPC requests to task-broker.
-var grpcCallTimeout = 30 * time.Second
-
 // CapabilityDispatcher dispatches capability activities to the task broker.
 // It is a plain Go struct — Temporal registers it as an activity source in
 // the infrastructure layer; no Temporal SDK is imported here (ADR-015).
 type CapabilityDispatcher struct {
 	broker       zynaxv1.TaskBrokerServiceClient
 	pollInterval time.Duration
+	callTimeout  time.Duration
 }
 
 // NewCapabilityDispatcher constructs a dispatcher backed by the given broker client.
-func NewCapabilityDispatcher(broker zynaxv1.TaskBrokerServiceClient) *CapabilityDispatcher {
-	return &CapabilityDispatcher{broker: broker, pollInterval: 500 * time.Millisecond}
+// callTimeout is applied as a per-call deadline on every outgoing gRPC request.
+func NewCapabilityDispatcher(broker zynaxv1.TaskBrokerServiceClient, callTimeout time.Duration) *CapabilityDispatcher {
+	return &CapabilityDispatcher{broker: broker, pollInterval: 500 * time.Millisecond, callTimeout: callTimeout}
 }
 
 // DispatchCapabilityActivity submits a task to the broker and polls until terminal.
@@ -54,7 +53,7 @@ func (d *CapabilityDispatcher) DispatchCapabilityActivity(ctx context.Context, i
 }
 
 func (d *CapabilityDispatcher) dispatch(ctx context.Context, in ActivityInput) (string, error) {
-	callCtx, cancel := context.WithTimeout(ctx, grpcCallTimeout)
+	callCtx, cancel := context.WithTimeout(ctx, d.callTimeout)
 	defer cancel()
 	resp, err := d.broker.DispatchTask(callCtx, &zynaxv1.DispatchTaskRequest{
 		Task: &zynaxv1.WorkflowTask{
@@ -78,7 +77,7 @@ func (d *CapabilityDispatcher) poll(ctx context.Context, taskID, capabilityName 
 		case <-time.After(d.pollInterval):
 		}
 
-		callCtx, callCancel := context.WithTimeout(ctx, grpcCallTimeout)
+		callCtx, callCancel := context.WithTimeout(ctx, d.callTimeout)
 		task, err := d.broker.GetTask(callCtx, &zynaxv1.GetTaskRequest{TaskId: taskID})
 		callCancel()
 		if err != nil {

--- a/services/engine-adapter/internal/domain/activity_test.go
+++ b/services/engine-adapter/internal/domain/activity_test.go
@@ -78,7 +78,7 @@ func (s *stubBroker) ListTasks(_ context.Context, _ *zynaxv1.ListTasksRequest, _
 }
 
 func newDispatcher(broker *stubBroker) *CapabilityDispatcher {
-	d := NewCapabilityDispatcher(broker)
+	d := NewCapabilityDispatcher(broker, 30*time.Second)
 	d.pollInterval = time.Millisecond
 	return d
 }
@@ -242,11 +242,7 @@ func TestHandleStatus_Cancelled(t *testing.T) {
 }
 
 func TestDispatch_BrokerTimeout(t *testing.T) {
-	old := grpcCallTimeout
-	grpcCallTimeout = 50 * time.Millisecond
-	defer func() { grpcCallTimeout = old }()
-
-	d := NewCapabilityDispatcher(&blockingBroker{})
+	d := NewCapabilityDispatcher(&blockingBroker{}, 50*time.Millisecond)
 	_, err := d.DispatchCapabilityActivity(context.Background(), ActivityInput{
 		CapabilityName: "summarize",
 		WorkflowID:     "wf-timeout",

--- a/services/task-broker/cmd/task-broker/main.go
+++ b/services/task-broker/cmd/task-broker/main.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/kelseyhightower/envconfig"
 	"google.golang.org/grpc"
@@ -27,9 +28,10 @@ import (
 )
 
 type config struct {
-	GRPCPort     int    `envconfig:"GRPC_PORT" default:"50053"`
-	RegistryAddr string `envconfig:"REGISTRY_ADDR" default:"localhost:50052"`
-	LogLevel     string `envconfig:"LOG_LEVEL" default:"info"`
+	GRPCPort         int    `envconfig:"GRPC_PORT" default:"50053"`
+	RegistryAddr     string `envconfig:"REGISTRY_ADDR" default:"localhost:50052"`
+	LogLevel         string `envconfig:"LOG_LEVEL" default:"info"`
+	GRPCCallTimeoutS int    `envconfig:"GRPC_CALL_TIMEOUT_S" default:"30"`
 }
 
 func main() {
@@ -48,7 +50,8 @@ func main() {
 }
 
 func run(cfg config) error {
-	finder, finderCleanup, err := infrastructure.NewRegistryClient(cfg.RegistryAddr)
+	callTimeout := time.Duration(cfg.GRPCCallTimeoutS) * time.Second
+	finder, finderCleanup, err := infrastructure.NewRegistryClient(cfg.RegistryAddr, callTimeout)
 	if err != nil {
 		return fmt.Errorf("task-broker: registry client: %w", err)
 	}

--- a/services/task-broker/internal/infrastructure/registry_client.go
+++ b/services/task-broker/internal/infrastructure/registry_client.go
@@ -14,29 +14,29 @@ import (
 	"github.com/zynax-io/zynax/services/task-broker/internal/domain"
 )
 
-// grpcCallTimeout is the per-call deadline for outgoing gRPC requests to agent-registry.
-var grpcCallTimeout = 30 * time.Second
-
 type registryClient struct {
-	client zynaxv1.AgentRegistryServiceClient
-	conn   *grpc.ClientConn
+	client      zynaxv1.AgentRegistryServiceClient
+	conn        *grpc.ClientConn
+	callTimeout time.Duration
 }
 
 // NewRegistryClient dials the agent registry and returns an AgentFinder.
+// callTimeout is applied as a per-call deadline on every outgoing gRPC request.
 // The returned cleanup function closes the connection and must be deferred by the caller.
-func NewRegistryClient(addr string) (domain.AgentFinder, func(), error) {
+func NewRegistryClient(addr string, callTimeout time.Duration) (domain.AgentFinder, func(), error) {
 	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return nil, func() {}, fmt.Errorf("task-broker: registry dial: %w", err)
 	}
 	return &registryClient{
-		client: zynaxv1.NewAgentRegistryServiceClient(conn),
-		conn:   conn,
+		client:      zynaxv1.NewAgentRegistryServiceClient(conn),
+		conn:        conn,
+		callTimeout: callTimeout,
 	}, func() { _ = conn.Close() }, nil
 }
 
 func (r *registryClient) FindByCapability(ctx context.Context, capabilityName string) ([]domain.AgentInfo, error) {
-	callCtx, cancel := context.WithTimeout(ctx, grpcCallTimeout)
+	callCtx, cancel := context.WithTimeout(ctx, r.callTimeout)
 	defer cancel()
 	resp, err := r.client.FindByCapability(callCtx, &zynaxv1.FindByCapabilityRequest{
 		CapabilityName: capabilityName,

--- a/services/task-broker/internal/infrastructure/registry_client_test.go
+++ b/services/task-broker/internal/infrastructure/registry_client_test.go
@@ -35,11 +35,7 @@ func (b *blockingRegistryClient) ListAgents(_ context.Context, _ *zynaxv1.ListAg
 }
 
 func TestFindByCapability_DeadlineExceeded(t *testing.T) {
-	old := grpcCallTimeout
-	grpcCallTimeout = 50 * time.Millisecond
-	defer func() { grpcCallTimeout = old }()
-
-	r := &registryClient{client: &blockingRegistryClient{}}
+	r := &registryClient{client: &blockingRegistryClient{}, callTimeout: 50 * time.Millisecond}
 	_, err := r.FindByCapability(context.Background(), "summarize")
 	if err == nil {
 		t.Fatal("expected error when registry hangs past deadline")

--- a/state/current-milestone.md
+++ b/state/current-milestone.md
@@ -143,6 +143,7 @@ Priority gaps to file immediately:
 
 - **#679** — Temporal NotFound → domain.ErrExecutionNotFound in engine-adapter (BATCH 5B)
 - **#622** — context.WithTimeout on all outgoing gRPC calls across 4 services (BATCH 6)
+- **#689** — Thread gRPC call timeout from config env vars; remove package-level globals
 
 ## Next Session Queue (priority order)
 


### PR DESCRIPTION
## Summary

- Replace `var grpcCallTimeout` package-level globals in `GatewayClients`, `CapabilityDispatcher`, and `registryClient` with a `callTimeout time.Duration` struct field
- Thread the value from each service's config struct through the infrastructure constructor
- Add `GRPC_CALL_TIMEOUT_S` env var to all three services (default 30s) so operators can tune per-call deadlines without recompiling
- Update timeout unit tests to inject the timeout directly rather than overriding a global

Env vars added:
- `ZYNAX_GW_GRPC_CALL_TIMEOUT_S` (api-gateway)
- `ZYNAX_ENGINE_ADAPTER_GRPC_CALL_TIMEOUT_S` (engine-adapter)
- `ZYNAX_BROKER_GRPC_CALL_TIMEOUT_S` (task-broker)

Closes #689

## Test plan
- [ ] `GOWORK=off go test ./... -race -timeout 60s` passes in all three service directories
- [ ] `TestCompileWorkflow_DeadlineExceeded`, `TestDispatch_BrokerTimeout`, `TestFindByCapability_DeadlineExceeded` all pass
- [ ] `ZYNAX_BROKER_GRPC_CALL_TIMEOUT_S=5 make run-task-broker` honours the env var

Assisted-by: Claude/claude-sonnet-4-6