### PR TITLE
refactor(workflow-compiler): drop in-memory IR store — make CompileWorkflow stateless

### DIFF
--- a/services/workflow-compiler/internal/api/server.go
+++ b/services/workflow-compiler/internal/api/server.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"sync"
 	"time"
 
 	zynaxv1 "github.com/zynax-io/zynax/protos/generated/go/zynax/v1"
@@ -19,33 +18,24 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-// Server implements WorkflowCompilerServiceServer using in-memory IR storage.
-// The in-memory store is appropriate for M5; a persistent backend is deferred to M6.
-//
-// WARNING: the store is an unbounded in-memory map with no TTL, no eviction, and no
-// persistence across restarts. GetCompiledWorkflow returns NOT_FOUND after any restart.
-// Durable storage is tracked in issue #466 (M6 — stateless-compiler refactor).
+// Server implements WorkflowCompilerServiceServer.
+// The compiler is stateless: each CompileWorkflow call compiles the manifest
+// and returns the IR in the response. Callers must retain ir_payload if they
+// need the IR after the RPC — GetCompiledWorkflow always returns NOT_FOUND.
 //
 // Server is not usable at zero value; always construct via New().
-// When future milestones add injectable dependencies (persistent store, tracer),
-// extend New() with functional options following the WithXxx(v) pattern.
 type Server struct {
 	zynaxv1.UnimplementedWorkflowCompilerServiceServer
-	mu         sync.RWMutex
-	store      map[string]*zynaxv1.WorkflowIR
 	generateID func() string
 }
 
 // New creates a Server ready to serve gRPC requests.
 func New() *Server {
-	return &Server{
-		store:      make(map[string]*zynaxv1.WorkflowIR),
-		generateID: generateWorkflowID,
-	}
+	return &Server{generateID: generateWorkflowID}
 }
 
 // CompileWorkflow parses, validates, and compiles a YAML manifest into a WorkflowIR.
