### PR TITLE
fix(task-broker): propagate request-ID via detached context in executeAsync (#570)

### DIFF
--- a/docs/milestones/M5-plan.md
+++ b/docs/milestones/M5-plan.md
@@ -671,7 +671,7 @@ open issues. File them before or during M5 execution:
 | G12: No fuzz tests | Medium | [#539](https://github.com/zynax-io/zynax/issues/539) (partial) | M5/M7 |
 | G13: No load tests | Medium | M7 backlog | M7 |
 | G14+G15: Manifest hash ADR + YAML canonicalization | Low | [#583](https://github.com/zynax-io/zynax/issues/583) | M6 |
-| G16: Background-context goroutines | Medium | [#570](https://github.com/zynax-io/zynax/issues/570) | M5 |
+| ~~G16: Background-context goroutines~~ | Medium | ~~[#570](https://github.com/zynax-io/zynax/issues/570)~~ ✅ Done | M5 |
 | G17: Stub services in SERVICE_LIST | Low | [#574](https://github.com/zynax-io/zynax/issues/574) | M5 |
 | G18: No community channel | Medium | [#470](https://github.com/zynax-io/zynax/issues/470) | M8 |
 | G19: Kagent positioning | **High** | [#575](https://github.com/zynax-io/zynax/issues/575) | M5 |

--- a/services/task-broker/internal/domain/detach_test.go
+++ b/services/task-broker/internal/domain/detach_test.go
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package domain
+
+import (
+	"context"
+	"testing"
+)
+
+// ── detach ────────────────────────────────────────────────────────────────
+
+func TestDetach_CancelledParentDoesNotCancelChild(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	child := detach(ctx)
+	if child.Err() != nil {
+		t.Errorf("detached context should not inherit cancellation error, got %v", child.Err())
+	}
+	_, hasDeadline := child.Deadline()
+	if hasDeadline {
+		t.Error("detached context should report no deadline")
+	}
+	select {
+	case <-child.Done():
+		t.Error("detached context Done() should never close")
+	default:
+		// correct — nil channel never receives
+	}
+}
+
+func TestDetach_PreservesContextValues(t *testing.T) {
+	type key struct{}
+	ctx := context.WithValue(context.Background(), key{}, "req-id-42")
+
+	child := detach(ctx)
+	if got := child.Value(key{}); got != "req-id-42" {
+		t.Errorf("expected value %q preserved in detached ctx, got %v", "req-id-42", got)
+	}
+}
+
+func TestDetach_NilValueForAbsentKey(t *testing.T) {
+	type key struct{}
+	child := detach(context.Background())
+	if got := child.Value(key{}); got != nil {
+		t.Errorf("expected nil for absent key, got %v", got)
+	}
+}

--- a/services/task-broker/internal/domain/service.go
+++ b/services/task-broker/internal/domain/service.go
@@ -58,11 +58,12 @@ func (s *TaskService) DispatchTask(ctx context.Context, task *Task) (taskID stri
 	}
 
 	s.bg.Add(1)
-	// context.Background() is intentional: the request context expires when the RPC
-	// returns, but task execution must outlive it.
-	go func() { //nolint:contextcheck,gosec // G118: background ctx required for long-running work
+	go func() {
 		defer s.bg.Done()
-		s.executeAsync(context.Background(), task.TaskID, agents)
+		// detach preserves context values (request-ID, trace) without inheriting
+		// the parent's cancellation deadline — the RPC handler returns before the
+		// task finishes, so the goroutine must outlive it.
+		s.executeAsync(detach(ctx), task.TaskID, agents)
 	}()
 
 	return task.TaskID, task.CreatedAt, nil
@@ -211,3 +212,17 @@ func newTaskID() string {
 	}
 	return "task-" + hex.EncodeToString(b)
 }
+
+// detachedCtx carries context values from parent but is never cancelled.
+// This allows async goroutines to outlive the RPC handler that spawned them
+// while still propagating request-ID and trace metadata via Value.
+type detachedCtx struct{ parent context.Context }
+
+func (d detachedCtx) Deadline() (time.Time, bool) { return time.Time{}, false }
+func (d detachedCtx) Done() <-chan struct{}       { return nil }
+func (d detachedCtx) Err() error                  { return nil }
+func (d detachedCtx) Value(key any) any           { return d.parent.Value(key) }
+
+// detach wraps ctx in a detachedCtx. The returned context preserves all
+// values but ignores any cancellation signal from ctx.
+func detach(ctx context.Context) context.Context { return detachedCtx{parent: ctx} }

--- a/state/current-milestone.md
+++ b/state/current-milestone.md
@@ -141,6 +141,7 @@ Priority gaps to file immediately:
 
 ## Recently Closed (this session)
 
+- **#570** — Detached context in task-broker executeAsync goroutine; preserves request-ID via detachedCtx (G16)
 - **#679** — Temporal NotFound → domain.ErrExecutionNotFound in engine-adapter (BATCH 5B)
 - **#622** — context.WithTimeout on all outgoing gRPC calls across 4 services (BATCH 6)
 - **#689** — Thread gRPC call timeout from config env vars; remove package-level globals
@@ -153,5 +154,5 @@ Priority gaps to file immediately:
 |----------|-------|-------|------|
 | P2 | [#555](https://github.com/zynax-io/zynax/issues/555) | DRY/KISS refactor — reusable workflows, composite actions | L, ci, needs-design |
 | P2 | [#569](https://github.com/zynax-io/zynax/issues/569) | Add RetryPolicy to DispatchCapabilityActivity (G4) | S, fix |
-| P2 | [#570](https://github.com/zynax-io/zynax/issues/570) | Propagate request-ID via detached context (G16) | S, fix |
+| P2 | ~~[#570](https://github.com/zynax-io/zynax/issues/570)~~ | ~~Propagate request-ID via detached context (G16)~~ | ✅ Done |
 | M6 prep | [#656](https://github.com/zynax-io/zynax/issues/656) | gRPC Health Checking Protocol in all services | L, deferred |


### PR DESCRIPTION
## Summary

- Replaces `context.Background()` with a `detachedCtx` in `DispatchTask`'s background goroutine
- `detachedCtx` propagates values (request-ID, trace) from the RPC context but ignores cancellation/deadline, so the task lifecycle survives the parent RPC ending
- Removes the `//nolint:contextcheck,gosec` suppression in favour of a meaningful explanation comment
- Adds `detach_test.go` with three unit tests verifying propagation and cancellation isolation

## Test plan

- [ ] `GOWORK=off go test ./internal/domain/... -race` passes
- [ ] `TestDetach_CancelledParentDoesNotCancelChild` confirms goroutine is not cancelled when RPC context expires
- [ ] `TestDetach_PreservesContextValues` confirms request-ID is still readable

Closes #570.

Assisted-by: Claude/claude-sonnet-4-6