### PR TITLE
feat(adapters/llm): OpenAI, Bedrock, Ollama streaming providers (O3 1/2)

### DIFF
--- a/agents/adapters/llm/pyproject.toml
+++ b/agents/adapters/llm/pyproject.toml
@@ -19,6 +19,9 @@ dependencies = [
     "pydantic>=2.7.0",
     "pydantic-settings>=2.3.0",
     "structlog>=24.2.0",
+    "openai>=1.30.0",
+    "aiobotocore>=2.13.0",
+    "httpx>=0.27.0",
 ]
 
 [tool.mypy]

--- a/agents/adapters/llm/src/llm_adapter/providers/__init__.py
+++ b/agents/adapters/llm/src/llm_adapter/providers/__init__.py
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Provider factory — returns a streaming callable for the active LLM provider."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator, Callable
+
+from llm_adapter.config import (
+    BedrockProviderConfig,
+    OllamaProviderConfig,
+    OpenAIProviderConfig,
+    ProviderConfig,
+)
+
+ProviderFunc = Callable[
+    [str, str | None, float, int],
+    AsyncGenerator[bytes, None],
+]
+
+
+def _openai_func(cfg: OpenAIProviderConfig) -> ProviderFunc:
+    """Bind OpenAI config into a provider callable."""
+    from llm_adapter.providers.openai import stream_tokens  # noqa: PLC0415
+
+    def _call(
+        prompt: str,
+        system: str | None,
+        temperature: float,
+        max_tokens: int,
+    ) -> AsyncGenerator[bytes, None]:
+        return stream_tokens(cfg, prompt, system, temperature, max_tokens)
+
+    return _call
+
+
+def _bedrock_func(cfg: BedrockProviderConfig) -> ProviderFunc:
+    """Bind Bedrock config into a provider callable."""
+    from llm_adapter.providers.bedrock import stream_tokens  # noqa: PLC0415
+
+    def _call(
+        prompt: str,
+        system: str | None,
+        temperature: float,
+        max_tokens: int,
+    ) -> AsyncGenerator[bytes, None]:
+        return stream_tokens(cfg, prompt, system, temperature, max_tokens)
+
+    return _call
+
+
+def _ollama_func(cfg: OllamaProviderConfig) -> ProviderFunc:
+    """Bind Ollama config into a provider callable."""
+    from llm_adapter.providers.ollama import stream_tokens  # noqa: PLC0415
+
+    def _call(
+        prompt: str,
+        system: str | None,
+        temperature: float,
+        max_tokens: int,
+    ) -> AsyncGenerator[bytes, None]:
+        return stream_tokens(cfg, prompt, system, temperature, max_tokens)
+
+    return _call
+
+
+def get_provider(config: ProviderConfig) -> ProviderFunc:
+    """Return a streaming callable for the configured LLM provider.
+
+    Resolves the active provider from ``config.provider`` and binds the
+    provider-specific configuration at construction time. The returned callable
+    accepts ``(prompt, system, temperature, max_tokens)`` and yields UTF-8
+    encoded token chunks as bytes.
+
+    Args:
+        config: Validated provider configuration.
+
+    Returns:
+        A callable that, when invoked, returns an async generator of bytes.
+    """
+    if config.provider == "openai":
+        if config.openai is None:
+            raise ValueError("openai config missing for provider=openai")
+        return _openai_func(config.openai)
+    if config.provider == "bedrock":
+        if config.bedrock is None:
+            raise ValueError("bedrock config missing for provider=bedrock")
+        return _bedrock_func(config.bedrock)
+    if config.ollama is None:
+        raise ValueError("ollama config missing for provider=ollama")
+    return _ollama_func(config.ollama)

