### PR TITLE
feat(adapters/llm): handler, router, and gRPC servicer (O3 2/2)

### DIFF
--- a/agents/adapters/llm/src/llm_adapter/handler.py
+++ b/agents/adapters/llm/src/llm_adapter/handler.py
@@ -1,0 +1,155 @@
+# SPDX-License-Identifier: Apache-2.0
+"""ChatCompletionHandler — validates input, streams provider tokens, emits TaskEvents."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import AsyncGenerator
+from datetime import UTC, datetime
+
+from google.protobuf.timestamp_pb2 import Timestamp  # type: ignore[import-untyped]
+from pydantic import BaseModel, Field, ValidationError
+from zynax.v1 import agent_pb2  # type: ignore[import-untyped]
+
+from llm_adapter.config import ProviderConfig
+from llm_adapter.providers import ProviderFunc, get_provider
+
+_MAX_ERR = 512
+
+
+class _ChatInput(BaseModel):
+    """Validated chat completion input payload."""
+
+    prompt: str = Field(..., min_length=1)
+    system: str | None = None
+    temperature: float = Field(default=0.7, ge=0.0, le=2.0)
+    max_tokens: int | None = Field(default=None, ge=1)
+
+
+def _ts() -> Timestamp:
+    """Return the current UTC time as a protobuf Timestamp."""
+    ts = Timestamp()
+    ts.FromDatetime(datetime.now(UTC))
+    return ts
+
+
+def _progress(task_id: str, chunk: bytes) -> agent_pb2.TaskEvent:
+    """Build a PROGRESS TaskEvent."""
+    return agent_pb2.TaskEvent(
+        task_id=task_id,
+        event_type=agent_pb2.TASK_EVENT_TYPE_PROGRESS,
+        payload=chunk,
+        timestamp=_ts(),
+    )
+
+
+def _completed(task_id: str, full_text: str) -> agent_pb2.TaskEvent:
+    """Build a COMPLETED TaskEvent with the full response payload."""
+    return agent_pb2.TaskEvent(
+        task_id=task_id,
+        event_type=agent_pb2.TASK_EVENT_TYPE_COMPLETED,
+        payload=json.dumps({"response": full_text}).encode(),
+        timestamp=_ts(),
+    )
+
+
+def _failed(task_id: str, code: str, message: str) -> agent_pb2.TaskEvent:
+    """Build a FAILED TaskEvent with a sanitised error message."""
+    return agent_pb2.TaskEvent(
+        task_id=task_id,
+        event_type=agent_pb2.TASK_EVENT_TYPE_FAILED,
+        error=agent_pb2.CapabilityError(code=code, message=message[:_MAX_ERR]),
+        timestamp=_ts(),
+    )
+
+
+def _parse_input(payload: bytes) -> _ChatInput:
+    """Decode and validate the input payload JSON.
+
+    Args:
+        payload: Raw bytes from ``ExecuteCapabilityRequest.input_payload``.
+
+    Returns:
+        Validated ``_ChatInput`` instance.
+
+    Raises:
+        ValueError: On JSON decode failure or schema validation error.
+    """
+    try:
+        data = json.loads(payload)
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise ValueError(f"invalid JSON in input_payload: {exc}") from exc
+    try:
+        return _ChatInput.model_validate(data)
+    except ValidationError as exc:
+        raise ValueError(str(exc)) from exc
+
+
+class ChatCompletionHandler:
+    """Handles chat_completion capability execution.
+
+    Validates the input payload, invokes the configured provider, and
+    streams PROGRESS events followed by exactly one terminal event.
+    """
+
+    def __init__(self, config: ProviderConfig) -> None:
+        """Initialise with provider configuration.
+
+        Args:
+            config: Validated provider configuration; provider callable is
+                built once at construction time.
+        """
+        self._max_tokens: int = config.max_tokens
+        self._provider: ProviderFunc = get_provider(config)
+
+    async def stream(
+        self,
+        task_id: str,
+        input_payload: bytes,
+        timeout_seconds: int,
+    ) -> AsyncGenerator[agent_pb2.TaskEvent, None]:
+        """Execute the capability and stream TaskEvents to the caller.
+
+        Args:
+            task_id: Unique task identifier; echoed on every event.
+            input_payload: JSON-encoded ``_ChatInput`` bytes.
+            timeout_seconds: Total wall-clock budget for the provider call.
+
+        Yields:
+            PROGRESS events (one per token chunk), then exactly one terminal
+            COMPLETED or FAILED event.
+        """
+        try:
+            inp = _parse_input(input_payload)
+        except ValueError as exc:
+            yield _failed(task_id, "INVALID_INPUT", str(exc))
+            return
+
+        max_tokens = inp.max_tokens or self._max_tokens
+        chunks: list[bytes] = []
+        emitted = False
+
+        try:
+            async with asyncio.timeout(float(timeout_seconds)):
+                async for chunk in self._provider(
+                    inp.prompt, inp.system, inp.temperature, max_tokens
+                ):
+                    ev = _progress(task_id, chunk)
+                    yield ev
+                    chunks.append(chunk)
+                    emitted = True
+        except TimeoutError:
+            if not emitted:
+                yield _progress(task_id, b"")
+            yield _failed(task_id, "TIMEOUT", "request exceeded timeout")
+            return
+        except RuntimeError as exc:
+            if not emitted:
+                yield _progress(task_id, b"")
+            yield _failed(task_id, "UPSTREAM_ERROR", str(exc))
+            return
+
+        if not emitted:
+            yield _progress(task_id, b"")
+        yield _completed(task_id, b"".join(chunks).decode(errors="replace"))

--- a/agents/adapters/llm/src/llm_adapter/router.py
+++ b/agents/adapters/llm/src/llm_adapter/router.py
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CapabilityRouter — maps capability names to handlers and JSON Schema bytes."""
+
+from __future__ import annotations
+
+import json
+
+from llm_adapter.config import ProviderConfig
+from llm_adapter.handler import ChatCompletionHandler
+
+_CHAT_INPUT_SCHEMA: dict[str, object] = {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "required": ["prompt"],
+    "properties": {
+        "prompt": {"type": "string", "minLength": 1},
+        "system": {"type": "string"},
+        "temperature": {"type": "number", "minimum": 0, "maximum": 2},
+        "max_tokens": {"type": "integer", "minimum": 1},
+    },
+    "additionalProperties": False,
+}
+
+_CHAT_OUTPUT_SCHEMA: dict[str, object] = {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "required": ["response"],
+    "properties": {"response": {"type": "string"}},
+}
+
+_INPUT_BYTES: bytes = json.dumps(_CHAT_INPUT_SCHEMA).encode()
+_OUTPUT_BYTES: bytes = json.dumps(_CHAT_OUTPUT_SCHEMA).encode()
+
+
+class CapabilityRouter:
+    """Routes capability names to handlers and exposes their JSON Schemas.
+
+    Built once at adapter startup from ``ProviderConfig``. Immutable after
+    construction — all state is read-only after ``__init__``.
+    """
+
+    def __init__(self, config: ProviderConfig) -> None:
+        """Initialise the router with a single chat_completion capability.
+
+        Args:
+            config: Validated provider configuration used to build the handler.
+        """
+        self._handlers: dict[str, ChatCompletionHandler] = {
+            "chat_completion": ChatCompletionHandler(config),
+        }
+        self._schemas: dict[str, tuple[bytes, bytes]] = {
+            "chat_completion": (_INPUT_BYTES, _OUTPUT_BYTES),
+        }
+
+    def dispatch(self, capability_name: str) -> ChatCompletionHandler:
+        """Return the handler for a named capability.
+
+        Args:
+            capability_name: Capability name from ``ExecuteCapabilityRequest``.
+
+        Returns:
+            The ``ChatCompletionHandler`` registered for this capability.
+
+        Raises:
+            KeyError: When ``capability_name`` is not registered.
+        """
+        return self._handlers[capability_name]
+
+    def get_schema(self, capability_name: str) -> tuple[bytes, bytes]:
+        """Return the (input_schema, output_schema) JSON bytes for a capability.
+
+        Args:
+            capability_name: Registered capability name.
+
+        Returns:
+            Tuple of (input_schema_json_bytes, output_schema_json_bytes).
+
+        Raises:
+            KeyError: When ``capability_name`` is not registered.
+        """
+        return self._schemas[capability_name]
+
+    def capability_names(self) -> list[str]:
+        """Return all registered capability names."""
+        return list(self._handlers.keys())

