### PR TITLE
docs(architecture): document CI gates as architecture fitness functions (#232)

### DIFF
--- a/docs/architecture/fitness-functions.md
+++ b/docs/architecture/fitness-functions.md
@@ -1,0 +1,45 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Architecture Fitness Functions
+
+An **architecture fitness function** (Richards & Ford, *Building Evolutionary Architectures*) is
+an automated, executable assertion on an architecture quality attribute. Every gate in the Zynax
+CI pipeline is a fitness function: it encodes a decision the team made and enforces it on every PR.
+
+See ADR-016 for the layered testing strategy that governs when each gate runs.
+
+---
+
+## Current Gates
+
+| Gate | CI job | Quality attribute | Threshold | Exception process |
+|------|--------|-------------------|-----------|-------------------|
+| `buf breaking` | `proto-breaking` | Proto backward compatibility | Zero field removals / renames | N/A — no exceptions; file a new proto version |
+| `golangci-lint` | `lint` | Go code quality | Zero warnings | `.golangci.yml` `nolint` directive with comment |
+| `ruff` + `mypy` | `lint` | Python code quality | Zero errors, `mypy --strict` | `# noqa` / `# type: ignore` with comment |
+| `coverage-gate` | `test-unit` | Domain logic coverage | ≥90% per Go service · ≥85% per adapter | None — raise the bar instead |
+| `pr-size` | `pr-size` | PR reviewability | ≤900 lines (excl. generated, lock files, fixtures) | Justify in PR body; human maintainer unblocks |
+| `gitleaks` | `security` | Secret exposure | Zero detected secrets | `.gitleaks.toml` allow-list entry with rationale |
+| `govulncheck` | `security` | Go CVEs | Zero HIGH/CRITICAL | No exceptions; upgrade or replace the dep |
+| `pip-audit` | `security` | Python CVEs | Zero | No exceptions; upgrade or replace the dep |
+| `bandit` | `security` | Python SAST | Zero HIGH/MEDIUM | `# nosec` with comment explaining why it's safe |
+| `canvas-freshness` | `canvas-freshness` | SPDD compliance | Canvas present and `Aligned` for `feat:` PRs | N/A — align or change type |
+| `dco` | `dco` | Contributor sign-off | Every commit has `Signed-off-by:` | N/A — rebase and re-sign |
+| `buf generate` | `proto-generate` | Generated stub freshness | Stubs match proto source | Regenerate via `make generate-protos` |
+| `trivy` | `release` | Container CVEs before GHCR push | Zero HIGH/CRITICAL in published images | Upgrade base image or dep |
+
+---
+
+## Adding a New Fitness Function
+
+When a quality attribute becomes important enough to enforce automatically:
+
+1. Write the check as a standalone CI step (prefer a pre-built tool; avoid bespoke scripts).
+2. Set a threshold that is *already met* on `main` — do not introduce a failing gate.
+3. Add it to this table.
+4. If the new gate enforces an architectural decision, create an ADR (see `docs/adr/INDEX.md`).
+5. If it is a required status check, update the branch protection rule.
+
+---
+
+*References: Epic #173 (Pillar 5 — Architecture Traceability) · ADR-016 (layered testing strategy)*

--- a/docs/milestones/M5-plan.md
+++ b/docs/milestones/M5-plan.md
@@ -6,7 +6,7 @@
 **GitHub Milestone:** [Adapter Library (M5)](https://github.com/zynax-io/zynax/milestone/5)
 **Parent epic:** [#377](https://github.com/zynax-io/zynax/issues/377)
 **Status:** In Progress
-**Last updated:** 2026-05-28 (rev 85 — #555 ✅; BATCH 5 Group E complete)
+**Last updated:** 2026-05-28 (rev 86 — #232 ✅; BATCH 9 added)
 
 ---
 
@@ -728,6 +728,24 @@ Standalone quality improvements that don't fit earlier batches. All are XS, SPDD
 | [#373](https://github.com/zynax-io/zynax/issues/373) | refactor | Thread ctx in workflow-compiler gRPC handlers | XS | ✅ Done |
 | [#374](https://github.com/zynax-io/zynax/issues/374) | docs | ctx-first mandate in services/AGENTS.md + Temporal comment | XS | ✅ Done |
 | [#375](https://github.com/zynax-io/zynax/issues/375) | ci | Enable ruff D (Google docstrings) in agents/sdk | XS | ✅ Done |
+
+---
+
+### BATCH 9 — Documentation Quality (P1/P2 · independent, no code dependencies)
+
+Open M5 milestone issues not previously tracked in this plan. All are SPDD-exempt (`docs:` / `refactor:` types).
+
+| Issue | Type | Title | Size | Status |
+|-------|------|-------|------|--------|
+| [#228](https://github.com/zynax-io/zynax/issues/228) | docs | Google-style docstrings on all public symbols in agents/sdk | S | ⬜ |
+| [#229](https://github.com/zynax-io/zynax/issues/229) | refactor | Strip explanatory comments in agents/sdk + agents/examples | S | ⬜ |
+| [#232](https://github.com/zynax-io/zynax/issues/232) | docs | Architecture fitness functions — document all CI gates | XS | ✅ Done |
+| [#248](https://github.com/zynax-io/zynax/issues/248) | docs | AI-output review checklist in PR template + ai-review-guide | S | ⬜ |
+| [#376](https://github.com/zynax-io/zynax/issues/376) | docs | Google-style docstrings — step 2 (blocked on SDK modules) | M | ⬜ blocked |
+
+**Notes:**
+- #235 (SBOM) and #239 (SLSA provenance) are superseded by M6.C child #489 — close when M6 goes active.
+- #376 is blocked until SDK runtime/context/capability modules are implemented (beyond M5 scope).
 
 ---
 

--- a/state/current-milestone.md
+++ b/state/current-milestone.md
@@ -159,7 +159,21 @@ Priority gaps to file immediately:
 | [#374](https://github.com/zynax-io/zynax/issues/374) | ctx-first mandate in services/AGENTS.md + Temporal comment | ✅ Done |
 | [#375](https://github.com/zynax-io/zynax/issues/375) | Enable ruff D (Google docstrings) in agents/sdk | ✅ Done |
 
+## Active Work (BATCH 9 — Documentation Quality)
+
+| Issue | Title | Status |
+|-------|-------|--------|
+| [#232](https://github.com/zynax-io/zynax/issues/232) | Architecture fitness functions doc | ✅ Done — PR pending |
+| [#248](https://github.com/zynax-io/zynax/issues/248) | AI-output review checklist in PR template | ⬜ In progress |
+| [#228](https://github.com/zynax-io/zynax/issues/228) | Google-style docstrings on SDK public symbols | ⬜ Ready |
+| [#229](https://github.com/zynax-io/zynax/issues/229) | Strip explanatory comments in agents/sdk | ⬜ Ready |
+
 ## Next Session Queue (priority order)
 
 Remaining open M5 non-epic issues:
+- **#248** (docs: AI-output review checklist, S) — HIGH priority; PR in progress
+- **#228** (docs: SDK docstrings, S) — LOW priority; ready
+- **#229** (refactor: strip comments, S) — LOW priority; ready
+- **#376** (docs: SDK docstrings step 2) — BLOCKED on SDK modules (M6+ scope)
+- **#235**, **#239** (SBOM/SLSA) — superseded by M6.C #489; close when M6 activates
 - **#656** (feat: gRPC Health Checking, L) — M6 prep; defer to M6


### PR DESCRIPTION
## Why

The project has many CI quality gates but they are scattered across workflow files with no
single authoritative list of what quality attributes are being asserted and why. Without this
list, new contributors don't know what's enforced, maintainers can't audit coverage, and adding
a new gate has no documented process.

Closes #232

---

## What Changed

- Created `docs/architecture/fitness-functions.md` (47 lines, ≤80 per AC) with:
  - Definition of "architecture fitness function" (Richards & Ford)
  - Table of all 13 current CI gates with quality attribute, threshold, and exception process
  - Documented process for adding new fitness functions
  - References to Epic #173 and ADR-016
- Added BATCH 9 to `docs/milestones/M5-plan.md` tracking five previously-untracked open M5
  docs issues (#228, #229, #232, #248, #376)

---

## Cluster

Part of BATCH 9 documentation cluster — independent siblings:

- **#232** → **this PR** (merge first)
- **#248** → docs/248-ai-review-checklist (open in parallel; merge after this)

---

## State Files Updated

- `docs/milestones/M5-plan.md` — BATCH 9 added; #232 row ⬜→✅; bumped "Last updated" to rev 86
- `state/current-milestone.md` — BATCH 9 active work table added; Next Session Queue updated

---

## Architecture Gaps

Gap scan on touched files: no G1/G4/G7/G16 candidates (docs-only change).

---

### Local pre-flight
- [x] `make lint-go`/`lint-protos`/`lint-agents` — N/A (docs only, no Go/Python/proto changed)
- [x] `GOWORK=off go test ./... -race` — N/A (docs only)
- [x] `make test-coverage` — N/A (docs only)
- [x] `make security` — N/A (docs only; gitleaks runs in CI)

### Acceptance (issue body / Canvas O-step)
- [x] `docs/architecture/fitness-functions.md` created with all current gates documented [file: docs/architecture/fitness-functions.md]
- [x] Each gate has: name, CI job name, quality attribute, threshold, exception process [fitness-functions.md table]
- [x] Document references Epic #173 and ADR-016 [last line of file]
- [x] ≤ 80 lines [47 lines total]

### Engineering hygiene
- [x] **`M5-plan.md` row flipped ⬜→✅ in this diff** (mandatory)
- [x] **`current-milestone.md` updated in this diff** (mandatory)
- [x] Branched from fresh `origin/main` · PR ≤900 lines (78 insertions) · trailers on every commit
- [x] Gap scan done (G1/G4/G7/G16) — N/A, docs-only
- [x] (N/A — docs:, SPDD-exempt) Canvas O-step · AGENTS.md not changed (no new capability)
- [x] No out-of-scope edits · no mTLS/SBOM/cosign docs claims

---

## Out of Scope

- No changes to CI workflows (gates are documented, not modified)
- No changes to actual quality thresholds

---

## AI Assistance

- [x] AI-assisted — tool/model: Claude/claude-sonnet-4-6