### PR TITLE
feat(adapters/git): Go module scaffold and config layer (#381, O2)

### DIFF
--- a/agents/adapters/git/agent-def.yaml.example
+++ b/agents/adapters/git/agent-def.yaml.example
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: Apache-2.0
+# git-adapter — example AgentDef YAML
+#
+# Copy this file to agent-def.yaml and set the ADAPTER_CONFIG env var to its path.
+# Set the env var named in git.auth_env to a GitHub PAT with repo scope.
+#
+# SSRF prevention: owner and repo are declared here — never in input_payload.
+
+agent_id: git-adapter
+name: Git Adapter
+description: Wraps GitHub repository operations as Zynax capabilities.
+endpoint: :50060
+registry_endpoint: agent-registry:50052
+
+git:
+  provider: github
+  auth_env: GITHUB_TOKEN  # name of the env var holding the PAT or GitHub App token
+
+capabilities:
+  - name: open_pr
+    owner: my-org
+    repo: my-repo
+    timeout_seconds: 30
+    description: Open a pull request in the configured repository.
+    input_schema_json: |
+      {
+        "type": "object",
+        "required": ["title", "head", "base"],
+        "properties": {
+          "title":  { "type": "string", "minLength": 1 },
+          "head":   { "type": "string", "minLength": 1 },
+          "base":   { "type": "string", "minLength": 1 },
+          "body":   { "type": "string" }
+        },
+        "additionalProperties": false
+      }
+    output_schema_json: |
+      {
+        "type": "object",
+        "properties": {
+          "pr_url":    { "type": "string" },
+          "pr_number": { "type": "integer" }
+        }
+      }
+
+  - name: request_review
+    owner: my-org
+    repo: my-repo
+    timeout_seconds: 60
+    description: Request reviewers on an existing pull request.
+    input_schema_json: |
+      {
+        "type": "object",
+        "required": ["pr_number", "reviewers"],
+        "properties": {
+          "pr_number": { "type": "integer", "minimum": 1 },
+          "reviewers": { "type": "array", "items": { "type": "string" }, "minItems": 1 }
+        },
+        "additionalProperties": false
+      }
+    output_schema_json: |
+      {
+        "type": "object",
+        "properties": {
+          "requested": { "type": "boolean" }
+        }
+      }
+
+  - name: get_diff
+    owner: my-org
+    repo: my-repo
+    timeout_seconds: 30
+    description: Fetch the unified diff for a pull request (truncated at 4 MB).
+    input_schema_json: |
+      {
+        "type": "object",
+        "required": ["pr_number"],
+        "properties": {
+          "pr_number": { "type": "integer", "minimum": 1 }
+        },
+        "additionalProperties": false
+      }
+    output_schema_json: |
+      {
+        "type": "object",
+        "properties": {
+          "diff":      { "type": "string" },
+          "truncated": { "type": "boolean" }
+        }
+      }

--- a/agents/adapters/git/cmd/git-adapter/main.go
+++ b/agents/adapters/git/cmd/git-adapter/main.go
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package main is the entry point for the git-adapter gRPC service.
+// Config path from ADAPTER_CONFIG env var; registry endpoint from config.
+// Full bootstrap wiring is added in O4 (#402).
+package main
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/zynax-io/zynax/agents/adapters/git/internal/config"
+)
+
+func main() {
+	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stdout, nil)))
+	if err := run(); err != nil {
+		slog.Error("git-adapter error", "err", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	cfgPath := os.Getenv("ADAPTER_CONFIG")
+	if cfgPath == "" {
+		return fmt.Errorf("ADAPTER_CONFIG env var is required")
+	}
+	_, err := config.Load(cfgPath)
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+	// Full gRPC server bootstrap added in O4 (#402).
+	return fmt.Errorf("git-adapter not yet fully bootstrapped — O4 (#402) pending")
+}

--- a/agents/adapters/git/go.mod
+++ b/agents/adapters/git/go.mod
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
+module github.com/zynax-io/zynax/agents/adapters/git
+
+go 1.26.3
+
+replace github.com/zynax-io/zynax/protos/generated/go => ../../../protos/generated/go
+
+require gopkg.in/yaml.v3 v3.0.1

--- a/agents/adapters/git/go.sum
+++ b/agents/adapters/git/go.sum
@@ -1,0 +1,4 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/agents/adapters/git/internal/config/config.go
+++ b/agents/adapters/git/internal/config/config.go
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package config parses and validates the git-adapter YAML configuration at startup.
+// Auth token values are never stored — only the env-var name is kept; the token is
+// resolved at runtime from the environment by the bootstrap layer.
+package config
+
+import (
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+// AdapterConfig is the top-level YAML struct parsed from the file at startup.
+// Path is read from the ADAPTER_CONFIG env var by the bootstrap layer.
+type AdapterConfig struct {
+	AgentID          string                `yaml:"agent_id"`
+	Name             string                `yaml:"name"`
+	Description      string                `yaml:"description"`
+	Endpoint         string                `yaml:"endpoint"`
+	RegistryEndpoint string                `yaml:"registry_endpoint"`
+	Git              GitConfig             `yaml:"git"`
+	Capabilities     []GitCapabilityConfig `yaml:"capabilities"`
+}
+
+// GitConfig holds provider-level settings shared across all capabilities.
+type GitConfig struct {
+	// Provider is the Git hosting provider: "github" or "gitlab" (stub only in M5).
+	Provider string `yaml:"provider"`
+	// AuthEnv is the name of the environment variable that holds the PAT or app token.
+	// The token value is never stored in config — it is resolved from the environment.
+	AuthEnv string `yaml:"auth_env"`
+}
+
+// GitCapabilityConfig maps one capability name to a static repository target.
+// Owner and repo are always declared in config — never derived from input_payload (SSRF prevention).
+type GitCapabilityConfig struct {
+	Name             string `yaml:"name"`
+	Owner            string `yaml:"owner"`
+	Repo             string `yaml:"repo"`
+	TimeoutSeconds   int    `yaml:"timeout_seconds"`
+	InputSchemaJSON  string `yaml:"input_schema_json"`
+	OutputSchemaJSON string `yaml:"output_schema_json"`
+	Description      string `yaml:"description"`
+}
+
+// Load reads, parses, and validates the YAML config at path.
+// Returns a descriptive error for missing required fields or malformed YAML.
+func Load(path string) (*AdapterConfig, error) {
+	data, err := os.ReadFile(path) //nolint:gosec // path sourced from ADAPTER_CONFIG env var (operator-controlled)
+	if err != nil {
+		return nil, fmt.Errorf("config: read %s: %w", path, err)
+	}
+
+	var cfg AdapterConfig
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("config: parse %s: %w", path, err)
+	}
+
+	if err := validate(&cfg); err != nil {
+		return nil, err
+	}
+
+	return &cfg, nil
+}
+
+func validate(cfg *AdapterConfig) error {
+	if cfg.AgentID == "" {
+		return fmt.Errorf("config: agent_id is required")
+	}
+	if cfg.Endpoint == "" {
+		return fmt.Errorf("config: endpoint is required")
+	}
+	if cfg.RegistryEndpoint == "" {
+		return fmt.Errorf("config: registry_endpoint is required")
+	}
+	if cfg.Git.Provider == "" {
+		return fmt.Errorf("config: git.provider is required")
+	}
+	if cfg.Git.AuthEnv == "" {
+		return fmt.Errorf("config: git.auth_env is required")
+	}
+	if len(cfg.Capabilities) == 0 {
+		return fmt.Errorf("config: at least one capability is required")
+	}
+	for i, c := range cfg.Capabilities {
+		if c.Name == "" {
+			return fmt.Errorf("config: capabilities[%d].name is required", i)
+		}
+		if c.Owner == "" {
+			return fmt.Errorf("config: capabilities[%d].owner is required", i)
+		}
+		if c.Repo == "" {
+			return fmt.Errorf("config: capabilities[%d].repo is required", i)
+		}
+	}
+	return nil
+}
+
+// ResolveToken reads the auth token from the env var named in cfg.Git.AuthEnv.
+// Returns an error if the env var is unset or empty.
+func ResolveToken(cfg *AdapterConfig) (string, error) {
+	token := os.Getenv(cfg.Git.AuthEnv)
+	if token == "" {
+		return "", fmt.Errorf("config: env var %s is required but not set", cfg.Git.AuthEnv)
+	}
+	return token, nil
+}

--- a/agents/adapters/git/internal/config/config_test.go
+++ b/agents/adapters/git/internal/config/config_test.go
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package config_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/zynax-io/zynax/agents/adapters/git/internal/config"
+)
+
+func TestLoad_Valid(t *testing.T) {
+	t.Parallel()
+	path := writeYAML(t, `
+agent_id: git-adapter-test
+name: Git Adapter Test
+description: test
+endpoint: :50060
+registry_endpoint: localhost:50052
+git:
+  provider: github
+  auth_env: GITHUB_TOKEN
+capabilities:
+  - name: open_pr
+    owner: zynax-io
+    repo: zynax
+    timeout_seconds: 30
+`)
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.AgentID != "git-adapter-test" {
+		t.Errorf("agent_id mismatch: got %q", cfg.AgentID)
+	}
+	if cfg.Git.Provider != "github" {
+		t.Errorf("git.provider mismatch: got %q", cfg.Git.Provider)
+	}
+	if cfg.Git.AuthEnv != "GITHUB_TOKEN" {
+		t.Errorf("git.auth_env mismatch: got %q", cfg.Git.AuthEnv)
+	}
+	if len(cfg.Capabilities) != 1 {
+		t.Fatalf("expected 1 capability, got %d", len(cfg.Capabilities))
+	}
+	if cfg.Capabilities[0].Owner != "zynax-io" {
+		t.Errorf("capabilities[0].owner mismatch: got %q", cfg.Capabilities[0].Owner)
+	}
+}
+
+func TestLoad_MissingFile(t *testing.T) {
+	t.Parallel()
+	_, err := config.Load("/nonexistent/path.yaml")
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+}
+
+func TestLoad_MalformedYAML(t *testing.T) {
+	t.Parallel()
+	path := writeYAML(t, ":::bad yaml:::")
+	_, err := config.Load(path)
+	if err == nil {
+		t.Fatal("expected error for malformed YAML")
+	}
+}
+
+func TestValidate_MissingAgentID(t *testing.T) {
+	t.Parallel()
+	path := writeYAML(t, `
+endpoint: :50060
+registry_endpoint: localhost:50052
+git:
+  provider: github
+  auth_env: GITHUB_TOKEN
+capabilities:
+  - name: open_pr
+    owner: zynax-io
+    repo: zynax
+`)
+	_, err := config.Load(path)
+	if err == nil {
+		t.Fatal("expected error for missing agent_id")
+	}
+}
+
+func TestValidate_MissingGitProvider(t *testing.T) {
+	t.Parallel()
+	path := writeYAML(t, `
+agent_id: git-adapter
+endpoint: :50060
+registry_endpoint: localhost:50052
+git:
+  auth_env: GITHUB_TOKEN
+capabilities:
+  - name: open_pr
+    owner: zynax-io
+    repo: zynax
+`)
+	_, err := config.Load(path)
+	if err == nil {
+		t.Fatal("expected error for missing git.provider")
+	}
+}
+
+func TestValidate_MissingAuthEnv(t *testing.T) {
+	t.Parallel()
+	path := writeYAML(t, `
+agent_id: git-adapter
+endpoint: :50060
+registry_endpoint: localhost:50052
+git:
+  provider: github
+capabilities:
+  - name: open_pr
+    owner: zynax-io
+    repo: zynax
+`)
+	_, err := config.Load(path)
+	if err == nil {
+		t.Fatal("expected error for missing git.auth_env")
+	}
+}
+
+func TestValidate_MissingCapabilityOwner(t *testing.T) {
+	t.Parallel()
+	path := writeYAML(t, `
+agent_id: git-adapter
+endpoint: :50060
+registry_endpoint: localhost:50052
+git:
+  provider: github
+  auth_env: GITHUB_TOKEN
+capabilities:
+  - name: open_pr
+    repo: zynax
+`)
+	_, err := config.Load(path)
+	if err == nil {
+		t.Fatal("expected error for missing capabilities[0].owner")
+	}
+}
+
+func TestResolveToken_Set(t *testing.T) {
+	// t.Setenv requires no t.Parallel
+	t.Setenv("TEST_TOKEN_123", "mytoken")
+	cfg := &config.AdapterConfig{
+		Git: config.GitConfig{AuthEnv: "TEST_TOKEN_123"},
+	}
+	tok, err := config.ResolveToken(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tok != "mytoken" {
+		t.Errorf("token mismatch: got %q", tok)
+	}
+}
+
+func TestResolveToken_Unset(t *testing.T) {
+	t.Parallel()
+	cfg := &config.AdapterConfig{
+		Git: config.GitConfig{AuthEnv: "TEST_TOKEN_UNSET_XYZ"},
+	}
+	_, err := config.ResolveToken(cfg)
+	if err == nil {
+		t.Fatal("expected error for unset env var")
+	}
+}
+
+func writeYAML(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("writeYAML: %v", err)
+	}
+	return path
+}

