### PR TITLE
feat(adapters/git): registry client and fully wired bootstrap (#381, O4)

### DIFF
--- a/agents/adapters/git/cmd/git-adapter/main.go
+++ b/agents/adapters/git/cmd/git-adapter/main.go
@@ -2,15 +2,25 @@
 
 // Package main is the entry point for the git-adapter gRPC service.
 // Config path from ADAPTER_CONFIG env var; registry endpoint from config.
-// Full bootstrap wiring is added in O4 (#402).
 package main
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
+	"net"
 	"os"
+	"os/signal"
+	"syscall"
 
+	"github.com/zynax-io/zynax/agents/adapters/git/internal/adapter"
 	"github.com/zynax-io/zynax/agents/adapters/git/internal/config"
+	"github.com/zynax-io/zynax/agents/adapters/git/internal/registry"
+	zynaxv1 "github.com/zynax-io/zynax/protos/generated/go/zynax/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/health"
+	"google.golang.org/grpc/health/grpc_health_v1"
 )
 
 func main() {
@@ -26,10 +36,71 @@ func run() error {
 	if cfgPath == "" {
 		return fmt.Errorf("ADAPTER_CONFIG env var is required")
 	}
-	_, err := config.Load(cfgPath)
+	cfg, err := config.Load(cfgPath)
 	if err != nil {
 		return fmt.Errorf("load config: %w", err)
 	}
-	// Full gRPC server bootstrap added in O4 (#402).
-	return fmt.Errorf("git-adapter not yet fully bootstrapped — O4 (#402) pending")
+	slog.Info("config loaded", "agent_id", cfg.AgentID, "endpoint", cfg.Endpoint) //nolint:gosec
+
+	token, err := config.ResolveToken(cfg)
+	if err != nil {
+		return fmt.Errorf("resolve token: %w", err)
+	}
+
+	regClient, cleanup, err := dialRegistry(cfg.RegistryEndpoint)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+	defer stop()
+
+	return serve(ctx, cfg, token, regClient)
+}
+
+func dialRegistry(endpoint string) (zynaxv1.AgentRegistryServiceClient, func(), error) {
+	conn, err := grpc.NewClient(endpoint, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return nil, nil, fmt.Errorf("registry dial %s: %w", endpoint, err)
+	}
+	return zynaxv1.NewAgentRegistryServiceClient(conn), func() { _ = conn.Close() }, nil
+}
+
+func serve(ctx context.Context, cfg *config.AdapterConfig, token string, regClient zynaxv1.AgentRegistryServiceClient) error {
+	lis, err := net.Listen("tcp", cfg.Endpoint)
+	if err != nil {
+		return fmt.Errorf("listen %s: %w", cfg.Endpoint, err)
+	}
+
+	grpcSrv := grpc.NewServer()
+	zynaxv1.RegisterAgentServiceServer(grpcSrv, adapter.NewAgentServer(cfg, token))
+	healthSrv := health.NewServer()
+	grpc_health_v1.RegisterHealthServer(grpcSrv, healthSrv)
+
+	def := registry.BuildAgentDef(cfg)
+	if err := registry.RegisterAgent(ctx, regClient, def); err != nil {
+		return fmt.Errorf("register: %w", err)
+	}
+	healthSrv.SetServingStatus("", grpc_health_v1.HealthCheckResponse_SERVING)
+	slog.Info("git-adapter serving", "endpoint", cfg.Endpoint) //nolint:gosec
+
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- grpcSrv.Serve(lis) }()
+
+	select {
+	case <-ctx.Done():
+		slog.Info("shutdown signal received")
+	case err := <-serveErr:
+		return fmt.Errorf("grpc serve: %w", err)
+	}
+
+	healthSrv.SetServingStatus("", grpc_health_v1.HealthCheckResponse_NOT_SERVING)
+	deregCtx := context.Background()
+	if err := registry.DeregisterAgent(deregCtx, regClient, cfg.AgentID); err != nil { //nolint:contextcheck // signal ctx already cancelled; fresh ctx for cleanup is intentional
+		slog.Warn("deregister failed", "err", err)
+	}
+	grpcSrv.GracefulStop()
+	slog.Info("git-adapter stopped")
+	return nil
 }

