### PR TITLE
docs(milestones): add BATCH 7.1 git-adapter coverage epic to M5-plan

### DIFF
--- a/docs/milestones/M5-plan.md
+++ b/docs/milestones/M5-plan.md
@@ -6,7 +6,7 @@
 **GitHub Milestone:** [Adapter Library (M5)](https://github.com/zynax-io/zynax/milestone/5)
 **Parent epic:** [#377](https://github.com/zynax-io/zynax/issues/377)
 **Status:** In Progress
-**Last updated:** 2026-05-27 (rev 59 — epics #459 #474 #479 #480 #543 #556 closed; Track Overview updated; #577 #574 #576 cluster shipped)
+**Last updated:** 2026-05-27 (rev 60 — #577 #574 #576 cluster shipped; git-adapter coverage epic #713 opened with child issues #714–#718; BATCH 7.1 added)
 
 ---
 
@@ -437,6 +437,30 @@ The adapter mounts a `StateGraph` as a Zynax capability. Each node becomes a `ca
 the workflow can invoke. The `GraphMount` config maps graph IDs to capability names.
 This is the proof-of-concept for engine-agnosticism (LangGraph apps become Zynax capabilities
 without rewriting the graph).
+
+---
+
+### BATCH 7.1 — git-adapter Quality (test coverage to ≥85%) (P1 · #713)
+
+The git-adapter shipped (BATCH 7 above) with 48.7% total coverage — well below the
+`COVERAGE_ADAPTER_GATE: 85` threshold. This was not caught because `GO_ADAPTER_LIST` was missing
+`git` when #381 closed. PR #574 exposed the gap. **Epic:** [#713](https://github.com/zynax-io/zynax/issues/713).
+
+**Coverage baseline (2026-05-27):** `internal/adapter` 57.5% · `internal/config` 81.8% ·
+`internal/registry` 50.0% · total **48.7%**
+
+| Issue | Type | Title | Size | Dependency | Status |
+|-------|------|-------|------|------------|--------|
+| [#714](https://github.com/zynax-io/zynax/issues/714) | ci | Revert git from GO_ADAPTER_LIST until coverage gate met | XS | None — do first | ⬜ Open |
+| [#715](https://github.com/zynax-io/zynax/issues/715) | test | Cover requestReview handler and progressEvent helper | S | None (parallel with #716, #717) | ⬜ Open |
+| [#716](https://github.com/zynax-io/zynax/issues/716) | test | Cover execute/sanitise/githubErrCode/parsePayload gaps | S | None (parallel with #715, #717) | ⬜ Open |
+| [#717](https://github.com/zynax-io/zynax/issues/717) | test | Cover RegisterAgent retry paths and isTransient | S | None (parallel with #715, #716) | ⬜ Open |
+| [#718](https://github.com/zynax-io/zynax/issues/718) | ci | Re-add git to GO_ADAPTER_LIST after coverage ≥85% | XS | After #715 + #716 + #717 | ⬜ Open (blocked) |
+
+**Exit criterion:** `GOWORK=off go test ./... -coverprofile=coverage.out` in `agents/adapters/git`
+reports **≥85% total** and CI adapter gate passes for all covered packages.
+
+**Blocks:** #712 (remove-summarizer-phantom) cannot auto-merge until #714 lands.
 
 ---
 

--- a/state/current-milestone.md
+++ b/state/current-milestone.md
@@ -78,6 +78,7 @@ All steps done: #526 ✅ #527 ✅ #528 ✅ #481 ✅. Compose wired.
 | Issue | Track | Title | Status |
 |-------|-------|-------|--------|
 | [#381](https://github.com/zynax-io/zynax/issues/381) | Adapters | git-adapter impl | ✅ Complete — #400 #401 #402 #403 all merged |
+| [#713](https://github.com/zynax-io/zynax/issues/713) | Adapters | git-adapter quality epic (coverage ≥85%) | 🔴 In Progress — #714 (revert, ready) → #715 #716 #717 (tests, parallel) → #718 (re-add) |
 | [#382](https://github.com/zynax-io/zynax/issues/382) | Adapters | ci-adapter impl | open — #404 BDD done; #405+ next (canvas Aligned) |
 | [#383](https://github.com/zynax-io/zynax/issues/383) | Adapters | llm-adapter impl | open — #409 BDD done; #410+ pending |
 | [#384](https://github.com/zynax-io/zynax/issues/384) | Adapters | langgraph-adapter impl | open — #414 BDD done; #415+ pending |
@@ -86,6 +87,8 @@ All steps done: #526 ✅ #527 ✅ #528 ✅ #481 ✅. Compose wired.
 
 ## Known Blockers
 
+- **#713 git-adapter coverage (48.7% vs 85% gate)** — #714 must land first (revert git from GO_ADAPTER_LIST) to unblock all other PRs. Then #715 #716 #717 (parallel tests) raise coverage; #718 re-adds git.
+- **#712 blocked by #714** — `chore(ci): remove summarizer phantom` can't auto-merge because git adapter coverage gate fires. Will unblock once #714 lands.
 - **✅ #655 FIXED** — `tools/healthcheck` static binary added to all 6 distroless Dockerfiles; `docker-compose.yml` migrated from `CMD-SHELL` + `wget`/`nc` to `CMD /healthcheck`; override file removed.
 - **#552 ✅ done** — all jobs now run in ci-runner container mode.
 - **adapter implementations** (#401–#418) — unblocked by #481 ✅; git-adapter scaffold #400 ✅; handler and registry steps pending.
@@ -134,6 +137,12 @@ Priority gaps to file immediately:
 
 | Priority | Issue | Title | Note |
 |----------|-------|-------|------|
+| **P0** | [#714](https://github.com/zynax-io/zynax/issues/714) | Revert git from GO_ADAPTER_LIST | XS, ci — unblocks #712 |
+| **P0** | [#712](https://github.com/zynax-io/zynax/issues/712) | Remove summarizer phantom (PR open, auto-merge set) | Rebase after #714 merges |
+| P1 | [#715](https://github.com/zynax-io/zynax/issues/715) | Cover requestReview + progressEvent | S, test, parallel with #716/#717 |
+| P1 | [#716](https://github.com/zynax-io/zynax/issues/716) | Cover execute/sanitise/githubErrCode/parsePayload | S, test, parallel |
+| P1 | [#717](https://github.com/zynax-io/zynax/issues/717) | Cover RegisterAgent + isTransient | S, test, parallel |
+| P1 (blocked) | [#718](https://github.com/zynax-io/zynax/issues/718) | Re-add git to GO_ADAPTER_LIST | XS, ci — after #715+#716+#717 |
 | P2 | [#405](https://github.com/zynax-io/zynax/issues/405) | ci-adapter Go module scaffold + config layer (O2) | S, feat, canvas Aligned |
 | P2 | [#579](https://github.com/zynax-io/zynax/issues/579) | README per-service status table | S, docs, M5.A |
 | P2 | [#555](https://github.com/zynax-io/zynax/issues/555) | DRY/KISS refactor — reusable workflows, composite actions | L, ci, needs-design |


### PR DESCRIPTION
## Summary

Adds BATCH 7.1 to `docs/milestones/M5-plan.md` and updates `state/current-milestone.md` to
track the new git-adapter coverage epic (#713) and its five child issues (#714–#718).

## Why

Epic #713 and issues #714–#718 were just created on GitHub but were not yet reflected in the
plan documents. This PR makes repo state and GitHub state consistent.

## State files updated

- `docs/milestones/M5-plan.md` — new BATCH 7.1 section; rev 60; Last updated bumped
- `state/current-milestone.md` — #713 added to Active Work; #714 added as P0 blocker to
  Known Blockers; Next Session Queue updated with #714–#718

## Architecture gaps

None.

## Test plan

### Local pre-flight
- [x] `make lint-go` — N/A (docs-only change)
- [x] `GOWORK=off go test ./... -race` — N/A (docs-only change)
- [x] `make test-coverage` — N/A (docs-only change)
- [x] `make test-coverage-adapters` / `make test-bdd` / `make security` — N/A

### Acceptance
- [x] BATCH 7.1 section present in M5-plan.md with correct issue numbers (#714–#718) [file:docs/milestones/M5-plan.md]
- [x] `current-milestone.md` Known Blockers updated with #713/#714 context [file:state/current-milestone.md]
- [x] Next Session Queue lists #714 as P0 [file:state/current-milestone.md]

### Engineering hygiene
- [x] **`M5-plan.md` row updated in this diff** (BATCH 7.1 added)
- [x] **`current-milestone.md` updated in this diff**
- [x] Branched from fresh `origin/main` · PR ≤900 lines · trailers on every commit
- [x] Gap scan done (G1/G4/G7/G16) — N/A (docs-only)
- [x] No out-of-scope edits · no mTLS/SBOM/cosign docs claims

## Out of scope

No code changes. No ci.yml change (that is #714's PR).

Refs #713
