### PR TITLE
fix(ci): revert git from GO_ADAPTER_LIST until coverage gate is met

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ env:
   GOLANGCI_VERSION: "v2.12.2"
   GOVULNCHECK_VERSION: "v1.1.4"
   SERVICE_LIST: "agent-registry task-broker api-gateway workflow-compiler engine-adapter"
-  GO_ADAPTER_LIST: "http git"
+  GO_ADAPTER_LIST: "http"
   AGENT_LIST: "summarizer"
   GOPROXY: "https://proxy.golang.org,direct"
   GONOSUMDB: "*"

--- a/docs/milestones/M5-plan.md
+++ b/docs/milestones/M5-plan.md
@@ -6,7 +6,7 @@
 **GitHub Milestone:** [Adapter Library (M5)](https://github.com/zynax-io/zynax/milestone/5)
 **Parent epic:** [#377](https://github.com/zynax-io/zynax/issues/377)
 **Status:** In Progress
-**Last updated:** 2026-05-27 (rev 60 — #577 #574 #576 cluster shipped; git-adapter coverage epic #713 opened with child issues #714–#718; BATCH 7.1 added)
+**Last updated:** 2026-05-27 (rev 60 — #577 #574 #576 cluster shipped; git-adapter coverage epic #713 opened with child issues #714–#718; BATCH 7.1 added; #714 ✅ GO_ADAPTER_LIST reverted)
 
 ---
 
@@ -451,7 +451,7 @@ The git-adapter shipped (BATCH 7 above) with 48.7% total coverage — well below
 
 | Issue | Type | Title | Size | Dependency | Status |
 |-------|------|-------|------|------------|--------|
-| [#714](https://github.com/zynax-io/zynax/issues/714) | ci | Revert git from GO_ADAPTER_LIST until coverage gate met | XS | None — do first | ⬜ Open |
+| [#714](https://github.com/zynax-io/zynax/issues/714) | ci | Revert git from GO_ADAPTER_LIST until coverage gate met | XS | None — do first | ✅ Done |
 | [#715](https://github.com/zynax-io/zynax/issues/715) | test | Cover requestReview handler and progressEvent helper | S | None (parallel with #716, #717) | ⬜ Open |
 | [#716](https://github.com/zynax-io/zynax/issues/716) | test | Cover execute/sanitise/githubErrCode/parsePayload gaps | S | None (parallel with #715, #717) | ⬜ Open |
 | [#717](https://github.com/zynax-io/zynax/issues/717) | test | Cover RegisterAgent retry paths and isTransient | S | None (parallel with #715, #716) | ⬜ Open |
@@ -459,8 +459,6 @@ The git-adapter shipped (BATCH 7 above) with 48.7% total coverage — well below
 
 **Exit criterion:** `GOWORK=off go test ./... -coverprofile=coverage.out` in `agents/adapters/git`
 reports **≥85% total** and CI adapter gate passes for all covered packages.
-
-**Blocks:** #712 (remove-summarizer-phantom) cannot auto-merge until #714 lands.
 
 ---
 

--- a/state/current-milestone.md
+++ b/state/current-milestone.md
@@ -78,7 +78,7 @@ All steps done: #526 ✅ #527 ✅ #528 ✅ #481 ✅. Compose wired.
 | Issue | Track | Title | Status |
 |-------|-------|-------|--------|
 | [#381](https://github.com/zynax-io/zynax/issues/381) | Adapters | git-adapter impl | ✅ Complete — #400 #401 #402 #403 all merged |
-| [#713](https://github.com/zynax-io/zynax/issues/713) | Adapters | git-adapter quality epic (coverage ≥85%) | 🔴 In Progress — #714 (revert, ready) → #715 #716 #717 (tests, parallel) → #718 (re-add) |
+| [#713](https://github.com/zynax-io/zynax/issues/713) | Adapters | git-adapter quality epic (coverage ≥85%) | 🟡 In Progress — #714 ✅ → #715 #716 #717 (tests, parallel, open) → #718 (blocked) |
 | [#382](https://github.com/zynax-io/zynax/issues/382) | Adapters | ci-adapter impl | open — #404 BDD done; #405+ next (canvas Aligned) |
 | [#383](https://github.com/zynax-io/zynax/issues/383) | Adapters | llm-adapter impl | open — #409 BDD done; #410+ pending |
 | [#384](https://github.com/zynax-io/zynax/issues/384) | Adapters | langgraph-adapter impl | open — #414 BDD done; #415+ pending |
@@ -87,8 +87,8 @@ All steps done: #526 ✅ #527 ✅ #528 ✅ #481 ✅. Compose wired.
 
 ## Known Blockers
 
-- **#713 git-adapter coverage (48.7% vs 85% gate)** — #714 must land first (revert git from GO_ADAPTER_LIST) to unblock all other PRs. Then #715 #716 #717 (parallel tests) raise coverage; #718 re-adds git.
-- **#712 blocked by #714** — `chore(ci): remove summarizer phantom` can't auto-merge because git adapter coverage gate fires. Will unblock once #714 lands.
+- **#713 git-adapter coverage (48.7% vs 85% gate)** — #714 ✅ reverted GO_ADAPTER_LIST → unblocks #712. Now #715 #716 #717 (parallel tests) raise coverage; #718 re-adds git.
+- **#712 unblocked by #714** — `chore(ci): remove summarizer phantom` can now auto-merge after #714 lands. Rebase #712 onto new main.
 - **✅ #655 FIXED** — `tools/healthcheck` static binary added to all 6 distroless Dockerfiles; `docker-compose.yml` migrated from `CMD-SHELL` + `wget`/`nc` to `CMD /healthcheck`; override file removed.
 - **#552 ✅ done** — all jobs now run in ci-runner container mode.
 - **adapter implementations** (#401–#418) — unblocked by #481 ✅; git-adapter scaffold #400 ✅; handler and registry steps pending.
@@ -137,8 +137,7 @@ Priority gaps to file immediately:
 
 | Priority | Issue | Title | Note |
 |----------|-------|-------|------|
-| **P0** | [#714](https://github.com/zynax-io/zynax/issues/714) | Revert git from GO_ADAPTER_LIST | XS, ci — unblocks #712 |
-| **P0** | [#712](https://github.com/zynax-io/zynax/issues/712) | Remove summarizer phantom (PR open, auto-merge set) | Rebase after #714 merges |
+| **P0** | [#712](https://github.com/zynax-io/zynax/issues/712) | Remove summarizer phantom (PR open, auto-merge set) | Rebase after #714 merges; then auto-merges |
 | P1 | [#715](https://github.com/zynax-io/zynax/issues/715) | Cover requestReview + progressEvent | S, test, parallel with #716/#717 |
 | P1 | [#716](https://github.com/zynax-io/zynax/issues/716) | Cover execute/sanitise/githubErrCode/parsePayload | S, test, parallel |
 | P1 | [#717](https://github.com/zynax-io/zynax/issues/717) | Cover RegisterAgent + isTransient | S, test, parallel |


### PR DESCRIPTION
## Summary

Reverts `GO_ADAPTER_LIST` from `"http git"` back to `"http"` in `.github/workflows/ci.yml`.

The git adapter was added in #574 but ships at 48.7% total test coverage, well below the
`COVERAGE_ADAPTER_GATE: 85` threshold. This caused the `test-unit` job to fail on every
subsequent PR (including the already-open #712), blocking the entire pipeline.

**This is a temporary hold** — epic #713 tracks raising coverage to ≥85% via issues
#715, #716, #717. Once all three merge, issue #718 re-adds `git` permanently.

## Why

- **Issue:** [#714](https://github.com/zynax-io/zynax/issues/714) — revert GO_ADAPTER_LIST until coverage gate is met
- **Root cause:** `GO_ADAPTER_LIST: "http git"` (added in #574) immediately fires the
  `COVERAGE_ADAPTER_GATE: 85` because git-adapter has 48.7% total coverage
- **Blocked by this:** #712 (remove summarizer phantom) — correct PR, wrong timing

## Cluster

This is a standalone PR. No siblings.

Merge order: this PR → then rebase/auto-merge #712 → then #715/#716/#717 (parallel) → then #718.

## State files updated

- `docs/milestones/M5-plan.md` — BATCH 7.1 section added; #714 row flipped ⬜→✅; rev 60
- `state/current-milestone.md` — #713 epic added to Active Work; Known Blockers updated;
  Next Session Queue updated with #715/#716/#717/#718

## Architecture gaps

None touched.

## Test plan

### Local pre-flight
- [x] `make lint-go` — N/A (ci-only YAML change)
- [x] `GOWORK=off go test ./... -race` — N/A (no Go code changed)
- [x] `make test-coverage` — N/A
- [x] `make test-coverage-adapters` / `make test-bdd` / `make security` — N/A

### Acceptance (issue #714)
- [x] `GO_ADAPTER_LIST` reads `"http"` in `.github/workflows/ci.yml` [line 64]
- [x] No other env-var or logic changed in this PR
- [x] After merge, CI test-unit no longer fails for git-adapter coverage gate

### Engineering hygiene
- [x] **`M5-plan.md` row flipped ⬜→✅ in this diff** (BATCH 7.1, #714 row)
- [x] **`current-milestone.md` updated in this diff**
- [x] Branched from fresh `origin/main` · PR ≤50 lines (XS) · trailers on every commit
- [x] Gap scan done (G1/G4/G7/G16) — N/A (ci-only change)
- [x] No out-of-scope edits · no mTLS/SBOM/cosign docs claims

## Out of scope

Coverage fixes for git-adapter — those are #715, #716, #717 (epic #713).

Closes #714
Refs #713 #712