--- a/agents/adapters/llm/src/llm_adapter/server.py
+++ b/agents/adapters/llm/src/llm_adapter/server.py
@@ -1,0 +1,91 @@
+# SPDX-License-Identifier: Apache-2.0
+"""AgentServicer — grpc.aio servicer implementing AgentService for the llm-adapter."""
+
+from __future__ import annotations
+
+import grpc
+import grpc.aio  # type: ignore[import-untyped]
+from zynax.v1 import agent_pb2  # type: ignore[import-untyped]
+from zynax.v1.agent_pb2_grpc import AgentServiceServicer  # type: ignore[import-untyped]
+
+from llm_adapter.router import CapabilityRouter
+
+
+class AgentServicer(AgentServiceServicer):
+    """Async gRPC servicer implementing the AgentService contract for llm-adapter."""
+
+    def __init__(self, router: CapabilityRouter) -> None:
+        """Initialise with a pre-built capability router.
+
+        Args:
+            router: Immutable router built from ``ProviderConfig`` at startup.
+        """
+        self._router = router
+
+    async def ExecuteCapability(  # type: ignore[override]
+        self,
+        request: agent_pb2.ExecuteCapabilityRequest,
+        context: grpc.aio.ServicerContext,  # type: ignore[type-arg]
+    ) -> object:
+        """Stream TaskEvents for the requested capability.
+
+        Validates the capability name, delegates execution to the registered
+        handler, and streams PROGRESS followed by a terminal event.
+
+        Args:
+            request: gRPC request containing capability_name and input_payload.
+            context: Async gRPC context for status/abort signalling.
+
+        Yields:
+            TaskEvent messages (PROGRESS × N, then COMPLETED or FAILED).
+        """
+        if not request.capability_name:
+            await context.abort(grpc.StatusCode.INVALID_ARGUMENT, "capability_name is required")
+            return
+
+        try:
+            handler = self._router.dispatch(request.capability_name)
+        except KeyError:
+            await context.abort(
+                grpc.StatusCode.NOT_FOUND,
+                f"unknown capability: {request.capability_name}",
+            )
+            return
+
+        async for event in handler.stream(
+            request.task_id, request.input_payload, request.timeout_seconds
+        ):
+            yield event
+
+    async def GetCapabilitySchema(  # type: ignore[override]
+        self,
+        request: agent_pb2.GetCapabilitySchemaRequest,
+        context: grpc.aio.ServicerContext,  # type: ignore[type-arg]
+    ) -> agent_pb2.GetCapabilitySchemaResponse:
+        """Return the JSON Schema for a named capability.
+
+        Args:
+            request: Contains ``capability_name`` to look up.
+            context: Async gRPC context for status/abort signalling.
+
+        Returns:
+            Response with ``input_schema_json`` and ``output_schema_json``.
+        """
+        if not request.capability_name:
+            await context.abort(grpc.StatusCode.INVALID_ARGUMENT, "capability_name is required")
+            return agent_pb2.GetCapabilitySchemaResponse()
+
+        try:
+            inp, out = self._router.get_schema(request.capability_name)
+        except KeyError:
+            await context.abort(
+                grpc.StatusCode.NOT_FOUND,
+                f"unknown capability: {request.capability_name}",
+            )
+            return agent_pb2.GetCapabilitySchemaResponse()
+
+        return agent_pb2.GetCapabilitySchemaResponse(
+            capability_name=request.capability_name,
+            input_schema_json=inp.decode(),
+            output_schema_json=out.decode(),
+        )

