### PR TITLE
ci: per-service change detection in changes job (#549)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,11 +121,14 @@ jobs:
 
 # ── Change Detection ──────────────────────────────────────────────────────────
 # Detects which path groups changed so downstream lanes can be skipped.
-# Outputs:
+# Outputs (coarse-grained, gate entire jobs):
 #   code   — true when services/, agents/, cmd/, protos/, or go.work change; gates test-unit
 #   proto  — true when protos/, spec/, or AI context files change
 #   go     — true when any Go code changes (services/, cmd/, Go adapters)
 #   python — true when Python agents change
+# Outputs (per-service, gate individual steps within lint-go and test-unit):
+#   engine_adapter / workflow_compiler / api_gateway / task_broker / agent_registry
+#   cli / adapters_go / adapters_python
 # On push to main uses git diff HEAD^1 HEAD; on PR uses the PR diff range.
   changes:
     name: changes
@@ -135,10 +138,18 @@ jobs:
       options: --user root
     needs: [dco]
     outputs:
-      code:   ${{ steps.detect.outputs.code   == 'true' || steps.force-detect.outputs.force == 'true' }}
-      proto:  ${{ steps.detect.outputs.proto  == 'true' || steps.force-detect.outputs.force == 'true' }}
-      go:     ${{ steps.detect.outputs.go     == 'true' || steps.force-detect.outputs.force == 'true' }}
-      python: ${{ steps.detect.outputs.python == 'true' || steps.force-detect.outputs.force == 'true' }}
+      code:             ${{ steps.detect.outputs.code             == 'true' || steps.force-detect.outputs.force == 'true' }}
+      proto:            ${{ steps.detect.outputs.proto            == 'true' || steps.force-detect.outputs.force == 'true' }}
+      go:               ${{ steps.detect.outputs.go               == 'true' || steps.force-detect.outputs.force == 'true' }}
+      python:           ${{ steps.detect.outputs.python           == 'true' || steps.force-detect.outputs.force == 'true' }}
+      engine_adapter:   ${{ steps.detect.outputs.engine_adapter   == 'true' || steps.force-detect.outputs.force == 'true' }}
+      workflow_compiler: ${{ steps.detect.outputs.workflow_compiler == 'true' || steps.force-detect.outputs.force == 'true' }}
+      api_gateway:      ${{ steps.detect.outputs.api_gateway      == 'true' || steps.force-detect.outputs.force == 'true' }}
+      task_broker:      ${{ steps.detect.outputs.task_broker      == 'true' || steps.force-detect.outputs.force == 'true' }}
+      agent_registry:   ${{ steps.detect.outputs.agent_registry   == 'true' || steps.force-detect.outputs.force == 'true' }}
+      cli:              ${{ steps.detect.outputs.cli              == 'true' || steps.force-detect.outputs.force == 'true' }}
+      adapters_go:      ${{ steps.detect.outputs.adapters_go      == 'true' || steps.force-detect.outputs.force == 'true' }}
+      adapters_python:  ${{ steps.detect.outputs.adapters_python  == 'true' || steps.force-detect.outputs.force == 'true' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -183,6 +194,14 @@ jobs:
               echo "proto=true"
               echo "go=true"
               echo "python=true"
+              echo "engine_adapter=true"
+              echo "workflow_compiler=true"
+              echo "api_gateway=true"
+              echo "task_broker=true"
+              echo "agent_registry=true"
+              echo "cli=true"
+              echo "adapters_go=true"
+              echo "adapters_python=true"
             } >> "$GITHUB_OUTPUT"
             echo "ℹ️  Unknown event '${{ github.event_name }}' — all lanes enabled."
             exit 0
@@ -190,14 +209,27 @@ jobs:
           if ! FILES=$(git diff --name-only "${BASE}...${HEAD_SHA}" 2>/tmp/git-diff-err.txt); then
             echo "⚠️  git diff failed — enabling all lanes as fail-safe"
             cat /tmp/git-diff-err.txt
-            echo "code=true"   >> "$GITHUB_OUTPUT"
-            echo "proto=true"  >> "$GITHUB_OUTPUT"
-            echo "go=true"     >> "$GITHUB_OUTPUT"
-            echo "python=true" >> "$GITHUB_OUTPUT"
+            {
+              echo "code=true"
+              echo "proto=true"
+              echo "go=true"
+              echo "python=true"
+              echo "engine_adapter=true"
+              echo "workflow_compiler=true"
+              echo "api_gateway=true"
+              echo "task_broker=true"
+              echo "agent_registry=true"
+              echo "cli=true"
+              echo "adapters_go=true"
+              echo "adapters_python=true"
+            } >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           code=false proto=false go=false python=false
+          engine_adapter=false workflow_compiler=false api_gateway=false
+          task_broker=false agent_registry=false cli=false
+          adapters_go=false adapters_python=false
 
           while IFS= read -r f; do
             [ -z "$f" ] && continue
@@ -219,6 +251,26 @@ jobs:
             if echo "$f" | grep -qE '^agents/' && ! echo "$f" | grep -qE '^agents/adapters/'; then
               python=true
             fi
+
+            # Per-service granularity: sets all service flags when shared deps change.
+            case "$f" in
+              services/engine-adapter/*)    engine_adapter=true ;;
+              services/workflow-compiler/*) workflow_compiler=true ;;
+              services/api-gateway/*)       api_gateway=true ;;
+              services/task-broker/*)       task_broker=true ;;
+              services/agent-registry/*)    agent_registry=true ;;
+              cmd/*)                        cli=true ;;
+              agents/adapters/http/*|agents/adapters/git/*|agents/adapters/ci/*) adapters_go=true ;;
+              agents/adapters/llm/*|agents/adapters/langgraph/*)                 adapters_python=true ;;
+              protos/generated/go/*|go.work|go.work.sum)
+                # Generated stubs and workspace file are imported by all Go services.
+                engine_adapter=true workflow_compiler=true api_gateway=true
+                task_broker=true agent_registry=true cli=true adapters_go=true ;;
+              tools/golangci-lint.yml)
+                # Lint config change requires re-linting every service.
+                engine_adapter=true workflow_compiler=true api_gateway=true
+                task_broker=true agent_registry=true cli=true adapters_go=true ;;
+            esac
           done <<< "$FILES"
 
           {
@@ -226,8 +278,17 @@ jobs:
             echo "proto=$proto"
             echo "go=$go"
             echo "python=$python"
+            echo "engine_adapter=$engine_adapter"
+            echo "workflow_compiler=$workflow_compiler"
+            echo "api_gateway=$api_gateway"
+            echo "task_broker=$task_broker"
+            echo "agent_registry=$agent_registry"
+            echo "cli=$cli"
+            echo "adapters_go=$adapters_go"
+            echo "adapters_python=$adapters_python"
           } >> "$GITHUB_OUTPUT"
           echo "── Changed path groups: code=$code  lint-proto=$proto  lint-go=$go  lint-python=$python"
+          echo "── Per-service: engine-adapter=$engine_adapter  workflow-compiler=$workflow_compiler  api-gateway=$api_gateway  task-broker=$task_broker  agent-registry=$agent_registry  cli=$cli  adapters-go=$adapters_go  adapters-python=$adapters_python"
 
 # ── Lint: Proto, AI context scan, and spec validation ────────────────────────
 # Runs: gitleaks (AI KB files), buf lint/format, stubs freshness,
@@ -409,43 +470,28 @@ jobs:
       - name: Trust workspace (git safe.directory for root container)
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
-      - name: Detect Go code
-        id: go-detect
-        run: |
-          # On push to main all lanes run (no reliable base SHA).
-          if [ "${{ github.event_name }}" != "pull_request" ]; then
-            echo "has_services=1" >> "$GITHUB_OUTPUT"
-            echo "has_adapters=1"  >> "$GITHUB_OUTPUT"
-            echo "has_cli=1"       >> "$GITHUB_OUTPUT"
-            echo "has_go=1"        >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          BASE="${{ github.event.pull_request.base.sha }}"
-          HEAD="${{ github.event.pull_request.head.sha }}"
-          if ! CHANGED=$(git diff --name-only "${BASE}...${HEAD}" 2>/tmp/git-diff-err.txt); then
-            echo "⚠️  git diff failed — treating as fully changed (fail-safe)"
-            cat /tmp/git-diff-err.txt
-            echo "has_services=1" >> "$GITHUB_OUTPUT"
-            echo "has_adapters=1" >> "$GITHUB_OUTPUT"
-            echo "has_cli=1"      >> "$GITHUB_OUTPUT"
-            echo "has_go=1"       >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          svc_count=$(echo "$CHANGED"  | grep "^services/"       | wc -l)
-          adapter_count=$(echo "$CHANGED" | grep "^agents/adapters/" | wc -l)
-          cli_count=$(echo "$CHANGED"  | grep "^cmd/"            | wc -l)
-          total=$((svc_count + adapter_count + cli_count))
-          echo "has_services=$svc_count"   >> "$GITHUB_OUTPUT"
-          echo "has_adapters=$adapter_count" >> "$GITHUB_OUTPUT"
-          echo "has_cli=$cli_count"         >> "$GITHUB_OUTPUT"
-          echo "has_go=$total"              >> "$GITHUB_OUTPUT"
-
       - name: golangci-lint (platform services)
-        if: steps.go-detect.outputs.has_services != '0'
+        if: >-
+          needs.changes.outputs.engine_adapter == 'true' ||
+          needs.changes.outputs.workflow_compiler == 'true' ||
+          needs.changes.outputs.api_gateway == 'true' ||
+          needs.changes.outputs.task_broker == 'true' ||
+          needs.changes.outputs.agent_registry == 'true'
+        env:
+          ENGINE_ADAPTER_CHANGED:   ${{ needs.changes.outputs.engine_adapter }}
+          WORKFLOW_COMPILER_CHANGED: ${{ needs.changes.outputs.workflow_compiler }}
+          API_GATEWAY_CHANGED:      ${{ needs.changes.outputs.api_gateway }}
+          TASK_BROKER_CHANGED:      ${{ needs.changes.outputs.task_broker }}
+          AGENT_REGISTRY_CHANGED:   ${{ needs.changes.outputs.agent_registry }}
         run: |
           failed=false
           for svc in ${{ env.SERVICE_LIST }}; do
             if [ -f "services/${svc}/go.mod" ]; then
+              var="$(echo "$svc" | tr '-' '_' | tr '[:lower:]' '[:upper:]')_CHANGED"
+              if [ "${!var:-false}" != "true" ]; then
+                echo "── lint: services/${svc} [SKIPPED — not changed]"
+                continue
+              fi
               echo "── lint: services/${svc}"
               cd "services/${svc}"
               GOWORK=off golangci-lint run ./... --config "../../tools/golangci-lint.yml" || failed=true
@@ -455,7 +501,7 @@ jobs:
           $failed && exit 1 || echo "✅ Go service lint passed"
 
       - name: golangci-lint (Go adapters)
-        if: steps.go-detect.outputs.has_adapters != '0'
+        if: needs.changes.outputs.adapters_go == 'true'
         run: |
           failed=false
           for adapter in ${{ env.GO_ADAPTER_LIST }}; do
@@ -469,7 +515,7 @@ jobs:
           $failed && exit 1 || echo "✅ Go adapter lint passed"
 
       - name: golangci-lint (CLI tools)
-        if: steps.go-detect.outputs.has_cli != '0'
+        if: needs.changes.outputs.cli == 'true'
         run: |
           failed=false
           for cli in zynax zynax-ci; do
@@ -627,10 +673,21 @@ jobs:
 
       - name: Go service unit tests
         if: steps.go-detect.outputs.has_services != '0'
+        env:
+          ENGINE_ADAPTER_CHANGED:    ${{ needs.changes.outputs.engine_adapter }}
+          WORKFLOW_COMPILER_CHANGED: ${{ needs.changes.outputs.workflow_compiler }}
+          API_GATEWAY_CHANGED:       ${{ needs.changes.outputs.api_gateway }}
+          TASK_BROKER_CHANGED:       ${{ needs.changes.outputs.task_broker }}
+          AGENT_REGISTRY_CHANGED:    ${{ needs.changes.outputs.agent_registry }}
         run: |
           failed=false
           for svc in ${{ env.SERVICE_LIST }}; do
             if [ -f "services/${svc}/go.mod" ]; then
+              var="$(echo "$svc" | tr '-' '_' | tr '[:lower:]' '[:upper:]')_CHANGED"
+              if [ "${!var:-false}" != "true" ]; then
+                echo "── test: services/${svc} [SKIPPED — not changed]"
+                continue
+              fi
               echo "── test: services/${svc}"
               cd "services/${svc}"
               GOWORK=off go test -tags="" ./... -v -timeout 60s -count=1 || failed=true
@@ -641,11 +698,22 @@ jobs:
 
       - name: Go domain coverage measurement
         if: steps.go-detect.outputs.has_services != '0'
+        env:
+          ENGINE_ADAPTER_CHANGED:    ${{ needs.changes.outputs.engine_adapter }}
+          WORKFLOW_COMPILER_CHANGED: ${{ needs.changes.outputs.workflow_compiler }}
+          API_GATEWAY_CHANGED:       ${{ needs.changes.outputs.api_gateway }}
+          TASK_BROKER_CHANGED:       ${{ needs.changes.outputs.task_broker }}
+          AGENT_REGISTRY_CHANGED:    ${{ needs.changes.outputs.agent_registry }}
         run: |
           # Run tests scoped to internal/domain/ only for a clean coverage profile.
           # go tool cover is run from inside the service dir so it resolves go.mod.
           for svc in ${{ env.SERVICE_LIST }}; do
             if [ -f "services/${svc}/go.mod" ] && [ -d "services/${svc}/internal/domain" ]; then
+              var="$(echo "$svc" | tr '-' '_' | tr '[:lower:]' '[:upper:]')_CHANGED"
+              if [ "${!var:-false}" != "true" ]; then
+                echo "── coverage: services/${svc} [SKIPPED — not changed]"
+                continue
+              fi
               cd "services/${svc}"
               GOWORK=off go test -tags="" ./internal/domain/... \
                 -coverprofile=domain-coverage.out \

--- a/docs/milestones/M5-plan.md
+++ b/docs/milestones/M5-plan.md
@@ -6,7 +6,7 @@
 **GitHub Milestone:** [Adapter Library (M5)](https://github.com/zynax-io/zynax/milestone/5)
 **Parent epic:** [#377](https://github.com/zynax-io/zynax/issues/377)
 **Status:** In Progress
-**Last updated:** 2026-05-26 (rev 50 — BATCH 5B: #679 ✅; BATCH 6: #622 ✅ #689 ✅)
+**Last updated:** 2026-05-26 (rev 51 — BATCH 5: #549 ✅ #550 ✅)
 
 ---
 
@@ -173,8 +173,8 @@ of tooling at run time. The image is rebuilt and published to
 | [#551](https://github.com/zynax-io/zynax/issues/551) | Create Dockerfile.ci-runner — self-contained Alpine image | S | ✅ Done | — |
 | [#552](https://github.com/zynax-io/zynax/issues/552) | Switch all GH Actions jobs to ci-runner container mode | M | ✅ Done | **P0** |
 | [#554](https://github.com/zynax-io/zynax/issues/554) | Force-full-pipeline trigger (dispatch, label, `[full-ci]`) | S | After #552 ✅ | ✅ Done |
-| [#549](https://github.com/zynax-io/zynax/issues/549) | Extend changes job per-service module granularity | M | After #552 | P1 |
-| [#550](https://github.com/zynax-io/zynax/issues/550) | Scope govulncheck to changed services only | M | After #549 | P1 |
+| [#549](https://github.com/zynax-io/zynax/issues/549) | Extend changes job per-service module granularity | M | After #552 | ✅ Done |
+| [#550](https://github.com/zynax-io/zynax/issues/550) | Scope govulncheck to changed services only | M | After #549 | ✅ Done |
 | [#555](https://github.com/zynax-io/zynax/issues/555) | DRY/KISS refactor — reusable workflows, composite actions | L | After #552 | P2 |
 | [#563](https://github.com/zynax-io/zynax/issues/563) | Deduplicate tools image — remove tools-publish.yml | XS | ✅ Done | — |
 | [#564](https://github.com/zynax-io/zynax/issues/564) | Pin action digests + add linux/arm64 to zynax-ci | XS | After #552 | P2 |

--- a/state/current-milestone.md
+++ b/state/current-milestone.md
@@ -30,8 +30,8 @@ M5 is structured into seven tracks. See full execution plan: **[docs/milestones/
 
 | Track | Epic | Status |
 |-------|------|--------|
-| **M5.F CI Sprint** | [#542](https://github.com/zynax-io/zynax/issues/542) | 🟡 In Progress — #551 ✅ #552 ✅ #554 ✅ force-full-pipeline; next: **#549** per-service change-detection |
-| **M5.F.R Release Pipeline** | [#556](https://github.com/zynax-io/zynax/issues/556) | 🟡 In Progress — #642 ✅ #641 ✅ #655 ✅; next: #549 per-service change-detection |
+| **M5.F CI Sprint** | [#542](https://github.com/zynax-io/zynax/issues/542) | 🟡 In Progress — #551 ✅ #552 ✅ #554 ✅ #549 ✅ #550 ✅; next: #555 DRY/KISS or #564 digest-pin |
+| **M5.F.R Release Pipeline** | [#556](https://github.com/zynax-io/zynax/issues/556) | 🟡 In Progress — #642 ✅ #641 ✅ #655 ✅ #549 ✅ #550 ✅; next: #555 DRY/KISS or #564 digest-pin |
 | M5.A Truth Pass | [#458](https://github.com/zynax-io/zynax/issues/458) | In Progress — 2/3 children done; #474 open |
 | M5.B Engine Correctness | [#459](https://github.com/zynax-io/zynax/issues/459) | In Progress — #538 ✅ #539 ✅ #540 ✅; #476 parent open |
 | M5.C Capability Dispatch | [#460](https://github.com/zynax-io/zynax/issues/460) | ✅ Compose wired — all 3 services in stack; E2E dispatch pending adapters |
@@ -144,12 +144,14 @@ Priority gaps to file immediately:
 - **#679** — Temporal NotFound → domain.ErrExecutionNotFound in engine-adapter (BATCH 5B)
 - **#622** — context.WithTimeout on all outgoing gRPC calls across 4 services (BATCH 6)
 - **#689** — Thread gRPC call timeout from config env vars; remove package-level globals
+- **#549** — Per-service change detection in `changes` job; removed redundant `go-detect` from `lint-go` (BATCH 5)
+- **#550** — govulncheck per-service scoping in `security` job (BATCH 5)
 
 ## Next Session Queue (priority order)
 
 | Priority | Issue | Title | Note |
 |----------|-------|-------|------|
-| ~~P1~~ | ~~[#679](https://github.com/zynax-io/zynax/issues/679)~~ | ~~Translate Temporal NotFound → domain.ErrExecutionNotFound~~ | ✅ Done |
-| ~~P1~~ | ~~[#622](https://github.com/zynax-io/zynax/issues/622)~~ | ~~context.WithTimeout on all gRPC calls~~ | ✅ Done |
-| P2 | [#549](https://github.com/zynax-io/zynax/issues/549) | Per-service change detection (CI test lanes) | M, ci |
+| P2 | [#555](https://github.com/zynax-io/zynax/issues/555) | DRY/KISS refactor — reusable workflows, composite actions | L, ci |
+| P2 | [#564](https://github.com/zynax-io/zynax/issues/564) | Pin action digests + add linux/arm64 to zynax-ci | XS, ci |
+| P2 | [#565](https://github.com/zynax-io/zynax/issues/565) | Add trivy container scan gate before GHCR push | S, ci |
 | M6 prep | [#656](https://github.com/zynax-io/zynax/issues/656) | gRPC Health Checking Protocol in all services | L, deferred |


### PR DESCRIPTION
## Summary

- Extends the `changes` job bash detect script with eight per-service boolean outputs: `engine_adapter`, `workflow_compiler`, `api_gateway`, `task_broker`, `agent_registry`, `cli`, `adapters_go`, `adapters_python`. Shared-dep cases (protos/generated/go/, go.work, tools/golangci-lint.yml) set all service flags to ensure correctness.
- Removes the redundant `Detect Go code` (`go-detect`) step from the `lint-go` job, which duplicated the changes job's diff logic. The three lint steps now use per-service output conditions and skip unchanged services via bash indirect expansion inside the existing `SERVICE_LIST` loop.
- In `test-unit`, adds per-service env vars to the service unit test and domain coverage loops so unchanged services emit a `[SKIPPED — not changed]` log line and are bypassed.

## Why

Resolves #549 (BATCH 5, Group B). A single-line change to `services/engine-adapter/` currently triggers golangci-lint and `go test` across all five Go services. This change cuts redundant CI work on narrow PRs.

## Cluster

- **#549** (this PR, base: `main`) → **#550** (stacked, base: this branch)
- Merge order: #549 first, then #550 (retargeted to main after this merges)

## State files updated

- `docs/milestones/M5-plan.md`: #549 and #550 ⬜→✅ (rev 51)
- `state/current-milestone.md`: M5.F track row updated; next queue reflects #555/#564

## Architecture gaps addressed

None — CI-only change.

## Test plan

### Local pre-flight
- [x] `make lint-fix` — N/A (no Go/Python source changes; YAML only)
- [x] `make lint-go` — N/A (no Go source changes)
- [x] `make lint-protos` — N/A (no proto changes)
- [x] `make lint-agents` — N/A (no Python agent changes)
- [x] `GOWORK=off go test ./... -race` — N/A (no Go source changes)
- [x] `make test-coverage` — N/A (no domain source changes)
- [x] `make test-coverage-adapters` — N/A (no adapter source changes)
- [x] `make test-bdd` — N/A (no .feature or contract changes)
- [x] `make security` — N/A (no Go/Python source changes)
- [x] `make validate-spec` — N/A (no spec changes)

### Acceptance (from issue #549)
- [x] `changes` job outputs at minimum: `engine_adapter`, `workflow_compiler`, `api_gateway`, `task_broker`, `agent_registry`, `cli`, `adapters_go`, `adapters_python` — all 8 added to `outputs:` section and to the detect bash script with all three fallback paths covered
- [x] `lint-go` job: internal `svc_count`/`adapter_count`/`cli_count` detection removed — `go-detect` step deleted; steps now use `needs.changes.outputs.*` directly
- [x] `lint-go` platform services step: each service in the loop checks `${!var:-false}` before running golangci-lint; step-level `if:` OR-gates on all 5 service outputs
- [x] `test-unit` job uses per-service outputs to skip `go test` on unchanged services — env vars + `${!var}` skip added to `Go service unit tests` and `Go domain coverage measurement`
- [x] `GOWORK=off go test ./... -race` preserved inside each service loop — unchanged
- [x] Force-full signal propagates to per-service outputs — the `outputs:` section uses the same `|| steps.force-detect.outputs.force == 'true'` pattern for each new output
- [x] Fallback paths (git diff failure, unknown event) output all per-service=true — both early-exit blocks extended

### Engineering hygiene
- [x] Branched from fresh `origin/main`
- [x] PR ≤ 900 lines (excl. generated) — `.github/workflows/` excluded from PR size gate
- [x] Every commit: `Signed-off-by:` + `Assisted-by: Claude/claude-sonnet-4-6`
- [x] No `Co-Authored-By:` for AI
- [x] No `panic` in prod paths; no silent `_ = err` — N/A (CI YAML only)
- [x] No mTLS/SBOM/cosign claims added to docs
- [x] Gap scan done (G1/G4/G7/G16) — N/A (no service code touched)
- [x] 4 state files updated (M5-plan ✅, current-milestone ✅, canvas N/A, AGENTS.md N/A)
- [x] `.feature` committed before impl — N/A (no new gRPC boundary)
- [x] No out-of-scope / drive-by edits

Closes #549
