### PR TITLE
docs(milestone): mark M5 complete — v0.4.0 released

### DIFF
--- a/docs/milestones/M5-plan.md
+++ b/docs/milestones/M5-plan.md
@@ -5,8 +5,8 @@
 **Milestone:** Adapter Library (M5) · v0.4.0
 **GitHub Milestone:** [Adapter Library (M5)](https://github.com/zynax-io/zynax/milestone/5)
 **Parent epic:** [#377](https://github.com/zynax-io/zynax/issues/377)
-**Status:** In Progress
-**Last updated:** 2026-05-28 (rev 90 — #460 E2E demo workflow created; DoD #1 updated to e2e-demo.yaml)
+**Status:** ✅ Complete — v0.4.0 released 2026-05-29
+**Last updated:** 2026-05-29 (rev 91 — v0.4.0 tag pushed; all DoD criteria met; M5 complete)
 
 ---
 
@@ -16,11 +16,10 @@
 
 M5 is done when ALL of the following are true:
 
-1. `make run-local && zynax apply spec/workflows/examples/e2e-demo.yaml` produces real,
-   observable state transitions through at least one capability dispatch (langgraph echo mock).
-   (`code-review.yaml` is an aspirational reference — it requires live GitHub credentials and a
-   real PR; `e2e-demo.yaml` is the self-contained E2E fixture using the `echo` capability.)
-2. v0.4.0 tag exists on GitHub with downloadable CLI binaries and GHCR service images.
+1. ✅ `make run-local && zynax apply spec/workflows/examples/e2e-demo.yaml` → `WORKFLOW_STATUS_COMPLETED`
+   (verified 2026-05-29 — echo dispatched via langgraph-adapter; full chain confirmed live)
+2. ✅ v0.4.0 tag exists on GitHub with downloadable CLI binaries and GHCR service images.
+   (https://github.com/zynax-io/zynax/releases/tag/v0.4.0)
 3. All five adapters (http ✅ + git + ci + llm + langgraph) have implementations merged.
 4. The Python SDK `Agent` base class is implemented (Option A, #474).
 5. cel-go replaces the bespoke guard evaluator (#476/#538).

--- a/state/current-milestone.md
+++ b/state/current-milestone.md
@@ -14,10 +14,11 @@
 | M2 — Workflow IR | ✅ Complete | v0.1.0 |
 | M3 — Temporal Execution | ⚠ Partial | v0.2.0 |
 | M4 — YAML System + CLI | ⚠ Partial | v0.3.0 |
-| **M5 — Adapter Library** | **In Progress** | v0.4.0 |
+| **M5 — Adapter Library** | ✅ **Complete** | **v0.4.0** |
 
 M3/M4 are partial because task-broker and agent-registry were not delivered in those milestones.
-Both are in-progress under M5.C (#460). CloudEvents publishing is log-only (not wired to NATS).
+Both completed under M5.C (#460). CloudEvents publishing is log-only (not wired to NATS).
+v0.4.0 tag pushed 2026-05-29; GitHub Release live at https://github.com/zynax-io/zynax/releases/tag/v0.4.0
 See [docs/milestones/M5-plan.md](../docs/milestones/M5-plan.md).
 
 ---
@@ -90,7 +91,7 @@ All steps done: #526 ✅ #527 ✅ #528 ✅ #481 ✅. Compose wired.
 - **git-adapter coverage** — ✅ complete; #714–#718 all merged; coverage ≥85% live on CI; git re-added to GO_ADAPTER_LIST.
 - **adapter implementations** (#405–#418) — ✅ all done; git/ci/llm/langgraph all merged.
 - **E2E demo** — ✅ `e2e-demo.yaml` created; langgraph `echo` capability wired; run `make run-local && zynax apply spec/workflows/examples/e2e-demo.yaml` to observe dispatch + completion in Temporal UI (http://localhost:7088).
-- **v0.4.0 tag** — CHANGELOG promoted; run `git tag -a v0.4.0 -m "M5 Adapter Library" && git push origin v0.4.0` on main to trigger the release workflow and create GitHub Release assets.
+- **v0.4.0 tag** — ✅ pushed 2026-05-29; GitHub Release live with CLI binaries, GHCR service images, and SBOMs.
 
 ---
 


### PR DESCRIPTION
## Summary

Marks M5 — Adapter Library as ✅ Complete in `state/current-milestone.md` and `docs/milestones/M5-plan.md`.

All 7 DoD criteria confirmed:

| # | Criterion | Status |
|---|---|---|
| 1 | E2E dispatch via e2e-demo.yaml | ✅ WORKFLOW_STATUS_COMPLETED (verified 2026-05-29) |
| 2 | v0.4.0 tag + GitHub Release | ✅ https://github.com/zynax-io/zynax/releases/tag/v0.4.0 |
| 3 | All 5 adapters merged | ✅ |
| 4 | Python SDK Agent base class | ✅ |
| 5 | cel-go guard evaluator | ✅ |
| 6 | SECURITY.md correct | ✅ |
| 7 | CI < 10 min | ✅ |

## Test plan

### Local pre-flight
- [x] N/A — docs-only change

### Acceptance
- [x] `current-milestone.md` reflects M5 Complete + v0.4.0 release URL
- [x] `M5-plan.md` DoD rows 1 and 2 flipped to ✅ with evidence

### Engineering hygiene
- [x] **`M5-plan.md` updated in this diff** (Status + DoD rows)
- [x] **`current-milestone.md` updated in this diff**
- [x] No out-of-scope edits