### PR TITLE
fix(ci): guard service BDD step against services with no test implementations

### DIFF
--- a/.github/workflows/_test-go.yml
+++ b/.github/workflows/_test-go.yml
@@ -188,8 +188,20 @@ jobs:
       - name: Service BDD tests (godog)
         if: steps.go-detect.outputs.has_svc_bdd != '0'
         run: |
-          bash tools/ci/run-go-svc-loop.sh services/ "${{ env.SERVICE_LIST }}" -- \
-            go test ./tests/... -v -timeout 120s
+          # Build a filtered list: only services whose tests/ dir has *_test.go files.
+          # Services with a feature spec but no step implementations yet are skipped
+          # gracefully — `go test ./tests/...` exits 1 on no packages, so we pre-filter.
+          svc_bdd_list=""
+          for svc in ${{ env.SERVICE_LIST }}; do
+            if find "services/${svc}/tests" -name "*_test.go" 2>/dev/null | grep -q .; then
+              svc_bdd_list="${svc_bdd_list} ${svc}"
+            fi
+          done
+          svc_bdd_list="${svc_bdd_list# }"
+          if [ -n "$svc_bdd_list" ]; then
+            bash tools/ci/run-go-svc-loop.sh services/ "$svc_bdd_list" -- \
+              go test ./tests/... -v -timeout 120s
+          fi
           echo "✅ Service BDD tests passed"
 
       - name: No service BDD step implementations yet


### PR DESCRIPTION
## Summary

- Pre-filters the `SERVICE_LIST` in the **Service BDD tests** CI step to only include services that have at least one `*_test.go` in their `tests/` directory.
- Services whose `tests/` folder contains only a `.feature` spec (but no step implementations) are now skipped gracefully instead of failing.

## Why

`go test ./tests/...` exits 1 with `no packages to test` when the `tests/` directory has no `.go` files. This caused the `test-go` job to fail whenever `services/*/AGENTS.md` files were changed (those paths trip the service path-filter, causing the loop to run for all 5 platform services, 4 of which have spec-only `tests/` directories).

The root cause: only `task-broker` has `tests/steps_test.go` today. The other services have `.feature` files committed (correct ADR-016 feature-first practice) but no step implementations yet. The CI must tolerate this intermediate state.

## Approach

Build a filtered list before calling `run-go-svc-loop.sh`:
```bash
svc_bdd_list=""
for svc in $SERVICE_LIST; do
  if find "services/${svc}/tests" -name "*_test.go" 2>/dev/null | grep -q .; then
    svc_bdd_list="${svc_bdd_list} ${svc}"
  fi
done
```

Forward-compatible: as each service gains step implementations (Fix 2 — companion PRs), it is automatically included without any further CI changes.

## Test plan

### Local pre-flight
- [x] `make lint-go` — (N/A — CI YAML only)
- [x] `GOWORK=off go test ./... -race` — (N/A — CI YAML only)
- [x] `make security` — (N/A)

### Acceptance
- [x] `test-go` job no longer exits 1 when services without `steps_test.go` are in the changed set
- [x] `task-broker` (which has `steps_test.go`) still runs its BDD tests — loop logic unchanged for services that pass the filter
- [x] `No service BDD step implementations yet` fallback step still fires when `has_svc_bdd == '0'`

### Engineering hygiene
- [x] **`M5-plan.md` row** — (N/A — CI fix)
- [x] **`current-milestone.md`** — (N/A)
- [x] Branched from fresh `origin/main` · PR ≤900 lines · trailers on every commit
- [x] Gap scan — (N/A — CI YAML only)
- [x] No out-of-scope edits

## Out of scope

Adding `steps_test.go` to the remaining 6 services — tracked in companion PRs (Fix 2).

Assisted-by: Claude/claude-sonnet-4-6