### PR TITLE
docs: dedupe AI-context files to single source of truth

### DIFF
--- a/.claude/commands/resume-m5.md
+++ b/.claude/commands/resume-m5.md
@@ -1,0 +1,308 @@
+---
+description: Resume Zynax M5 work — pick a cluster of ≤3 related issues, ship each as its own PR, merge in order, leave state consistent, stop.
+argument-hint: "[optional: issue numbers to prefer, e.g. 530 531]"
+---
+
+# Resume M5 — Adapter Library (v0.4.0)
+
+Pick the next ready cluster, ship each issue as its own PR, merge them in order, leave every
+state file consistent, then stop. **Stateless & compaction-safe:** derive all position from
+`gh`/`git`/state files, never from session memory. Safe to re-run after `/compact`, crash, or a
+fresh session.
+
+> **Rules are not restated here.** Commit/PR format, conventional types, DCO + `Assisted-by`
+> trailers, anti-patterns, `GOWORK=off`, PR-size, hexagonal layout, coverage gates, and the SPDD
+> requirement all live in **`AGENTS.md`** (constitution) and **`CLAUDE.md`** (dev loop). Read them;
+> obey them. This file is only the *session loop*.
+
+**Session policy.** One **cluster of ≤3 related issues**. Each ships as its **own** PR. Open all
+PRs in parallel, then merge them **strictly in order** — auto-merge enabled on PR_i only after
+PR_(i-1) is MERGED and PR_i is rebased onto fresh `origin/main`. Never enable auto-merge on >1 PR
+at once. Never merge by hand (`--admin` forbidden) — auto-merge + the Merge Queue run the required
+checks. The **pre-merge required checks are the gate; do NOT chase post-merge `main` CI** (publish/
+release run on `main` and aren't your concern). Every PR flips its own `M5-plan.md` row and updates
+`current-milestone.md` **in its own diff**.
+
+---
+
+## STEP 1 — Orient & resume (run first)
+
+**1.1 Sync main**
+```bash
+git fetch origin --prune && git checkout main && git pull --rebase origin main
+[ "$(git rev-parse main)" = "$(git rev-parse origin/main)" ] || { echo "main diverged — STOP, ask"; exit 1; }
+[ -z "$(git status --porcelain)" ] || { echo "dirty tree — STOP, ask"; git status; exit 1; }
+```
+
+**1.2 Read** — mandatory: `state/current-milestone.md`, `docs/milestones/M5-plan.md` (scoped: Track
+Overview + current batch + gap table), `CLAUDE.md`. On demand by trigger:
+
+| Read when | File |
+|---|---|
+| gap status / quality lens (G1–G24) | `docs/reviews/04-architecture-gaps.md` |
+| forming a cluster from findings / re-planning | `docs/reviews/05-action-plan.md` |
+| verifying M5 Definition of Done | `docs/reviews/03-m5-state.md` |
+| any `docs:`/truth-pass (G2) | `docs/reviews/02-reality-vs-docs.md` |
+| touching an ADR'd decision | `docs/reviews/01-decision-ledger.md` |
+| feat / issue lacks acceptance criteria | the canvas covering it (see STEP 2) |
+
+Run `/help` to confirm SPDD commands are available.
+
+**1.3 Reconcile milestone ⟷ plan** (must agree)
+```bash
+gh issue list --milestone "Adapter Library (M5)" --state open   --limit 100 --json number,title,state
+gh issue list --milestone "Adapter Library (M5)" --state closed --limit 200 --json number,title,state
+```
+Open issue ⇒ ⬜ row; closed issue ⇒ ✅ row. Any mismatch → fix `M5-plan.md` **and**
+`current-milestone.md` now (small `docs:` commit, no PR; bump "Last updated").
+
+**1.4 Detect in-flight + health gate**
+```bash
+gh pr list --author "@me" --state open --json number,title,headRefName,statusCheckRollup,mergeStateStatus,autoMergeRequest
+git branch -a | grep -E "^\* (feat|fix|refactor|docs|test|ci|chore)/" ; git status --porcelain
+```
+**Health gate:** an open PR with red required checks won't auto-merge — fix it before advancing or
+starting a new cluster. Then apply the **Resumption tree** (bottom) and report the matching row to
+the user in one paragraph; wait for `go`/`stop`.
+
+---
+
+## STEP 2 — Pick a cluster (1–3 related issues)
+
+"Related" = same area/service/layer or same task kind; may be a dependency chain (A→B→C) or
+independent siblings. Rules: draw from the **same BATCH** in order **0→1→2→3→4→5→6**; prefer
+lower-numbered issues; exclude any issue whose dependency is ⬜ open **and outside this cluster**
+(intra-cluster deps are fine — handled by merge order); skip XL (>900 — split first); never exceed
+3; mixed types OK if genuinely related.
+
+```bash
+gh issue view <N> --json number,title,body,labels,state,milestone,assignees,comments  # never bare view (deprecated projectCards → exit 1)
+grep -rln -E "(#|issue[: ]*)<N>\b" docs/spdd/*/canvas.md   # canvas may be a PARENT-EPIC, not <N>-*
+ls docs/spdd/ | grep -E "^<N>-"
+```
+If a canvas covers an issue (by name or O-step reference), that canvas is the scoping contract —
+record which canvas + O-step each member maps to (or "no canvas"). **State the cluster + merge
+order + shared context before coding.**
+
+Batch map: `0` CI-unblock · `1` release · `2` engine-correctness · `3` SDK+truth · `4` dispatch-E2E
+(ordered: task-broker→agent-registry→compose #481) · `5` CI-DX · `6` adapters (after #481). Live
+⬜/✅ + issue #s are in `M5-plan.md` — never hardcode from memory.
+
+---
+
+## STEP 3 — Entry path (per issue)
+
+Scope is fixed before any code: by an **Aligned** canvas for `feat`, by the issue body for
+everything else. Implement exactly that one logical change — no cleanup, no extras, no drift.
+
+| Type | Path |
+|---|---|
+| `feat` | Canvas MUST be `**Status:** Aligned` before code → `/spdd-generate <canvas>` (scopes to one O-step, then stops). Draft → align first (`/spdd-reasons-canvas`). No canvas referencing #N → not ready as feat. |
+| `fix` `test` `ci` `chore` `refactor` | Implement directly (SPDD-exempt). |
+| `docs` | Edit; truth-pass (G2); no mTLS/SBOM/cosign claims (M6+). |
+
+Non-`feat`: still read a covering canvas O-step if one exists, and commit the `.feature` file
+**before** implementation when a public boundary is touched.
+
+---
+
+## STEP 4 — Scope + fresh main + branch (per issue)
+
+```bash
+git fetch origin --prune && git checkout main && git pull --rebase origin main
+[ "$(git rev-parse main)" = "$(git rev-parse origin/main)" ] || { echo "main diverged"; exit 1; }
+git checkout -b <type>/<issue-N>-<short-slug>
+```
+**Branching:** independent siblings each branch off `main` (base `main`). Dependency chain A→B→C:
+**stack** branches (B off A, C off B); each PR base = branch below; bottom PR base = `main`
+(GitHub auto-retargets on merge).
+
+**Size:** XS<50 / S 50–150 / M 150–400 → proceed · L 401–900 → justify + flag user · **XL>900 →
+STOP**, scope to first 400 lines, open follow-up. (PR-size thresholds: `AGENTS.md`.)
+
+**Gap lens** on every file touched (full list: `docs/reviews/04-architecture-gaps.md`): **G1**
+const-time bearer compare · **G4** Temporal Activity `RetryPolicy` · **G7** `mergePayload` scalar
+type-asserts · **G16** derived ctx + request-ID propagation. <10-line fix → note `Opportunistic
+fix: G<N>` in PR body; else open a follow-up.
+
+---
+
+## STEP 5 — Implement
+
+If a canvas covers the issue, implement via `/spdd-generate <canvas>` (read the O-step first).
+Otherwise hand-implement the single logical change. `GOWORK=off` for every `go` command in
+`services/*/`, `cmd/zynax/`, `protos/tests/` (ADR-017). Run the relevant checks and capture
+evidence for the test plan:
+
+| Check | Command | When |
+|---|---|---|
+| lint | `make lint-fix` / `make lint-go` / `make lint-protos` / `make lint-agents` | per change type |
+| unit | `GOWORK=off go test ./... -race -timeout 60s` | always |
+| domain cov ≥90% | `make test-coverage` | `internal/domain/` |
+| adapter cov ≥80% | `make test-coverage-adapters` | adapter changes |
+| BDD | `make test-bdd` | `.feature`/contract |
+| security | `make security` | always |
+| AI-context | `zynax-ci check ai-context` | AI-context files |
+
+Tool missing locally → its box stays unchecked → do **not** enable auto-merge; open for human
+review and surface it.
+
+---
+
+## STEP 6 — State consistency (per PR, in its own diff)
+
+Each PR updates **only its own issue's row** (avoids sibling/stacked conflicts):
+1. `docs/milestones/M5-plan.md` — flip this issue's row ⬜→✅; bump "Last updated"; update Track
+   Overview if a track is now fully ✅. **Mandatory — not N/A.**
+2. `state/current-milestone.md` — update the track row; remove the done issue from Active/IMMEDIATE;
+   move any newly-unblocked downstream issue to "ready". **Mandatory.**
+3. Canvas (feat only) — mark the O-step ✅; `/spdd-sync` if impl diverged.
+4. `services/<svc>/AGENTS.md` — only if a new endpoint/type/capability was added (ADR-016).
+
+Bundle into the implementation commit (or a follow-up commit on the **same branch**).
+
+---
+
+## STEP 7 — Commit
+
+```bash
+echo -n "<type>(<scope>): <subject>" | wc -c   # ≤ 72
+git commit -s -m "<type>(<scope>): <subject>
+
+<why; issue + Canvas O-step if feat>
+
+Closes #<N>
+Assisted-by: Claude/<model-id-from-this-session>"
+```
+Exact trailer spec (`Signed-off-by` + `Assisted-by`, never `Co-Authored-By` for AI):
+`AGENTS.md §Hard Constraints`.
+
+---
+
+## STEP 8 — Open ALL cluster PRs in parallel (no auto-merge yet)
+
+Per PR: assemble `pr-body-<N>.md` from the template (bottom), run every check, paste evidence,
+flip all boxes.
+```bash
+git push -u origin HEAD
+grep -cE '^- \[ \]' pr-body-<N>.md   # MUST be 0 before any auto-merge
+echo -n "<type>(<scope>): <subject>" | wc -c   # ≤ 72
+gh pr create --base <main|branch-below> --title "<type>(<scope>): <subject>" --assignee "@me" \
+  --label "type: <kind>,milestone: M5,area: <area>" --body-file pr-body-<N>.md
+```
+Body sections: Summary · Why (issue link) · Cluster (sibling PRs + merge order) · State files
+updated · Architecture gaps (G-IDs) · Test plan · Out of scope · `Closes #N`. Don't `gh pr edit`
+the title afterward. Open **all** cluster PRs before STEP 9. Confirm no *other* in-flight PR is red.
+
+---
+
+## STEP 9 — Ordered, in-sync merge (one PR at a time)
+
+For `i = 1…n` in merge order (bottom-up for stacked):
+```bash
+PR=<pr_i> ; BR=<branch_i> ; ISSUE=<issue_i>
+# 1) sync main (incl. PR_1..PR_(i-1)) and rebase THIS PR onto it
+git fetch origin --prune && git checkout main && git pull --rebase origin main
+git checkout "$BR" && gh pr edit "$PR" --base main 2>/dev/null || true
+git rebase origin/main || { echo "rebase conflict on $BR — resolve or stop+ask"; exit 1; }
+git push --force-with-lease
+# 2) wait for required checks green on the rebased head (red → smallest fix → re-watch; same check fails twice → stop+ask)
+gh pr checks "$PR" --watch --interval 30
+# 3) NOW enable auto-merge — only this PR
+gh pr merge "$PR" --auto --squash --subject "<subject> (#$PR)" --body "Closes #$ISSUE
+
+Assisted-by: Claude/<model-id-from-this-session>"
+# 4) wait until it lands (do NOT query post-merge main CI)
+until [ "$(gh pr view "$PR" --json state --jq '.state')" = "MERGED" ]; do sleep 30; done
+# 5) reconcile (9.R) before PR_(i+1)
+```
+
+**9.R — reconcile after each merge**
+```bash
+gh issue view "$ISSUE" --json number,state,milestone --jq '{n:.number,state,ms:.milestone.title}'  # expect CLOSED
+[ "$(gh issue view "$ISSUE" --json state --jq .state)" = "CLOSED" ] || gh issue close "$ISSUE" --reason completed
+git fetch origin && git checkout main && git pull --rebase origin main
+grep -nE "#?$ISSUE\b" docs/milestones/M5-plan.md   # row must be ✅ (merged in the PR diff)
+```
+Row not ✅ on merged `main` → open a tiny `docs:` fix PR now.
+
+---
+
+## STEP 10 — Verify, summarize, stop
+
+```bash
+git fetch origin --prune && git checkout main && git pull --rebase origin main
+for n in <issue_1> <issue_2> <issue_3>; do gh issue view "$n" --json number,state,milestone --jq '{n:.number,state,ms:.milestone.title}'; done  # all CLOSED
+for p in <pr_1> <pr_2> <pr_3>;       do gh pr view "$p" --json number,state,mergedAt --jq '{p:.number,state,mergedAt}'; done                    # all MERGED
+gh issue list --milestone "Adapter Library (M5)" --state closed --limit 200 --json number --jq '.[].number' | sort -n  # cross-check ✅ rows
+gh issue list --milestone "Adapter Library (M5)" --state open   --limit 200 --json number --jq '.[].number' | sort -n  # cross-check ⬜ rows
+gh pr list --author "@me" --state open --json number,title   # none from this cluster
+git status --porcelain                                        # clean
+```
+Any mismatch → fix `M5-plan.md` + `current-milestone.md` (`docs:` commit) **before** the summary.
+Post the **Session summary** (below) on each merged PR and as the final chat message. **One cluster
+per session — end the turn.**
+
+---
+
+## Resumption tree (apply in STEP 1.4)
+
+Health gate first, then resume in-progress, then start new.
+
+| Observed | Action |
+|---|---|
+| Any open PR of mine with **red** required checks | Fix first — debug → smallest fix → push → re-watch. Don't advance/start. |
+| ≥1 cluster PR merged, others open | Resume STEP 9 on the remaining PRs in order. |
+| All cluster PRs open, none merged | Resume STEP 9 from the bottom of the order. |
+| Cluster fully merged | STEP 10 summary. STOP. |
+| Local branch w/ uncommitted work, PRs not all open | Finish STEP 5→8, then 9. |
+| Local branch clean, no PR | Inspect last commit; open PR (→8) or delete branch. |
+| No in-flight work, batch has ready issues | Form a cluster (STEP 2) → 5→8 → 9 → 10. STOP. |
+| Closed issues not yet ✅ in plan | Flip ✅ (small `docs:` commit), then form next cluster. |
+| All M5 batches exhausted | Report M5 exit-criteria status; ask user re: milestone close / M6. |
+
+**Ordering:** A→B if B touches A's code, needs A's type/endpoint, or `M5-plan.md` lists A as B's
+dependency; else independent. When unsure, treat as dependent (stack + merge after).
+
+---
+
+## Test plan template (`pr-body-<N>.md`)
+
+> Every box `- [x]` with evidence before auto-merge. N/A → `- [x] (N/A — reason)`. CI required
+> checks (DCO, lint, unit, security, pr-size) are the merge-queue gate, not duplicated here.
+
+```markdown
+### Local pre-flight
+- [ ] `make lint-go`/`lint-protos`/`lint-agents` — exit 0 (or N/A)  [evidence]
+- [ ] `GOWORK=off go test ./... -race` — pass  [evidence]
+- [ ] `make test-coverage` — domain ≥90% (or N/A)  [evidence]
+- [ ] `make test-coverage-adapters` ≥80% / `make test-bdd` / `make security` (or N/A)  [evidence]
+### Acceptance (issue body / Canvas O-step)
+- [ ] <criterion>  [evidence: test / file:line / log]
+### Engineering hygiene
+- [ ] **`M5-plan.md` row flipped ⬜→✅ in this diff** (mandatory)
+- [ ] **`current-milestone.md` updated in this diff** (mandatory)
+- [ ] Branched from fresh `origin/main` · PR ≤900 lines · trailers on every commit
+- [ ] Gap scan done (G1/G4/G7/G16); opportunistic fixes noted
+- [ ] Canvas O-step ✅ (feat) · `AGENTS.md` updated if new capability · `.feature` before impl
+- [ ] No out-of-scope edits · no mTLS/SBOM/cosign docs claims
+```
+
+---
+
+## Session summary (comment on each merged PR + final message)
+
+```markdown
+## Session summary — <YYYY-MM-DD HH:MM TZ>
+**Outcome:** <CLUSTER-MERGED | CLUSTER-PARTIAL (n/m) | CLUSTER-OPENED-NOT-MERGED | STATE-RECONCILED-ONLY | STOPPED-HEALTH-GATE>
+**Cluster:** BATCH/track · merge order #A→#B→#C (dependent|independent) · shared context: <one line>
+
+| Issue | PR | type | size | gaps | state |
+|---|---|---|---|---|---|
+| #A | <url> | <feat/…> | <S> | <G-IDs> | MERGED |
+
+**State files:** M5-plan rows ⬜→✅ <…> · current-milestone <change> · canvas <…/N/A> · AGENTS.md <svc/N/A>
+**Verify (all ✓ to continue safely):** issues CLOSED ✓ · PRs MERGED ✓ · milestone⟷plan lockstep ✓ · no stray PRs/branches, tree clean ✓ · milestone now <X closed / Y open>
+**Repo state:** main HEAD <sha> "<subject>" · my open PRs <list/none> · health <green | red on #PR> · branches <list/none>
+**Next:** recommended cluster <#,#,# — BATCH X> (or "resume STEP 9") · decision-tree row <one line> · review first <bullets/nothing>
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,7 +131,8 @@ A feature is DONE when **all** are true:
 - No `@mentions` in commit messages — issue refs in footer only (`Closes #123`)
 - No emojis in commit messages
 - Always rebase (`git rebase origin/main`), never merge main into feature branches
-- `Assisted-by: Claude/claude-sonnet-4-6` for AI — never `Co-Authored-By:` for AI
+- `Assisted-by: Claude/<model-id>` for AI — use the exact model ID from the current session (e.g. `claude-sonnet-4-6`); never `Co-Authored-By:` for AI
+- No `🤖 Generated with [Claude Code]` lines in commit messages
 - Every commit needs `Signed-off-by: Oscar Gómez Manresa <ogomezmanresa@gmail.com>`
 
 **PR title (CI-enforced `conventional-commit` check):**
@@ -139,6 +140,7 @@ A feature is DONE when **all** are true:
 - Valid types: `feat` `fix` `refactor` `docs` `test` `ci` `chore`
 - Rejected: `spec:` `proto:` `adr:` `service:` `make:` `security:`
 - Use `docs:` for spec/ADR changes · `chore:` for Makefile/tooling
+- Scope matches the directory: `(workflow-compiler)`, `(engine-adapter)`, `(api-gateway)`, `(protos)`, `(spec)`, `(infra)`, `(agents)`. Omit scope when type is `ci` or `docs`.
 
 **Go services:**
 - Never `panic` in production · never discard errors (`_ = f()`)
@@ -187,6 +189,8 @@ Observed mistakes in AI-assisted contributions — check before writing code.
 | Opening a `feat:` PR without a REASONS Canvas | Create `docs/spdd/<issue>-<slug>/canvas.md` before writing any code (ADR-019) |
 | Patching AI-generated code for a logic change without updating Canvas | Update Canvas first (prompt-first rule), then patch — or the Canvas drifts from intent |
 | Putting internal hostnames, IPs, or credentials in a Canvas | Canvas is public — Tier 2 context goes in `canvas.private.md` (gitignored) |
+| Mocking the database in integration tests | Use `testcontainers-go` to spin up real backing services (ADR-016) |
+| Adding complexity beyond the current issue scope | Implement exactly what the issue asks; open a follow-up issue for anything extra |
 
 ---
 
@@ -227,4 +231,4 @@ Observed mistakes in AI-assisted contributions — check before writing code.
 
 ---
 
-*Zynax — The control plane for AI-driven systems · Apache 2.0 · CNCF Sandbox Candidate*
+*Zynax — The control plane for AI-driven systems · Apache 2.0*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,80 +6,32 @@ any layer.
 
 ## Milestone Status
 
-| Milestone | Status | Version | Review |
-|-----------|--------|---------|--------|
-| M1 — Contracts Foundation | **Complete** | v0.1.0 | [Engineering Review](docs/milestones/M1-engineering-review.md) · [Release Notes](docs/milestones/M1-release-notes.md) |
-| M2 — Workflow IR | **Complete** | v0.1.0 | [Epic #101](https://github.com/zynax-io/zynax/issues/101) |
-| M3 — Temporal Execution | ⚠ **Partial** | v0.2.0 | [Epic #214](https://github.com/zynax-io/zynax/issues/214) · [Canvas](docs/spdd/214-temporal-execution/canvas.md) · no task-broker (blocked by M5.C #460) |
-| M4 — YAML System + CLI | ⚠ **Partial** | v0.3.0 | [Epic #314](https://github.com/zynax-io/zynax/issues/314) · [Canvas](docs/spdd/314-yaml-system-cli/canvas.md) · no agent-registry (blocked by M5.C #460) |
-| **M5 — Adapter Library** | 🔄 **In Progress** | v0.4.0 | [Epic #377](https://github.com/zynax-io/zynax/issues/377) · [Plan](docs/milestones/M5-plan.md) · M5.D ✅ M5.E ✅ · M5.F CI Sprint 🔴 · M5.C in progress |
-
-M1 delivered: 8 gRPC contracts, AsyncAPI spec, JSON schemas, Go + Python generated stubs,
-140+ BDD scenarios across all services, 5 CI gates. All work tracked in Epic #1 (closed).
-
-M2 delivered: YAML parser + WorkflowGraph builder (#83), structural validators (#84),
-semantic validators (#85), WorkflowGraph → WorkflowIR serialization (#86), gRPC API
-layer with CompileWorkflow / ValidateManifest / GetCompiledWorkflow (#87), BDD contract
-steps (#154), coverage gate ≥90% + make test pipeline (#155, #142).
-
-M3 delivered: `WorkflowEngine` interface + `TemporalEngine`, `IRInterpreterWorkflow` state machine,
-`DispatchCapabilityActivity`, cel-go guards, all 5 `EngineAdapterService` gRPC methods.
-CloudEvents is a log stub (NATS not wired). Step issues #301–#305. [Epic #214](https://github.com/zynax-io/zynax/issues/214).
-
-M4 delivered: api-gateway REST (`/api/v1/apply`, `/api/v1/workflows/{id}`), `zynax` CLI
-(apply/get/delete/status/logs), Docker Compose local runner, GitOps watch.
-Step issues #315–#320. [Epic #314](https://github.com/zynax-io/zynax/issues/314) · [Canvas](docs/spdd/314-yaml-system-cli/canvas.md).
+> Current status, per-track progress, and active blockers:
+> [state/current-milestone.md](state/current-milestone.md) · full plan: [docs/milestones/M5-plan.md](docs/milestones/M5-plan.md).
 
 ## Key pointers
 
-| Directory | AGENTS.md covers |
-|-----------|-----------------|
-| `/` | Three-layer architecture, workflow model, hard constraints |
-| `services/` | Go service structure, domain/api/infra separation |
-| `cmd/zynax/` | Standalone CLI module — not in go.work; HTTP REST to api-gateway only |
-| `agents/` | Python adapter pattern, gRPC stub usage |
-| `protos/` | Proto naming, backward-compatibility rules |
-| `spec/` | YAML manifest schemas |
-| `infra/` | Docker, env var conventions |
-| `docs/adr/INDEX.md` | Searchable ADR register — check here before proposing a design change |
-| `docs/architecture/` | Architecture reviews, competitive analysis |
-| `docs/patterns/` | Code templates: Go service, Python agent, proto interop, BDD, Helm, SPDD guide |
-| `docs/patterns/spdd-guide.md` | Full SPDD workflow — REASONS Canvas, 6 steps, worked examples |
-| `docs/spdd/` | REASONS Canvas artifacts — one `canvas.md` per `feat:` issue |
+Each directory has an `AGENTS.md`; see [AGENTS.md §Knowledge Base Index](AGENTS.md#knowledge-base-index) for all reference docs and patterns. Notable entry points:
+
+| Path | What it covers |
+|------|---------------|
+| `AGENTS.md` | Constitution: three-layer arch, mandates, hard constraints, anti-patterns |
+| `services/AGENTS.md` | Go service layout, testing, service-layer anti-patterns |
+| `agents/AGENTS.md` | Python adapter/SDK pattern, path selection |
+| `protos/AGENTS.md` | Proto naming, backward-compat rules, BDD contract tests |
+| `cmd/zynax/AGENTS.md` | Standalone CLI — not in go.work; HTTP REST to api-gateway only |
+| `docs/adr/INDEX.md` | ADR register — check before proposing any design change |
 | `state/current-milestone.md` | Active milestone, open PRs, known blockers |
 
 ## AI attribution
 
-Every commit **must** carry both trailers or the DCO check fails:
+> AI attribution rules (trailers, `Assisted-by`, no `Co-Authored-By` for AI):
+> see [AGENTS.md §Hard Constraints](AGENTS.md#hard-constraints) and [docs/ai-assistant-setup.md](docs/ai-assistant-setup.md).
 
-```
-Signed-off-by: Oscar Gómez Manresa <ogomezmanresa@gmail.com>
-Assisted-by: Claude/claude-sonnet-4-6
-```
+## Conventional commit rules
 
-- `Signed-off-by` — the **human author's** DCO certification. AI cannot certify DCO.
-- `Assisted-by` — records AI involvement; use the exact model ID from the session.
-- **Never** use `Co-Authored-By:` for AI — reserved for humans certifying DCO.
-- **Never** add `🤖 Generated with [Claude Code]` lines to commit messages.
-- See `docs/ai-assistant-setup.md` and `CONTRIBUTING.md §AI Contribution`.
-
-## Conventional commit scope rules
-
-PR titles and commit subjects must use a valid type. Scope is optional but recommended.
-
-| Type | When to use |
-|------|-------------|
-| `feat` | New capability visible to users or callers |
-| `fix` | Bug fix |
-| `docs` | `AGENTS.md`, `README`, ADR, or any documentation-only change |
-| `ci` | GitHub Actions workflows, Makefile CI targets |
-| `chore` | Dependency updates, tooling, housekeeping |
-| `refactor` | Code restructuring with no behaviour change |
-| `test` | Test-only changes |
-
-Scope matches the directory: `(workflow-compiler)`, `(engine-adapter)`, `(api-gateway)`, `(protos)`, `(spec)`, `(infra)`, `(agents)`. Omit scope when type is already `ci` or `docs`.
-
-Rejected prefixes (CI will fail): `spec:`, `proto:`, `adr:`, `service:`, `security:`, `make:`.
+> Commit type rules, valid types, rejected prefixes, and scope-directory mapping:
+> see [AGENTS.md §Hard Constraints](AGENTS.md#hard-constraints).
 
 ## PR size
 
@@ -97,6 +49,7 @@ make generate-protos # regenerate Go + Python stubs (commit the output)
                      # Note: stubs auto-regenerate on main via proto-generate.yml
                      # when .proto or buf config files change (post-merge gate).
 make validate-spec   # AsyncAPI + capability schema validation
+make security        # govulncheck + bandit + pip-audit
 ```
 
 All commands run inside Docker — only prerequisite is Docker Desktop.
@@ -114,14 +67,8 @@ Tiers (ADR-016): BDD at gRPC boundaries (`protos/tests/`), unit ≥ 90% on `inte
 
 ## Architecture Invariants
 
-These three rules must never be broken regardless of milestone:
-
-1. **No shared database.** Each service owns its own schema/namespace. Cross-service
-   reads go through gRPC, never through a shared table or ORM model.
-2. **No Layer 1→3 coupling.** YAML manifests (`spec/`) are never imported by Go
-   services. The Workflow Compiler transforms Layer 1 → Layer 2 (WorkflowIR).
-3. **Contracts before implementations.** `.proto` files and `.feature` files are
-   committed and CI-green before any service implementation begins (ADR-016).
+> No shared DB · No Layer 1→3 coupling · Contracts before implementations.
+> See [AGENTS.md §The Three-Layer Separation](AGENTS.md#the-three-layer-separation-non-negotiable) and [§Five Non-Negotiable Mandates](AGENTS.md#five-non-negotiable-mandates).
 
 ## SPDD — feat: PR Workflow
 
@@ -156,28 +103,9 @@ Full guide: `docs/patterns/spdd-guide.md` · Template: `docs/spdd/CANVAS_TEMPLAT
 | **M4** (⚠ Partial) | api-gateway REST layer, `zynax` CLI, `kind: AgentDef` routing, Docker Compose runner, GitOps watch | Observability, production hardening · agent-registry missing (M5.C #460) |
 | **M5** (Active) | M5.A docs alignment, M5.B engine fixes, M5.C capability dispatch (task-broker ✅ code, agent-registry pending), M5.D security ✅, M5.E DX ✅, http-adapter ✅, git/ci/llm/langgraph adapters | Persistence, K8s deployment, event-bus |
 
-Active milestone: M5 (Adapter Library). See [docs/milestones/M5-plan.md](docs/milestones/M5-plan.md) for the full execution plan.
+## AI Anti-Patterns
 
-## Common AI Anti-Patterns
-
-Things that have gone wrong in this repo — avoid these:
-
-| Anti-pattern | Correct approach |
-|--------------|-----------------|
-| Writing Python in `services/` | All platform services are Go (ADR-009). Python lives only in `agents/` |
-| Editing `protos/generated/` directly | Run `make generate-protos` — generated files are never hand-edited |
-| Mocking the database in integration tests | Use `testcontainers-go` for real DB (ADR-016) |
-| Adding complexity beyond the issue scope | Implement exactly what the issue asks; open a follow-up for anything extra |
-| Using `Co-Authored-By:` for AI | Use `Assisted-by: Claude/<model>` — DCO is human-only |
-| Omitting `Signed-off-by:` from a commit | Every commit needs `Signed-off-by: Name <email>` or the DCO gate fails — include it even on AI-assisted commits |
-| PR title prefix `spec:` / `proto:` / `adr:` | Use `docs:` for spec/ADR changes, `feat:`/`chore:` for proto changes |
-| Running `go test` in `protos/tests/` without `GOWORK=off` | Always prefix: `GOWORK=off go test ./...` (ADR-017) |
-| Running `go test` in `services/<svc>/` without `GOWORK=off` | Same rule — applies to ALL go commands in any service directory |
-| Embedding multi-line scripts in `run: \|` YAML blocks | Extract to `tools/<name>.py` — un-indented Python terminates the YAML scalar |
-| Using `govulncheck@latest` with Go 1.22 | Pin to `GOVULNCHECK_VERSION` env var — @latest requires Go ≥ 1.25 |
-| `golang:1.22-alpine` COPY paths using `/root/go/bin/` | Use `/go/bin/` — GOPATH on Alpine is `/go`, not `/root/go` |
-| Importing domain types across services | Cross-service communication is gRPC only, never shared types |
-| Any SPDD violation (`feat:` PR without Canvas, Tier 2 in Canvas, code before Canvas update) | See SPDD section above — ADR-019, `docs/patterns/spdd-guide.md` |
+> Full anti-patterns table (Go/Python/proto/commit/SPDD rules): [AGENTS.md §AI Anti-patterns](AGENTS.md#ai-anti-patterns).
 
 ## Decision-Making Guide
 

--- a/docs/ai-assistant-setup.md
+++ b/docs/ai-assistant-setup.md
@@ -127,7 +127,7 @@ commit slips through, but the PR gate is the primary enforcement point.
 
 ## What AI Tools Must Not Do
 
-These constraints from `AGENTS.md §12` apply to AI-generated output as strictly
+These constraints from `AGENTS.md §AI Anti-patterns` apply to AI-generated output as strictly
 as to hand-written code. Review AI output against these before committing:
 
 - No `panic` in production Go code

--- a/docs/reviews/02-reality-vs-docs.md
+++ b/docs/reviews/02-reality-vs-docs.md
@@ -203,6 +203,9 @@ These were flagged in the 2026-05-20 review and have since been fixed:
 | `CompileWorkflow` returned only first error | Returns full error list | #477 |
 | GOWORK=off documentation | Added to AGENTS.md, CLAUDE.md | ADR-017 |
 | Non-constant-time bearer compare | Filed as #567 | Open |
+| AGENTS.md footer "CNCF Sandbox Candidate" | Removed (badge dropped in #472, footer not updated) | docs/compress-ai-context |
+| CLAUDE.md Go-1.22-specific anti-patterns | Removed (toolchain is Go 1.26.3) | docs/compress-ai-context |
+| `docs/ai-assistant-setup.md` "AGENTS.md §12" | Fixed to "AGENTS.md §AI Anti-patterns" (§12 never existed) | docs/compress-ai-context |
 
 ---
 

--- a/tools/gitleaks-baseline.json
+++ b/tools/gitleaks-baseline.json
@@ -1,8 +1,8 @@
 [
  {
   "Description": "Email address — must not appear in public AI context files",
-  "StartLine": 135,
-  "EndLine": 135,
+  "StartLine": 136,
+  "EndLine": 136,
   "StartColumn": 61,
   "EndColumn": 83,
   "Match": "ogomezmanresa@gmail.com",
@@ -20,29 +20,6 @@
    "email"
   ],
   "RuleID": "email-address",
-  "Fingerprint": "AGENTS.md:email-address:135"
- },
- {
-  "Description": "Email address — must not appear in public AI context files",
-  "StartLine": 56,
-  "EndLine": 56,
-  "StartColumn": 39,
-  "EndColumn": 61,
-  "Match": "ogomezmanresa@gmail.com",
-  "Secret": "ogomezmanresa@gmail.com",
-  "File": "CLAUDE.md",
-  "SymlinkFile": "",
-  "Commit": "",
-  "Entropy": 3.5883543,
-  "Author": "",
-  "Email": "",
-  "Date": "",
-  "Message": "",
-  "Tags": [
-   "pii",
-   "email"
-  ],
-  "RuleID": "email-address",
-  "Fingerprint": "CLAUDE.md:email-address:56"
+  "Fingerprint": "AGENTS.md:email-address:136"
  }
 ]


### PR DESCRIPTION
## Summary

- **CLAUDE.md** cut from 195 → 123 lines (−72) by collapsing 6 sections into 1-line references to `AGENTS.md`
- **AGENTS.md** absorbs 5 migrated rules (+4 net): mocking-DB anti-pattern, scope anti-pattern, parametrised `Assisted-by`, no-emoji rule, scope-directory mapping
- **3 drift fixes**: stale CNCF Sandbox Candidate footer, obsolete Go-1.22 anti-patterns, broken `AGENTS.md §12` cross-reference
- **Total**: 2,080 → 2,012 lines (−68) across 20 AI-context files; zero rule loss

## Ownership map

| Topic | Canonical owner |
|---|---|
| Hard constraints, anti-patterns, commit/PR rules | `AGENTS.md` |
| Dev-loop commands, GOWORK=off, testing | `CLAUDE.md` |
| Milestone status / per-track progress | `state/current-milestone.md` |
| SPDD slash-command cheat-list | `CLAUDE.md` |
| AI tool setup, Assisted-by labelling prose | `docs/ai-assistant-setup.md` |

## Drift evidence and resolutions

1. **CNCF Sandbox Candidate** — AGENTS.md footer said "CNCF Sandbox Candidate"; badge was removed in #472 (Truth Pass) but the footer was never updated. Removed.
2. **Go 1.22 anti-patterns** — `go.work` and all service `go.mod` files are on Go 1.26.3. Two CLAUDE.md rows (`govulncheck@latest with Go 1.22`, `golang:1.22-alpine COPY paths`) were stale since Go ≥ 1.25 makes the workarounds obsolete. Removed.
3. **`AGENTS.md §12` reference** — `docs/ai-assistant-setup.md` cited a section that never existed. Fixed to `AGENTS.md §AI Anti-patterns`.
4. **Milestone status** — README already shows M3/M4 as ⚠ Partial, matching CLAUDE.md. No contradiction.
5. **PR-size threshold** — CLAUDE.md and CONTRIBUTING.md both say ≤200 ideal; CI warns at >400, blocks at >900. Consistent; kept.

## Before/after

| File | Before | After | Δ |
|---|---|---|---|
| CLAUDE.md | 195 | 123 | −72 |
| AGENTS.md | 230 | 234 | +4 |
| docs/ai-assistant-setup.md | 139 | 139 | 0 |
| 16 sub-AGENTS.md | 1,516 | 1,516 | 0 |
| **Total** | **2,080** | **2,012** | **−68** |

## Test plan

- [x] Pre-commit hooks pass (no secrets, no lint failures)
- [x] All KB-index paths verified against HEAD — no dangling references
- [x] Every removed row confirmed present in canonical file
- [x] No mTLS/SBOM/cosign unsubstantiated claims introduced
- [x] `make lint` (Docker) not run locally — CI gate covers it

## Deferred

- `.claude/commands/resume-m5.md` (bootstrap prompt slash command) — user confirmed yes but current prompt is not in the repo. Requires separate PR once content is provided.

---

> This is a `docs:` PR — SPDD-exempt (no Canvas required).