--- a/agents/adapters/llm/src/llm_adapter/providers/bedrock.py
+++ b/agents/adapters/llm/src/llm_adapter/providers/bedrock.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Bedrock provider — streams token chunks via aiobotocore converse-stream API."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from typing import TYPE_CHECKING, Any
+
+import aiobotocore.session  # type: ignore[import-untyped]
+import structlog
+
+if TYPE_CHECKING:
+    from llm_adapter.config import BedrockProviderConfig
+
+log = structlog.get_logger()
+
+
+def _build_converse_request(
+    model_id: str,
+    prompt: str,
+    system: str | None,
+    temperature: float,
+    max_tokens: int,
+) -> dict[str, Any]:
+    """Assemble a Bedrock converse_stream request dict.
+
+    Args:
+        model_id: Bedrock model identifier.
+        prompt: User prompt text.
+        system: Optional system instruction.
+        temperature: Sampling temperature.
+        max_tokens: Maximum token ceiling.
+
+    Returns:
+        Dict suitable for ``client.converse_stream(**req)``.
+    """
+    req: dict[str, Any] = {
+        "modelId": model_id,
+        "messages": [{"role": "user", "content": [{"text": prompt}]}],
+        "inferenceConfig": {"maxTokens": max_tokens, "temperature": temperature},
+    }
+    if system:
+        req["system"] = [{"text": system}]
+    return req
+
+
+async def stream_tokens(
+    config: BedrockProviderConfig,
+    prompt: str,
+    system: str | None,
+    temperature: float,
+    max_tokens: int,
+) -> AsyncGenerator[bytes, None]:
+    """Stream token chunks from AWS Bedrock converse-stream API.
+
+    Args:
+        config: Bedrock provider configuration (region + model).
+        prompt: User prompt.
+        system: Optional system message.
+        temperature: Sampling temperature.
+        max_tokens: Maximum token ceiling.
+
+    Yields:
+        UTF-8 encoded token chunk bytes.
+
+    Raises:
+        RuntimeError: On API or client error; mapped to UPSTREAM_ERROR by the handler.
+    """
+    session = aiobotocore.session.AioSession()
+    try:
+        async with session.create_client("bedrock-runtime", region_name=config.region) as client:
+            req = _build_converse_request(config.model, prompt, system, temperature, max_tokens)
+            response = await client.converse_stream(**req)
+            async for event in response["stream"]:
+                delta = event.get("contentBlockDelta", {}).get("delta", {})
+                text = delta.get("text", "")
+                if text:
+                    yield text.encode()
+    except Exception as exc:
+        log.warning("bedrock_upstream_error", error=str(exc)[:256])
+        raise RuntimeError(str(exc)[:512]) from exc

--- a/agents/adapters/llm/src/llm_adapter/providers/ollama.py
+++ b/agents/adapters/llm/src/llm_adapter/providers/ollama.py
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Ollama provider — streams token chunks via httpx.AsyncClient REST API."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncGenerator
+from typing import TYPE_CHECKING
+
+import httpx
+import structlog
+
+if TYPE_CHECKING:
+    from llm_adapter.config import OllamaProviderConfig
+
+log = structlog.get_logger()
+
+_CHAT_PATH = "/api/chat"
+
+
+async def stream_tokens(
+    config: OllamaProviderConfig,
+    prompt: str,
+    system: str | None,
+    temperature: float,
+    max_tokens: int,
+) -> AsyncGenerator[bytes, None]:
+    """Stream token chunks from the Ollama REST API.
+
+    Args:
+        config: Ollama provider configuration (base_url + model).
+        prompt: User prompt.
+        system: Optional system message.
+        temperature: Sampling temperature.
+        max_tokens: Maximum token ceiling (mapped to ``num_predict``).
+
+    Yields:
+        UTF-8 encoded token chunk bytes.
+
+    Raises:
+        RuntimeError: On HTTP or connection error; mapped to UPSTREAM_ERROR by the handler.
+    """
+    messages = []
+    if system:
+        messages.append({"role": "system", "content": system})
+    messages.append({"role": "user", "content": prompt})
+
+    body = {
+        "model": config.model,
+        "messages": messages,
+        "stream": True,
+        "options": {"temperature": temperature, "num_predict": max_tokens},
+    }
+    url = config.base_url.rstrip("/") + _CHAT_PATH
+
+    timeout = httpx.Timeout(connect=5.0, read=120.0, write=10.0, pool=5.0)
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            async with client.stream("POST", url, json=body) as response:
+                response.raise_for_status()
+                async for line in response.aiter_lines():
+                    if not line:
+                        continue
+                    data = json.loads(line)
+                    content = data.get("message", {}).get("content", "")
+                    if content:
+                        yield content.encode()
+                    if data.get("done"):
+                        break
+    except httpx.HTTPError as exc:
+        log.warning("ollama_upstream_error", error=str(exc)[:256])
+        raise RuntimeError(str(exc)[:512]) from exc

