### PR TITLE
docs: reconcile M5 plan — close completed epics, fix track overview

### DIFF
--- a/docs/milestones/M5-plan.md
+++ b/docs/milestones/M5-plan.md
@@ -6,7 +6,7 @@
 **GitHub Milestone:** [Adapter Library (M5)](https://github.com/zynax-io/zynax/milestone/5)
 **Parent epic:** [#377](https://github.com/zynax-io/zynax/issues/377)
 **Status:** In Progress
-**Last updated:** 2026-05-26 (rev 58 — #403 git-adapter Dockerfile + docker-compose + AGENTS.md merged; #381 epic complete)
+**Last updated:** 2026-05-27 (rev 59 — epics #459 #474 #479 #480 #543 #556 closed; Track Overview updated; #577 #574 #576 cluster shipped)
 
 ---
 
@@ -53,15 +53,15 @@ the developer's responsibility; auto-merge fires automatically once all checks p
 
 | # | Track | Epic | Status | Priority |
 |---|-------|------|--------|----------|
-| **M5.F** | CI/CD Performance Sprint | [#542](https://github.com/zynax-io/zynax/issues/542) | 🔴 **Do first** | **P0** |
-| **M5.F.R** | Release Pipeline | [#556](https://github.com/zynax-io/zynax/issues/556) | 🔴 **Do first** | **P0** |
-| **M5.C** | Capability Dispatch E2E | [#460](https://github.com/zynax-io/zynax/issues/460) | 🟡 In Progress | **P0** |
-| **M5.B** | Engine Correctness | [#459](https://github.com/zynax-io/zynax/issues/459) | 🟡 In Progress (3/4 done) | **P1** |
-| **M5.A** | Truth Pass | [#458](https://github.com/zynax-io/zynax/issues/458) | 🟡 In Progress (2/3 done) | **P1** |
-| **Adapters** | Adapter Library | [#377](https://github.com/zynax-io/zynax/issues/377) | 🟡 In Progress (1/5 done) | **P2** |
-| **M5.D** | Security Baseline | [#461](https://github.com/zynax-io/zynax/issues/461) | ✅ Complete | — |
-| **M5.E** | DX Polish | [#462](https://github.com/zynax-io/zynax/issues/462) | ✅ Complete | — |
-| **Tooling** | Containerized Make | [#442](https://github.com/zynax-io/zynax/issues/442) | ✅ Complete | — |
+| **M5.F** | CI/CD Performance Sprint | [#542](https://github.com/zynax-io/zynax/issues/542) | 🟡 In Progress — #555 (DRY/KISS L) remaining | **P2** |
+| **M5.F.R** | Release Pipeline | [#556](https://github.com/zynax-io/zynax/issues/556) | ✅ Complete (closed) | — |
+| **M5.C** | Capability Dispatch E2E | [#460](https://github.com/zynax-io/zynax/issues/460) | 🟡 In Progress — dispatch wired; E2E demo pending adapters | **P0** |
+| **M5.B** | Engine Correctness | [#459](https://github.com/zynax-io/zynax/issues/459) | ✅ Complete (closed) — #475 #476 #477 #478 all ✅ | — |
+| **M5.A** | Truth Pass | [#458](https://github.com/zynax-io/zynax/issues/458) | 🟡 In Progress — #472 ✅ #473 ✅ #474 ✅; #579 ⬜ | **P1** |
+| **Adapters** | Adapter Library | [#377](https://github.com/zynax-io/zynax/issues/377) | 🟡 In Progress — http ✅ git ✅; ci/llm/langgraph pending | **P2** |
+| **M5.D** | Security Baseline | [#461](https://github.com/zynax-io/zynax/issues/461) | ✅ Complete (closed) | — |
+| **M5.E** | DX Polish | [#462](https://github.com/zynax-io/zynax/issues/462) | ✅ Complete (closed) | — |
+| **Tooling** | Containerized Make | [#442](https://github.com/zynax-io/zynax/issues/442) | ✅ Complete (closed) | — |
 
 ---
 

--- a/state/current-milestone.md
+++ b/state/current-milestone.md
@@ -30,10 +30,10 @@ M5 is structured into seven tracks. See full execution plan: **[docs/milestones/
 
 | Track | Epic | Status |
 |-------|------|--------|
-| **M5.F CI Sprint** | [#542](https://github.com/zynax-io/zynax/issues/542) | 🟡 In Progress — #551 ✅ #552 ✅ #554 ✅ #549 ✅ #550 ✅ #564 ✅ #565 ✅; next: #555 DRY/KISS |
-| **M5.F.R Release Pipeline** | [#556](https://github.com/zynax-io/zynax/issues/556) | 🟡 In Progress — #642 ✅ #641 ✅ #655 ✅ #549 ✅ #550 ✅ #564 ✅ #565 ✅; next: #555 DRY/KISS |
-| M5.A Truth Pass | [#458](https://github.com/zynax-io/zynax/issues/458) | In Progress — 2/3 children done; #474 open |
-| M5.B Engine Correctness | [#459](https://github.com/zynax-io/zynax/issues/459) | In Progress — #538 ✅ #539 ✅ #540 ✅; #476 parent open |
+| **M5.F CI Sprint** | [#542](https://github.com/zynax-io/zynax/issues/542) | 🟡 In Progress — all done except #555 (DRY/KISS L, P2) |
+| **M5.F.R Release Pipeline** | [#556](https://github.com/zynax-io/zynax/issues/556) | ✅ Complete (closed) |
+| M5.A Truth Pass | [#458](https://github.com/zynax-io/zynax/issues/458) | In Progress — #472 ✅ #473 ✅ #474 ✅ #579 ⬜ open |
+| M5.B Engine Correctness | [#459](https://github.com/zynax-io/zynax/issues/459) | ✅ Complete (closed) — #475 ✅ #476 ✅ #477 ✅ #478 ✅ |
 | M5.C Capability Dispatch | [#460](https://github.com/zynax-io/zynax/issues/460) | ✅ Compose wired — all 3 services in stack; E2E dispatch pending adapters |
 | M5.D Security Baseline | [#461](https://github.com/zynax-io/zynax/issues/461) | ✅ Complete (closed) |
 | M5.E DX Polish | [#462](https://github.com/zynax-io/zynax/issues/462) | ✅ Complete (closed) |
@@ -63,28 +63,13 @@ M5 is structured into seven tracks. See full execution plan: **[docs/milestones/
 
 ## Active Work (M5.C)
 
-### task-broker (#479) — code complete, quality in progress
+### task-broker (#479) ✅ Complete (closed)
 
-Implementation PRs #520, #522, #523 merged. Domain coverage: 92.7%.
+All steps done: impl PRs #520 #522 #523, quality #530 ✅ #531 ✅ #532 ✅. Domain 92.7%.
 
-**Open cleanup issues (M5.C):**
+### agent-registry (#480) ✅ Complete (closed)
 
-| Issue | Step | Status |
-|-------|------|--------|
-| [#530](https://github.com/zynax-io/zynax/issues/530) | Update AGENTS.md | ✅ Done |
-| [#531](https://github.com/zynax-io/zynax/issues/531) | Align service BDD + godog steps | ✅ Done |
-| [#532](https://github.com/zynax-io/zynax/issues/532) | Handler unit tests | ✅ Done — api 84.9%, domain 92.7% |
-
-### agent-registry (#480) — pending implementation
-
-Canvas aligned. Ordered delivery: #526 → #527 → #528 → #481.
-
-| Issue | Step | Status |
-|-------|------|--------|
-| [#526](https://github.com/zynax-io/zynax/issues/526) | Trim BDD to proto scope | ✅ Done |
-| [#527](https://github.com/zynax-io/zynax/issues/527) | Domain layer | ✅ Done |
-| [#528](https://github.com/zynax-io/zynax/issues/528) | gRPC wiring + go.work | ✅ Done |
-| [#481](https://github.com/zynax-io/zynax/issues/481) | Compose wiring | ✅ Done |
+All steps done: #526 ✅ #527 ✅ #528 ✅ #481 ✅. Compose wired.
 
 ---
 
@@ -92,12 +77,10 @@ Canvas aligned. Ordered delivery: #526 → #527 → #528 → #481.
 
 | Issue | Track | Title | Status |
 |-------|-------|-------|--------|
-| [#474](https://github.com/zynax-io/zynax/issues/474) | M5.A | Python SDK Agent base class | ✅ Complete — #535 ✅ #536 ✅ #537 ✅; BATCH 3 done |
-| [#476](https://github.com/zynax-io/zynax/issues/476) | M5.B | Guard parser (cel-go) | ✅ closed — all 3 children merged |
-| [#381](https://github.com/zynax-io/zynax/issues/381) | Adapters | git-adapter impl | ✅ Complete — all 5 steps merged (#400 #401 #402 #403) |
-| [#382](https://github.com/zynax-io/zynax/issues/382) | Adapters | ci-adapter impl | open (#404 BDD done; #405+ pending, wait for #481) |
-| [#383](https://github.com/zynax-io/zynax/issues/383) | Adapters | llm-adapter impl | open (#409 BDD done; #410+ pending, wait for #481) |
-| [#384](https://github.com/zynax-io/zynax/issues/384) | Adapters | langgraph-adapter impl | open (#414 BDD done; #415+ pending, wait for #481) |
+| [#381](https://github.com/zynax-io/zynax/issues/381) | Adapters | git-adapter impl | ✅ Complete — #400 #401 #402 #403 all merged |
+| [#382](https://github.com/zynax-io/zynax/issues/382) | Adapters | ci-adapter impl | open — #404 BDD done; #405+ next (canvas Aligned) |
+| [#383](https://github.com/zynax-io/zynax/issues/383) | Adapters | llm-adapter impl | open — #409 BDD done; #410+ pending |
+| [#384](https://github.com/zynax-io/zynax/issues/384) | Adapters | langgraph-adapter impl | open — #414 BDD done; #415+ pending |
 
 ---
 
@@ -141,20 +124,16 @@ Priority gaps to file immediately:
 
 ## Recently Closed (this session)
 
-- **#403** — git-adapter Dockerfile, docker-compose service, AGENTS.md (O5); closes #381 git-adapter epic
-- **#569** — Add RetryPolicy + nonRetryableErrorTypes to DispatchCapabilityActivity (G4 fix)
-- **#571** — Reject non-string `.set{}` values at compile time (TransitionSetValidator)
-- **#570** — Detached context in task-broker executeAsync goroutine; preserves request-ID via detachedCtx (G16)
-- **#679** — Temporal NotFound → domain.ErrExecutionNotFound in engine-adapter (BATCH 5B)
-- **#622** — context.WithTimeout on all outgoing gRPC calls across 4 services (BATCH 6)
-- **#689** — Thread gRPC call timeout from config env vars; remove package-level globals
-- **#549** — Per-service change detection in `changes` job; removed redundant `go-detect` from `lint-go` (BATCH 5)
-- **#550** — govulncheck per-service scoping in `security` job (BATCH 5)
+- **#474** #459 #479 #480 #543 #556 — epics closed; all children had merged prior sessions
+- **#577** — remove phantom researcher/calculator agents from AGENT_LIST
+- **#574** — remove memory-service/event-bus from SERVICE_LIST; add git to GO_ADAPTER_LIST
+- **#576** — remove summarizer phantom; delete agents/examples/summarizer/
 
 ## Next Session Queue (priority order)
 
 | Priority | Issue | Title | Note |
 |----------|-------|-------|------|
-| P2 | [#405](https://github.com/zynax-io/zynax/issues/405) | ci-adapter Go module scaffold + config layer (O2) | S, feat, canvas needed |
+| P2 | [#405](https://github.com/zynax-io/zynax/issues/405) | ci-adapter Go module scaffold + config layer (O2) | S, feat, canvas Aligned |
+| P2 | [#579](https://github.com/zynax-io/zynax/issues/579) | README per-service status table | S, docs, M5.A |
 | P2 | [#555](https://github.com/zynax-io/zynax/issues/555) | DRY/KISS refactor — reusable workflows, composite actions | L, ci, needs-design |
 | M6 prep | [#656](https://github.com/zynax-io/zynax/issues/656) | gRPC Health Checking Protocol in all services | L, deferred |


### PR DESCRIPTION
## Summary

- Close 6 epics where all child issues had already merged: #459 (M5.B), #474 (Python SDK), #479 (task-broker), #480 (agent-registry), #543 (ci-runner), #556 (M5.F.R)
- Fix stale Track Overview: M5.B was "3/4 done" (all 4 are ✅); M5.F.R was "In Progress" (all children ✅); M5.A was "2/3 done" (all 3 ✅ — #579 still open)
- Update M5-plan.md "Last updated" and adapter track status (git ✅ now)

## Why

State files and GitHub were out of sync — epics with all children merged remained open, and the Track Overview referenced stale "In Progress" states. This is a maintenance pass to keep plan ↔ GitHub in lockstep before the next cluster.

## Test plan

### Local pre-flight
- [x] `make lint-go`/`lint-protos`/`lint-agents` — N/A (docs only)
- [x] `GOWORK=off go test ./...` — N/A (docs only)
- [x] `make test-coverage` — N/A
- [x] `make test-bdd` / `make security` — N/A

### Acceptance
- [x] `gh issue view 459 --json state` → CLOSED
- [x] `gh issue view 474 --json state` → CLOSED
- [x] `gh issue view 479 --json state` → CLOSED
- [x] `gh issue view 480 --json state` → CLOSED
- [x] `gh issue view 543 --json state` → CLOSED
- [x] `gh issue view 556 --json state` → CLOSED
- [x] M5-plan.md Track Overview matches closed/open state

### Engineering hygiene
- [x] `M5-plan.md` Track Overview updated in this diff (mandatory)
- [x] `current-milestone.md` updated in this diff (mandatory)
- [x] No code changes — docs only
- [x] No out-of-scope edits · no mTLS/SBOM/cosign docs claims