### PR TITLE
chore(ci): remove phantom researcher and calculator agents from AGENT_LIST

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ env:
   GOVULNCHECK_VERSION: "v1.1.4"
   SERVICE_LIST: "agent-registry task-broker api-gateway workflow-compiler engine-adapter"
   GO_ADAPTER_LIST: "http git"
-  AGENT_LIST: "summarizer researcher calculator"
+  AGENT_LIST: "summarizer"
   GOPROXY: "https://proxy.golang.org,direct"
   GONOSUMDB: "*"
 

--- a/docs/milestones/M5-plan.md
+++ b/docs/milestones/M5-plan.md
@@ -678,7 +678,7 @@ open issues. File them before or during M5 execution:
 | G20: pkg.go.dev module reference | Medium | [#582](https://github.com/zynax-io/zynax/issues/582) | M6 |
 | G21: Python SDK claims v0.1.0, is 3-line placeholder | High | [#474](https://github.com/zynax-io/zynax/issues/474) | M5 |
 | G22: Summarizer phantom | Low | [#576](https://github.com/zynax-io/zynax/issues/576) | M5 |
-| G23: Phantom AGENT_LIST entries | Low | [#577](https://github.com/zynax-io/zynax/issues/577) | M5 |
+| ~~G23: Phantom AGENT_LIST entries~~ | Low | ~~[#577](https://github.com/zynax-io/zynax/issues/577)~~ ✅ Done | M5 |
 | G24: Compose omits task-broker/agent-registry | High | [#481](https://github.com/zynax-io/zynax/issues/481) | M5 |
 | H8: ADR-021 scale plan | High | [#578](https://github.com/zynax-io/zynax/issues/578) | M6 |
 | H9: Unimplemented gRPC skeletons | Medium | [#574](https://github.com/zynax-io/zynax/issues/574) | M5 |

--- a/state/current-milestone.md
+++ b/state/current-milestone.md
@@ -108,6 +108,7 @@ Priority gaps to file immediately:
 | ~~G16: background-context goroutines in task-broker (#570)~~ | ✅ fixed #570 |
 | G19: competitive positioning doc (Kagent/Dapr) (#575) | High |
 | ~~G17: stub services in SERVICE_LIST (#574)~~ | ✅ fixed |
+| ~~G23: Phantom AGENT_LIST entries (#577)~~ | ✅ fixed |
 
 ---
 


### PR DESCRIPTION
## Summary

Remove `researcher` and `calculator` from `AGENT_LIST` in `ci.yml`. Neither agent has a directory, a `pyproject.toml`, or any implementation — they silently NOOP in all CI loops (each loop guards with `if [ -f pyproject.toml ]`), but their presence suggests two agents exist when they do not.

## Why

Closes #577 (G23 — Phantom AGENT_LIST entries). `AGENT_LIST` must only contain agents that exist in `agents/examples/` with real implementations. Phantom entries mislead contributors and inflate the apparent test coverage.

## Cluster

Cluster: BATCH-gap independent siblings · merge order #574 → #577 → #576 (shared context: phantom CI reference cleanup in `ci.yml`)

Sibling PRs:
- #574 (SERVICE_LIST + GO_ADAPTER_LIST) — merges first (independent)
- **This PR** (#577) — merges second
- #576 (summarizer phantom) — merges third, stacked on this branch

## State files updated

- `docs/milestones/M5-plan.md` — G23 row ~~struck through~~ ✅ Done
- `state/current-milestone.md` — G23 gap row marked ✅ fixed
- Note: reconciliation commit (close completed epics) is bundled as an additional commit; it was blocked from pushing directly to `main` by branch protection.

## Architecture gaps

G23 (Phantom AGENT_LIST entries) — fixed in this PR.

## Test plan

### Local pre-flight
- [x] `make lint-go`/`lint-protos`/`lint-agents` — N/A (ci.yml + docs only)
- [x] `GOWORK=off go test ./...` — N/A (no Go/Python code changed)
- [x] `make test-coverage` — N/A
- [x] `make test-bdd` / `make security` — N/A

### Acceptance (issue #577)
- [x] `AGENT_LIST` contains only agents that exist: `"summarizer"` (has tests/features dir — handled by #576)
- [x] `grep -r "researcher\|calculator" .github/` → no active references: `ci.yml:65` now reads `"summarizer"`
- [x] CI lint/test loops skip missing agents via `if [ -f pyproject.toml ]` guard — phantom entries simply removed

### Engineering hygiene
- [x] **`M5-plan.md` row flipped ⬜→✅ in this diff** (mandatory)
- [x] **`current-milestone.md` updated in this diff** (mandatory)
- [x] Branched from fresh `origin/main` · PR ≤900 lines · trailers on every commit
- [x] Gap scan done (G1/G4/G7/G16) — N/A for ci.yml-only change
- [x] Canvas O-step N/A (chore type, SPDD-exempt) · no new capability · no `.feature` needed
- [x] No out-of-scope edits · no mTLS/SBOM/cosign docs claims

## Out of scope

#576 (summarizer removal from AGENT_LIST) is handled in the stacked PR.

Closes #577
