### PR TITLE
fix(ci): add missing adapter allowlist entries to .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -69,4 +69,9 @@ infra/k8s/
 # Adapter Dockerfiles are built from repo root and need their module source
 # plus the generated proto stubs to resolve the workspace replace directive.
 !agents/adapters/http/
+!agents/adapters/git/
+!agents/adapters/ci/
+!agents/adapters/llm/
+!agents/adapters/langgraph/
 !protos/generated/go/
+!tools/healthcheck/


### PR DESCRIPTION
## Summary

`.dockerignore` excluded `agents/` but only restored `!agents/adapters/http/`. The git/ci/llm/langgraph adapters were added in BATCH 7 without updating the allowlist, causing `make run-local --build` to fail:

```
failed to calculate checksum of ref .../agents/adapters/ci: not found
```

Adds the missing negations and `!tools/healthcheck/` (adapter Dockerfiles COPY the static healthcheck binary from it).

## Test plan

### Local pre-flight
- [x] `make lint-go`/`lint-protos`/`lint-agents` — N/A (.dockerignore only)
- [x] `GOWORK=off go test ./... -race` — N/A
- [x] `make test-coverage` — N/A
- [x] `make test-coverage-adapters` / `make test-bdd` / `make security` — N/A

### Acceptance
- [x] `make run-local` completes without "not found" errors for adapter build contexts (verified locally)

### Engineering hygiene
- [x] **`M5-plan.md` row** — N/A (infrastructure fix, no plan row)
- [x] **`current-milestone.md`** — N/A
- [x] Branched from fresh `origin/main` · PR ≤900 lines · trailers on every commit
- [x] Gap scan done — N/A for .dockerignore
- [x] No out-of-scope edits