### PR TITLE
feat(adapters/langgraph): registry client and bootstrap

### DIFF
--- a/agents/adapters/langgraph/src/langgraph_adapter/__main__.py
+++ b/agents/adapters/langgraph/src/langgraph_adapter/__main__.py
@@ -1,0 +1,131 @@
+# SPDX-License-Identifier: Apache-2.0
+"""langgraph-adapter bootstrap — load graphs, register, serve, deregister on SIGTERM."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import signal
+import sys
+
+import grpc.aio  # type: ignore[import-untyped]
+from zynax.v1 import agent_registry_pb2_grpc  # type: ignore[import-untyped]
+from zynax.v1.agent_pb2_grpc import (
+    add_AgentServiceServicer_to_server,  # type: ignore[import-untyped]
+)
+
+from langgraph_adapter.config import AdapterConfig
+from langgraph_adapter.graph_loader import GraphLoader
+from langgraph_adapter.handler import LangGraphHandler
+from langgraph_adapter.registry.client import (
+    RegistrySettings,
+    build_agent_def,
+    deregister_agent,
+    register_agent,
+)
+from langgraph_adapter.router import CapabilityRouter
+from langgraph_adapter.server import AgentServicer
+
+log = logging.getLogger(__name__)
+
+
+async def main() -> None:
+    """Bootstrap: load graphs, register with agent-registry, serve, deregister on exit."""
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    config = AdapterConfig()  # type: ignore[call-arg]
+    settings = RegistrySettings()  # type: ignore[call-arg]
+    graphs = _load_graphs(config)
+    router = CapabilityRouter(graphs)
+    channel = grpc.aio.insecure_channel(config.registry_addr)
+    stub = agent_registry_pb2_grpc.AgentRegistryServiceStub(channel)
+    agent_def = _build_def(settings, router)
+    await register_agent(agent_def, stub)
+    server = await _start_server(router, settings.grpc_port)
+    await _wait_for_signal()
+    await _shutdown(settings.agent_id, stub, server, channel)
+
+
+def _load_graphs(config: AdapterConfig) -> dict[str, object]:
+    """Load and compile all graphs declared in config, exit on failure.
+
+    Args:
+        config: Validated adapter config containing the list of graph mounts.
+
+    Returns:
+        Map of capability name → compiled graph (exits non-zero on any failure).
+    """
+    try:
+        return GraphLoader.load_all(config.graph_mounts)
+    except RuntimeError as exc:
+        log.error("graph load failed — aborting", extra={"err": str(exc)})
+        sys.exit(1)
+
+
+def _build_def(settings: RegistrySettings, router: CapabilityRouter) -> object:
+    """Construct the AgentDef proto from settings and router capability list.
+
+    Args:
+        settings: Registry settings containing agent_id and endpoint.
+        router: Built capability router; provides names and schema bytes.
+
+    Returns:
+        Populated AgentDef proto ready for registration.
+    """
+    cap_names = router.capability_names()
+    schemas = {n: router.get_schema(n) for n in cap_names}
+    return build_agent_def(settings, cap_names, schemas)
+
+
+async def _start_server(router: CapabilityRouter, port: int) -> grpc.aio.Server:
+    """Create and start the gRPC server on the given port.
+
+    Args:
+        router: The capability router wired into the servicer.
+        port: TCP port to bind (``[::]:<port>``).
+
+    Returns:
+        A started ``grpc.aio.Server`` instance.
+    """
+    server = grpc.aio.server()
+    handler = LangGraphHandler()
+    add_AgentServiceServicer_to_server(AgentServicer(router, handler), server)
+    server.add_insecure_port(f"[::]:{port}")
+    await server.start()
+    log.info("langgraph-adapter serving", extra={"port": port})
+    return server
+
+
+async def _wait_for_signal() -> None:
+    """Block until SIGTERM or SIGINT is received."""
+    stop_event = asyncio.Event()
+    loop = asyncio.get_running_loop()
+    loop.add_signal_handler(signal.SIGTERM, stop_event.set)
+    loop.add_signal_handler(signal.SIGINT, stop_event.set)
+    await stop_event.wait()
+
+
+async def _shutdown(
+    agent_id: str,
+    stub: object,
+    server: grpc.aio.Server,
+    channel: grpc.aio.Channel,
+) -> None:
+    """Deregister, stop the gRPC server, and close the registry channel.
+
+    Args:
+        agent_id: The registered agent identifier to deregister.
+        stub: Registry stub used for DeregisterAgent.
+        server: The running gRPC server to stop.
+        channel: The registry channel to close.
+    """
+    try:
+        await deregister_agent(agent_id, stub)
+    except Exception as exc:
+        log.warning("deregister failed", extra={"err": str(exc)})
+    await server.stop(grace=5)
+    await channel.close()
+    log.info("langgraph-adapter stopped")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/agents/adapters/langgraph/src/langgraph_adapter/registry/__init__.py
+++ b/agents/adapters/langgraph/src/langgraph_adapter/registry/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+"""langgraph-adapter registry sub-package — RegisterAgent / DeregisterAgent helpers."""

--- a/agents/adapters/langgraph/src/langgraph_adapter/registry/client.py
+++ b/agents/adapters/langgraph/src/langgraph_adapter/registry/client.py
@@ -1,0 +1,124 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Registry client — RegisterAgent / DeregisterAgent with exponential-backoff retry."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+import grpc
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+from zynax.v1 import agent_registry_pb2  # type: ignore[import-untyped]
+
+log = logging.getLogger(__name__)
+
+_MAX_ATTEMPTS = 5
+_BASE_DELAY = 2.0
+
+
+class RegistrySettings(BaseSettings):
+    """Registry and gRPC endpoint settings loaded from environment variables.
+
+    Attributes:
+        agent_id: Unique agent identifier for registration (``AGENT_ID``).
+        adapter_endpoint: gRPC address the task-broker dials for this adapter
+            (``ADAPTER_ENDPOINT``), e.g. ``"langgraph-adapter:50058"``.
+        grpc_port: Port the adapter's own gRPC server binds to
+            (``ZYNAX_LANGGRAPH_ADAPTER_GRPC_PORT``, default ``50058``).
+    """
+
+    model_config = SettingsConfigDict(env_prefix="", extra="ignore")
+
+    agent_id: str = Field(..., alias="AGENT_ID", min_length=1)
+    adapter_endpoint: str = Field(..., alias="ADAPTER_ENDPOINT", min_length=1)
+    grpc_port: int = Field(default=50058, alias="ZYNAX_LANGGRAPH_ADAPTER_GRPC_PORT", ge=1)
+
+
+def _is_transient(exc: Exception) -> bool:
+    """Return True when exc carries a retriable gRPC status code."""
+    code_fn = getattr(exc, "code", None)
+    if not callable(code_fn):
+        return False
+    return code_fn() in (
+        grpc.StatusCode.UNAVAILABLE,
+        grpc.StatusCode.INTERNAL,
+        grpc.StatusCode.DEADLINE_EXCEEDED,
+    )
+
+
+def build_agent_def(
+    settings: RegistrySettings,
+    capability_names: list[str],
+    schemas: dict[str, tuple[bytes, bytes]],
+) -> Any:
+    """Build an ``AgentDef`` proto from registry settings and capability list.
+
+    Args:
+        settings: Registry settings containing ``agent_id`` and ``adapter_endpoint``.
+        capability_names: Ordered list of capability names to register (one per mount).
+        schemas: Map of capability name → ``(input_schema_bytes, output_schema_bytes)``.
+
+    Returns:
+        A populated ``agent_registry_pb2.AgentDef`` instance.
+    """
+    caps = [
+        agent_registry_pb2.CapabilityDef(
+            name=name,
+            input_schema=schemas.get(name, (b"", b""))[0],
+            output_schema=schemas.get(name, (b"", b""))[1],
+        )
+        for name in capability_names
+    ]
+    return agent_registry_pb2.AgentDef(
+        agent_id=settings.agent_id,
+        name="langgraph-adapter",
+        endpoint=settings.adapter_endpoint,
+        capabilities=caps,
+    )
+
+
+async def register_agent(agent_def: Any, stub: Any) -> None:
+    """Register the adapter with the agent-registry using exponential-backoff retry.
+
+    Args:
+        agent_def: Populated ``AgentDef`` proto built by ``build_agent_def``.
+        stub: Async ``AgentRegistryServiceStub`` to call ``RegisterAgent`` on.
+
+    Raises:
+        Exception: On non-transient gRPC error, or after all retry attempts exhausted.
+    """
+    req = agent_registry_pb2.RegisterAgentRequest(agent=agent_def)
+    delay = _BASE_DELAY
+    last_exc: Exception | None = None
+    for attempt in range(_MAX_ATTEMPTS):
+        if attempt > 0:
+            log.info("retrying registration", extra={"attempt": attempt + 1, "delay_s": delay})
+            await asyncio.sleep(delay)
+            delay *= 2
+        try:
+            await stub.RegisterAgent(req)
+            log.info("agent registered", extra={"agent_id": agent_def.agent_id})
+            return
+        except Exception as exc:
+            if not _is_transient(exc):
+                raise
+            last_exc = exc
+            log.warning(
+                "registration attempt failed",
+                extra={"attempt": attempt + 1, "err": str(exc)},
+            )
+    raise RuntimeError(f"register failed after {_MAX_ATTEMPTS} attempts") from last_exc
+
+
+async def deregister_agent(agent_id: str, stub: Any) -> None:
+    """Deregister the adapter from the agent-registry (no retry).
+
+    Args:
+        agent_id: The agent identifier supplied at registration time.
+        stub: Async ``AgentRegistryServiceStub`` to call ``DeregisterAgent`` on.
+    """
+    req = agent_registry_pb2.DeregisterAgentRequest(agent_id=agent_id)
+    await stub.DeregisterAgent(req)
+    log.info("agent deregistered", extra={"agent_id": agent_id})

--- a/agents/adapters/langgraph/tests/conftest.py
+++ b/agents/adapters/langgraph/tests/conftest.py
@@ -9,3 +9,6 @@ _PROTO_PYTHON = os.path.abspath(
 )
 if _PROTO_PYTHON not in sys.path:
     sys.path.insert(0, _PROTO_PYTHON)
+
+# Pre-register the well-known timestamp descriptor required by agent_registry_pb2.
+import google.protobuf.timestamp_pb2  # noqa: E402, F401

--- a/agents/adapters/langgraph/tests/test_registry.py
+++ b/agents/adapters/langgraph/tests/test_registry.py
@@ -1,0 +1,205 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for langgraph_adapter.registry.client."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import grpc
+import pytest
+from zynax.v1 import agent_registry_pb2  # type: ignore[import-untyped]
+
+from langgraph_adapter.registry.client import (
+    _MAX_ATTEMPTS,
+    RegistrySettings,
+    _is_transient,
+    build_agent_def,
+    deregister_agent,
+    register_agent,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _TransientError(Exception):
+    """Fake gRPC error with a retriable status code."""
+
+    def code(self) -> grpc.StatusCode:
+        return grpc.StatusCode.UNAVAILABLE
+
+
+class _PermanentError(Exception):
+    """Fake gRPC error with a non-retriable status code."""
+
+    def code(self) -> grpc.StatusCode:
+        return grpc.StatusCode.ALREADY_EXISTS
+
+
+def _settings() -> RegistrySettings:
+    return RegistrySettings(
+        AGENT_ID="lg-test",
+        ADAPTER_ENDPOINT="langgraph-adapter:50058",
+    )
+
+
+def _fake_def() -> agent_registry_pb2.AgentDef:
+    return agent_registry_pb2.AgentDef(agent_id="lg-test", endpoint="langgraph-adapter:50058")
+
+
+# ---------------------------------------------------------------------------
+# _is_transient
+# ---------------------------------------------------------------------------
+
+
+class TestIsTransient:
+    """_is_transient classifies gRPC status codes correctly."""
+
+    def test_unavailable_is_transient(self) -> None:
+        assert _is_transient(_TransientError()) is True
+
+    def test_already_exists_is_not_transient(self) -> None:
+        assert _is_transient(_PermanentError()) is False
+
+    def test_plain_exception_is_not_transient(self) -> None:
+        assert _is_transient(ValueError("nope")) is False
+
+
+# ---------------------------------------------------------------------------
+# build_agent_def
+# ---------------------------------------------------------------------------
+
+
+class TestBuildAgentDef:
+    """build_agent_def populates AgentDef from settings and capability list."""
+
+    def test_single_capability_included(self) -> None:
+        settings = _settings()
+        schemas = {"research_topic": (b'{"type":"object"}', b'{"type":"object"}')}
+        agent_def = build_agent_def(settings, ["research_topic"], schemas)
+        assert len(agent_def.capabilities) == 1
+        assert agent_def.capabilities[0].name == "research_topic"
+
+    def test_multiple_capabilities(self) -> None:
+        settings = _settings()
+        caps = ["graph_a", "graph_b"]
+        agent_def = build_agent_def(settings, caps, {})
+        assert [c.name for c in agent_def.capabilities] == caps
+
+    def test_agent_id_and_endpoint_set(self) -> None:
+        settings = _settings()
+        agent_def = build_agent_def(settings, [], {})
+        assert agent_def.agent_id == "lg-test"
+        assert agent_def.endpoint == "langgraph-adapter:50058"
+
+    def test_schema_bytes_copied(self) -> None:
+        settings = _settings()
+        inp, out = b'{"in":1}', b'{"out":1}'
+        agent_def = build_agent_def(settings, ["cap"], {"cap": (inp, out)})
+        cap = agent_def.capabilities[0]
+        assert cap.input_schema == inp
+        assert cap.output_schema == out
+
+
+# ---------------------------------------------------------------------------
+# register_agent
+# ---------------------------------------------------------------------------
+
+
+class TestRegisterAgent:
+    """register_agent retries on transient errors and raises on permanent ones."""
+
+    @pytest.mark.asyncio
+    async def test_succeeds_on_first_attempt(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("langgraph_adapter.registry.client.asyncio.sleep", AsyncMock())
+        stub = MagicMock()
+        stub.RegisterAgent = AsyncMock(return_value=MagicMock())
+        await register_agent(_fake_def(), stub)
+        stub.RegisterAgent.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_retries_on_transient_then_succeeds(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr("langgraph_adapter.registry.client.asyncio.sleep", AsyncMock())
+        stub = MagicMock()
+        stub.RegisterAgent = AsyncMock(
+            side_effect=[_TransientError(), _TransientError(), MagicMock()]
+        )
+        await register_agent(_fake_def(), stub)
+        assert stub.RegisterAgent.await_count == 3
+
+    @pytest.mark.asyncio
+    async def test_raises_on_permanent_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("langgraph_adapter.registry.client.asyncio.sleep", AsyncMock())
+        stub = MagicMock()
+        stub.RegisterAgent = AsyncMock(side_effect=_PermanentError())
+        with pytest.raises(_PermanentError):
+            await register_agent(_fake_def(), stub)
+        stub.RegisterAgent.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_raises_after_max_attempts_exhausted(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr("langgraph_adapter.registry.client.asyncio.sleep", AsyncMock())
+        stub = MagicMock()
+        stub.RegisterAgent = AsyncMock(side_effect=_TransientError())
+        with pytest.raises(RuntimeError):
+            await register_agent(_fake_def(), stub)
+        assert stub.RegisterAgent.await_count == _MAX_ATTEMPTS
+
+
+# ---------------------------------------------------------------------------
+# deregister_agent
+# ---------------------------------------------------------------------------
+
+
+class TestDeregisterAgent:
+    """deregister_agent calls stub once with the correct agent_id."""
+
+    @pytest.mark.asyncio
+    async def test_calls_stub_once(self) -> None:
+        stub = MagicMock()
+        stub.DeregisterAgent = AsyncMock(return_value=MagicMock())
+        await deregister_agent("lg-test", stub)
+        stub.DeregisterAgent.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_propagates_errors(self) -> None:
+        stub = MagicMock()
+        stub.DeregisterAgent = AsyncMock(side_effect=RuntimeError("down"))
+        with pytest.raises(RuntimeError):
+            await deregister_agent("lg-test", stub)
+
+
+# ---------------------------------------------------------------------------
+# RegistrySettings
+# ---------------------------------------------------------------------------
+
+
+class TestRegistrySettings:
+    """RegistrySettings loads from env vars and validates required fields."""
+
+    def test_valid_settings(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("AGENT_ID", "lg-1")
+        monkeypatch.setenv("ADAPTER_ENDPOINT", "langgraph-adapter:50058")
+        s = RegistrySettings()  # type: ignore[call-arg]
+        assert s.agent_id == "lg-1"
+        assert s.grpc_port == 50058
+
+    def test_custom_grpc_port(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("AGENT_ID", "lg-1")
+        monkeypatch.setenv("ADAPTER_ENDPOINT", "langgraph-adapter:50060")
+        monkeypatch.setenv("ZYNAX_LANGGRAPH_ADAPTER_GRPC_PORT", "50060")
+        s = RegistrySettings()  # type: ignore[call-arg]
+        assert s.grpc_port == 50060
+
+    def test_missing_agent_id_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from pydantic import ValidationError
+
+        monkeypatch.delenv("AGENT_ID", raising=False)
+        monkeypatch.setenv("ADAPTER_ENDPOINT", "langgraph-adapter:50058")
+        with pytest.raises(ValidationError):
+            RegistrySettings()  # type: ignore[call-arg]

--- a/docs/milestones/M5-plan.md
+++ b/docs/milestones/M5-plan.md
@@ -6,7 +6,7 @@
 **GitHub Milestone:** [Adapter Library (M5)](https://github.com/zynax-io/zynax/milestone/5)
 **Parent epic:** [#377](https://github.com/zynax-io/zynax/issues/377)
 **Status:** In Progress
-**Last updated:** 2026-05-28 (rev 75 — #412 ✅ llm-adapter registry client + bootstrap)
+**Last updated:** 2026-05-28 (rev 76 — #417 ✅ langgraph-adapter registry client + bootstrap)
 
 ---
 
@@ -429,7 +429,7 @@ Streaming response must emit `PROGRESS` task events during generation.
 |-------|------|-------|--------|
 | [#415](https://github.com/zynax-io/zynax/issues/415) | O2 | Module scaffold + GraphMount config | ✅ Done |
 | [#416](https://github.com/zynax-io/zynax/issues/416) | O3 | GraphLoader + LangGraphHandler | ✅ Done |
-| [#417](https://github.com/zynax-io/zynax/issues/417) | O4 | Registry client + bootstrap | ⬜ Open (blocked on #416) |
+| [#417](https://github.com/zynax-io/zynax/issues/417) | O4 | Registry client + bootstrap | ✅ Done |
 | [#418](https://github.com/zynax-io/zynax/issues/418) | O5 | Dockerfile, docker-compose, AGENTS.md | ⬜ Open (blocked on #417) |
 
 **Engineer profile:** Python engineer with LangGraph experience. Read `docs/spdd/384-langgraph-adapter/canvas.md`.

--- a/state/current-milestone.md
+++ b/state/current-milestone.md
@@ -81,7 +81,7 @@ All steps done: #526 ✅ #527 ✅ #528 ✅ #481 ✅. Compose wired.
 | [#713](https://github.com/zynax-io/zynax/issues/713) | Adapters | git-adapter quality epic (coverage ≥85%) | ✅ Complete — #714 ✅ #715 ✅ #716 ✅ #717 ✅ #718 ✅ all merged |
 | ~~[#382](https://github.com/zynax-io/zynax/issues/382)~~ | Adapters | ci-adapter impl | ✅ Closed — all steps done (#404–#408) |
 | [#383](https://github.com/zynax-io/zynax/issues/383) | Adapters | llm-adapter impl | open — #409 BDD ✅; #410 ✅ scaffold+config; #411 ✅ providers+handler+router+server; #412 ✅ registry+bootstrap; #413 pending |
-| [#384](https://github.com/zynax-io/zynax/issues/384) | Adapters | langgraph-adapter impl | open — #414 BDD ✅; #415 ✅ scaffold+config; #416 ✅ GraphLoader+handler+router+server; #417+ pending |
+| [#384](https://github.com/zynax-io/zynax/issues/384) | Adapters | langgraph-adapter impl | open — #414 BDD ✅; #415 ✅ scaffold+config; #416 ✅ GraphLoader+handler+router+server; #417 ✅ registry+bootstrap; #418 pending |
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds `src/langgraph_adapter/registry/client.py`: `RegistrySettings` (env-var settings), `build_agent_def`, `register_agent` (5-attempt exponential backoff, 2 s base), `deregister_agent`
- Adds `src/langgraph_adapter/__main__.py`: asyncio bootstrap — load `AdapterConfig` + `RegistrySettings`, call `GraphLoader.load_all` (exit 1 on failure), build `CapabilityRouter`, register all graph capabilities with agent-registry, start gRPC server on `ZYNAX_LANGGRAPH_ADAPTER_GRPC_PORT` (default `50058`), await SIGTERM, deregister, stop
- Adds `tests/test_registry.py`: 16 tests covering retry paths, transient/permanent error classification, multi-capability `build_agent_def`, and settings validation
- Pre-imports `google.protobuf.timestamp_pb2` in `conftest.py` to fix descriptor-pool initialization for `agent_registry_pb2` tests

## Why

Canvas 384-langgraph-adapter O4 — [#417](https://github.com/zynax-io/zynax/issues/417)

## Cluster

Sibling cluster with [#412](https://github.com/zynax-io/zynax/pull/new/feat/412-llm-registry-client-bootstrap) (llm-adapter O4, independent). Merge order: either order acceptable — both branch from `main`.

## State files updated

- `docs/milestones/M5-plan.md` — `#417` row ⬜→✅, rev 76
- `state/current-milestone.md` — langgraph-adapter track updated; next queue updated

## Architecture gaps

Gap scan done: G1/G4/G7/G16 — none applicable to Python adapter code.

## Test plan

### Local pre-flight
- [x] `ruff check src/ tests/` — exit 0 (All checks passed)
- [x] `uv run pytest tests/test_registry.py -v` — 16/16 passed
- [x] `make test-coverage` — N/A (Go only)
- [x] `make security` — N/A (Python adapters not yet in security make gate)

### Acceptance (issue body / Canvas O4)
- [x] `RegisterAgent` called once per `GraphMount.capability_name` on startup — `_build_def` in `__main__.py` calls `router.capability_names()` and passes all to `build_agent_def`; `TestBuildAgentDef::test_multiple_capabilities` verifies
- [x] Registration retries ≥ 3 attempts with exponential backoff — `TestRegisterAgent::test_retries_on_transient_then_succeeds` confirms 3 calls with `asyncio.sleep` mocked
- [x] `DeregisterAgent` called on SIGTERM — `TestDeregisterAgent::test_calls_stub_once` covers; `_shutdown` in `__main__.py` calls it
- [x] gRPC server starts only after all graphs loaded and registration succeeds — `main()` calls `_load_graphs` then awaits `register_agent` before `_start_server`; `_load_graphs` exits non-zero on any failure
- [x] Port configurable via `ZYNAX_LANGGRAPH_ADAPTER_GRPC_PORT` — `RegistrySettings.grpc_port` field; `TestRegistrySettings::test_custom_grpc_port` verifies

### Engineering hygiene
- [x] **`M5-plan.md` row flipped ⬜→✅ in this diff** (mandatory)
- [x] **`current-milestone.md` updated in this diff** (mandatory)
- [x] Branched from fresh `origin/main` · PR ≤900 lines · trailers on every commit
- [x] Gap scan done (G1/G4/G7/G16) — none applicable
- [x] Canvas O4 ✅ (`docs/spdd/384-langgraph-adapter/canvas.md` — O4 step: registry client + bootstrap) · no new public capability/endpoint
- [x] No out-of-scope edits · no mTLS/SBOM/cosign docs claims

Closes #417
