### PR TITLE
docs: post-M5 truth pass — align all docs to v0.4.0 reality

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -19,7 +19,7 @@
 | M2 — Workflow IR | ✅ **Complete** | v0.1.0 | YAML parser, WorkflowGraph builder, structural + semantic validators, WorkflowGraph→WorkflowIR serialisation, `CompileWorkflow`/`ValidateManifest`/`GetCompiledWorkflow` gRPC, JSON schemas for Workflow/AgentDef/Policy |
 | M3 — Temporal Execution | ⚠ **Partial** | v0.2.0 | `WorkflowEngine` interface, `TemporalEngine`, `IRInterpreterWorkflow` state machine, `DispatchCapabilityActivity`, cel-go guard evaluation, 5 `EngineAdapterService` gRPC methods. **Not delivered in M3:** task-broker + agent-registry (delivered M5.C #479/#480). CloudEvents publish is a log stub. |
 | M4 — YAML System + CLI | ⚠ **Partial** | v0.3.0 | api-gateway REST layer, `zynax` CLI, Docker Compose runner, GitOps watch. **Not delivered in M4:** agent-registry routing — delivered M5.C (#480); capability dispatch was unblocked by compose wiring (#481). |
-| M5 — Adapter Library | 🔄 **In Progress** | v0.4.0 | task-broker MVP, agent-registry MVP, compose wiring, git/ci/llm/langgraph adapters (all five adapters ✅), cel-go guard, Python SDK Agent base class, unified release pipeline, CI runner, distroless images, gRPC deadlines. **Remaining:** E2E demo · v0.4.0 tag · #555 CI refactor. See `docs/milestones/M5-plan.md`. |
+| M5 — Adapter Library | ✅ **Complete** | v0.4.0 | task-broker MVP, agent-registry MVP, compose wiring, all five adapters (http ✅ git ✅ ci ✅ llm ✅ langgraph ✅), cel-go guard, Python SDK `Agent` base class, unified release pipeline, CI runner, distroless images, gRPC deadlines, e2e-demo wired. Released 2026-05-29. See `docs/milestones/M5-plan.md`. |
 | M6 — K8s Production | 📅 **Planned** | v0.5.0 | TLS/mTLS (ADR-020), SBOM+cosign, persistent stores, rate limiting, OTel baseline, Helm charts |
 | M7 — Full Observability | 📅 **Planned** | v0.6.0 | Benchmarks, load tests, SLOs, Watch polling fix |
 | M8 — CNCF Sandbox | 📅 **Planned** | v1.0.0 | Community traction, second maintainer, trademark policy |
@@ -86,9 +86,9 @@ Layer 3 engines are always behind the `WorkflowEngine` interface.
             └──────────┬──────────────┘
                        │ HTTP/REST :7080
             ┌──────────▼──────────────┐
-            │  api-gateway  ✅         │  bearer-token auth (non-const-time ⚠ #567)
+            │  api-gateway  ✅         │  bearer-token auth (constant-time ✅ #567)
             │  POST /api/v1/apply      │  X-Request-ID propagation
-            │  GET  /api/v1/workflows  │  no ReadHeaderTimeout ⚠ #568
+            │  GET  /api/v1/workflows  │  ReadHeaderTimeout ✅ #568
             └──────┬──────────┬───────┘
                    │          │ gRPC (insecure ⚠ — no TLS yet)
           ┌────────▼──────┐ ┌─▼─────────────────┐
@@ -100,14 +100,13 @@ Layer 3 engines are always behind the `WorkflowEngine` interface.
                                       │ gRPC: DispatchCapabilityActivity
                                       ▼
                             ┌─────────────────────┐
-                            │ task-broker 🟡        │  in-memory only
-                            │ round-robin dispatch  │  NOT in compose (#481)
-                            │ no RetryPolicy ⚠ #569│
+                            │ task-broker 🟡        │  in-memory only (Postgres in M6)
+                            │ round-robin dispatch  │  wired in compose (#481 ✅)
                             └──────────┬────────────┘
                                        │ FindByCapability + ExecuteCapability gRPC
                                        ▼
                   ┌────────────────────────────────────────┐
-                  │ agent-registry  ❌ 0 LoC (#480 pending) │
+                  │ agent-registry  🟡 In-memory MVP ✅       │
                   │ event-bus       ❌ 0 LoC (M6+)          │
                   │ memory-service  ❌ 0 LoC (M6+)          │
                   └────────────────────────────────────────┘
@@ -115,18 +114,18 @@ Layer 3 engines are always behind the `WorkflowEngine` interface.
                   ┌────────────────────────────────────────┐
                   │ Adapters (Layer 4 — Python + Go)        │
                   │ http-adapter ✅ (Go)                     │
-                  │ git-adapter  🟡 BDD done, impl pending  │
-                  │ ci-adapter   🟡 BDD done, impl pending  │
-                  │ llm-adapter  🟡 BDD done, impl pending  │
-                  │ langgraph    🟡 BDD done, impl pending  │
+                  │ git-adapter  ✅ (Go)                     │
+                  │ ci-adapter   ✅ (Go)                     │
+                  │ llm-adapter  ✅ (Python)                 │
+                  │ langgraph    ✅ (Python)                 │
                   └────────────────────────────────────────┘
 ```
 
 **Legend:** ✅ Implemented · 🟡 Partial / in-progress · ❌ Not yet implemented · ⚠ Known issue with issue link
 
-> **Critical note:** Every workflow with capability actions will fail at the first
-> `DispatchCapabilityActivity` until task-broker is in the compose stack and
-> agent-registry is implemented. This is M5.C tracked by #460 / #481.
+> **M5.C complete:** End-to-end capability dispatch is fully wired. task-broker and
+> agent-registry are in the compose stack (#481 ✅). Run `make run-local && zynax apply
+> spec/workflows/examples/e2e-demo.yaml` to observe a full dispatch round-trip.
 
 ---
 
@@ -240,7 +239,7 @@ Capability routing (loose): task → capability:summarize
 Named routing breaks when an agent is replaced. Capability routing decouples the workflow
 definition from any specific executor — swap a summarizer, zero workflow changes.
 
-### Capability Resolution Flow (M5.C target state)
+### Capability Resolution Flow (implemented in M5.C)
 
 ```
 Workflow YAML:
@@ -291,9 +290,9 @@ execution from any engine. Adding `ArgoEngine` or `LangGraphEngine` is ~500 LoC,
 
 ### Activity RetryPolicy Note
 
-Temporal's default Activity retry is exponential backoff with no max attempts — **this means
-permanent failures (e.g. capability not found) will retry forever**. Explicit `RetryPolicy`
-must be set on `DispatchCapabilityActivity`. Tracked by #569.
+Temporal's default Activity retry is exponential backoff with no max attempts. An explicit
+`RetryPolicy` is set on `DispatchCapabilityActivity` (3 max attempts, non-retryable on
+`ErrCapabilityNotFound` and gRPC `NOT_FOUND` — fixed #569).
 
 ---
 
@@ -367,7 +366,7 @@ two domain interfaces (`ActivityExecutor`, `EventPublisher`). The Temporal SDK a
 
 ---
 
-## 10. Service LoC Inventory (as of 2026-05-21)
+## 10. Service LoC Inventory (as of 2026-05-29)
 
 | Service | Code LoC | Test LoC | Status |
 |---|---:|---:|---|
@@ -375,7 +374,7 @@ two domain interfaces (`ActivityExecutor`, `EventPublisher`). The Temporal SDK a
 | engine-adapter | ~1,143 | ~1,209 | ✅ Implemented |
 | api-gateway | ~1,047 | ~1,071 | ✅ Implemented |
 | task-broker | ~905 | ~455 | 🟡 In-memory MVP |
-| agent-registry | 0 | 0 | ❌ Stub (BDD files only) |
+| agent-registry | ~565 | ~691 | 🟡 In-memory MVP |
 | event-bus | 0 | 0 | ❌ Stub |
 | memory-service | 0 | 0 | ❌ Stub |
 | cmd/zynax | ~1,470 | ~1,200 | ✅ Implemented |
@@ -440,13 +439,10 @@ See ADR-017 and `docs/decisions/004-gowork-off-isolation.md`.
 
 | Limitation | Severity | Tracked by | Target milestone |
 |---|---|---|---|
-| No E2E capability dispatch (agent-registry missing) | Critical | #460 | M5 |
-| workflow-compiler IR store unbounded in-memory | High | #466 | M5 |
+| workflow-compiler IR store unbounded in-memory | High | #466 | M6 |
 | All inter-service gRPC insecure (no TLS) | High | #488 / ADR-020 | M6 |
-| Bearer-token compare not constant-time | High | #567 | M5 |
-| No OTel tracing on api-gateway + engine-adapter | High | #491 | M5/M6 |
+| No OTel tracing on api-gateway + engine-adapter | High | #491 | M6 |
 | CloudEvents publishing is a log stub | High | #460 | M6 |
-| Temporal Activity with no explicit RetryPolicy | Medium | #569 | M5 |
 | No rate limiting on POST /apply | Medium | #580 | M6 |
 | No SBOM / cosign / SLSA provenance | High | #489 | M6 |
 

--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ make test        # full suite (unit + BDD + coverage gate)
 | **M2 — Workflow IR** | **Complete** | v0.1.0 | [Epic #101](https://github.com/zynax-io/zynax/issues/101) |
 | **M3 — Temporal Execution** | ⚠ **Partial** | v0.2.0 | [Epic #214](https://github.com/zynax-io/zynax/issues/214) · [Canvas](docs/spdd/214-temporal-execution/canvas.md) · task-broker + agent-registry delivered M5.C |
 | **M4 — YAML System + CLI** | ⚠ **Partial** | v0.3.0 | [Epic #314](https://github.com/zynax-io/zynax/issues/314) · [Canvas](docs/spdd/314-yaml-system-cli/canvas.md) · agent-registry delivered M5.C · compose wired (#481 ✅) |
-| **M5 — Adapter Library** | 🔄 **In Progress** | v0.4.0 | [Plan](docs/milestones/M5-plan.md) · all 5 adapters ✅ · M5.C ✅ · M5.D ✅ · M5.E ✅ · E2E demo + v0.4.0 tag pending |
+| **M5 — Adapter Library** | ✅ **Complete** | v0.4.0 | [Plan](docs/milestones/M5-plan.md) · all 5 adapters ✅ · M5.C ✅ · M5.D ✅ · M5.E ✅ · E2E demo ✅ · v0.4.0 released 2026-05-29 |
 
 **M1** delivered the contracts-only foundation: 8 gRPC services defined as protobuf contracts,
 AsyncAPI spec covering 11 event channels, generated Go + Python stubs, 140+ BDD contract
@@ -412,9 +412,9 @@ Current implementation status per service and adapter (as of M5 v0.4.0):
 |---------|----------|--------|-------|
 | http-adapter | Go | ✅ Complete | Generic HTTP capability bridge; SSRF-safe static routing |
 | git-adapter | Go | ✅ Complete | `open_pr`, `request_review`, `get_diff` via GitHub REST API |
-| ci-adapter | Go | 🔄 In Progress | BDD ✅; scaffold + handler pending ([#405](https://github.com/zynax-io/zynax/issues/405)+) |
-| llm-adapter | Python | 🔄 In Progress | BDD ✅; OpenAI/Bedrock/Ollama pending ([#410](https://github.com/zynax-io/zynax/issues/410)+) |
-| langgraph-adapter | Python | 🔄 In Progress | BDD ✅; graph-mount impl pending ([#415](https://github.com/zynax-io/zynax/issues/415)+) |
+| ci-adapter | Go | ✅ Complete | `trigger_workflow`, `get_run_status` via GitHub Actions REST API |
+| llm-adapter | Python | ✅ Complete | `chat_completion` — OpenAI, AWS Bedrock, Ollama |
+| langgraph-adapter | Python | ✅ Complete | LangGraph `StateGraph` as Zynax capabilities; wired in e2e-demo |
 
 **Legend:** ✅ Complete · 🟡 MVP (in-memory, ephemeral) · 🔄 In Progress · 📋 Planned
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -125,29 +125,30 @@ Each roadmap milestone maps to a GitHub Milestone:
 
 ---
 
-## Milestone 5 — Adapter Library 🔄 In Progress (v0.4.0)
+## Milestone 5 — Adapter Library ✅ Complete (v0.4.0)
 
 **Goal:** Existing systems become capabilities without SDK adoption. First green E2E demo.
 
-> Label: `milestone: M5` · Epic: [#377](https://github.com/zynax-io/zynax/issues/377)
-> Execution plan: [docs/milestones/M5-plan.md](docs/milestones/M5-plan.md)
+> Released 2026-05-29. Label: `milestone: M5` · Epic: [#377](https://github.com/zynax-io/zynax/issues/377)
+> Full plan: [docs/milestones/M5-plan.md](docs/milestones/M5-plan.md)
 
-### M5 Definition of Done (7 criteria)
-1. `make run-local && zynax apply code-review.yaml` → real state transitions + ≥1 dispatch
-2. v0.4.0 tag with downloadable CLI + GHCR images
-3. All 5 adapters (http ✅ + git + ci + llm + langgraph) merged
-4. Python SDK `Agent` base class implemented ✅
-5. cel-go replaces bespoke guard evaluator ✅
-6. SECURITY.md matches shipped reality ✅
-7. CI < 10 minutes per PR 🟡
+### M5 Definition of Done (7/7 criteria met)
 
-### M5.A — Truth Pass ([#458](https://github.com/zynax-io/zynax/issues/458))
+1. [x] `make run-local && zynax apply spec/workflows/examples/e2e-demo.yaml` → `WORKFLOW_STATUS_COMPLETED`
+2. [x] v0.4.0 tag with downloadable CLI + GHCR images (released 2026-05-29)
+3. [x] All 5 adapters merged (http ✅ git ✅ ci ✅ llm ✅ langgraph ✅)
+4. [x] Python SDK `Agent` base class implemented (#474 / #535 #536 #537)
+5. [x] cel-go replaces bespoke guard evaluator (#476 / #538 #539 #540)
+6. [x] SECURITY.md matches shipped reality
+7. [x] CI < 10 minutes per PR (#552)
+
+### M5.A — Truth Pass ([#458](https://github.com/zynax-io/zynax/issues/458)) ✅
 
 - [x] Remove CNCF Sandbox Candidate badge (#472)
 - [x] Audit CHANGELOG for phantom entries (#473)
 - [x] Python SDK Agent base class (#474 / #535 #536 #537)
 - [x] Fix SECURITY.md — remove mTLS/SBOM/cosign false claims
-- [ ] Add per-service status table to README (#579)
+- [x] Add per-service status table to README (#579)
 
 ### M5.B — Engine Correctness Hardening ([#459](https://github.com/zynax-io/zynax/issues/459)) ✅
 
@@ -156,11 +157,11 @@ Each roadmap milestone maps to a GitHub Milestone:
 - [x] Return full `CompilationError` list from `CompileWorkflow` (#477)
 - [x] Fix SSE `WriteTimeout` breaking `zynax logs` at 30 s (#478)
 
-### M5.C — Capability Dispatch End-to-End ([#460](https://github.com/zynax-io/zynax/issues/460)) 🔴 Critical path
+### M5.C — Capability Dispatch End-to-End ([#460](https://github.com/zynax-io/zynax/issues/460)) ✅
 
-- [x] `task-broker` MVP: in-memory `TaskBrokerService`, 5 RPCs, 92.7% coverage (#479 / #520 #522 #523)
-- [ ] `agent-registry` MVP: BDD trim (#526) → domain (#527) → gRPC wiring (#528)
-- [ ] Docker Compose wiring: task-broker + agent-registry in `make run-local` (#481)
+- [x] `task-broker` MVP: in-memory `TaskBrokerService`, 5 RPCs, 92.7% domain coverage (#479)
+- [x] `agent-registry` MVP: domain (#527) → gRPC wiring (#528) → in-memory round-robin (#480)
+- [x] Docker Compose wiring: task-broker + agent-registry in `make run-local` (#481)
 
 ### M5.D — Control Plane Security Baseline ([#461](https://github.com/zynax-io/zynax/issues/461)) ✅
 
@@ -174,23 +175,24 @@ Each roadmap milestone maps to a GitHub Milestone:
 
 - [x] Idempotent apply and compose consolidation (#485 #486)
 
-### M5.F — CI/CD Performance Sprint ([#542](https://github.com/zynax-io/zynax/issues/542)) 🟡
+### M5.F — CI/CD Performance Sprint ([#542](https://github.com/zynax-io/zynax/issues/542)) ✅
 
 - [x] Concurrency + stale-run cancellation (#545)
 - [x] Unified release workflow — fix race condition (#557)
-- [x] v0.4.0 CHANGELOG promoted; tag push pending
+- [x] v0.4.0 tag pushed and GitHub Release live
 - [x] All service/adapter images public on GHCR (#562)
 - [x] CI runner container image (#551 #552)
-- [ ] Force-full-pipeline trigger (#554)
-- [ ] Per-service change detection (#549 #550)
+- [x] Force-full-pipeline trigger (#554)
+- [x] Per-service change detection (#549 #550)
+- [x] DRY/KISS CI refactor (#555)
 
-### Adapter Library ([#377](https://github.com/zynax-io/zynax/issues/377))
+### Adapter Library ([#377](https://github.com/zynax-io/zynax/issues/377)) ✅
 
 - [x] `http-adapter`: REST API proxy — all step issues merged (#380)
-- [ ] `git-adapter`: `open_pr`, `request_review`, `get_diff` (#381 — BDD done, impl pending #481)
-- [ ] `ci-adapter`: `trigger_workflow`, `get_run_status` (#382 — BDD done, impl pending #481)
-- [ ] `llm-adapter`: OpenAI / Bedrock / Ollama `chat_completion` (#383 — BDD done, impl pending #481)
-- [ ] `langgraph-adapter`: LangGraph StateGraph as Zynax capabilities (#384 — BDD done, impl pending #481)
+- [x] `git-adapter`: `open_pr`, `request_review`, `get_diff` — all steps merged (#381); coverage ≥85% (#713)
+- [x] `ci-adapter`: `trigger_workflow`, `get_run_status` — all steps merged (#382)
+- [x] `llm-adapter`: OpenAI / Bedrock / Ollama `chat_completion` — all steps merged (#383)
+- [x] `langgraph-adapter`: LangGraph StateGraph as Zynax capabilities — all steps merged (#384); wired in e2e-demo
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -30,21 +30,21 @@ Include: description, reproduction steps, impact assessment, and suggested fix i
 See `AGENTS.md`, `docs/adr/ADR-001`, `ADR-008` and `docs/reviews/04-architecture-gaps.md` for the full security posture.
 
 ### Current (shipped)
-- Non-root containers — all service images run as `USER zynax` (uid 1001)
-- Bearer-token authentication on all mutating api-gateway endpoints
+- Non-root containers — all service images use `gcr.io/distroless/static:nonroot` (uid 65532)
+- Bearer-token authentication on all mutating api-gateway endpoints (constant-time compare ✅ #567)
+- `ReadHeaderTimeout` + `MaxBytesReader` on HTTP server (slow-read DoS protection ✅ #568)
 - X-Request-ID correlation propagated across all services
 - Structured JSON logging with no sensitive fields
 - Renovate dependency updates (weekly, patch auto-merge)
 - Trivy CVE scanning in release pipeline (#565)
 - `ZYNAX_API_KEY` required at startup — gateway refuses to start without it
+- gRPC call deadlines on all outbound calls (#622); configurable via `ZYNAX_GRPC_TIMEOUT_MS`
 
-### In Progress
-- SBOM per release artifact — tracked by [#235](https://github.com/zynax-io/zynax/issues/235) / [#556](https://github.com/zynax-io/zynax/issues/556)
+### In Progress (M6)
+- SBOM per release artifact — tracked by [#235](https://github.com/zynax-io/zynax/issues/235) / [#489](https://github.com/zynax-io/zynax/issues/489)
 - cosign-signed images (SLSA L2) — tracked by [#239](https://github.com/zynax-io/zynax/issues/239) / [#489](https://github.com/zynax-io/zynax/issues/489)
-- Constant-time bearer comparison — tracked by [#567](https://github.com/zynax-io/zynax/issues/567) (to be filed)
 
 ### Planned (M6+)
 - mTLS between all platform services — tracked by [#464](https://github.com/zynax-io/zynax/issues/464) / [#488](https://github.com/zynax-io/zynax/issues/488)
 - OIDC/JWT authentication replacing static bearer token
 - Rate limiting on `POST /api/v1/apply`
-- `ReadHeaderTimeout` on all HTTP servers

--- a/docs/spdd/377-adapter-library/canvas.md
+++ b/docs/spdd/377-adapter-library/canvas.md
@@ -9,7 +9,7 @@
 **Issue:** #377
 **Author:** Oscar Gómez Manresa
 **Date:** 2026-05-07
-**Status:** Aligned
+**Status:** Implemented
 
 > **Scope note:** This is a milestone-level Canvas. It states the M5 objective and cross-cutting
 > constraints for all five adapters. Each child `feat:` issue carries its own Aligned Canvas before

--- a/docs/spdd/381-git-adapter/canvas.md
+++ b/docs/spdd/381-git-adapter/canvas.md
@@ -9,7 +9,7 @@
 **Issue:** #381
 **Author:** Oscar Gómez Manresa
 **Date:** 2026-05-08
-**Status:** Aligned
+**Status:** Implemented
 
 ---
 

--- a/docs/spdd/382-ci-adapter/canvas.md
+++ b/docs/spdd/382-ci-adapter/canvas.md
@@ -9,7 +9,7 @@
 **Issue:** #382
 **Author:** Oscar Gómez Manresa
 **Date:** 2026-05-08
-**Status:** Aligned
+**Status:** Implemented
 
 ---
 

--- a/docs/spdd/383-llm-adapter/canvas.md
+++ b/docs/spdd/383-llm-adapter/canvas.md
@@ -9,7 +9,7 @@
 **Issue:** #383
 **Author:** Oscar Gómez Manresa
 **Date:** 2026-05-08
-**Status:** Aligned
+**Status:** Implemented
 
 ---
 

--- a/docs/spdd/384-langgraph-adapter/canvas.md
+++ b/docs/spdd/384-langgraph-adapter/canvas.md
@@ -9,7 +9,7 @@
 **Issue:** #384
 **Author:** Oscar Gómez Manresa
 **Date:** 2026-05-08
-**Status:** Aligned
+**Status:** Implemented
 
 ---
 

--- a/docs/spdd/442-containerized-make/canvas.md
+++ b/docs/spdd/442-containerized-make/canvas.md
@@ -3,7 +3,7 @@
 **Issue:** #442
 **Author:** Oscar Gómez Manresa
 **Date:** 2026-05-13
-**Status:** Aligned
+**Status:** Implemented
 
 ---
 

--- a/docs/spdd/458-truth-pass/canvas.md
+++ b/docs/spdd/458-truth-pass/canvas.md
@@ -8,7 +8,7 @@
 **Issue:** #458
 **Author:** Oscar Gómez Manresa
 **Date:** 2026-05-18
-**Status:** Aligned
+**Status:** Implemented
 
 **Child issues:** #472 (remove CNCF badge + milestone status) · #473 (CHANGELOG audit) · #474 (Python SDK decision)
 

--- a/docs/spdd/459-engine-correctness/canvas.md
+++ b/docs/spdd/459-engine-correctness/canvas.md
@@ -7,7 +7,7 @@
 **Issue:** #459
 **Author:** Oscar Gómez Manresa
 **Date:** 2026-05-18
-**Status:** Aligned
+**Status:** Implemented
 
 **Child issues:** #475 (resolveTemplate determinism) · #476 (guard parser) · #477 (compiler error contract) · #478 (SSE WriteTimeout)
 

--- a/docs/spdd/460-capability-dispatch/canvas.md
+++ b/docs/spdd/460-capability-dispatch/canvas.md
@@ -7,7 +7,7 @@
 **Issue:** #460
 **Author:** Oscar Gómez Manresa
 **Date:** 2026-05-18
-**Status:** Aligned
+**Status:** Implemented
 
 **Child issues:** #479 (task-broker MVP — code merged; cleanup: #530 #531 #532) · #480 (agent-registry MVP — steps: #526 #527 #528) · #481 (compose wiring)
 

--- a/docs/spdd/461-security-baseline/canvas.md
+++ b/docs/spdd/461-security-baseline/canvas.md
@@ -7,7 +7,7 @@
 **Issue:** #461
 **Author:** Oscar Gómez Manresa
 **Date:** 2026-05-18
-**Status:** Aligned
+**Status:** Implemented
 
 **Child issues:** #482 (bearer-token auth) · #483 (event publish observability) · #484 (request ID propagation)
 

--- a/docs/spdd/462-dx-polish/canvas.md
+++ b/docs/spdd/462-dx-polish/canvas.md
@@ -7,7 +7,7 @@
 **Issue:** #462
 **Author:** Oscar Gómez Manresa
 **Date:** 2026-05-18
-**Status:** Aligned
+**Status:** Implemented
 
 **Child issues:** #485 (idempotent Apply) · #486 (compose consolidation)
 

--- a/docs/spdd/474-python-sdk/canvas.md
+++ b/docs/spdd/474-python-sdk/canvas.md
@@ -7,7 +7,7 @@
 **Issue:** #474 (Epic)
 **Author:** Oscar Gómez Manresa
 **Date:** 2026-05-19
-**Status:** Aligned
+**Status:** Implemented
 
 **Parent epic:** [#458 M5.A Truth Pass](https://github.com/zynax-io/zynax/issues/458)
 **Track:** M5.A

--- a/docs/spdd/476-guard-parser/canvas.md
+++ b/docs/spdd/476-guard-parser/canvas.md
@@ -7,7 +7,7 @@
 **Issue:** #476 (Epic)
 **Author:** Oscar Gómez Manresa
 **Date:** 2026-05-19
-**Status:** Aligned
+**Status:** Implemented
 
 **Parent epic:** [#459 M5.B Engine Correctness Hardening](https://github.com/zynax-io/zynax/issues/459)
 **Track:** M5.B

--- a/docs/spdd/479-task-broker/canvas.md
+++ b/docs/spdd/479-task-broker/canvas.md
@@ -9,7 +9,7 @@
 **Issue:** #479 (Epic)
 **Author:** Oscar Gómez Manresa
 **Date:** 2026-05-19
-**Status:** Aligned
+**Status:** Implemented
 
 **Parent epic:** [#460 M5.C Capability Dispatch End-to-End](https://github.com/zynax-io/zynax/issues/460)
 **Continues:** [#460 canvas](../460-capability-dispatch/canvas.md) O1

--- a/docs/spdd/480-agent-registry/canvas.md
+++ b/docs/spdd/480-agent-registry/canvas.md
@@ -7,7 +7,7 @@
 **Issue:** #480 (Epic)
 **Author:** Oscar Gómez Manresa
 **Date:** 2026-05-19
-**Status:** Aligned
+**Status:** Implemented
 
 **Child issues:** #526 (BDD trim) · #527 (domain layer) · #528 (gRPC wiring + cmd)
 **Continues:** #481 (compose wiring, existing)

--- a/services/agent-registry/AGENTS.md
+++ b/services/agent-registry/AGENTS.md
@@ -1,7 +1,7 @@
 # services/agent-registry — AGENTS.md
 
 > Go 1.26.3. Inherits rules from root `AGENTS.md` and `services/AGENTS.md`.
-> **Status: M5.C (active).** gRPC service wired with in-memory store (M5); persistence deferred to M6.
+> **Status: M5 Complete.** gRPC service wired with in-memory round-robin store; compose-wired (#481); persistence deferred to M6 (#480 delivered).
 
 ---
 

--- a/services/api-gateway/AGENTS.md
+++ b/services/api-gateway/AGENTS.md
@@ -1,7 +1,7 @@
 # services/api-gateway — AGENTS.md
 
 > Go 1.26.3+. Inherits rules from root `AGENTS.md` and `services/AGENTS.md`.
-> **Status: M4 in progress** — HTTP REST layer implemented; auth/rate-limit deferred to M5.
+> **Status: M5 Complete** — HTTP REST layer, bearer-token auth (constant-time), ReadHeaderTimeout, X-Request-ID middleware, gRPC deadlines all implemented. Rate limiting deferred to M6 (#580).
 
 ---
 

--- a/services/engine-adapter/AGENTS.md
+++ b/services/engine-adapter/AGENTS.md
@@ -1,7 +1,7 @@
 # services/engine-adapter — AGENTS.md
 
 > Go 1.26.3+. Inherits rules from root `AGENTS.md` and `services/AGENTS.md`.
-> **Status: M3 Complete.** Temporal backend fully implemented; LangGraph/Argo deferred to M5/M6.
+> **Status: M5 Complete.** Temporal backend fully implemented; cel-go guard evaluation live (#538); explicit RetryPolicy on `DispatchCapabilityActivity` (#569). LangGraph/Argo `WorkflowEngine` backends deferred to M6+.
 
 ---
 

--- a/services/event-bus/AGENTS.md
+++ b/services/event-bus/AGENTS.md
@@ -1,7 +1,7 @@
 # services/event-bus — AGENTS.md
 
 > Go 1.22+. Inherits rules from root `AGENTS.md` and `services/AGENTS.md`.
-> **Status: M5+ (not yet implemented).** BDD contract tests exist in `protos/tests/`. NATS JetStream backend; CloudEvents published by engine-adapter in M3 bypass this service stub for now.
+> **Status: M6+ (not yet implemented).** BDD contract tests exist in `protos/tests/`. NATS JetStream backend; `PublishLifecycleEventActivity` in engine-adapter is a log-only stub until this service ships.
 
 ---
 

--- a/services/memory-service/AGENTS.md
+++ b/services/memory-service/AGENTS.md
@@ -1,7 +1,7 @@
 # services/memory-service — AGENTS.md
 
 > Go 1.22+. Inherits rules from root `AGENTS.md` and `services/AGENTS.md`.
-> **Status: M5+ (not yet implemented).** BDD contract tests exist in `protos/tests/`.
+> **Status: M6+ (not yet implemented).** BDD contract tests exist in `protos/tests/`.
 
 ---
 

--- a/services/task-broker/AGENTS.md
+++ b/services/task-broker/AGENTS.md
@@ -1,8 +1,7 @@
 # services/task-broker — AGENTS.md
 
 > Go 1.26.3+. Inherits rules from root `AGENTS.md` and `services/AGENTS.md`.
-> **Status: M5 Implemented — quality cleanup in progress (#531, #532).**
-> Implementation merged in PRs #520, #522, #523. BDD contract tests in `protos/tests/task_broker_service/`.
+> **Status: M5 Complete** — Implementation merged in PRs #520, #522, #523. BDD aligned (#531), handler unit tests complete (#532). Domain coverage 92.7%. BDD contract tests in `protos/tests/task_broker_service/`.
 
 ---
 

--- a/services/workflow-compiler/AGENTS.md
+++ b/services/workflow-compiler/AGENTS.md
@@ -1,13 +1,12 @@
 # services/workflow-compiler — AGENTS.md
 
 > Go 1.26.3. Inherits rules from root `AGENTS.md` and `services/AGENTS.md`.
-> **Status: M2 Complete.** Fully implemented — one of two complete platform services (M3 adds engine-adapter).
+> **Status: M5 Complete.** Fully implemented — YAML → WorkflowIR, structured error list, cel-go guard wiring. IR store is in-memory (durable storage in M6, #466).
 
-> **⚠ Persistence limitation (M5):** The IR store is an unbounded in-memory map (`sync.RWMutex` +
+> **⚠ Persistence limitation (M6):** The IR store is an unbounded in-memory map (`sync.RWMutex` +
 > `map[string]*WorkflowIR`) with **no TTL, no eviction, and no persistence across restarts**.
-> `GetCompiledWorkflow` returns `NOT_FOUND` after any pod restart. There is no 30-day retention
-> guarantee in M5. Durable retention is tracked in [#466](https://github.com/zynax-io/zynax/issues/466)
-> (M6 — stateless-compiler refactor).
+> `GetCompiledWorkflow` returns `NOT_FOUND` after any pod restart. Durable retention is tracked in
+> [#466](https://github.com/zynax-io/zynax/issues/466) (M6 — stateless-compiler refactor).
 
 ---
 


### PR DESCRIPTION
## Summary

Full documentation truth-pass after M5 completion (v0.4.0 released 2026-05-29).
Every document that still described M5 as in-progress or referenced completed work as pending has been corrected.

**Scope:** 26 files — no code changes, no API changes, no behaviour changes.

## Changes by area

### Top-level docs
- **README.md** — M5 milestone row → Complete; ci/llm/langgraph adapter rows → ✅ Complete with accurate descriptions
- **ARCHITECTURE.md** — M5 milestone row; runtime diagram updated (bearer-token constant-time ✅, ReadHeaderTimeout ✅, task-broker in compose ✅, agent-registry 0 LoC → MVP ✅, adapters pending → ✅); capability flow label updated; RetryPolicy note updated to reflect #569 fix; Known Limitations table — removed 3 resolved items (G1 #567, G4 #569, M5.C #460); LoC table updated with agent-registry counts
- **ROADMAP.md** — M5 header → Complete; all M5.A/B/C/D/E/F track items and Adapter Library items → ✅
- **SECURITY.md** — constant-time compare (#567) and ReadHeaderTimeout (#568) moved to Shipped; gRPC deadlines added; distroless user note corrected (uid 65532, not USER zynax); "In Progress" section retitled M6; ReadHeaderTimeout removed from Planned

### Canvas files — Aligned → Implemented (15 files)
All M5-delivered canvases: #377 #381 #382 #383 #384 #442 #458 #459 #460 #461 #462 #474 #476 #479 #480

M6+ planned canvases remain `Aligned` (correct — design approved, implementation not yet started).

### Service AGENTS.md status headers (7 services)
| Service | Before | After |
|---------|--------|-------|
| api-gateway | M4 in progress | M5 Complete |
| task-broker | quality cleanup in progress | M5 Complete |
| engine-adapter | M3 Complete | M5 Complete |
| workflow-compiler | M2 Complete | M5 Complete; persistence note M5→M6 |
| agent-registry | M5.C (active) | M5 Complete |
| event-bus | M5+ not yet implemented | M6+ not yet implemented |
| memory-service | M5+ not yet implemented | M6+ not yet implemented |

## Why

M5 is complete (v0.4.0 released 2026-05-29, GitHub milestone closed PR #759). Every document in the repo was still describing M5 as "In Progress" or referencing completed issues as pending. This PR makes the repository documentation self-consistent.

## Test plan

### Local pre-flight
- [x] `make lint-go`/`lint-protos`/`lint-agents` — N/A (docs-only)
- [x] `GOWORK=off go test ./... -race` — N/A (docs-only)
- [x] `make test-coverage` — N/A (docs-only)
- [x] `make security` — N/A (docs-only)

### Acceptance
- [x] All M5-complete canvases show `**Status:** Implemented` — verified via grep
- [x] README.md Milestone table: M5 → Complete ✅
- [x] README.md Adapter table: all 5 adapters → ✅ Complete
- [x] ARCHITECTURE.md runtime diagram: no stale ⚠ annotations on fixed issues
- [x] ARCHITECTURE.md Known Limitations: no M5-resolved issues remain
- [x] ROADMAP.md M5 section: all checklist items ✅
- [x] SECURITY.md: #567, #568 in Shipped; distroless user correct
- [x] All 7 service AGENTS.md headers reflect M5/M6 reality

### Engineering hygiene
- [x] **`M5-plan.md` row** — N/A (docs-only; M5-plan already updated in #759)
- [x] **`current-milestone.md`** — N/A (already up-to-date from #759)
- [x] Branched from fresh `origin/main` · PR ≤900 lines · trailers on every commit
- [x] Gap scan: G1/G4 resolved items removed from Known Limitations ✅
- [x] No out-of-scope edits · no mTLS/SBOM/cosign "shipped" claims

## Out of scope

- M6 planning (no execution plan yet)
- adapter AGENTS.md files (no status headers; content matches implementation)
- CHANGELOG.md (already accurate)
- ADR files (no status claims to update)

Assisted-by: Claude/claude-sonnet-4-6