--- a/agents/adapters/git/internal/registry/client.go
+++ b/agents/adapters/git/internal/registry/client.go
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package registry provides helpers for registering and deregistering the
+// git-adapter with AgentRegistryService on startup and graceful shutdown.
+package registry
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/zynax-io/zynax/agents/adapters/git/internal/config"
+	zynaxv1 "github.com/zynax-io/zynax/protos/generated/go/zynax/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+const (
+	maxAttempts = 5
+	baseDelay   = 2 * time.Second
+)
+
+// RegisterAgent calls AgentRegistryService.RegisterAgent with exponential backoff.
+// Retries up to 5 times on transient gRPC errors; base delay 2 s, doubles each attempt.
+// Non-transient errors (INVALID_ARGUMENT, ALREADY_EXISTS, …) are returned immediately.
+func RegisterAgent(ctx context.Context, stub zynaxv1.AgentRegistryServiceClient, def *zynaxv1.AgentDef) error {
+	req := &zynaxv1.RegisterAgentRequest{Agent: def}
+
+	var lastErr error
+	for attempt := range maxAttempts {
+		if attempt > 0 {
+			delay := baseDelay * (1 << (attempt - 1))
+			slog.Info("retrying agent registration", "attempt", attempt+1, "delay", delay)
+			select {
+			case <-time.After(delay):
+			case <-ctx.Done():
+				return fmt.Errorf("registry: registration cancelled after %d attempts: %w", attempt, ctx.Err())
+			}
+		}
+
+		_, err := stub.RegisterAgent(ctx, req)
+		if err == nil {
+			slog.Info("agent registered", "agent_id", def.AgentId)
+			return nil
+		}
+		if !isTransient(err) {
+			return fmt.Errorf("registry: register failed (non-transient): %w", err)
+		}
+		lastErr = err
+		slog.Warn("registration attempt failed", "attempt", attempt+1, "err", err)
+	}
+	return fmt.Errorf("registry: register failed after %d attempts: %w", maxAttempts, lastErr)
+}
+
+// DeregisterAgent calls AgentRegistryService.DeregisterAgent once, no retry.
+func DeregisterAgent(ctx context.Context, stub zynaxv1.AgentRegistryServiceClient, agentID string) error {
+	_, err := stub.DeregisterAgent(ctx, &zynaxv1.DeregisterAgentRequest{AgentId: agentID})
+	if err != nil {
+		return fmt.Errorf("registry: deregister failed: %w", err)
+	}
+	slog.Info("agent deregistered", "agent_id", agentID)
+	return nil
+}
+
+// BuildAgentDef constructs the AgentDef proto from the parsed AdapterConfig.
+func BuildAgentDef(cfg *config.AdapterConfig) *zynaxv1.AgentDef {
+	caps := make([]*zynaxv1.CapabilityDef, 0, len(cfg.Capabilities))
+	for _, c := range cfg.Capabilities {
+		caps = append(caps, &zynaxv1.CapabilityDef{
+			Name:         c.Name,
+			Description:  c.Description,
+			InputSchema:  []byte(c.InputSchemaJSON),
+			OutputSchema: []byte(c.OutputSchemaJSON),
+		})
+	}
+	return &zynaxv1.AgentDef{
+		AgentId:      cfg.AgentID,
+		Name:         cfg.Name,
+		Description:  cfg.Description,
+		Endpoint:     cfg.Endpoint,
+		Capabilities: caps,
+	}
+}
+
+func isTransient(err error) bool {
+	st, ok := status.FromError(err)
+	if !ok {
+		return false
+	}
+	switch st.Code() {
+	case codes.Unavailable, codes.Internal, codes.DeadlineExceeded:
+		return true
+	}
+	return false
+}