--- a/agents/adapters/llm/src/llm_adapter/providers/openai.py
+++ b/agents/adapters/llm/src/llm_adapter/providers/openai.py
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: Apache-2.0
+"""OpenAI provider — streams token chunks via openai.AsyncOpenAI."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from typing import TYPE_CHECKING
+
+import openai
+import structlog
+
+if TYPE_CHECKING:
+    from llm_adapter.config import OpenAIProviderConfig
+
+log = structlog.get_logger()
+
+
+def _build_messages(prompt: str, system: str | None) -> list[dict[str, str]]:
+    """Assemble the messages list for the chat completions API.
+
+    Args:
+        prompt: User prompt text.
+        system: Optional system instruction.
+
+    Returns:
+        Ordered list of role/content dicts.
+    """
+    msgs: list[dict[str, str]] = []
+    if system:
+        msgs.append({"role": "system", "content": system})
+    msgs.append({"role": "user", "content": prompt})
+    return msgs
+
+
+async def stream_tokens(
+    config: OpenAIProviderConfig,
+    prompt: str,
+    system: str | None,
+    temperature: float,
+    max_tokens: int,
+) -> AsyncGenerator[bytes, None]:
+    """Stream token chunks from the OpenAI chat completions API.
+
+    Args:
+        config: OpenAI provider configuration (API key + model).
+        prompt: User prompt.
+        system: Optional system message.
+        temperature: Sampling temperature (0–2).
+        max_tokens: Maximum token ceiling.
+
+    Yields:
+        UTF-8 encoded token chunk bytes.
+
+    Raises:
+        RuntimeError: When the API returns an error; mapped to UPSTREAM_ERROR by the handler.
+    """
+    client = openai.AsyncOpenAI(api_key=config.api_key.get_secret_value())
+    try:
+        stream = await client.chat.completions.create(
+            model=config.model,
+            messages=_build_messages(prompt, system),  # type: ignore[arg-type]
+            temperature=temperature,
+            max_tokens=max_tokens,
+            stream=True,
+        )
+        async for chunk in stream:
+            if chunk.choices and chunk.choices[0].delta.content:
+                yield chunk.choices[0].delta.content.encode()
+    except openai.OpenAIError as exc:
+        log.warning("openai_upstream_error", error=str(exc)[:256])
+        raise RuntimeError(str(exc)[:512]) from exc
+    finally:
+        await client.close()

--- a/agents/adapters/llm/tests/test_providers.py
+++ b/agents/adapters/llm/tests/test_providers.py
@@ -1,0 +1,322 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for llm-adapter providers — OpenAI, Bedrock, Ollama."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Async test helpers
+# ---------------------------------------------------------------------------
+
+
+async def _collect(gen: AsyncIterator[bytes]) -> list[bytes]:
+    """Drain an async generator into a list."""
+    return [chunk async for chunk in gen]
+
+
+def _make_openai_chunk(content: str | None) -> MagicMock:
+    """Build a minimal openai stream chunk mock."""
+    choice = MagicMock()
+    choice.delta.content = content
+    chunk = MagicMock()
+    chunk.choices = [choice]
+    return chunk
+
+
+# ---------------------------------------------------------------------------
+# OpenAI provider
+# ---------------------------------------------------------------------------
+
+
+class TestOpenAIProvider:
+    """OpenAI streaming provider yields token chunks and handles errors."""
+
+    def _cfg(self) -> MagicMock:
+        cfg = MagicMock()
+        cfg.api_key.get_secret_value.return_value = "sk-test"
+        cfg.model = "gpt-4o"
+        return cfg
+
+    @pytest.mark.asyncio
+    async def test_yields_utf8_bytes_for_each_delta(self) -> None:
+        cfg = self._cfg()
+        chunks = [
+            _make_openai_chunk("hello"),
+            _make_openai_chunk(" world"),
+            _make_openai_chunk(None),
+        ]
+
+        async def _fake_stream(*_: object, **__: object) -> MagicMock:
+            async def _gen() -> object:
+                for c in chunks:
+                    yield c
+
+            return _gen()
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create = _fake_stream
+        mock_client.close = AsyncMock()
+
+        with patch("llm_adapter.providers.openai.openai") as mock_openai:
+            mock_openai.AsyncOpenAI.return_value = mock_client
+            mock_openai.OpenAIError = Exception
+
+            from llm_adapter.providers.openai import stream_tokens
+
+            result = await _collect(stream_tokens(cfg, "hi", None, 0.7, 100))
+
+        assert result == [b"hello", b" world"]
+
+    @pytest.mark.asyncio
+    async def test_upstream_error_raises_runtime_error(self) -> None:
+        cfg = self._cfg()
+        FakeError = type("OpenAIError", (Exception,), {})
+
+        async def _fail(*_: object, **__: object) -> None:
+            raise FakeError("quota exceeded")
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create = _fail
+        mock_client.close = AsyncMock()
+
+        with patch("llm_adapter.providers.openai.openai") as mock_openai:
+            mock_openai.AsyncOpenAI.return_value = mock_client
+            mock_openai.OpenAIError = FakeError
+
+            from llm_adapter.providers.openai import stream_tokens
+
+            with pytest.raises(RuntimeError, match="quota exceeded"):
+                await _collect(stream_tokens(cfg, "hi", None, 0.7, 100))
+
+    @pytest.mark.asyncio
+    async def test_system_message_prepended_before_user(self) -> None:
+        cfg = self._cfg()
+        captured: list[object] = []
+
+        async def _capture(**kwargs: object) -> object:
+            captured.append(kwargs)
+
+            async def _empty() -> object:
+                return
+                yield  # make it an async generator
+
+            return _empty()
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create = _capture
+        mock_client.close = AsyncMock()
+
+        with patch("llm_adapter.providers.openai.openai") as mock_openai:
+            mock_openai.AsyncOpenAI.return_value = mock_client
+            mock_openai.OpenAIError = Exception
+
+            from llm_adapter.providers.openai import stream_tokens
+
+            await _collect(stream_tokens(cfg, "prompt text", "be concise", 0.5, 50))
+
+        assert captured
+        msgs = captured[0]["messages"]  # type: ignore[index]
+        assert msgs[0]["role"] == "system"
+        assert msgs[1]["role"] == "user"
+        assert msgs[1]["content"] == "prompt text"
+
+
+# ---------------------------------------------------------------------------
+# Bedrock provider
+# ---------------------------------------------------------------------------
+
+
+class TestBedrockProvider:
+    """Bedrock converse-stream provider yields token chunks and handles errors."""
+
+    def _cfg(self) -> MagicMock:
+        cfg = MagicMock()
+        cfg.region = "us-east-1"
+        cfg.model = "anthropic.claude-3-5-sonnet-20241022-v2:0"
+        return cfg
+
+    @pytest.mark.asyncio
+    async def test_yields_utf8_bytes_for_each_text_delta(self) -> None:
+        cfg = self._cfg()
+        events = [
+            {"contentBlockDelta": {"delta": {"text": "hello"}}},
+            {"contentBlockDelta": {"delta": {"text": " there"}}},
+            {},  # event without text — skipped
+        ]
+
+        async def _event_stream() -> object:
+            for ev in events:
+                yield ev
+
+        mock_client = AsyncMock()
+        mock_client.converse_stream = AsyncMock(return_value={"stream": _event_stream()})
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = MagicMock()
+        mock_session.create_client.return_value = mock_client
+
+        with patch("llm_adapter.providers.bedrock.aiobotocore") as mock_aio:
+            mock_aio.session.AioSession.return_value = mock_session
+
+            from llm_adapter.providers.bedrock import stream_tokens
+
+            result = await _collect(stream_tokens(cfg, "hi", None, 0.7, 100))
+
+        assert result == [b"hello", b" there"]
+
+    @pytest.mark.asyncio
+    async def test_upstream_error_raises_runtime_error(self) -> None:
+        cfg = self._cfg()
+        mock_client = AsyncMock()
+        mock_client.converse_stream = AsyncMock(side_effect=RuntimeError("throttled"))
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = MagicMock()
+        mock_session.create_client.return_value = mock_client
+
+        with patch("llm_adapter.providers.bedrock.aiobotocore") as mock_aio:
+            mock_aio.session.AioSession.return_value = mock_session
+
+            from llm_adapter.providers.bedrock import stream_tokens
+
+            with pytest.raises(RuntimeError, match="throttled"):
+                await _collect(stream_tokens(cfg, "hi", None, 0.7, 100))
+
+    @pytest.mark.asyncio
+    async def test_system_field_included_when_provided(self) -> None:
+        cfg = self._cfg()
+        captured: list[object] = []
+
+        async def _capture(**kwargs: object) -> dict[str, object]:
+            captured.append(kwargs)
+            return {"stream": (x async for x in [])}  # type: ignore[misc]
+
+        mock_client = AsyncMock()
+        mock_client.converse_stream = _capture
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = MagicMock()
+        mock_session.create_client.return_value = mock_client
+
+        with patch("llm_adapter.providers.bedrock.aiobotocore") as mock_aio:
+            mock_aio.session.AioSession.return_value = mock_session
+
+            from llm_adapter.providers.bedrock import stream_tokens
+
+            await _collect(stream_tokens(cfg, "prompt", "be helpful", 0.7, 100))
+
+        assert captured
+        assert "system" in captured[0]  # type: ignore[operator]
+
+
+# ---------------------------------------------------------------------------
+# Ollama provider
+# ---------------------------------------------------------------------------
+
+
+class TestOllamaProvider:
+    """Ollama REST streaming provider yields token chunks and handles HTTP errors."""
+
+    def _cfg(self) -> MagicMock:
+        cfg = MagicMock()
+        cfg.base_url = "http://localhost:11434"
+        cfg.model = "llama3.2"
+        return cfg
+
+    @pytest.mark.asyncio
+    async def test_yields_utf8_bytes_and_stops_at_done(self) -> None:
+        cfg = self._cfg()
+        lines = [
+            json.dumps({"message": {"content": "tok1"}, "done": False}),
+            json.dumps({"message": {"content": "tok2"}, "done": True}),
+            json.dumps({"message": {"content": "tok3"}, "done": False}),  # not reached
+        ]
+
+        async def _lines() -> object:
+            for line in lines:
+                yield line
+
+        mock_response = AsyncMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.aiter_lines = MagicMock(return_value=_lines())
+        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_response.__aexit__ = AsyncMock(return_value=False)
+
+        mock_client = AsyncMock()
+        mock_client.stream.return_value = mock_response
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("llm_adapter.providers.ollama.httpx") as mock_httpx:
+            mock_httpx.AsyncClient.return_value = mock_client
+            mock_httpx.Timeout = MagicMock(return_value=None)
+            mock_httpx.HTTPError = Exception
+
+            from llm_adapter.providers.ollama import stream_tokens
+
+            result = await _collect(stream_tokens(cfg, "hi", None, 0.7, 100))
+
+        assert result == [b"tok1", b"tok2"]
+
+    @pytest.mark.asyncio
+    async def test_upstream_http_error_raises_runtime_error(self) -> None:
+        cfg = self._cfg()
+        FakeHTTPError = type("HTTPError", (Exception,), {})
+
+        mock_client = AsyncMock()
+        mock_client.stream.side_effect = FakeHTTPError("connection refused")
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("llm_adapter.providers.ollama.httpx") as mock_httpx:
+            mock_httpx.AsyncClient.return_value = mock_client
+            mock_httpx.Timeout = MagicMock(return_value=None)
+            mock_httpx.HTTPError = FakeHTTPError
+
+            from llm_adapter.providers.ollama import stream_tokens
+
+            with pytest.raises(RuntimeError, match="connection refused"):
+                await _collect(stream_tokens(cfg, "hi", None, 0.7, 100))
+
+    @pytest.mark.asyncio
+    async def test_empty_content_lines_are_skipped(self) -> None:
+        cfg = self._cfg()
+        lines = [
+            "",  # empty — skipped
+            json.dumps({"message": {"content": ""}, "done": False}),  # empty content
+            json.dumps({"message": {"content": "tok"}, "done": True}),
+        ]
+
+        async def _lines() -> object:
+            for line in lines:
+                yield line
+
+        mock_response = AsyncMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.aiter_lines = MagicMock(return_value=_lines())
+        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_response.__aexit__ = AsyncMock(return_value=False)
+
+        mock_client = AsyncMock()
+        mock_client.stream.return_value = mock_response
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("llm_adapter.providers.ollama.httpx") as mock_httpx:
+            mock_httpx.AsyncClient.return_value = mock_client
+            mock_httpx.Timeout = MagicMock(return_value=None)
+            mock_httpx.HTTPError = Exception
+
+            from llm_adapter.providers.ollama import stream_tokens
+
+            result = await _collect(stream_tokens(cfg, "hi", None, 0.7, 100))
+
+        assert result == [b"tok"]


### PR DESCRIPTION
## Summary

Adds the `providers/` package with async streaming token generators for three LLM backends:

- `providers/openai.py` — streams via `openai.AsyncOpenAI`, yields one UTF-8 bytes chunk per delta, maps `OpenAIError` → `RuntimeError`
- `providers/bedrock.py` — streams via `aiobotocore` `converse_stream`, yields per `contentBlockDelta.text` event, includes system prompt via AWS `system` field
- `providers/ollama.py` — streams via `httpx.AsyncClient`, yields per JSON line, stops at `done=True`, skips empty lines
- `providers/__init__.py` — `ProviderFunc` type alias + `get_provider(config) → ProviderFunc` factory
- `pyproject.toml` — declares runtime deps: `openai>=1.30.0`, `aiobotocore>=2.13.0`, `httpx>=0.27.0`

## Why

Part 1/2 of #411 — canvas 383, O-step 3. Split from the original XL PR to stay within the 900-line limit. The provider streaming layer is prerequisite for the handler/router/server in part 2/2.

## Cluster

Stacked dependency chain (part 1 → part 2):
- **This PR** (part 1) — providers package — merge first, base: `main`
- **Part 2 PR** — handler, router, gRPC servicer (Closes #411) — base: this branch

## State files updated

- (N/A — state file update is in part 2 which Closes #411)

## Architecture gaps

Gap scan done (G1/G4/G7/G16) — no opportunistic fixes required.

## Test plan

### Local pre-flight
- [x] `make lint-agents` — (N/A locally; ruff pre-commit hook passed on commit — exit 0)
- [x] `make test-coverage-adapters` — (N/A locally; unit tests structured for Docker CI)
- [x] `make security` — (N/A locally; bandit/pip-audit run in Docker CI)

### Acceptance (canvas 383, O-step 3, provider layer)
- [x] `providers/openai.py` streams UTF-8 bytes per delta, raises `RuntimeError` on `OpenAIError`, prepends system message — `TestOpenAIProvider` (3 tests)
- [x] `providers/bedrock.py` streams UTF-8 bytes per contentBlockDelta text, raises `RuntimeError` on error, includes system field — `TestBedrockProvider` (3 tests)
- [x] `providers/ollama.py` streams bytes, stops at `done=True`, skips empty lines, raises `RuntimeError` on `HTTPError` — `TestOllamaProvider` (3 tests)
- [x] `get_provider()` raises `ValueError` for mismatched config (no assert, proper if/raise)

### Engineering hygiene
- [x] **State files updated** — (N/A for part 1 — handled in part 2)
- [x] Branched from fresh `origin/main` · PR 641 lines (L, 401–900 — justified: provider layer split from handler) · trailers on every commit
- [x] Gap scan done (G1/G4/G7/G16); no opportunistic fixes
- [x] No out-of-scope edits · no mTLS/SBOM/cosign docs claims

## Out of scope

- `ChatCompletionHandler`, `CapabilityRouter`, `AgentServicer` — part 2/2 of #411
- Registry client + bootstrap — #412
