### PR TITLE
docs(milestone): close M5 GitHub milestone — move 5 deferred issues to M6

### DIFF
--- a/docs/milestones/M5-plan.md
+++ b/docs/milestones/M5-plan.md
@@ -5,8 +5,8 @@
 **Milestone:** Adapter Library (M5) · v0.4.0
 **GitHub Milestone:** [Adapter Library (M5)](https://github.com/zynax-io/zynax/milestone/5)
 **Parent epic:** [#377](https://github.com/zynax-io/zynax/issues/377)
-**Status:** ✅ Complete — v0.4.0 released 2026-05-29
-**Last updated:** 2026-05-29 (rev 91 — v0.4.0 tag pushed; all DoD criteria met; M5 complete)
+**Status:** ✅ Complete — v0.4.0 released 2026-05-29; GitHub milestone closed 2026-05-29
+**Last updated:** 2026-05-29 (rev 92 — GitHub milestone closed; 5 deferred issues moved to M6)
 
 ---
 
@@ -715,7 +715,7 @@ open issues. File them before or during M5 execution:
 | README status table | High | [#579](https://github.com/zynax-io/zynax/issues/579) | M5 |
 | ~~NEW-1: gRPC call deadlines~~ | High | ~~[#622](https://github.com/zynax-io/zynax/issues/622)~~ | ✅ Done |
 | NEW-4: `ZYNAX_GW_API_KEY=""` bypass | High | [#623](https://github.com/zynax-io/zynax/issues/623) | M5 |
-| H1: Stateless workflow-compiler (OOM risk R4) | **High** | [#466](https://github.com/zynax-io/zynax/issues/466) | M5 (**promoted from M6** 2026-05-21) |
+| H1: Stateless workflow-compiler (OOM risk R4) | **High** | [#466](https://github.com/zynax-io/zynax/issues/466) | M6 (deferred — not completed in M5) |
 | ~~Architecture overhaul docs (tracking)~~ | — | ~~[#624](https://github.com/zynax-io/zynax/issues/624)~~ ✅ Done | M5 |
 | PE-1: Stale `COMPILER_ADDR` default (`50051` vs actual `50054`) | **High** | [#661](https://github.com/zynax-io/zynax/issues/661) | M5 |
 | PE-2: `sbom` + `scan-image` Makefile targets broken (wrong build context) | **High** | [#662](https://github.com/zynax-io/zynax/issues/662) | M5 |
@@ -749,7 +749,7 @@ Open M5 milestone issues not previously tracked in this plan. All are SPDD-exemp
 | [#229](https://github.com/zynax-io/zynax/issues/229) | refactor | Strip explanatory comments in agents/sdk + agents/examples | S | ✅ |
 | [#232](https://github.com/zynax-io/zynax/issues/232) | docs | Architecture fitness functions — document all CI gates | XS | ✅ Done |
 | [#248](https://github.com/zynax-io/zynax/issues/248) | docs | AI-output review checklist in PR template + ai-review-guide | S | ✅ Done |
-| [#376](https://github.com/zynax-io/zynax/issues/376) | docs | Google-style docstrings — step 2 (blocked on SDK modules) | M | ⬜ blocked |
+| [#376](https://github.com/zynax-io/zynax/issues/376) | docs | Google-style docstrings — step 2 (blocked on SDK modules) | M | ➡ M6 (moved — blocked until SDK runtime modules exist) |
 
 **Notes:**
 - #235 (SBOM) and #239 (SLSA provenance) are superseded by M6.C child #489 — close when M6 goes active.

--- a/state/current-milestone.md
+++ b/state/current-milestone.md
@@ -15,10 +15,12 @@
 | M3 — Temporal Execution | ⚠ Partial | v0.2.0 |
 | M4 — YAML System + CLI | ⚠ Partial | v0.3.0 |
 | **M5 — Adapter Library** | ✅ **Complete** | **v0.4.0** |
+| **M6 — K8s Production-Ready** | 🔜 **Next** | — |
 
 M3/M4 are partial because task-broker and agent-registry were not delivered in those milestones.
 Both completed under M5.C (#460). CloudEvents publishing is log-only (not wired to NATS).
 v0.4.0 tag pushed 2026-05-29; GitHub Release live at https://github.com/zynax-io/zynax/releases/tag/v0.4.0
+GitHub milestone "Adapter Library (M5)" closed 2026-05-29; 5 deferred issues (#235 #239 #376 #466 #656) moved to M6.
 See [docs/milestones/M5-plan.md](../docs/milestones/M5-plan.md).
 
 ---


### PR DESCRIPTION
## Summary

- Closes the "Adapter Library (M5)" GitHub milestone (all 7 DoD criteria met; v0.4.0 released 2026-05-29).
- Moves 5 M6-deferred issues (#235 #239 #376 #466 #656) from M5 → M6 milestone (already done via GH API).
- Updates `state/current-milestone.md` to add the M6 "next" row.
- Updates `docs/milestones/M5-plan.md`: rev 92, fixes deferred-issues milestone column.

## Why

The M5 GitHub milestone was still open despite all 7 DoD criteria being met and v0.4.0 being released. The 5 remaining open issues are all M6-scope. This closes the milestone cleanly.

## State files updated

- `docs/milestones/M5-plan.md` — rev 92; #466 milestone column M5→M6; #376 ⬜→➡ M6; Last updated bumped
- `state/current-milestone.md` — added M6 "next" row; noted milestone closed + 5 issues moved

## Architecture gaps

N/A — docs-only change.

## Test plan

### Local pre-flight
- [x] `make lint-go`/`lint-protos`/`lint-agents` — (N/A — docs-only)
- [x] `GOWORK=off go test ./... -race` — (N/A — docs-only)
- [x] `make test-coverage` — (N/A — docs-only)
- [x] `make test-coverage-adapters` / `make test-bdd` / `make security` — (N/A — docs-only)

### Acceptance
- [x] GitHub milestone "Adapter Library (M5)" closed (0 open issues) — verified via `gh api`
- [x] Issues #235 #239 #376 #466 #656 moved to M6 milestone — verified via `gh issue view`
- [x] `M5-plan.md` status line and deferred rows updated
- [x] `current-milestone.md` reflects M6 as next

### Engineering hygiene
- [x] **`M5-plan.md` row flipped ⬜→✅ in this diff** — rev bump + deferred rows corrected
- [x] **`current-milestone.md` updated in this diff** — M6 row added
- [x] Branched from fresh `origin/main` · PR ≤900 lines · trailers on every commit
- [x] Gap scan done — N/A (docs-only)
- [x] Canvas O-step — N/A (docs:, SPDD-exempt)
- [x] No out-of-scope edits · no mTLS/SBOM/cosign docs claims

## Out of scope

- M6 planning (no execution plan file yet; 30 open issues on M6 milestone)

Closes #758

Assisted-by: Claude/claude-sonnet-4-6