--- a/agents/adapters/git/internal/registry/client_test.go
+++ b/agents/adapters/git/internal/registry/client_test.go
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package registry_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/zynax-io/zynax/agents/adapters/git/internal/config"
+	"github.com/zynax-io/zynax/agents/adapters/git/internal/registry"
+	zynaxv1 "github.com/zynax-io/zynax/protos/generated/go/zynax/v1"
+	"google.golang.org/grpc"
+)
+
+func TestBuildAgentDef(t *testing.T) {
+	t.Parallel()
+	cfg := &config.AdapterConfig{
+		AgentID:     "git-adapter",
+		Name:        "Git Adapter",
+		Description: "wraps GitHub ops",
+		Endpoint:    ":50060",
+		Capabilities: []config.GitCapabilityConfig{
+			{
+				Name:            "open_pr",
+				Description:     "Open a PR",
+				InputSchemaJSON: `{"type":"object"}`,
+			},
+		},
+	}
+	def := registry.BuildAgentDef(cfg)
+	if def.AgentId != "git-adapter" {
+		t.Errorf("agent_id mismatch: got %q", def.AgentId)
+	}
+	if def.Endpoint != ":50060" {
+		t.Errorf("endpoint mismatch: got %q", def.Endpoint)
+	}
+	if len(def.Capabilities) != 1 {
+		t.Fatalf("expected 1 capability, got %d", len(def.Capabilities))
+	}
+	if def.Capabilities[0].Name != "open_pr" {
+		t.Errorf("capability name mismatch: got %q", def.Capabilities[0].Name)
+	}
+	if string(def.Capabilities[0].InputSchema) != `{"type":"object"}` {
+		t.Errorf("input_schema mismatch: got %q", def.Capabilities[0].InputSchema)
+	}
+}
+
+// stubRegistryClient implements AgentRegistryServiceClient for testing.
+type stubRegistryClient struct {
+	registerErr   error
+	deregisterErr error
+	calls         int
+}
+
+func (s *stubRegistryClient) RegisterAgent(_ context.Context, _ *zynaxv1.RegisterAgentRequest, _ ...grpc.CallOption) (*zynaxv1.RegisterAgentResponse, error) {
+	s.calls++
+	return &zynaxv1.RegisterAgentResponse{}, s.registerErr
+}
+
+func (s *stubRegistryClient) DeregisterAgent(_ context.Context, _ *zynaxv1.DeregisterAgentRequest, _ ...grpc.CallOption) (*zynaxv1.DeregisterAgentResponse, error) {
+	return &zynaxv1.DeregisterAgentResponse{}, s.deregisterErr
+}
+
+func (s *stubRegistryClient) GetAgent(_ context.Context, _ *zynaxv1.GetAgentRequest, _ ...grpc.CallOption) (*zynaxv1.AgentDef, error) {
+	return nil, nil
+}
+
+func (s *stubRegistryClient) ListAgents(_ context.Context, _ *zynaxv1.ListAgentsRequest, _ ...grpc.CallOption) (*zynaxv1.ListAgentsResponse, error) {
+	return nil, nil
+}
+
+func (s *stubRegistryClient) FindByCapability(_ context.Context, _ *zynaxv1.FindByCapabilityRequest, _ ...grpc.CallOption) (*zynaxv1.FindByCapabilityResponse, error) {
+	return nil, nil
+}
+
+func TestRegisterAgent_Success(t *testing.T) {
+	t.Parallel()
+	stub := &stubRegistryClient{}
+	def := &zynaxv1.AgentDef{AgentId: "git-adapter", Endpoint: ":50060"}
+	err := registry.RegisterAgent(context.Background(), stub, def)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if stub.calls != 1 {
+		t.Errorf("expected 1 register call, got %d", stub.calls)
+	}
+}
+
+func TestDeregisterAgent_Success(t *testing.T) {
+	t.Parallel()
+	stub := &stubRegistryClient{}
+	err := registry.DeregisterAgent(context.Background(), stub, "git-adapter")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/docs/milestones/M5-plan.md
+++ b/docs/milestones/M5-plan.md
@@ -6,7 +6,7 @@
 **GitHub Milestone:** [Adapter Library (M5)](https://github.com/zynax-io/zynax/milestone/5)
 **Parent epic:** [#377](https://github.com/zynax-io/zynax/issues/377)
 **Status:** In Progress
-**Last updated:** 2026-05-26 (rev 56 — #401 git-adapter capability handler merged)
+**Last updated:** 2026-05-26 (rev 57 — #402 git-adapter registry client + bootstrap merged)
 
 ---
 
@@ -388,7 +388,7 @@ register against.
 |-------|------|-------|--------|
 | [#400](https://github.com/zynax-io/zynax/issues/400) | O2 | Go module scaffold + config layer | ✅ Done |
 | [#401](https://github.com/zynax-io/zynax/issues/401) | O3 | Capability handler (open_pr, request_review, get_diff) | ✅ Done |
-| [#402](https://github.com/zynax-io/zynax/issues/402) | O4 | Registry client + bootstrap | ⬜ Open (blocked on #401) |
+| [#402](https://github.com/zynax-io/zynax/issues/402) | O4 | Registry client + bootstrap | ✅ Done |
 | [#403](https://github.com/zynax-io/zynax/issues/403) | O5 | Dockerfile, docker-compose, AGENTS.md | ⬜ Open (blocked on #402) |
 
 **Engineer profile:** Go engineer with GitHub REST API experience. Read

--- a/state/current-milestone.md
+++ b/state/current-milestone.md
@@ -94,7 +94,7 @@ Canvas aligned. Ordered delivery: #526 → #527 → #528 → #481.
 |-------|-------|-------|--------|
 | [#474](https://github.com/zynax-io/zynax/issues/474) | M5.A | Python SDK Agent base class | ✅ Complete — #535 ✅ #536 ✅ #537 ✅; BATCH 3 done |
 | [#476](https://github.com/zynax-io/zynax/issues/476) | M5.B | Guard parser (cel-go) | ✅ closed — all 3 children merged |
-| [#381](https://github.com/zynax-io/zynax/issues/381) | Adapters | git-adapter impl | In Progress — #400 ✅ scaffold; #401 ✅ handler; #402 registry pending |
+| [#381](https://github.com/zynax-io/zynax/issues/381) | Adapters | git-adapter impl | In Progress — #400 ✅ scaffold; #401 ✅ handler; #402 ✅ registry+bootstrap; #403 Dockerfile pending |
 | [#382](https://github.com/zynax-io/zynax/issues/382) | Adapters | ci-adapter impl | open (#404 BDD done; #405+ pending, wait for #481) |
 | [#383](https://github.com/zynax-io/zynax/issues/383) | Adapters | llm-adapter impl | open (#409 BDD done; #410+ pending, wait for #481) |
 | [#384](https://github.com/zynax-io/zynax/issues/384) | Adapters | langgraph-adapter impl | open (#414 BDD done; #415+ pending, wait for #481) |
@@ -154,7 +154,6 @@ Priority gaps to file immediately:
 
 | Priority | Issue | Title | Note |
 |----------|-------|-------|------|
-| P2 | [#401](https://github.com/zynax-io/zynax/issues/401) | git-adapter capability handler (O3) | M, feat, canvas aligned; next after #400 ✅ |
-| P2 | [#402](https://github.com/zynax-io/zynax/issues/402) | git-adapter registry client + bootstrap (O4) | M, feat, canvas aligned; next after #401 |
+| P2 | [#403](https://github.com/zynax-io/zynax/issues/403) | git-adapter Dockerfile + docker-compose (O5) | S, feat, canvas aligned; next after #402 ✅ |
 | P2 | [#555](https://github.com/zynax-io/zynax/issues/555) | DRY/KISS refactor — reusable workflows, composite actions | L, ci, needs-design |
 | M6 prep | [#656](https://github.com/zynax-io/zynax/issues/656) | gRPC Health Checking Protocol in all services | L, deferred |


### PR DESCRIPTION
## Summary

- `registry.RegisterAgent`: 5-attempt exponential backoff (2 s base, ×2); transient gRPC errors retry; non-transient return immediately
- `registry.DeregisterAgent`: single call, no retry; called on SIGTERM/SIGINT
- `registry.BuildAgentDef`: maps `AdapterConfig` capabilities to `proto.AgentDef` with `CapabilityDef` entries
- `main.go` fully wired: `ADAPTER_CONFIG` → config load → token resolve → registry dial → gRPC server (AgentService + health) → RegisterAgent → serve → signal → DeregisterAgent → GracefulStop
- Follows exact same pattern as http-adapter (`main.go` refactored into `run` + `dialRegistry` + `serve` to satisfy funlen lint)

## Why

Canvas O4 — completes the operational git-adapter binary. After this PR merges, the adapter can start, register its 3 capabilities, serve `ExecuteCapability` requests, and cleanly deregister on shutdown. Stacked on #401 (handler).

Closes #402

## Cluster

BATCH 7 — git-adapter O2→O3→O4 (dependency chain)
- #400 (scaffold) → #401 (handler) → **#402 (this PR)**
- Base: `feat/401-git-adapter-handler`

## State files updated

- `docs/milestones/M5-plan.md` — row #402 ⬜→✅; rev 57
- `state/current-milestone.md` — #381 track updated; #403 now in next queue

## Architecture gaps

Gap scan done: G1/G4/G7/G16 — none applicable to registry/bootstrap layer.

## Test plan

### Local pre-flight
- [x] `make lint-go` / golangci-lint — exit 0 (pre-commit hook passed)
- [x] `GOWORK=off go test ./... -race` — pass (config ✓ adapter ✓ registry ✓)
- [x] `make test-coverage` — domain ≥90% (N/A — bootstrap, not domain layer)
- [x] `make test-coverage-adapters` / `make test-bdd` / `make security` — (N/A — full stack in #403 Dockerfile step)

### Acceptance (Canvas O4)
- [x] `RegisterAgent` calls registry with 5-attempt exponential backoff, 2 s base
- [x] `DeregisterAgent` called on SIGTERM/SIGINT before `GracefulStop`
- [x] `BuildAgentDef` maps all config capabilities to proto `CapabilityDef`
- [x] `main.go` compiles and links: `GOWORK=off go build ./...` exit 0
- [x] gRPC health server registered (health check support)

### Engineering hygiene
- [x] **`M5-plan.md` row flipped ⬜→✅ in this diff** (mandatory)
- [x] **`current-milestone.md` updated in this diff** (mandatory)
- [x] Stacked on `feat/401-git-adapter-handler` · PR ≤900 lines · trailers on every commit
- [x] Gap scan done (G1/G4/G7/G16): none applicable
- [x] Canvas O4 scope only — no Dockerfile, no docker-compose
- [x] No out-of-scope edits · no mTLS/SBOM/cosign docs claims

## Out of scope

- Dockerfile and docker-compose entry (#403 O5 — next issue)
