### PR TITLE
chore(adapters/llm): containerise adapter and wire into compose

### DIFF
--- a/agents/adapters/llm/AGENTS.md
+++ b/agents/adapters/llm/AGENTS.md
@@ -1,0 +1,65 @@
+# agents/adapters/llm — LLM Provider Capability Adapter
+
+Python adapter service implementing `AgentService` for LLM inference via OpenAI, AWS Bedrock, and Ollama.
+
+## Module
+
+`llm-adapter` · `src/llm_adapter/`
+
+## Capabilities
+
+| Name | Description |
+|------|-------------|
+| `chat_completion` | Stream a multi-turn chat completion. Provider is selected by `LLM_PROVIDER`. Returns streamed `PROGRESS` events during generation and a final `COMPLETED` event with the full response text. |
+
+## Supported Providers
+
+| `LLM_PROVIDER` value | SDK | Required env vars |
+|----------------------|-----|-------------------|
+| `openai` | `openai` | `OPENAI_API_KEY` |
+| `bedrock` | `aiobotocore` | `AWS_REGION` (+ ambient AWS credentials) |
+| `ollama` | `httpx` (REST) | `OLLAMA_BASE_URL` |
+
+## Environment Variables
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `LLM_PROVIDER` | ✓ | — | Active provider: `openai`, `bedrock`, or `ollama`. |
+| `AGENT_ID` | ✓ | — | Unique agent identifier registered with agent-registry. |
+| `ADAPTER_ENDPOINT` | ✓ | — | gRPC address the task-broker dials, e.g. `llm-adapter:50057`. |
+| `REGISTRY_ADDR` | ✓ | — | agent-registry gRPC address, e.g. `agent-registry:50052`. |
+| `OPENAI_API_KEY` | ✓ if openai | — | OpenAI API key (never log or echo). |
+| `OLLAMA_BASE_URL` | ✓ if ollama | — | Ollama REST base URL, e.g. `http://ollama:11434`. |
+| `AWS_REGION` | ✓ if bedrock | — | AWS region for the Bedrock endpoint. |
+| `LLM_MODEL` | — | `gpt-4o` / `anthropic.claude-3-5-sonnet-20241022-v2:0` / `llama3.2` | Model name; provider-specific default applies when unset. |
+| `LLM_MAX_TOKENS` | — | `4096` | Maximum token ceiling enforced before calling the provider. |
+| `ZYNAX_LLM_ADAPTER_GRPC_PORT` | — | `50057` | TCP port the adapter's gRPC server binds to. |
+
+API keys are stored as `pydantic.SecretStr` — they never appear in repr, logs, or error messages.
+
+## gRPC Port
+
+Default: **50057** (override via `ZYNAX_LLM_ADAPTER_GRPC_PORT`).
+
+## Docker Compose (local dev — Ollama)
+
+Add to your `.env` (values never in `docker-compose.yml`):
+```
+LLM_PROVIDER=ollama
+OLLAMA_BASE_URL=http://host.docker.internal:11434
+LLM_MODEL=llama3.2
+```
+
+Ollama must be running on the Docker host. With Docker Desktop, `host.docker.internal` resolves to the host machine automatically. On Linux, add `--add-host=host.docker.internal:host-gateway` or use your host IP.
+
+## Testing
+
+```bash
+cd agents/adapters/llm
+uv run pytest tests/ -v
+uv run pytest tests/ --cov=src --cov-fail-under=80 -v
+```
+
+## Reference
+
+Canvas: `docs/spdd/383-llm-adapter/canvas.md`

