### PR TITLE
fix(engine-adapter): add explicit RetryPolicy to DispatchCapabilityActivity (#569)

### DIFF
--- a/services/engine-adapter/cmd/engine-adapter/main.go
+++ b/services/engine-adapter/cmd/engine-adapter/main.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"math"
 	"net"
 	"net/http"
 	"os"
@@ -116,7 +117,11 @@ func buildEngine(cfg config) (domain.WorkflowEngine, func(), error) {
 		return nil, func() {}, fmt.Errorf("unsupported engine %q: only \"temporal\" is supported in M3", cfg.ActiveEngine)
 	}
 
-	infrastructure.DefaultActivityMaxAttempts = int32(cfg.MaxActivityAttempts) //nolint:gosec // G115: bounded by env-var with default 3; no overflow risk
+	attempts := cfg.MaxActivityAttempts
+	if attempts > math.MaxInt32 {
+		attempts = math.MaxInt32
+	}
+	infrastructure.DefaultActivityMaxAttempts = int32(attempts) //nolint:gosec // G115: bounded above by MaxInt32 check
 
 	tc, err := client.Dial(client.Options{
 		HostPort:  cfg.TemporalHostPort,

--- a/services/engine-adapter/cmd/engine-adapter/main.go
+++ b/services/engine-adapter/cmd/engine-adapter/main.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"math"
 	"net"
 	"net/http"
 	"os"
@@ -43,7 +42,7 @@ type config struct {
 	TaskBrokerAddr      string
 	ActiveEngine        string
 	GRPCCallTimeoutS    int
-	MaxActivityAttempts int
+	MaxActivityAttempts int32
 }
 
 func loadConfig() config {
@@ -57,7 +56,7 @@ func loadConfig() config {
 		TaskBrokerAddr:      getEnv("ZYNAX_ENGINE_ADAPTER_TASK_BROKER_ADDR", "localhost:50053"),
 		ActiveEngine:        getEnv("ZYNAX_ENGINE_ADAPTER_ACTIVE_ENGINE", "temporal"),
 		GRPCCallTimeoutS:    getEnvInt("ZYNAX_ENGINE_ADAPTER_GRPC_CALL_TIMEOUT_S", 30),
-		MaxActivityAttempts: getEnvInt("ZYNAX_ENGINE_MAX_ACTIVITY_ATTEMPTS", 3),
+		MaxActivityAttempts: getEnvInt32("ZYNAX_ENGINE_MAX_ACTIVITY_ATTEMPTS", 3),
 	}
 }
 
@@ -117,11 +116,7 @@ func buildEngine(cfg config) (domain.WorkflowEngine, func(), error) {
 		return nil, func() {}, fmt.Errorf("unsupported engine %q: only \"temporal\" is supported in M3", cfg.ActiveEngine)
 	}
 
-	attempts := cfg.MaxActivityAttempts
-	if attempts > math.MaxInt32 {
-		attempts = math.MaxInt32
-	}
-	infrastructure.DefaultActivityMaxAttempts = int32(attempts) //nolint:gosec // G115: bounded above by MaxInt32 check
+	infrastructure.DefaultActivityMaxAttempts = cfg.MaxActivityAttempts
 
 	tc, err := client.Dial(client.Options{
 		HostPort:  cfg.TemporalHostPort,
@@ -239,6 +234,15 @@ func getEnvInt(key string, fallback int) int {
 	if v := os.Getenv(key); v != "" {
 		if n, err := strconv.Atoi(v); err == nil {
 			return n
+		}
+	}
+	return fallback
+}
+
+func getEnvInt32(key string, fallback int32) int32 {
+	if v := os.Getenv(key); v != "" {
+		if n, err := strconv.ParseInt(v, 10, 32); err == nil {
+			return int32(n) //nolint:gosec // G115: ParseInt with bitSize=32 guarantees value fits in int32
 		}
 	}
 	return fallback

--- a/services/engine-adapter/cmd/engine-adapter/main.go
+++ b/services/engine-adapter/cmd/engine-adapter/main.go
@@ -33,28 +33,30 @@ import (
 )
 
 type config struct {
-	GRPCPort          int
-	MetricsPort       int
-	LogLevel          string
-	TemporalHostPort  string
-	TemporalNamespace string
-	TemporalTaskQueue string
-	TaskBrokerAddr    string
-	ActiveEngine      string
-	GRPCCallTimeoutS  int
+	GRPCPort            int
+	MetricsPort         int
+	LogLevel            string
+	TemporalHostPort    string
+	TemporalNamespace   string
+	TemporalTaskQueue   string
+	TaskBrokerAddr      string
+	ActiveEngine        string
+	GRPCCallTimeoutS    int
+	MaxActivityAttempts int
 }
 
 func loadConfig() config {
 	return config{
-		GRPCPort:          getEnvInt("ZYNAX_ENGINE_ADAPTER_GRPC_PORT", 50055),
-		MetricsPort:       getEnvInt("ZYNAX_ENGINE_ADAPTER_METRICS_PORT", 9095),
-		LogLevel:          getEnv("ZYNAX_ENGINE_ADAPTER_LOG_LEVEL", "info"),
-		TemporalHostPort:  getEnv("ZYNAX_ENGINE_ADAPTER_TEMPORAL_HOST_PORT", "localhost:7233"),
-		TemporalNamespace: getEnv("ZYNAX_ENGINE_ADAPTER_TEMPORAL_NAMESPACE", "default"),
-		TemporalTaskQueue: getEnv("ZYNAX_ENGINE_ADAPTER_TEMPORAL_TASK_QUEUE", "engine-adapter"),
-		TaskBrokerAddr:    getEnv("ZYNAX_ENGINE_ADAPTER_TASK_BROKER_ADDR", "localhost:50053"),
-		ActiveEngine:      getEnv("ZYNAX_ENGINE_ADAPTER_ACTIVE_ENGINE", "temporal"),
-		GRPCCallTimeoutS:  getEnvInt("ZYNAX_ENGINE_ADAPTER_GRPC_CALL_TIMEOUT_S", 30),
+		GRPCPort:            getEnvInt("ZYNAX_ENGINE_ADAPTER_GRPC_PORT", 50055),
+		MetricsPort:         getEnvInt("ZYNAX_ENGINE_ADAPTER_METRICS_PORT", 9095),
+		LogLevel:            getEnv("ZYNAX_ENGINE_ADAPTER_LOG_LEVEL", "info"),
+		TemporalHostPort:    getEnv("ZYNAX_ENGINE_ADAPTER_TEMPORAL_HOST_PORT", "localhost:7233"),
+		TemporalNamespace:   getEnv("ZYNAX_ENGINE_ADAPTER_TEMPORAL_NAMESPACE", "default"),
+		TemporalTaskQueue:   getEnv("ZYNAX_ENGINE_ADAPTER_TEMPORAL_TASK_QUEUE", "engine-adapter"),
+		TaskBrokerAddr:      getEnv("ZYNAX_ENGINE_ADAPTER_TASK_BROKER_ADDR", "localhost:50053"),
+		ActiveEngine:        getEnv("ZYNAX_ENGINE_ADAPTER_ACTIVE_ENGINE", "temporal"),
+		GRPCCallTimeoutS:    getEnvInt("ZYNAX_ENGINE_ADAPTER_GRPC_CALL_TIMEOUT_S", 30),
+		MaxActivityAttempts: getEnvInt("ZYNAX_ENGINE_MAX_ACTIVITY_ATTEMPTS", 3),
 	}
 }
 
@@ -113,6 +115,8 @@ func buildEngine(cfg config) (domain.WorkflowEngine, func(), error) {
 	if cfg.ActiveEngine != "temporal" {
 		return nil, func() {}, fmt.Errorf("unsupported engine %q: only \"temporal\" is supported in M3", cfg.ActiveEngine)
 	}
+
+	infrastructure.DefaultActivityMaxAttempts = int32(cfg.MaxActivityAttempts) //nolint:gosec // G115: bounded by env-var with default 3; no overflow risk
 
 	tc, err := client.Dial(client.Options{
 		HostPort:  cfg.TemporalHostPort,

--- a/services/engine-adapter/internal/infrastructure/temporal_workflow.go
+++ b/services/engine-adapter/internal/infrastructure/temporal_workflow.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"time"
 
+	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
 
 	zynaxv1 "github.com/zynax-io/zynax/protos/generated/go/zynax/v1"
@@ -21,6 +22,21 @@ const (
 	publishEventActivityName       = "PublishLifecycleEventActivity"
 	defaultActivityTimeout         = 30 * time.Second
 )
+
+// DefaultActivityMaxAttempts is the maximum number of retry attempts for
+// DispatchCapabilityActivity before Temporal marks the activity as permanently
+// failed. Overridable from ZYNAX_ENGINE_MAX_ACTIVITY_ATTEMPTS in main before
+// the Temporal worker is started.
+var DefaultActivityMaxAttempts int32 = 3
+
+// nonRetryableActivityErrors lists Temporal ApplicationError type names that
+// must not be retried. These strings must match the Type field set by the
+// activity when wrapping permanent domain errors as temporal.ApplicationError.
+var nonRetryableActivityErrors = []string{
+	"ErrCapabilityNotFound",
+	"ErrTaskTerminal",
+	"ErrInvalidArgument",
+}
 
 // IRInterpreterWorkflow is the Temporal workflow function registered by the worker
 // in cmd/engine-adapter/main.go. It bridges Temporal's workflow.Context to
@@ -49,6 +65,13 @@ func (e *temporalActivityExecutor) DispatchCapability(_ context.Context, in doma
 	actCtx := workflow.WithActivityOptions(e.ctx, workflow.ActivityOptions{
 		TaskQueue:           workflow.GetInfo(e.ctx).TaskQueueName,
 		StartToCloseTimeout: timeout,
+		RetryPolicy: &temporal.RetryPolicy{
+			InitialInterval:        time.Second,
+			BackoffCoefficient:     2.0,
+			MaximumInterval:        30 * time.Second,
+			MaximumAttempts:        DefaultActivityMaxAttempts,
+			NonRetryableErrorTypes: nonRetryableActivityErrors,
+		},
 	})
 	var result domain.ActivityResult
 	if err := workflow.ExecuteActivity(actCtx, dispatchCapabilityActivityName, in).Get(e.ctx, &result); err != nil {

--- a/services/engine-adapter/internal/infrastructure/temporal_workflow_retry_test.go
+++ b/services/engine-adapter/internal/infrastructure/temporal_workflow_retry_test.go
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package infrastructure
+
+import (
+	"testing"
+)
+
+func TestDefaultActivityMaxAttempts_Default(t *testing.T) {
+	if DefaultActivityMaxAttempts != 3 {
+		t.Errorf("DefaultActivityMaxAttempts = %d; want 3", DefaultActivityMaxAttempts)
+	}
+}
+
+func TestNonRetryableActivityErrors_Contents(t *testing.T) {
+	want := map[string]bool{
+		"ErrCapabilityNotFound": true,
+		"ErrTaskTerminal":       true,
+		"ErrInvalidArgument":    true,
+	}
+	if len(nonRetryableActivityErrors) != len(want) {
+		t.Fatalf("nonRetryableActivityErrors len = %d; want %d", len(nonRetryableActivityErrors), len(want))
+	}
+	for _, v := range nonRetryableActivityErrors {
+		if !want[v] {
+			t.Errorf("unexpected entry in nonRetryableActivityErrors: %q", v)
+		}
+	}
+}

--- a/state/current-milestone.md
+++ b/state/current-milestone.md
@@ -121,8 +121,8 @@ Priority gaps to file immediately:
 |-----|----------|
 | ~~G1: constant-time bearer compare~~ | ✅ fixed #567 |
 | ~~G2: ReadHeaderTimeout + MaxBytesReader~~ | ✅ fixed #568 |
-| G4: no RetryPolicy on Temporal Activities (#569) | Medium |
-| G16: background-context goroutines in task-broker (#570) | Medium |
+| ~~G4: no RetryPolicy on Temporal Activities (#569)~~ | ✅ fixed #569 |
+| ~~G16: background-context goroutines in task-broker (#570)~~ | ✅ fixed #570 |
 | G19: competitive positioning doc (Kagent/Dapr) (#575) | High |
 | G17: stub services in SERVICE_LIST (#574) | Low |
 
@@ -141,6 +141,7 @@ Priority gaps to file immediately:
 
 ## Recently Closed (this session)
 
+- **#569** — Add RetryPolicy + nonRetryableErrorTypes to DispatchCapabilityActivity (G4 fix)
 - **#570** — Detached context in task-broker executeAsync goroutine; preserves request-ID via detachedCtx (G16)
 - **#679** — Temporal NotFound → domain.ErrExecutionNotFound in engine-adapter (BATCH 5B)
 - **#622** — context.WithTimeout on all outgoing gRPC calls across 4 services (BATCH 6)
@@ -153,6 +154,4 @@ Priority gaps to file immediately:
 | Priority | Issue | Title | Note |
 |----------|-------|-------|------|
 | P2 | [#555](https://github.com/zynax-io/zynax/issues/555) | DRY/KISS refactor — reusable workflows, composite actions | L, ci, needs-design |
-| P2 | [#569](https://github.com/zynax-io/zynax/issues/569) | Add RetryPolicy to DispatchCapabilityActivity (G4) | S, fix |
-| P2 | ~~[#570](https://github.com/zynax-io/zynax/issues/570)~~ | ~~Propagate request-ID via detached context (G16)~~ | ✅ Done |
 | M6 prep | [#656](https://github.com/zynax-io/zynax/issues/656) | gRPC Health Checking Protocol in all services | L, deferred |


### PR DESCRIPTION
## Summary

- Adds `RetryPolicy` with exponential backoff (`1s → 30s`) and `NonRetryableErrorTypes` (`ErrCapabilityNotFound`, `ErrTaskTerminal`, `ErrInvalidArgument`) to `DispatchCapabilityActivity`
- Prevents spurious retries on permanent domain errors; preserves retry behaviour for transient failures
- `MaxAttempts` is configurable via `ZYNAX_ENGINE_MAX_ACTIVITY_ATTEMPTS` (default 3), threaded from config into `DefaultActivityMaxAttempts` before the Temporal worker starts
- Adds `temporal_workflow_retry_test.go` asserting defaults and `nonRetryableActivityErrors` contents

## Test plan

- [ ] `GOWORK=off go test ./internal/infrastructure/... -race` passes
- [ ] `TestDefaultActivityMaxAttempts_Default` asserts value is 3
- [ ] `TestNonRetryableActivityErrors_Contents` asserts all three error type names are present

Closes #569. Fixes G4 from the 2026-05-20 architecture review.

Assisted-by: Claude/claude-sonnet-4-6