### PR TITLE
ci(adapters/git): re-add git to GO_ADAPTER_LIST after coverage gate met

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ env:
   GOLANGCI_VERSION: "v2.12.2"
   GOVULNCHECK_VERSION: "v1.1.4"
   SERVICE_LIST: "agent-registry task-broker api-gateway workflow-compiler engine-adapter"
-  GO_ADAPTER_LIST: "http"
+  GO_ADAPTER_LIST: "http git"
   AGENT_LIST: ""
   GOPROXY: "https://proxy.golang.org,direct"
   GONOSUMDB: "*"

--- a/docs/milestones/M5-plan.md
+++ b/docs/milestones/M5-plan.md
@@ -6,7 +6,7 @@
 **GitHub Milestone:** [Adapter Library (M5)](https://github.com/zynax-io/zynax/milestone/5)
 **Parent epic:** [#377](https://github.com/zynax-io/zynax/issues/377)
 **Status:** In Progress
-**Last updated:** 2026-05-27 (rev 63 — #717 ✅ registry retry + isTransient + cmd/serve tests; combined coverage →85.1%)
+**Last updated:** 2026-05-27 (rev 64 — #718 ✅ re-add git to GO_ADAPTER_LIST; coverage gate live on CI)
 
 ---
 
@@ -455,7 +455,7 @@ The git-adapter shipped (BATCH 7 above) with 48.7% total coverage — well below
 | [#715](https://github.com/zynax-io/zynax/issues/715) | test | Cover requestReview handler and progressEvent helper | S | None (parallel with #716, #717) | ✅ Done |
 | [#716](https://github.com/zynax-io/zynax/issues/716) | test | Cover execute/sanitise/githubErrCode/parsePayload gaps | S | None (parallel with #715, #717) | ✅ Done |
 | [#717](https://github.com/zynax-io/zynax/issues/717) | test | Cover RegisterAgent retry paths and isTransient | S | None (parallel with #715, #716) | ✅ Done |
-| [#718](https://github.com/zynax-io/zynax/issues/718) | ci | Re-add git to GO_ADAPTER_LIST after coverage ≥85% | XS | After #715 + #716 + #717 | ⬜ Open (blocked) |
+| [#718](https://github.com/zynax-io/zynax/issues/718) | ci | Re-add git to GO_ADAPTER_LIST after coverage ≥85% | XS | After #715 + #716 + #717 | ✅ Done |
 
 **Exit criterion:** `GOWORK=off go test ./... -coverprofile=coverage.out` in `agents/adapters/git`
 reports **≥85% total** and CI adapter gate passes for all covered packages.

--- a/state/current-milestone.md
+++ b/state/current-milestone.md
@@ -78,7 +78,7 @@ All steps done: #526 ✅ #527 ✅ #528 ✅ #481 ✅. Compose wired.
 | Issue | Track | Title | Status |
 |-------|-------|-------|--------|
 | [#381](https://github.com/zynax-io/zynax/issues/381) | Adapters | git-adapter impl | ✅ Complete — #400 #401 #402 #403 all merged |
-| [#713](https://github.com/zynax-io/zynax/issues/713) | Adapters | git-adapter quality epic (coverage ≥85%) | 🟡 In Progress — #714 ✅ #715 ✅ #716 ✅ → #717 (PR #724, this PR) → #718 (blocked) |
+| [#713](https://github.com/zynax-io/zynax/issues/713) | Adapters | git-adapter quality epic (coverage ≥85%) | ✅ Complete — #714 ✅ #715 ✅ #716 ✅ #717 ✅ #718 ✅ all merged |
 | [#382](https://github.com/zynax-io/zynax/issues/382) | Adapters | ci-adapter impl | open — #404 BDD done; #405+ next (canvas Aligned) |
 | [#383](https://github.com/zynax-io/zynax/issues/383) | Adapters | llm-adapter impl | open — #409 BDD done; #410+ pending |
 | [#384](https://github.com/zynax-io/zynax/issues/384) | Adapters | langgraph-adapter impl | open — #414 BDD done; #415+ pending |
@@ -87,7 +87,7 @@ All steps done: #526 ✅ #527 ✅ #528 ✅ #481 ✅. Compose wired.
 
 ## Known Blockers
 
-- **#713 git-adapter coverage (target ≥85%)** — #715 ✅ #716 ✅ merged; #717 PR #724 open (this PR); #718 blocked until #717 merges. Combined coverage 85.1% when #717 on main.
+- **git-adapter coverage** — ✅ complete; #714–#718 all merged; coverage ≥85% live on CI; git re-added to GO_ADAPTER_LIST.
 - **adapter implementations** (#405–#418) — unblocked by #481 ✅; git-adapter impl ✅; ci/llm/langgraph pending.
 - **E2E demo** — compose wired (#481 ✅); needs an adapter registered for capability dispatch.
 - **v0.4.0 tag** — CHANGELOG promoted; run `git tag -a v0.4.0 -m "M5 Adapter Library" && git push origin v0.4.0` on main to trigger the release workflow and create GitHub Release assets.
@@ -139,16 +139,14 @@ Priority gaps to file immediately:
 |-------|-------|--------|
 | [#715](https://github.com/zynax-io/zynax/issues/715) | Cover requestReview + progressEvent | ✅ Done — PR #722 merged |
 | [#716](https://github.com/zynax-io/zynax/issues/716) | Cover execute/sanitise/githubErrCode/parsePayload | ✅ Done — PR #723 merged |
-| [#717](https://github.com/zynax-io/zynax/issues/717) | Cover RegisterAgent retry + isTransient + cmd | 🟡 In Progress — PR #724 (this PR) |
-| [#718](https://github.com/zynax-io/zynax/issues/718) | Re-add git to GO_ADAPTER_LIST | ⬜ Blocked on #716+#717 |
+| [#717](https://github.com/zynax-io/zynax/issues/717) | Cover RegisterAgent retry + isTransient + cmd | ✅ Done — PR #724 merged |
+| [#718](https://github.com/zynax-io/zynax/issues/718) | Re-add git to GO_ADAPTER_LIST | 🟡 In Progress — PR open (this PR) |
 
 ## Next Session Queue (priority order)
 
 | Priority | Issue | Title | Note |
 |----------|-------|-------|------|
-| P1 | [#717](https://github.com/zynax-io/zynax/issues/717) | Cover RegisterAgent + isTransient + cmd tests | PR #724 — auto-merge after rebase |
-| P1 (blocked) | [#718](https://github.com/zynax-io/zynax/issues/718) | Re-add git to GO_ADAPTER_LIST | XS, ci — after #716+#717 merged |
-| P2 | [#405](https://github.com/zynax-io/zynax/issues/405) | ci-adapter Go module scaffold + config layer (O2) | S, feat, canvas Aligned |
+| P1 | [#405](https://github.com/zynax-io/zynax/issues/405) | ci-adapter Go module scaffold + config layer (O2) | S, feat, canvas Aligned |
 | P2 | [#579](https://github.com/zynax-io/zynax/issues/579) | README per-service status table | S, docs, M5.A |
 | P2 | [#555](https://github.com/zynax-io/zynax/issues/555) | DRY/KISS refactor — reusable workflows, composite actions | L, ci, needs-design |
 | M6 prep | [#656](https://github.com/zynax-io/zynax/issues/656) | gRPC Health Checking Protocol in all services | L, deferred |


### PR DESCRIPTION
## Summary

Re-add `git` to `GO_ADAPTER_LIST` in `.github/workflows/ci.yml` so the
git-adapter is permanently covered by the CI coverage gate (≥85%).

Single-line change:
```diff
-  GO_ADAPTER_LIST: "http"
+  GO_ADAPTER_LIST: "http git"
```

## Why

Closes #718 — final step of the git-adapter coverage epic (#713).

Issue #714 temporarily removed `git` from `GO_ADAPTER_LIST` while the
coverage gap was closed. Issues #715 (#722), #716 (#723), and #717 (#724)
raised combined coverage to **85.1%** (229/269 stmts), clearing the
`COVERAGE_ADAPTER_GATE=85` CI threshold. This PR re-adds `git` to make
the gate permanent.

## Cluster

BATCH 7.1 (git-adapter quality epic) · **merge order: #714 → #715 → #716 → #717 → #718**

| PR | Issue | Status |
|----|-------|--------|
| #722 | #715 requestReview + progressEvent | ✅ Merged |
| #723 | #716 execute dispatch + handler helpers | ✅ Merged |
| #724 | #717 registry retry + isTransient + serve | ✅ Merged |
| **this PR** | **#718 re-add git to GO_ADAPTER_LIST** | 🟡 PR open |

## State files updated

- `docs/milestones/M5-plan.md` — #718 row ⬜→✅, rev 64
- `state/current-milestone.md` — BATCH 7.1 table updated; #713 epic → Complete

## Architecture gaps

No production code changed — CI workflow only. Gap scan N/A.

## Test plan

### Local pre-flight
- [x] `make lint-go` — (N/A — only `.github/workflows/ci.yml` changed)
- [x] `GOWORK=off go test ./... -race` — (N/A — no Go source changed)
- [x] `make test-coverage` — (N/A — no domain code changed)
- [x] `make test-coverage-adapters` — (N/A — no adapter source changed; gate now live on CI via GO_ADAPTER_LIST)

### Acceptance (#718 issue body)
- [x] `GO_ADAPTER_LIST` in `.github/workflows/ci.yml` reads `"http git"` [ci.yml:64]
- [x] No other env-var or logic change in this PR [diff: 1 line changed in ci.yml]

### Engineering hygiene
- [x] **`M5-plan.md` row flipped ⬜→✅ in this diff** (mandatory)
- [x] **`current-milestone.md` updated in this diff** (mandatory)
- [x] Branched from fresh `origin/main` (after #717 merged) · PR ≤900 lines · trailers on every commit
- [x] Gap scan done (G1/G4/G7/G16) — only CI workflow changed; no gaps applicable
- [x] Canvas O-step N/A (ci: PR, SPDD-exempt) · `AGENTS.md` not changed · no `.feature` needed
- [x] No out-of-scope edits · no mTLS/SBOM/cosign docs claims

## Out of scope

- #713 epic close — will close automatically when #718 merges (all children done)
- Coverage report artifacts — generated by CI run; no source change needed

Closes #718
