### PR TITLE
fix(ci): guard bdd-select-packages dedup against empty-pkgs pipefail

### DIFF
--- a/tools/ci/bdd-select-packages.sh
+++ b/tools/ci/bdd-select-packages.sh
@@ -54,6 +54,8 @@ while IFS= read -r f; do
   esac
 done <<< "$changed"
 
-# Deduplicate
-pkgs=$(echo "$pkgs" | tr ' ' '\n' | sort -u | grep -v '^$' | tr '\n' ' ' | xargs)
+# Deduplicate — guard avoids grep exiting 1 on empty input (pipefail)
+if [ -n "$pkgs" ]; then
+  pkgs=$(echo "$pkgs" | tr ' ' '\n' | sort -u | grep -v '^$' | tr '\n' ' ' | xargs)
+fi
 echo "${pkgs:-}"


### PR DESCRIPTION
## Summary
- Fix `tools/ci/bdd-select-packages.sh`: when no proto files change, `pkgs=""` and the final deduplication pipeline's `grep -v '^$'` exits 1 (no matching lines). With `set -euo pipefail`, this propagates and fails the Godog BDD step.
- Guard the deduplication pipeline with `if [ -n "$pkgs" ]; then ... fi` so the "no proto changes → BDD skipped" path exits cleanly.

## Why
Regression introduced in #749 (DRY/KISS CI refactor). Affects any PR that touches `agents/` or `services/` but no `protos/` files — the first such PRs are #752 and #753 (BATCH 9 docs/refactor).

Root cause: `grep -v '^$'` with empty input returns exit code 1 (POSIX: grep exits 1 when no lines match). With `pipefail`, the whole pipeline exit code becomes 1. The outer BDD step's `set -e` exits immediately with no output.

## Test plan
- [x] Tested locally: empty `pkgs` path now exits 0 and outputs empty string
- [x] Tested locally: non-empty `pkgs` path still deduplicates correctly
- [x] (N/A — no domain/service/adapter/Python changes)
- [x] Branched from fresh `origin/main` · PR is XS · trailers on every commit
- [x] Gap scan: no G1/G4/G7/G16 exposures (CI script only)
- [x] No state files to update (no milestone issue)