--- a/docs/milestones/M5-plan.md
+++ b/docs/milestones/M5-plan.md
@@ -6,7 +6,7 @@
 **GitHub Milestone:** [Adapter Library (M5)](https://github.com/zynax-io/zynax/milestone/5)
 **Parent epic:** [#377](https://github.com/zynax-io/zynax/issues/377)
 **Status:** In Progress
-**Last updated:** 2026-05-26 (rev 54 — reconcile M5.C/M5.B/M5.F closed issues)
+**Last updated:** 2026-05-26 (rev 55 — #400 git-adapter scaffold merged)
 
 ---
 
@@ -386,7 +386,7 @@ register against.
 #### git-adapter (#381)
 | Issue | Step | Title | Status |
 |-------|------|-------|--------|
-| [#400](https://github.com/zynax-io/zynax/issues/400) | O2 | Go module scaffold + config layer | ⬜ Open |
+| [#400](https://github.com/zynax-io/zynax/issues/400) | O2 | Go module scaffold + config layer | ✅ Done |
 | [#401](https://github.com/zynax-io/zynax/issues/401) | O3 | Capability handler (open_pr, request_review, get_diff) | ⬜ Open (blocked on #400) |
 | [#402](https://github.com/zynax-io/zynax/issues/402) | O4 | Registry client + bootstrap | ⬜ Open (blocked on #401) |
 | [#403](https://github.com/zynax-io/zynax/issues/403) | O5 | Dockerfile, docker-compose, AGENTS.md | ⬜ Open (blocked on #402) |

--- a/go.work
+++ b/go.work
@@ -5,6 +5,7 @@
 go 1.26.3
 
 use (
+	./agents/adapters/git
 	./agents/adapters/http
 	./protos/generated/go
 	./services/agent-registry

--- a/state/current-milestone.md
+++ b/state/current-milestone.md
@@ -94,7 +94,7 @@ Canvas aligned. Ordered delivery: #526 → #527 → #528 → #481.
 |-------|-------|-------|--------|
 | [#474](https://github.com/zynax-io/zynax/issues/474) | M5.A | Python SDK Agent base class | ✅ Complete — #535 ✅ #536 ✅ #537 ✅; BATCH 3 done |
 | [#476](https://github.com/zynax-io/zynax/issues/476) | M5.B | Guard parser (cel-go) | ✅ closed — all 3 children merged |
-| [#381](https://github.com/zynax-io/zynax/issues/381) | Adapters | git-adapter impl | open (#399 BDD done; #400+ pending, wait for #481) |
+| [#381](https://github.com/zynax-io/zynax/issues/381) | Adapters | git-adapter impl | In Progress — #400 ✅ scaffold; #401 handler pending; #402 registry pending |
 | [#382](https://github.com/zynax-io/zynax/issues/382) | Adapters | ci-adapter impl | open (#404 BDD done; #405+ pending, wait for #481) |
 | [#383](https://github.com/zynax-io/zynax/issues/383) | Adapters | llm-adapter impl | open (#409 BDD done; #410+ pending, wait for #481) |
 | [#384](https://github.com/zynax-io/zynax/issues/384) | Adapters | langgraph-adapter impl | open (#414 BDD done; #415+ pending, wait for #481) |
@@ -105,7 +105,7 @@ Canvas aligned. Ordered delivery: #526 → #527 → #528 → #481.
 
 - **✅ #655 FIXED** — `tools/healthcheck` static binary added to all 6 distroless Dockerfiles; `docker-compose.yml` migrated from `CMD-SHELL` + `wget`/`nc` to `CMD /healthcheck`; override file removed.
 - **#552 ✅ done** — all jobs now run in ci-runner container mode.
-- **adapter implementations** (#400–#418) — unblocked by #481 ✅; adapters need a live registry to register against.
+- **adapter implementations** (#401–#418) — unblocked by #481 ✅; git-adapter scaffold #400 ✅; handler and registry steps pending.
 - **E2E demo** — compose wired (#481 ✅); needs an adapter registered for capability dispatch.
 - **v0.4.0 tag** — CHANGELOG promoted; run `git tag -a v0.4.0 -m "M5 Adapter Library" && git push origin v0.4.0` on main to trigger the release workflow and create GitHub Release assets.
 
@@ -154,5 +154,7 @@ Priority gaps to file immediately:
 
 | Priority | Issue | Title | Note |
 |----------|-------|-------|------|
+| P2 | [#401](https://github.com/zynax-io/zynax/issues/401) | git-adapter capability handler (O3) | M, feat, canvas aligned; next after #400 ✅ |
+| P2 | [#402](https://github.com/zynax-io/zynax/issues/402) | git-adapter registry client + bootstrap (O4) | M, feat, canvas aligned; next after #401 |
 | P2 | [#555](https://github.com/zynax-io/zynax/issues/555) | DRY/KISS refactor — reusable workflows, composite actions | L, ci, needs-design |
 | M6 prep | [#656](https://github.com/zynax-io/zynax/issues/656) | gRPC Health Checking Protocol in all services | L, deferred |


### PR DESCRIPTION
## Summary

- Add `agents/adapters/git/` Go module with `AdapterConfig`, `GitConfig`, `GitCapabilityConfig` YAML-parsed structs
- Config validation: required fields, SSRF prevention (owner/repo in static config, never `input_payload`)
- Auth token resolved from named env var at runtime — value never stored
- `go.work` updated with `use agents/adapters/git`
- 9 unit tests covering valid load, malformed YAML, missing required fields, token resolution

## Why

Part of git-adapter implementation (canvas O2). Establishes the module skeleton and config
layer that O3 (handler) and O4 (registry/bootstrap) build on. #481 (compose wiring) landed in
M5.C, unblocking all adapter work.

Closes #400

## Cluster

BATCH 7 — git-adapter O2→O3→O4 (dependency chain)
- **#400 (this PR)** → #401 (handler) → #402 (registry+bootstrap)
- Merge order: #400 first, then #401, then #402

## State files updated

- `docs/milestones/M5-plan.md` — row #400 ⬜→✅; rev 55
- `state/current-milestone.md` — #381 track updated; #400–#401–#402 in next queue

## Architecture gaps

Gap scan done: G1/G4/G7/G16 — none applicable to config-only scaffold.

## Test plan

### Local pre-flight
- [x] `make lint-go` / golangci-lint — exit 0 (pre-commit hook passed)
- [x] `GOWORK=off go test ./... -race` — pass (`ok  config  1.008s`)
- [x] `make test-coverage` — domain ≥90% (N/A — no domain layer in this step)
- [x] `make test-coverage-adapters` / `make test-bdd` / `make security` — (N/A — handler/registry steps pending)

### Acceptance (Canvas O2)
- [x] `go.mod` has module path + replace directive for generated stubs (yaml.v3 dep; go-github added in O3 when imported)
- [x] `go.work` updated with `use agents/adapters/git`
- [x] `cmd/git-adapter/main.go` skeleton compiles (`GOWORK=off go build ./...` exit 0)
- [x] `config.Load` validates agent_id, endpoint, registry_endpoint, git.provider, git.auth_env, capability owner/repo
- [x] `config.ResolveToken` reads token from named env var; errors on unset

### Engineering hygiene
- [x] **`M5-plan.md` row flipped ⬜→✅ in this diff** (mandatory)
- [x] **`current-milestone.md` updated in this diff** (mandatory)
- [x] Branched from fresh `origin/main` · PR ≤900 lines · trailers on every commit
- [x] Gap scan done (G1/G4/G7/G16): none applicable to config-only scaffold
- [x] Canvas O2 scope only — no handler, no registry, no Dockerfile
- [x] No out-of-scope edits · no mTLS/SBOM/cosign docs claims

## Out of scope

- go-github dependency (added in O3 when handler imports it)
- Capability handler implementation (#401 O3)
- Registry client and full bootstrap (#402 O4)
- Dockerfile and docker-compose entry (#403 O5)