--- a/agents/adapters/llm/Dockerfile
+++ b/agents/adapters/llm/Dockerfile
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: Apache-2.0
+# Build context: repo root  (docker build -f agents/adapters/llm/Dockerfile .)
+#
+# Two-stage build:
+#   builder  — python:3.12-slim + uv; installs locked dependencies into /app/.venv
+#   runtime  — python:3.12-slim; copies venv + source + proto stubs; runs as zynax (UID 1001)
+#
+# Required env vars at runtime: LLM_PROVIDER, REGISTRY_ADDR, AGENT_ID, ADAPTER_ENDPOINT
+# Provider-specific: OPENAI_API_KEY | AWS_REGION | OLLAMA_BASE_URL
+# Optional: LLM_MODEL, LLM_MAX_TOKENS, ZYNAX_LLM_ADAPTER_GRPC_PORT (default 50057)
+
+# renovate: datasource=docker depName=python versioning=docker
+FROM python:3.12-slim@sha256:68f78b84b35ab1d74a1a7a04a5447b2d1f5fcf0b7f38dee97a3a1de3c2eac65e AS builder
+
+WORKDIR /app
+
+# Install uv for fast, deterministic dependency resolution
+# renovate: datasource=docker depName=ghcr.io/astral-sh/uv
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
+# Install locked dependencies (without the project itself — source is copied separately)
+COPY agents/adapters/llm/pyproject.toml agents/adapters/llm/uv.lock ./
+RUN uv sync --no-dev --no-install-project --frozen
+
+# renovate: datasource=docker depName=python versioning=docker
+FROM python:3.12-slim@sha256:68f78b84b35ab1d74a1a7a04a5447b2d1f5fcf0b7f38dee97a3a1de3c2eac65e
+
+WORKDIR /app
+
+# Non-root user (ADR-002)
+RUN useradd -r -u 1001 -g nogroup zynax
+
+# Venv with all locked dependencies
+COPY --from=builder /app/.venv /app/.venv
+
+# Generated proto stubs (zynax.v1.*)
+COPY protos/generated/python/ /protos/
+
+# Adapter source package
+COPY agents/adapters/llm/src/ /app/src/
+
+ENV PATH="/app/.venv/bin:$PATH"
+ENV PYTHONPATH="/app/src:/protos"
+
+USER zynax
+
+CMD ["python", "-m", "llm_adapter"]

