### PR TITLE
docs(agents): Google-style docstrings on all public SDK symbols

### DIFF
--- a/agents/sdk/src/zynax_sdk/agent.py
+++ b/agents/sdk/src/zynax_sdk/agent.py
@@ -25,6 +25,13 @@ def capability(name: str) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
         async def summarize(self, request: Any, context: Any) -> AsyncGenerator[Any, None]:
             yield self.report_progress(request.task_id, {"step": 1})
             yield self.report_completed(request.task_id, {"summary": "done"})
+
+    Args:
+        name: The capability identifier used in ``ExecuteCapabilityRequest.capability_name``.
+
+    Returns:
+        A decorator that attaches ``_capability_name`` to the wrapped method and
+        registers it during ``Agent.__init_subclass__``.
     """
 
     def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
@@ -74,14 +81,24 @@ class Agent(agent_pb2_grpc.AgentServiceServicer, ABC):  # type: ignore[misc]
                 caps[cap_name] = method
         cls._capabilities = caps
 
-    # ── gRPC handlers ──────────────────────────────────────────────────────────
-
     def ExecuteCapability(
         self,
         request: Any,
         context: Any,
     ) -> Generator[Any, None, None]:
-        """Route the request to the registered capability handler and stream events."""
+        """Route the request to the registered capability handler and stream events.
+
+        Validates ``capability_name``, ``task_id``, and ``input_payload`` before
+        dispatching.  Unknown capabilities yield a FAILED event rather than raising.
+
+        Args:
+            request: ``ExecuteCapabilityRequest`` proto message.
+            context: gRPC ``ServicerContext`` used to abort on validation failure.
+
+        Yields:
+            ``TaskEvent`` proto messages produced by the capability handler,
+            followed by at most one FAILED event if the capability is not found.
+        """
         if not request.capability_name:
             context.abort(
                 grpc.StatusCode.INVALID_ARGUMENT, "capability_name must not be empty"
@@ -122,7 +139,17 @@ class Agent(agent_pb2_grpc.AgentServiceServicer, ABC):  # type: ignore[misc]
         request: Any,
         context: Any,
     ) -> Any:
-        """Return schema metadata for a registered capability."""
+        """Return schema metadata for a registered capability.
+
+        Args:
+            request: ``GetCapabilitySchemaRequest`` proto message containing
+                ``capability_name``.
+            context: gRPC ``ServicerContext`` used to abort on validation failure.
+
+        Returns:
+            ``GetCapabilitySchemaResponse`` with placeholder JSON schemas, or
+            ``None`` after aborting the context when the capability is unknown.
+        """
         if not request.capability_name:
             context.abort(
                 grpc.StatusCode.INVALID_ARGUMENT, "capability_name must not be empty"
@@ -141,11 +168,17 @@ class Agent(agent_pb2_grpc.AgentServiceServicer, ABC):  # type: ignore[misc]
             description=f"Capability '{request.capability_name}'",
         )
 
-    # ── Event helpers ──────────────────────────────────────────────────────────
-
     @staticmethod
     def report_progress(task_id: str, payload: dict[str, Any]) -> Any:
-        """Create a PROGRESS TaskEvent."""
+        """Create a PROGRESS TaskEvent.
+
+        Args:
+            task_id: Opaque identifier from the originating ``ExecuteCapabilityRequest``.
+            payload: Arbitrary JSON-serialisable progress data yielded to the caller.
+
+        Returns:
+            A ``TaskEvent`` with ``event_type`` set to ``TASK_EVENT_TYPE_PROGRESS``.
+        """
         return agent_pb2.TaskEvent(
             task_id=task_id,
             event_type=agent_pb2.TASK_EVENT_TYPE_PROGRESS,
@@ -155,7 +188,15 @@ class Agent(agent_pb2_grpc.AgentServiceServicer, ABC):  # type: ignore[misc]
 
     @staticmethod
     def report_completed(task_id: str, payload: dict[str, Any]) -> Any:
-        """Create a COMPLETED TaskEvent."""
+        """Create a COMPLETED TaskEvent.
+
+        Args:
+            task_id: Opaque identifier from the originating ``ExecuteCapabilityRequest``.
+            payload: Final JSON-serialisable result data for the task.
+
+        Returns:
+            A ``TaskEvent`` with ``event_type`` set to ``TASK_EVENT_TYPE_COMPLETED``.
+        """
         return agent_pb2.TaskEvent(
             task_id=task_id,
             event_type=agent_pb2.TASK_EVENT_TYPE_COMPLETED,
@@ -165,7 +206,17 @@ class Agent(agent_pb2_grpc.AgentServiceServicer, ABC):  # type: ignore[misc]
 
     @staticmethod
     def report_failed(task_id: str, code: str, message: str) -> Any:
-        """Create a FAILED TaskEvent with structured CapabilityError."""
+        """Create a FAILED TaskEvent with structured CapabilityError.
+
+        Args:
+            task_id: Opaque identifier from the originating ``ExecuteCapabilityRequest``.
+            code: Machine-readable error code (e.g. ``"CAPABILITY_NOT_FOUND"``).
+            message: Human-readable description of the failure.
+
+        Returns:
+            A ``TaskEvent`` with ``event_type`` set to ``TASK_EVENT_TYPE_FAILED``
+            and a populated ``CapabilityError`` field.
+        """
         return agent_pb2.TaskEvent(
             task_id=task_id,
             event_type=agent_pb2.TASK_EVENT_TYPE_FAILED,

--- a/docs/milestones/M5-plan.md
+++ b/docs/milestones/M5-plan.md
@@ -6,7 +6,7 @@
 **GitHub Milestone:** [Adapter Library (M5)](https://github.com/zynax-io/zynax/milestone/5)
 **Parent epic:** [#377](https://github.com/zynax-io/zynax/issues/377)
 **Status:** In Progress
-**Last updated:** 2026-05-28 (rev 87 — #232 ✅ #248 ✅; BATCH 9 added)
+**Last updated:** 2026-05-28 (rev 88 — #228 ✅; #564 ✅ row fix in BATCH 5 table)
 
 ---
 
@@ -177,7 +177,7 @@ of tooling at run time. The image is rebuilt and published to
 | [#550](https://github.com/zynax-io/zynax/issues/550) | Scope govulncheck to changed services only | M | After #549 | ✅ Done |
 | [#555](https://github.com/zynax-io/zynax/issues/555) | DRY/KISS refactor — reusable workflows, composite actions | L | After #552 | ✅ Done |
 | [#563](https://github.com/zynax-io/zynax/issues/563) | Deduplicate tools image — remove tools-publish.yml | XS | ✅ Done | — |
-| [#564](https://github.com/zynax-io/zynax/issues/564) | Pin action digests + add linux/arm64 to zynax-ci | XS | After #552 | P2 |
+| [#564](https://github.com/zynax-io/zynax/issues/564) | Pin action digests + add linux/arm64 to zynax-ci | XS | After #552 | ✅ Done |
 | [#565](https://github.com/zynax-io/zynax/issues/565) | Add trivy container scan gate before GHCR push | S | After #552 | ✅ Done |
 | [#641](https://github.com/zynax-io/zynax/issues/641) | Per-service change detection for image builds in release.yml | M | After #552 | ✅ Done |
 | [#642](https://github.com/zynax-io/zynax/issues/642) | Switch service Dockerfiles to distroless/static:nonroot + `-ldflags "-s -w"` | S | None | ✅ Done |
@@ -737,7 +737,7 @@ Open M5 milestone issues not previously tracked in this plan. All are SPDD-exemp
 
 | Issue | Type | Title | Size | Status |
 |-------|------|-------|------|--------|
-| [#228](https://github.com/zynax-io/zynax/issues/228) | docs | Google-style docstrings on all public symbols in agents/sdk | S | ⬜ |
+| [#228](https://github.com/zynax-io/zynax/issues/228) | docs | Google-style docstrings on all public symbols in agents/sdk | S | ✅ |
 | [#229](https://github.com/zynax-io/zynax/issues/229) | refactor | Strip explanatory comments in agents/sdk + agents/examples | S | ⬜ |
 | [#232](https://github.com/zynax-io/zynax/issues/232) | docs | Architecture fitness functions — document all CI gates | XS | ✅ Done |
 | [#248](https://github.com/zynax-io/zynax/issues/248) | docs | AI-output review checklist in PR template + ai-review-guide | S | ✅ Done |

--- a/state/current-milestone.md
+++ b/state/current-milestone.md
@@ -165,13 +165,13 @@ Priority gaps to file immediately:
 |-------|-------|--------|
 | [#232](https://github.com/zynax-io/zynax/issues/232) | Architecture fitness functions doc | ✅ Done — PR #750 merged |
 | [#248](https://github.com/zynax-io/zynax/issues/248) | AI-output review checklist in PR template | ✅ Done — PR #751 pending |
-| [#228](https://github.com/zynax-io/zynax/issues/228) | Google-style docstrings on SDK public symbols | ⬜ Ready |
+| [#228](https://github.com/zynax-io/zynax/issues/228) | Google-style docstrings on SDK public symbols | ✅ Done |
 | [#229](https://github.com/zynax-io/zynax/issues/229) | Strip explanatory comments in agents/sdk | ⬜ Ready |
 
 ## Next Session Queue (priority order)
 
 Remaining open M5 non-epic issues:
-- **#228** (docs: SDK docstrings, S) — LOW priority; ready
+- **#228** (docs: SDK docstrings, S) — ✅ Done
 - **#229** (refactor: strip comments, S) — LOW priority; ready
 - **#376** (docs: SDK docstrings step 2) — BLOCKED on SDK modules (M6+ scope)
 - **#235**, **#239** (SBOM/SLSA) — superseded by M6.C #489; close when M6 activates


### PR DESCRIPTION
## Summary
- Add Google-style `Args:`, `Returns:`, and `Yields:` sections to all public symbols in `agents/sdk/src/zynax_sdk/agent.py`: `capability()`, `ExecuteCapability`, `GetCapabilitySchema`, `report_progress`, `report_completed`, and `report_failed`.
- Enables autodoc generation (Sphinx, pdoc) and precise type/behaviour contracts for every public API surface.
- Also fixes M5-plan.md BATCH 5 table: #564 row was showing "P2" instead of ✅ Done (closed on GitHub since 2026-05-16).

## Why
Closes #228 — part of BATCH 9 (Documentation Quality). Public symbols lacked structured docstrings, making autodoc impossible and leaving AI assistants without function-level contracts.

## Cluster
BATCH 9, independent sibling pair. Merge order: **this PR (#228) → #229 (refactor: strip comments)**.

## State files updated
- `docs/milestones/M5-plan.md` — #228 row ⬜→✅; #564 BATCH 5 row P2→✅; Last updated rev 87→88.
- `state/current-milestone.md` — #228 row ⬜→✅ Done; removed from Next Session Queue.

## Architecture gaps
Gap scan: no G1/G4/G7/G16 exposures in `agents/sdk/` (Python only).

## Test plan

### Local pre-flight
- [x] `make lint-agents` — exit 0 (`ruff` + `mypy --strict` both pass)
- [x] `make test-unit-agents` — 57 passed, 100% coverage (≥90% gate met)
- [x] (N/A — no Go/proto/bdd changes)
- [x] `make security` — (N/A for this SDK-docs change; no new deps)

### Acceptance (issue body / #228)
- [x] All public symbols in `zynax_sdk/` have Google-style docstrings — `capability()`, `ExecuteCapability`, `GetCapabilitySchema`, `report_progress`, `report_completed`, `report_failed` all updated with `Args:`, `Returns:`, and/or `Yields:` sections.
- [x] `make lint-agents` passes with no new suppressions (ruff D enforcement in place via #375).
- [x] Docstrings contain no Tier 2 content (internal hostnames, private context).

### Engineering hygiene
- [x] **`M5-plan.md` row flipped ⬜→✅ in this diff** (mandatory)
- [x] **`current-milestone.md` updated in this diff** (mandatory)
- [x] Branched from fresh `origin/main` · PR ≤900 lines · trailers on every commit
- [x] Gap scan done (G1/G4/G7/G16); no exposures in SDK Python code
- [x] (N/A — feat/canvas/AGENTS.md exemptions apply; docs type, no new capability)
- [x] No out-of-scope edits · no mTLS/SBOM/cosign docs claims

## Out of scope
- `__init_subclass__` (dunder, not a public API surface) — no docstring added.
- `_now()` / `_is_valid_json()` (private) — unchanged.
- Test files — issue scope is `agents/sdk/src/zynax_sdk/` only.

## Closes
Closes #228