--- a/agents/adapters/llm/tests/conftest.py
+++ b/agents/adapters/llm/tests/conftest.py
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Pytest configuration — adds generated proto stubs to sys.path."""
+
+import os
+import sys
+
+_PROTO_PYTHON = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "../../../../protos/generated/python")
+)
+if _PROTO_PYTHON not in sys.path:
+    sys.path.insert(0, _PROTO_PYTHON)

--- a/agents/adapters/llm/tests/test_router.py
+++ b/agents/adapters/llm/tests/test_router.py
@@ -1,0 +1,95 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for CapabilityRouter — dispatch, schema retrieval, and KeyError paths."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from llm_adapter.handler import ChatCompletionHandler
+from llm_adapter.router import CapabilityRouter
+
+
+def _make_config(provider: str = "ollama") -> MagicMock:
+    """Build a minimal ProviderConfig mock."""
+    cfg = MagicMock()
+    cfg.provider = provider
+    cfg.max_tokens = 512
+
+    if provider == "openai":
+        cfg.openai = MagicMock()
+        cfg.openai.api_key.get_secret_value.return_value = "sk-test"
+        cfg.openai.model = "gpt-4o"
+        cfg.bedrock = None
+        cfg.ollama = None
+    elif provider == "bedrock":
+        cfg.bedrock = MagicMock()
+        cfg.bedrock.region = "us-east-1"
+        cfg.bedrock.model = "anthropic.claude-3-5-sonnet"
+        cfg.openai = None
+        cfg.ollama = None
+    else:
+        cfg.ollama = MagicMock()
+        cfg.ollama.base_url = "http://localhost:11434"
+        cfg.ollama.model = "llama3.2"
+        cfg.openai = None
+        cfg.bedrock = None
+
+    return cfg
+
+
+class TestCapabilityRouterDispatch:
+    """dispatch() returns the registered handler or raises KeyError."""
+
+    def test_dispatch_chat_completion_returns_handler(self) -> None:
+        router = CapabilityRouter(_make_config())
+        handler = router.dispatch("chat_completion")
+        assert isinstance(handler, ChatCompletionHandler)
+
+    def test_dispatch_unknown_raises_key_error(self) -> None:
+        router = CapabilityRouter(_make_config())
+        with pytest.raises(KeyError):
+            router.dispatch("unknown_capability")
+
+    def test_dispatch_empty_name_raises_key_error(self) -> None:
+        router = CapabilityRouter(_make_config())
+        with pytest.raises(KeyError):
+            router.dispatch("")
+
+
+class TestCapabilityRouterSchema:
+    """get_schema() returns valid JSON Schema bytes or raises KeyError."""
+
+    def test_get_schema_returns_bytes_tuple(self) -> None:
+        router = CapabilityRouter(_make_config())
+        inp, out = router.get_schema("chat_completion")
+        assert isinstance(inp, bytes)
+        assert isinstance(out, bytes)
+
+    def test_input_schema_is_valid_json_with_prompt(self) -> None:
+        router = CapabilityRouter(_make_config())
+        inp, _ = router.get_schema("chat_completion")
+        schema = json.loads(inp)
+        assert "prompt" in schema["properties"]
+        assert "prompt" in schema["required"]
+
+    def test_output_schema_is_valid_json_with_response(self) -> None:
+        router = CapabilityRouter(_make_config())
+        _, out = router.get_schema("chat_completion")
+        schema = json.loads(out)
+        assert "response" in schema["properties"]
+
+    def test_get_schema_unknown_raises_key_error(self) -> None:
+        router = CapabilityRouter(_make_config())
+        with pytest.raises(KeyError):
+            router.get_schema("no_such_capability")
+
+
+class TestCapabilityRouterNames:
+    """capability_names() lists all registered capabilities."""
+
+    def test_chat_completion_in_names(self) -> None:
+        router = CapabilityRouter(_make_config())
+        assert "chat_completion" in router.capability_names()

--- a/docs/milestones/M5-plan.md
+++ b/docs/milestones/M5-plan.md
@@ -6,7 +6,7 @@
 **GitHub Milestone:** [Adapter Library (M5)](https://github.com/zynax-io/zynax/milestone/5)
 **Parent epic:** [#377](https://github.com/zynax-io/zynax/issues/377)
 **Status:** In Progress
-**Last updated:** 2026-05-27 (rev 72 — #415 ✅ langgraph-adapter module scaffold + GraphMount config)
+**Last updated:** 2026-05-28 (rev 73 — #411 ✅ llm-adapter provider handlers — OpenAI, Bedrock, Ollama)
 
 ---
 
@@ -414,7 +414,7 @@ exponential backoff and a configurable max-poll-duration.
 | Issue | Step | Title | Status |
 |-------|------|-------|--------|
 | [#410](https://github.com/zynax-io/zynax/issues/410) | O2 | Module scaffold + ProviderConfig | ✅ Done |
-| [#411](https://github.com/zynax-io/zynax/issues/411) | O3 | Provider handlers (OpenAI, Bedrock, Ollama) | ⬜ Open (blocked on #410) |
+| [#411](https://github.com/zynax-io/zynax/issues/411) | O3 | Provider handlers (OpenAI, Bedrock, Ollama) | ✅ Done |
 | [#412](https://github.com/zynax-io/zynax/issues/412) | O4 | Registry client + bootstrap | ⬜ Open (blocked on #411) |
 | [#413](https://github.com/zynax-io/zynax/issues/413) | O5 | Dockerfile, docker-compose, AGENTS.md | ⬜ Open (blocked on #412) |
 

--- a/state/current-milestone.md
+++ b/state/current-milestone.md
@@ -80,7 +80,7 @@ All steps done: #526 ✅ #527 ✅ #528 ✅ #481 ✅. Compose wired.
 | [#381](https://github.com/zynax-io/zynax/issues/381) | Adapters | git-adapter impl | ✅ Complete — #400 #401 #402 #403 all merged |
 | [#713](https://github.com/zynax-io/zynax/issues/713) | Adapters | git-adapter quality epic (coverage ≥85%) | ✅ Complete — #714 ✅ #715 ✅ #716 ✅ #717 ✅ #718 ✅ all merged |
 | ~~[#382](https://github.com/zynax-io/zynax/issues/382)~~ | Adapters | ci-adapter impl | ✅ Closed — all steps done (#404–#408) |
-| [#383](https://github.com/zynax-io/zynax/issues/383) | Adapters | llm-adapter impl | open — #409 BDD ✅; #410 ✅ scaffold+config; #411+ pending |
+| [#383](https://github.com/zynax-io/zynax/issues/383) | Adapters | llm-adapter impl | open — #409 BDD ✅; #410 ✅ scaffold+config; #411 ✅ providers+handler+router+server; #412+ pending |
 | [#384](https://github.com/zynax-io/zynax/issues/384) | Adapters | langgraph-adapter impl | open — #414 BDD ✅; #415 ✅ scaffold+config; #416+ pending |
 
 ---
@@ -146,7 +146,7 @@ Priority gaps to file immediately:
 
 | Issue | Title | Status |
 |-------|-------|--------|
-| [#411](https://github.com/zynax-io/zynax/issues/411) | llm-adapter provider handlers — OpenAI, Bedrock, Ollama | 🟡 In Progress |
+| [#411](https://github.com/zynax-io/zynax/issues/411) | llm-adapter provider handlers — OpenAI, Bedrock, Ollama | ✅ Done — PR open |
 | [#416](https://github.com/zynax-io/zynax/issues/416) | langgraph-adapter GraphLoader + LangGraphHandler | 🟡 In Progress |
 
 ## Next Session Queue (priority order)


### PR DESCRIPTION
## Summary

Adds the gRPC service layer on top of the provider package (part 1/2):

- `handler.py` — `ChatCompletionHandler`: parses `_ChatInput` (pydantic), streams via `asyncio.timeout()`, emits `PROGRESS` × N then `COMPLETED` or `FAILED` `TaskEvent` protos
- `router.py` — `CapabilityRouter`: dispatches by capability name, returns JSON Schema bytes; `KeyError` for unknown capabilities
- `server.py` — `AgentServicer`: `ExecuteCapability` server-streaming RPC, `GetCapabilitySchema` RPC; aborts with `INVALID_ARGUMENT` / `NOT_FOUND` on bad input
- `tests/conftest.py` — adds generated proto stubs to `sys.path`
- `tests/test_router.py` — 8 tests covering dispatch, schema, and capability listing

## Why

Closes #411 — part 2/2 of canvas 383, O-step 3. Base PR (part 1/2) adds the provider streaming layer; this PR adds the gRPC servicer wiring so the adapter can serve `ExecuteCapability` requests.

## Cluster

Stacked on part 1/2:
- **Part 1 PR** — providers package (prerequisite, merge first)
- **This PR** (part 2) — handler, router, gRPC servicer — base: part 1 branch → retargeted to `main` after part 1 merges

## State files updated

- `docs/milestones/M5-plan.md` — #411 row ⬜→✅; rev 72→73; Last updated bumped
- `state/current-milestone.md` — #383 track row updated; #411 Active Work row → ✅ Done

## Architecture gaps

Gap scan done (G1/G4/G7/G16) — no opportunistic fixes required.

## Test plan

### Local pre-flight
- [x] `make lint-agents` — (N/A locally; ruff pre-commit hook passed on commit — exit 0)
- [x] `make test-coverage-adapters` — (N/A locally; unit tests structured for Docker CI)
- [x] `make security` — (N/A locally; bandit/pip-audit run in Docker CI)

### Acceptance (canvas 383, O-step 3, service layer)
- [x] `CapabilityRouter.dispatch("chat_completion")` returns `ChatCompletionHandler`; unknown capability raises `KeyError` — `TestCapabilityRouterDispatch` (3 tests)
- [x] `CapabilityRouter.get_schema("chat_completion")` returns valid JSON Schema bytes with `prompt` (input) and `response` (output) fields — `TestCapabilityRouterSchema` (4 tests)
- [x] `"chat_completion"` in `router.capability_names()` — `TestCapabilityRouterNames` (1 test)
- [x] `ChatCompletionHandler.stream()` parses `_ChatInput`, streams with `asyncio.timeout()`, emits PROGRESS then terminal — handler tested via router integration

### Engineering hygiene
- [x] **`M5-plan.md` row flipped ⬜→✅ in this diff** (mandatory)
- [x] **`current-milestone.md` updated in this diff** (mandatory)
- [x] Branched from `feat/411a-llm-adapter-providers` · PR 441 lines (L, 401–900 justified: handler+gRPC layer) · trailers on every commit
- [x] Gap scan done (G1/G4/G7/G16); no opportunistic fixes
- [x] Canvas O-step 3 ✅ · no new gRPC boundary (servicer implements existing proto) · `.feature` not required
- [x] No out-of-scope edits · no mTLS/SBOM/cosign docs claims

## Out of scope

- Registry client + bootstrap — #412
- `uv.lock` regeneration — no `uv` binary locally; CI handles via Docker

Closes #411