--- a/docs/milestones/M5-plan.md
+++ b/docs/milestones/M5-plan.md
@@ -6,7 +6,7 @@
 **GitHub Milestone:** [Adapter Library (M5)](https://github.com/zynax-io/zynax/milestone/5)
 **Parent epic:** [#377](https://github.com/zynax-io/zynax/issues/377)
 **Status:** In Progress
-**Last updated:** 2026-05-28 (rev 76 — #417 ✅ langgraph-adapter registry client + bootstrap)
+**Last updated:** 2026-05-28 (rev 77 — #413 ✅ llm-adapter Dockerfile + compose + AGENTS.md)
 
 ---
 
@@ -416,7 +416,7 @@ exponential backoff and a configurable max-poll-duration.
 | [#410](https://github.com/zynax-io/zynax/issues/410) | O2 | Module scaffold + ProviderConfig | ✅ Done |
 | [#411](https://github.com/zynax-io/zynax/issues/411) | O3 | Provider handlers (OpenAI, Bedrock, Ollama) | ✅ Done |
 | [#412](https://github.com/zynax-io/zynax/issues/412) | O4 | Registry client + bootstrap | ✅ Done |
-| [#413](https://github.com/zynax-io/zynax/issues/413) | O5 | Dockerfile, docker-compose, AGENTS.md | ⬜ Open (blocked on #412) |
+| [#413](https://github.com/zynax-io/zynax/issues/413) | O5 | Dockerfile, docker-compose, AGENTS.md | ✅ Done |
 
 **Engineer profile:** Python engineer with LLM API experience. Read `docs/spdd/383-llm-adapter/canvas.md`.
 Capability: `chat_completion`. Provider support: OpenAI (via `openai` SDK), AWS Bedrock

--- a/infra/docker-compose/docker-compose.yml
+++ b/infra/docker-compose/docker-compose.yml
@@ -231,6 +231,30 @@ services:
       retries: 10
       start_period: 15s
 
+  llm-adapter:
+    image: ghcr.io/zynax-io/zynax/llm-adapter:main
+    build:
+      context: ../..
+      dockerfile: agents/adapters/llm/Dockerfile
+    environment:
+      AGENT_ID: llm-adapter
+      ADAPTER_ENDPOINT: "llm-adapter:50057"
+      REGISTRY_ADDR: "agent-registry:50052"
+      ZYNAX_LLM_ADAPTER_GRPC_PORT: "50057"
+      LLM_PROVIDER: ${LLM_PROVIDER:-ollama}
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      OLLAMA_BASE_URL: ${OLLAMA_BASE_URL:-http://ollama:11434}
+      LLM_MODEL: ${LLM_MODEL:-llama3.2}
+    depends_on:
+      agent-registry:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "python", "-c", "import socket; socket.create_connection(('localhost', 50057), 2).close()"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+
 volumes:
   postgres-data:
   nats-data:

--- a/state/current-milestone.md
+++ b/state/current-milestone.md
@@ -142,15 +142,15 @@ Priority gaps to file immediately:
 | [#717](https://github.com/zynax-io/zynax/issues/717) | Cover RegisterAgent retry + isTransient + cmd | ✅ Done — PR #724 merged |
 | [#718](https://github.com/zynax-io/zynax/issues/718) | Re-add git to GO_ADAPTER_LIST | ✅ Done — PR #725 merged |
 
-## Active Work (BATCH 7 — adapter O4 step)
+## Active Work (BATCH 7 — adapter O5 step)
 
 | Issue | Title | Status |
 |-------|-------|--------|
-| [#411](https://github.com/zynax-io/zynax/issues/411) | llm-adapter provider handlers — OpenAI, Bedrock, Ollama | ✅ Done — PR #738/#736 merged |
-| [#416](https://github.com/zynax-io/zynax/issues/416) | langgraph-adapter GraphLoader + LangGraphHandler | ✅ Done — PR #737 merged |
-| [#412](https://github.com/zynax-io/zynax/issues/412) | llm-adapter registry client + bootstrap | ✅ Done — PR pending merge |
-| [#417](https://github.com/zynax-io/zynax/issues/417) | langgraph-adapter registry client + bootstrap | ⬜ Open — in progress |
+| [#412](https://github.com/zynax-io/zynax/issues/412) | llm-adapter registry client + bootstrap | ✅ Done — merged |
+| [#417](https://github.com/zynax-io/zynax/issues/417) | langgraph-adapter registry client + bootstrap | ✅ Done — merged |
+| [#413](https://github.com/zynax-io/zynax/issues/413) | llm-adapter Dockerfile + docker-compose + AGENTS.md | ✅ Done — PR in review |
+| [#418](https://github.com/zynax-io/zynax/issues/418) | langgraph-adapter Dockerfile + docker-compose + AGENTS.md | ⬜ Open — in progress |
 
 ## Next Session Queue (priority order)
 
-After #412 + #417: #413/#418 (Dockerfile + docker-compose service).
+After #413 + #418: close epics #383 #384, then check #377 (Adapter Library) exit criteria.

--- a/tools/gitleaks-ai-context.toml
+++ b/tools/gitleaks-ai-context.toml
@@ -56,12 +56,13 @@ tags        = ["infrastructure"]
 # 'local' as a standalone word or in NATS URLs is fine (dev environment docs)
 regexes     = ['''nats://localhost|nats://local\b|description.*[Ll]ocal''']
 # .dockerignore / .gitignore list glob patterns — never real hostnames
-# infra/AGENTS.md documents .env.local as a filename, not a hostname
+# infra/AGENTS.md and agents/*/AGENTS.md document Docker bridge hostnames (host.docker.internal)
 # Policy doc uses counter-examples
 paths       = [
   '''\.dockerignore$''',
   '''\.gitignore$''',
   '''infra/AGENTS\.md''',
+  '''agents/.*/AGENTS\.md''',
   '''docs/knowledge-base-policy\.md''',
 ]
 


### PR DESCRIPTION
## Summary

- Add `agents/adapters/llm/Dockerfile` — two-stage `python:3.12-slim` build; uv installs locked dependencies into `.venv`; source and proto stubs injected via `PYTHONPATH`; runs as unprivileged user `zynax` (UID 1001)
- Add `llm-adapter` service to `infra/docker-compose/docker-compose.yml` — port 50057, defaults to Ollama provider for local dev
- Add `agents/adapters/llm/AGENTS.md` — documents `chat_completion` capability, all three providers, required env vars, gRPC port, and local dev setup
- Fix gitleaks `internal-hostname` rule: add `agents/*/AGENTS.md` to paths allowlist (`host.docker.internal` is a public Docker hostname, not an infrastructure secret)
- Fix `state/current-milestone.md`: #417 was closed on GitHub but showed ⬜

## Why

Closes [#413](https://github.com/zynax-io/zynax/issues/413) — llm-adapter O5 step (Dockerfile + docker-compose + AGENTS.md).
Canvas step: `docs/spdd/383-llm-adapter/canvas.md` O7.
Completes epic [#383](https://github.com/zynax-io/zynax/issues/383) (llm-adapter).

## Cluster

Sibling PRs (independent, merge in order):
1. **This PR** — #413 llm-adapter O5
2. [#418 langgraph-adapter O5](#418) — to be opened next

## State files updated

- `docs/milestones/M5-plan.md` — #413 row ⬜→✅; Last updated bumped
- `state/current-milestone.md` — #413 ✅, #417 mismatch fixed

## Architecture gaps

Gap scan: G1/G4/G7/G16 — not touched by this PR (packaging only).

## Test plan

### Local pre-flight
- [x] `make lint-agents` — N/A (AGENTS.md + Dockerfile only, no Python source changes)
- [x] `GOWORK=off go test ./...` — N/A (no Go changes)
- [x] `make test-coverage` — N/A (no domain changes)
- [x] `make test-coverage-adapters` — N/A (no Python source changes)
- [x] `make security` — N/A (no source changes; gitleaks config fix validated locally: `gitleaks protect --staged` passes)
- [x] Dockerfile syntax: two-stage python:3.12-slim build with uv; CMD `python -m llm_adapter`
- [x] docker-compose service: correct env vars (AGENT_ID, ADAPTER_ENDPOINT, REGISTRY_ADDR, LLM_PROVIDER, OPENAI_API_KEY, OLLAMA_BASE_URL, LLM_MODEL, ZYNAX_LLM_ADAPTER_GRPC_PORT)
- [x] healthcheck uses Python socket (no external binary required in slim image)

### Acceptance (issue #413)
- [x] `agents/adapters/llm/Dockerfile` present — two-stage python:3.12-slim + uv
- [x] `llm-adapter` service in `docker-compose.yml` with all required env vars documented
- [x] `AGENTS.md` documents: capability name, providers, required env vars, gRPC port (50057)
- [x] No credentials in `AGENTS.md` or Dockerfile

### Engineering hygiene
- [x] **`M5-plan.md` row flipped ⬜→✅ in this diff** (mandatory)
- [x] **`current-milestone.md` updated in this diff** (mandatory)
- [x] Branched from fresh `origin/main` · PR ≤900 lines (155 lines) · trailers on every commit
- [x] Gap scan done (G1/G4/G7/G16 — N/A for packaging PR)
- [x] Canvas O7 step addressed · AGENTS.md added as new capability doc
- [x] No out-of-scope edits · no mTLS/SBOM/cosign docs claims

## Out of scope

- Kubernetes Helm chart (M6+)
- GPU-specific container configuration (M6+)
- Any capability or registry client changes

Closes #413