### PR TITLE
docs: add per-service implementation status table to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,6 +387,36 @@ Canvas: `docs/spdd/314-yaml-system-cli/canvas.md`.
 
 ---
 
+## Service Status
+
+Current implementation status per service and adapter (as of M5 v0.4.0):
+
+### Platform Services
+
+| Service | Status | Notes |
+|---------|--------|-------|
+| api-gateway | ✅ Implemented | REST → gRPC translation, bearer auth, context deadline propagation |
+| workflow-compiler | ✅ Implemented | YAML → WorkflowIR; in-memory store (ephemeral — re-compile on restart; durable storage in M6 [#466](https://github.com/zynax-io/zynax/issues/466)) |
+| engine-adapter | ✅ Implemented | Temporal backend; cel-go guard evaluation; CloudEvents = log-only (NATS not wired until M6) |
+| task-broker | 🟡 MVP | In-memory; restart loses in-flight tasks; gRPC wired in compose |
+| agent-registry | 🟡 MVP | In-memory round-robin with heartbeat; gRPC wired in compose |
+| event-bus | 📋 Planned | M6 — NATS JetStream; contract-only today |
+| memory-service | 📋 Planned | M6 — Redis KV + vector; contract-only today |
+
+### Execution Adapters
+
+| Adapter | Language | Status | Notes |
+|---------|----------|--------|-------|
+| http-adapter | Go | ✅ Complete | Generic HTTP capability bridge; SSRF-safe static routing |
+| git-adapter | Go | ✅ Complete | `open_pr`, `request_review`, `get_diff` via GitHub REST API |
+| ci-adapter | Go | 🔄 In Progress | BDD ✅; scaffold + handler pending ([#405](https://github.com/zynax-io/zynax/issues/405)+) |
+| llm-adapter | Python | 🔄 In Progress | BDD ✅; OpenAI/Bedrock/Ollama pending ([#410](https://github.com/zynax-io/zynax/issues/410)+) |
+| langgraph-adapter | Python | 🔄 In Progress | BDD ✅; graph-mount impl pending ([#415](https://github.com/zynax-io/zynax/issues/415)+) |
+
+**Legend:** ✅ Complete · 🟡 MVP (in-memory, ephemeral) · 🔄 In Progress · 📋 Planned
+
+---
+
 ## AI Context Architecture
 
 AI assistants working in this repo load context in layers. Smaller budgets = higher signal density.

--- a/docs/milestones/M5-plan.md
+++ b/docs/milestones/M5-plan.md
@@ -6,7 +6,7 @@
 **GitHub Milestone:** [Adapter Library (M5)](https://github.com/zynax-io/zynax/milestone/5)
 **Parent epic:** [#377](https://github.com/zynax-io/zynax/issues/377)
 **Status:** In Progress
-**Last updated:** 2026-05-27 (rev 65 — #572 ✅ workflow-compiler retention contract truth pass)
+**Last updated:** 2026-05-27 (rev 66 — #579 ✅ README per-service status table; M5.A truth pass complete)
 
 ---
 
@@ -57,7 +57,7 @@ the developer's responsibility; auto-merge fires automatically once all checks p
 | **M5.F.R** | Release Pipeline | [#556](https://github.com/zynax-io/zynax/issues/556) | ✅ Complete (closed) | — |
 | **M5.C** | Capability Dispatch E2E | [#460](https://github.com/zynax-io/zynax/issues/460) | 🟡 In Progress — dispatch wired; E2E demo pending adapters | **P0** |
 | **M5.B** | Engine Correctness | [#459](https://github.com/zynax-io/zynax/issues/459) | ✅ Complete (closed) — #475 #476 #477 #478 all ✅ | — |
-| **M5.A** | Truth Pass | [#458](https://github.com/zynax-io/zynax/issues/458) | 🟡 In Progress — #472 ✅ #473 ✅ #474 ✅; #579 ⬜ | **P1** |
+| **M5.A** | Truth Pass | [#458](https://github.com/zynax-io/zynax/issues/458) | ✅ Complete — #472 ✅ #473 ✅ #474 ✅ #572 ✅ #579 ✅ | — |
 | **Adapters** | Adapter Library | [#377](https://github.com/zynax-io/zynax/issues/377) | 🟡 In Progress — http ✅ git ✅; ci/llm/langgraph pending | **P2** |
 | **M5.D** | Security Baseline | [#461](https://github.com/zynax-io/zynax/issues/461) | ✅ Complete (closed) | — |
 | **M5.E** | DX Polish | [#462](https://github.com/zynax-io/zynax/issues/462) | ✅ Complete (closed) | — |
@@ -555,7 +555,7 @@ reports **≥85% total** and CI adapter gate passes for all covered packages.
 | [#473](https://github.com/zynax-io/zynax/issues/473) | Audit CHANGELOG for phantom entries | ✅ Done |
 | [#474](https://github.com/zynax-io/zynax/issues/474) | Python SDK decision → implement minimal Agent base class | ✅ Epic complete (BATCH 3) |
 | **NEW** | Fix SECURITY.md — remove mTLS/SBOM/cosign false claims | ✅ Done (2026-05-20) |
-| [#579](https://github.com/zynax-io/zynax/issues/579) | Add per-service status table to README | ⬜ Open |
+| [#579](https://github.com/zynax-io/zynax/issues/579) | Add per-service status table to README | ✅ Done |
 
 ### Python SDK epic (#474) — promoted
 

--- a/state/current-milestone.md
+++ b/state/current-milestone.md
@@ -32,7 +32,7 @@ M5 is structured into seven tracks. See full execution plan: **[docs/milestones/
 |-------|------|--------|
 | **M5.F CI Sprint** | [#542](https://github.com/zynax-io/zynax/issues/542) | 🟡 In Progress — all done except #555 (DRY/KISS L, P2) |
 | **M5.F.R Release Pipeline** | [#556](https://github.com/zynax-io/zynax/issues/556) | ✅ Complete (closed) |
-| M5.A Truth Pass | [#458](https://github.com/zynax-io/zynax/issues/458) | In Progress — #472 ✅ #473 ✅ #474 ✅ #572 ✅ #579 ⬜ open |
+| M5.A Truth Pass | [#458](https://github.com/zynax-io/zynax/issues/458) | ✅ Complete — #472 ✅ #473 ✅ #474 ✅ #572 ✅ #579 ✅ |
 | M5.B Engine Correctness | [#459](https://github.com/zynax-io/zynax/issues/459) | ✅ Complete (closed) — #475 ✅ #476 ✅ #477 ✅ #478 ✅ |
 | M5.C Capability Dispatch | [#460](https://github.com/zynax-io/zynax/issues/460) | ✅ Compose wired — all 3 services in stack; E2E dispatch pending adapters |
 | M5.D Security Baseline | [#461](https://github.com/zynax-io/zynax/issues/461) | ✅ Complete (closed) |


### PR DESCRIPTION
## Summary

Add a `## Service Status` section to `README.md` with per-service implementation status tables for all 7 platform services and 5 execution adapters. Part of the M5.A truth pass (#458).

## Why

Closes #579 (M5.A — README per-service status table).

Users and contributors cannot tell from the README which services are fully implemented vs in-memory MVPs vs contract-only stubs. A new engineer has no way to know that `event-bus` and `memory-service` are zero-LoC stubs, or that `task-broker` is an in-memory MVP that loses state on restart.

This PR adds a legible status table using ✅/🟡/🔄/📋 symbols matching the milestone-status style already present in the README.

## Cluster

This PR is part of a 3-PR independent cluster (all branch from `main`):

| PR | Issue | Type | Merge order |
|----|-------|------|-------------|
| TBD | #572 | fix | 1st |
| **this** | #579 | docs | 2nd |
| TBD | #405 | feat | 3rd |

All are independent — no code dependencies between them.

## State files updated

- `docs/milestones/M5-plan.md` — #579 row flipped ⬜→✅; M5.A track marked ✅ Complete
- `state/current-milestone.md` — M5.A row updated (✅ Complete — all child issues done)

## Architecture gaps

No G1/G4/G7/G16 exposure in files touched (README + state files only).

## Test plan

### Local pre-flight
- [x] `make lint-go` — N/A (no Go files changed)
- [x] `GOWORK=off go test ./... -race` — N/A (no Go files changed)
- [x] `make test-coverage` — N/A
- [x] `make test-coverage-adapters` — N/A
- [x] `make security` — N/A

### Acceptance (issue body)
- [x] README has `## Service Status` section with ✅/🟡/🔄/📋 table for all 7 platform services
- [x] README has adapter status table for all 5 adapters with accurate statuses
- [x] Statuses accurate as of merge date:
  - git-adapter: ✅ Complete (impl PRs #400–#403 and coverage #714–#718 all merged)
  - task-broker / agent-registry: 🟡 MVP (in-memory, not just "in progress")
  - ci/llm/langgraph-adapters: 🔄 In Progress (BDD ✅, impl pending)
  - event-bus / memory-service: 📋 Planned (M6 — correct; they are contract-only)

### Engineering hygiene
- [x] **`M5-plan.md` row flipped ⬜→✅ in this diff** (mandatory)
- [x] **`current-milestone.md` updated in this diff** (mandatory)
- [x] Branched from fresh `origin/main` · PR ≤900 lines · trailers on every commit
- [x] Gap scan done (G1/G4/G7/G16 not present in touched files)
- [x] Canvas N/A (docs type, SPDD-exempt) · no new capability added
- [x] No out-of-scope edits · no mTLS/SBOM/cosign docs claims

## Out of scope

- Updating the `## Docker Images` table (already lists images, separate concern)
- Adding architecture diagrams

Closes #579
