### PR TITLE
ci: filter empty pkg_args entries from trailing space in selective BDD run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -823,7 +823,7 @@ jobs:
               echo "── BDD: full suite"
               GOWORK=off go test ./... -v -timeout 120s 2>&1 | tee bdd-results.txt
             else
-              pkg_args=$(echo "$pkgs" | tr ' ' '\n' | sed 's|^|./|;s|$|/...|' | tr '\n' ' ')
+              pkg_args=$(echo "$pkgs" | tr ' ' '\n' | grep -v '^$' | sed 's|^|./|;s|$|/...|' | tr '\n' ' ')
               echo "── BDD: selective — $pkgs"
               GOWORK=off go test $pkg_args -v -timeout 120s 2>&1 | tee bdd-results.txt
             fi


### PR DESCRIPTION
## Summary
- The BDD selective-run logic builds `pkg_args` from `pkgs` via `tr ' ' '\n' | sed 's|^|./|;s|$|/...|'`
- The dedup step ends with `tr '\n' ' '`, which leaves a **trailing space** in `pkgs`
- That trailing space becomes an empty line after the next `tr ' ' '\n'`, which `sed` transforms into `.//...` (≡ `./...`), appending a full-suite wildcard to the selective package list
- This caused the full BDD suite to run whenever only specific packages were selected, exposing unrelated pre-existing failures

**Fix:** add `grep -v '^$'` before `sed` to filter out empty lines before they are prefixed/suffixed.

## Test plan
- [ ] Verify CI runs only the changed package on a PR that touches a single test file in `protos/tests/<pkg>/`
- [ ] Verify "BDD: selective — <pkg>" in CI log and that other packages are not executed

🤖 Generated with [Claude Code](https://claude.com/claude-code)