-// The compiled IR is stored unless dry_run is true.
+// The compiled IR is returned in the response; it is not stored anywhere.
 func (s *Server) CompileWorkflow(ctx context.Context, req *zynaxv1.CompileWorkflowRequest) (*zynaxv1.CompileWorkflowResponse, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, status.FromContextError(err).Err()
@@ -84,12 +74,6 @@ func (s *Server) CompileWorkflow(ctx context.Context, req *zynaxv1.CompileWorkfl
 	wfIR, err := ir.ToIR(ctx, g, wfID, manifest.APIVersion, time.Now().UTC())
 	if err != nil {
 		return nil, grpcErr(fmt.Errorf("IR generation: %w", err))
-	}
-
-	if !req.DryRun {
-		s.mu.Lock()
-		s.store[wfID] = wfIR
-		s.mu.Unlock()
 	}
 
 	durationMs := time.Since(start).Milliseconds()
@@ -136,7 +120,10 @@ func (s *Server) ValidateManifest(ctx context.Context, req *zynaxv1.ValidateMani
 	}, nil
 }
 
-// GetCompiledWorkflow retrieves a previously compiled WorkflowIR by workflow_id.
+// GetCompiledWorkflow always returns NOT_FOUND. The compiler is stateless — the
+// compiled IR is returned in the CompileWorkflow response and is not stored.
+// Callers must retain the ir_payload from CompileWorkflowResponse and pass it
+// directly to EngineAdapterService.SubmitWorkflow.
 func (s *Server) GetCompiledWorkflow(ctx context.Context, req *zynaxv1.GetCompiledWorkflowRequest) (*zynaxv1.GetCompiledWorkflowResponse, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, status.FromContextError(err).Err()
@@ -144,19 +131,10 @@ func (s *Server) GetCompiledWorkflow(ctx context.Context, req *zynaxv1.GetCompil
 	if req.WorkflowId == "" {
 		return nil, status.Error(codes.InvalidArgument, "workflow_id must not be empty")
 	}
-
-	s.mu.RLock()
-	wfIR, ok := s.store[req.WorkflowId]
-	s.mu.RUnlock()
-
-	if !ok {
-		return nil, status.Errorf(codes.NotFound, "workflow %q not found", req.WorkflowId)
-	}
-
-	return &zynaxv1.GetCompiledWorkflowResponse{
-		WorkflowIr: wfIR,
-		CompiledAt: wfIR.CompiledAt,
-	}, nil
+	return nil, status.Errorf(codes.NotFound,
+		"workflow %q not found: compiler is stateless — retain ir_payload from CompileWorkflow response",
+		req.WorkflowId,
+	)
 }
 
 // errorCodeMap maps domain codes to proto codes.

--- a/services/workflow-compiler/internal/api/server_test.go
+++ b/services/workflow-compiler/internal/api/server_test.go
@@ -177,9 +177,8 @@ func TestCompileWorkflow_LineNumberBoundsCheck(t *testing.T) {
 	}
 }
 
-func TestCompileWorkflow_DryRunDoesNotStore(t *testing.T) {
-	s := newServer()
-	resp, err := s.CompileWorkflow(context.Background(), &zynaxv1.CompileWorkflowRequest{
+func TestCompileWorkflow_DryRunReturnsIR(t *testing.T) {
+	resp, err := newServer().CompileWorkflow(context.Background(), &zynaxv1.CompileWorkflowRequest{
 		ManifestYaml: validYAML,
 		DryRun:       true,
 	})
@@ -187,15 +186,7 @@ func TestCompileWorkflow_DryRunDoesNotStore(t *testing.T) {
 		t.Fatalf("CompileWorkflow dry_run: %v", err)
 	}
 	if resp.WorkflowIr == nil {
-		t.Fatal("expected WorkflowIR even on dry_run")
-	}
-	// GetCompiledWorkflow must not find it
-	wfID := resp.WorkflowIr.WorkflowId
-	_, getErr := s.GetCompiledWorkflow(context.Background(), &zynaxv1.GetCompiledWorkflowRequest{
-		WorkflowId: wfID,
-	})
-	if grpcCode(getErr) != codes.NotFound {
-		t.Errorf("dry_run IR should not be stored: expected NotFound, got %v", getErr)
+		t.Fatal("expected WorkflowIR in response even on dry_run")
 	}
 }
 
@@ -273,22 +264,15 @@ func TestValidateManifest_NoWorkflowIR(t *testing.T) {
 
 // GetCompiledWorkflow ──────────────────────────────────────────────────────────
 
-func TestGetCompiledWorkflow_RoundTrip(t *testing.T) {
+func TestGetCompiledWorkflow_AlwaysNotFound(t *testing.T) {
+	// The compiler is stateless: GetCompiledWorkflow always returns NOT_FOUND.
+	// Callers must retain the ir_payload from CompileWorkflow response.
 	s := newServer()
-	compiled := compile(t, s, validYAML)
-	wfID := compiled.WorkflowIr.WorkflowId
-
-	got, err := s.GetCompiledWorkflow(context.Background(), &zynaxv1.GetCompiledWorkflowRequest{
-		WorkflowId: wfID,
+	_, err := s.GetCompiledWorkflow(context.Background(), &zynaxv1.GetCompiledWorkflowRequest{
+		WorkflowId: "any-id",
 	})
-	if err != nil {
-		t.Fatalf("GetCompiledWorkflow: %v", err)
-	}
-	if got.WorkflowIr.WorkflowId != wfID {
-		t.Errorf("workflow_id: got %q, want %q", got.WorkflowIr.WorkflowId, wfID)
-	}
-	if got.CompiledAt == nil {
-		t.Error("compiled_at must not be nil")
+	if grpcCode(err) != codes.NotFound {
+		t.Errorf("expected NotFound (stateless compiler), got %v", err)
 	}
 }
 
@@ -321,6 +305,17 @@ func TestGetCompiledWorkflow_IDsAreUnique(t *testing.T) {
 	r2 := compile(t, s, validYAML)
 	if r1.WorkflowIr.WorkflowId == r2.WorkflowIr.WorkflowId {
 		t.Error("successive compiles must generate unique workflow IDs")
+	}
+}
+
+func BenchmarkCompileWorkflow(b *testing.B) {
+	s := newServer()
+	req := &zynaxv1.CompileWorkflowRequest{ManifestYaml: validYAML}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := s.CompileWorkflow(context.Background(), req); err != nil {
+			b.Fatal(err)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- Deletes the `sync.RWMutex` / `map[string]*WorkflowIR` store from `workflow-compiler.Server` — the only horizontal-scaling blocker remaining in this service (canvas #466, ADR-008)
- `GetCompiledWorkflow` now returns `NOT_FOUND` unconditionally with a message directing callers to retain `ir_payload` from `CompileWorkflowResponse`
- api-gateway was already stateless with respect to this store: `compileResultFromProto` marshals the IR from the response, and `ApplyService.submit` passes `compiled.IRBytes` directly to `SubmitWorkflow` without ever calling `GetCompiledWorkflow`

## REASONS Canvas

`docs/spdd/466-stateless-compiler/canvas.md` — Status: Aligned

## Test plan

- [x] `GOWORK=off go test ./... -race` passes in `services/workflow-compiler/` — all tests green
- [x] `GOWORK=off go test ./... -race` passes in `services/api-gateway/` — no regression
- [x] `TestGetCompiledWorkflow_RoundTrip` replaced with `TestGetCompiledWorkflow_AlwaysNotFound` (documents new stateless behaviour)
- [x] `TestCompileWorkflow_DryRunDoesNotStore` replaced with `TestCompileWorkflow_DryRunReturnsIR` (dry_run still returns IR in response)
- [x] `BenchmarkCompileWorkflow` added per canvas Norm (no latency regression: lock contention eliminated)
- [x] `golangci-lint` passes; `gofmt` passes

Closes #490

Assisted-by: Claude/claude-sonnet-4-6