### PR TITLE
docs(milestones): M6 planning §6–8 — SPDD runbook, GitHub bootstrap, open questions

### DIFF
--- a/docs/milestones/M6-planning.md
+++ b/docs/milestones/M6-planning.md
@@ -485,3 +485,728 @@ Stateless Deployments (all Go services + adapters):
 
 ---
 
+## Section 6 — SPDD Command Runbook (Deliverable 4)
+
+> Commands use the **exact signatures** read from `.claude/commands/`:
+>
+> - `/spdd-analysis <issue-number | issue-URL | feature-description>`
+> - `/spdd-story <issue-number | issue-URL | raw feature description>`
+> - `/spdd-reasons-canvas <issue-number | feature-description>` → writes `docs/spdd/<issue>-<slug>/canvas.md`
+> - `/spdd-security-review <path/to/canvas.md>` → PASS required before commit
+> - `/spdd-generate <path/to/aligned-canvas.md>` → Canvas status must be `Aligned`; executes ONE Operations step
+> - `/spdd-api-test <path/to/canvas.md>` → generates BDD .feature + grpcurl scenarios
+> - `/spdd-sync <path/to/canvas.md>` → syncs Canvas after refactoring (sets status: Synced)
+> - `/spdd-prompt-update <path/to/canvas.md>` → requirements changed → update Canvas first (resets to Draft)
+>
+> `ci:`, `test:`, `refactor:`, `docs:`, `chore:` stories are **SPDD-exempt** (no Canvas required).
+
+---
+
+### EPIC B (ArgoEngine) — Full SPDD Command Sequence
+
+```
+# --- B.1: Argo proto + .feature (feat:, new gRPC boundary) ---
+/spdd-analysis <ARGO_PROTO_ISSUE>
+  # Reads: services/engine-adapter/AGENTS.md, protos/AGENTS.md, ADR-015, ADR-016
+  # Surfaces: WorkflowEngine interface, EngineAdapterService RPCs, Argo Workflows CRD shape
+  # Tier 2 flags: any internal Argo cluster hostnames → canvas.private.md
+
+/spdd-story <ARGO_PROTO_ISSUE>
+  # Produces: INVEST stories B.1–B.4 with conventional-commit titles
+  # Creates GitHub issues via gh issue create; reports issue URLs
+
+/spdd-reasons-canvas <ARGO_PROTO_ISSUE>
+  # Writes: docs/spdd/<ARGO_PROTO_ISSUE>-argo-engine-proto/canvas.md (Status: Draft)
+  # Immediately runs /spdd-security-review on the output
+
+/spdd-security-review docs/spdd/<ARGO_PROTO_ISSUE>-argo-engine-proto/canvas.md
+  # Must PASS before canvas is committed
+  # [human reviews and sets status: Aligned]
+
+/spdd-api-test docs/spdd/<ARGO_PROTO_ISSUE>-argo-engine-proto/canvas.md
+  # Generates protos/tests/engine_adapter_service/features/argo_engine.feature
+  # (new gRPC boundary: ArgoEngine config in EngineConfig oneof)
+
+/spdd-generate docs/spdd/<ARGO_PROTO_ISSUE>-argo-engine-proto/canvas.md
+  # Executes O step 1 (proto changes), stops, waits for review
+  # [review → PR B.1 merged]
+
+# --- B.2: ArgoEngine Submit/Signal ---
+/spdd-analysis <ARGO_SUBMIT_ISSUE>
+/spdd-story <ARGO_SUBMIT_ISSUE>
+/spdd-reasons-canvas <ARGO_SUBMIT_ISSUE>
+/spdd-security-review docs/spdd/<ARGO_SUBMIT_ISSUE>-argo-submit/canvas.md
+  # [human sets: Aligned]
+/spdd-generate docs/spdd/<ARGO_SUBMIT_ISSUE>-argo-submit/canvas.md
+  # O step 1: ArgoClient wrapper + SubmitWorkflow
+  # [review] → /spdd-generate (O step 2: SignalWorkflow) → [review → PR B.2 merged]
+
+# --- B.3: ArgoEngine Query/Cancel/Watch ---
+/spdd-analysis <ARGO_QUERY_ISSUE>
+/spdd-story <ARGO_QUERY_ISSUE>
+/spdd-reasons-canvas <ARGO_QUERY_ISSUE>
+/spdd-security-review docs/spdd/<ARGO_QUERY_ISSUE>-argo-query/canvas.md
+  # [human sets: Aligned]
+/spdd-generate docs/spdd/<ARGO_QUERY_ISSUE>-argo-query/canvas.md
+  # [repeat per O step] → [PR B.3 merged]
+
+# --- B.4: ArgoEngine wiring + multi-engine dispatch ---
+/spdd-analysis <ARGO_WIRING_ISSUE>
+/spdd-reasons-canvas <ARGO_WIRING_ISSUE>
+/spdd-security-review docs/spdd/<ARGO_WIRING_ISSUE>-argo-wiring/canvas.md
+  # [human sets: Aligned]
+/spdd-generate docs/spdd/<ARGO_WIRING_ISSUE>-argo-wiring/canvas.md
+  # [PR B.4 merged]
+```
+
+---
+
+### EPIC G (e2e Harness) — SPDD Command Sequence
+
+```
+# --- G.1: kind cluster bootstrap (feat:) ---
+/spdd-analysis <E2E_CLUSTER_ISSUE>
+  # Reads: infra/AGENTS.md, docs/patterns/helm-charts.md, all EPIC A canvases
+  # Surfaces: cluster config, helmfile or helm umbrella, kind/k3d choice
+
+/spdd-story <E2E_CLUSTER_ISSUE>
+/spdd-reasons-canvas <E2E_CLUSTER_ISSUE>
+  # Canvas S-Structure: scripts/e2e/, .github/workflows/e2e-smoke.yml (skeleton)
+  # Canvas S-Safeguards: no real cluster credentials in canvas; CI kubeconfig ephemeral
+
+/spdd-security-review docs/spdd/<E2E_CLUSTER_ISSUE>-e2e-cluster/canvas.md
+  # [Aligned]
+/spdd-generate docs/spdd/<E2E_CLUSTER_ISSUE>-e2e-cluster/canvas.md
+  # O step 1: kind config + helmfile
+  # [review] → O step 2: deploy script → [PR G.1]
+
+# --- G.2: happy-path e2e (feat:) ---
+/spdd-analysis <E2E_HAPPY_ISSUE>
+/spdd-reasons-canvas <E2E_HAPPY_ISSUE>
+  # R: YAML → api-gateway → compiler → engine-adapter → Temporal → task-broker
+  #    → http-adapter → EventBusService (JetStream) → memory-service → assert
+  # O steps: (1) workflow YAML fixture, (2) deploy stack, (3) trigger, (4) assert CloudEvents, (5) assert memory reads
+/spdd-security-review docs/spdd/<E2E_HAPPY_ISSUE>-e2e-happy/canvas.md
+  # [Aligned]
+/spdd-generate docs/spdd/<E2E_HAPPY_ISSUE>-e2e-happy/canvas.md
+  # [repeat per step → PR G.2]
+
+# --- G.3–G.5: Argo path, failure path, upgrade/rollback (all feat:) ---
+# Same pattern as G.2: analysis → canvas → security-review → [Aligned] → generate (per step) → PR
+
+# NOTE: G.3–G.5 are SPDD-eligible (feat:) but smaller; canvas is brief (2–3 O steps each)
+```
+
+---
+
+### EPIC J (memory-service — stateful service) — Full SPDD Command Sequence
+
+```
+# --- J.0: Postgres-backed task-broker repo (prereq, feat:) ---
+/spdd-analysis <POSTGRES_TASKBROKER_ISSUE>
+  # Reads: services/task-broker/AGENTS.md, docs/adr/ADR-021-horizontal-scale.md,
+  #        docs/adr/ADR-008-no-shared-databases.md
+  # Surfaces: TaskRepository interface, pgx/v5 adapter, golang-migrate, testcontainers-go
+
+/spdd-story <POSTGRES_TASKBROKER_ISSUE>
+/spdd-reasons-canvas <POSTGRES_TASKBROKER_ISSUE>
+  # Canvas S-Structure: services/task-broker/internal/infrastructure/postgres/repository.go,
+  #   migrations/001_initial.sql, go.mod deps: pgx/v5, golang-migrate
+  # Canvas S-Safeguards:
+  #   - Never share the tasks table with any other service (ADR-008)
+  #   - In-memory adapter RETAINED as test double (not deleted)
+  #   - Integration tests use testcontainers-go — no shared/external DB (ADR-016)
+  #   - ZYNAX_DB_ENABLED=false in unit tests; true in K8s and compose (ADR-021)
+
+/spdd-security-review docs/spdd/<POSTGRES_TASKBROKER_ISSUE>-postgres-taskbroker/canvas.md
+  # Tier 2 check: no DSN literals, no real DB credentials, no internal hostnames → PASS
+  # [human sets: Aligned]
+
+/spdd-generate docs/spdd/<POSTGRES_TASKBROKER_ISSUE>-postgres-taskbroker/canvas.md
+  # O step 1: go.mod + pgx/v5 + golang-migrate dependency
+  # [review] → O step 2: 001_initial.sql migration → [review]
+  # → O step 3: postgres/repository.go (TaskRepository impl) → [review]
+  # → O step 4: main.go wiring (env-flag switch: memory vs postgres) → [PR J.0]
+
+# --- J.1: Postgres-backed agent-registry repo (same pattern as J.0) ---
+/spdd-analysis <POSTGRES_REGISTRY_ISSUE>
+/spdd-reasons-canvas <POSTGRES_REGISTRY_ISSUE>
+/spdd-security-review docs/spdd/<POSTGRES_REGISTRY_ISSUE>-postgres-registry/canvas.md
+  # [Aligned]
+/spdd-generate docs/spdd/<POSTGRES_REGISTRY_ISSUE>-postgres-registry/canvas.md
+  # [per O step → PR J.1]
+
+# --- J.2: memory-service scaffold (feat:) ---
+/spdd-analysis <MEMORY_SCAFFOLD_ISSUE>
+/spdd-story <MEMORY_SCAFFOLD_ISSUE>
+/spdd-reasons-canvas <MEMORY_SCAFFOLD_ISSUE>
+  # Canvas S-Structure:
+  #   services/memory-service/cmd/memory-service/main.go
+  #   internal/domain/kv.go, vector.go, namespace.go, errors.go
+  #   internal/api/handler.go
+  #   internal/infrastructure/redis_kv.go, pgvector.go
+  # Canvas S-Safeguards (MANDATORY content per state-minimization):
+  #   - Single-store evaluation: Redis Stack vs Redis+pgvector — RECORD decision and rationale
+  #   - memory-service is the ONLY consumer of its Redis instance; no sharing (ADR-008)
+  #   - Postgres schema is exclusively `memory` — no shared tables with task-broker/agent-registry
+  #   - Why JetStream cannot substitute: JetStream is message delivery, not synchronous KV
+  #     with TTL and similarity search — these are fundamentally different access patterns
+  #   - K8s topology: memory-service Go pod = stateless Deployment; Redis = StatefulSet/PVC
+  #   - KV TTL is best-effort (per proto invariant 3); callers must not depend on sub-second precision
+  #   - workflow_id isolation: service MUST reject any cross-namespace access (proto invariant 2)
+
+/spdd-security-review docs/spdd/<MEMORY_SCAFFOLD_ISSUE>-memory-scaffold/canvas.md
+  # Tier 2 flags: no real Redis/Postgres hostnames, no credentials → must PASS
+  # [human sets: Aligned]
+
+/spdd-api-test docs/spdd/<MEMORY_SCAFFOLD_ISSUE>-memory-scaffold/canvas.md
+  # Generates BDD grpcurl scenarios for MemoryService 10 RPCs
+  # (BDD feature file already committed — this generates test script and verifies coverage)
+
+/spdd-generate docs/spdd/<MEMORY_SCAFFOLD_ISSUE>-memory-scaffold/canvas.md
+  # O step 1: go.mod + domain interfaces
+  # [review → PR J.2]
+
+# --- J.3: Redis KV adapter ---
+/spdd-analysis <REDIS_KV_ISSUE>
+/spdd-reasons-canvas <REDIS_KV_ISSUE>
+  # Inherits single-store decision from J.2 Canvas; links [[memory-scaffold]]
+/spdd-security-review docs/spdd/<REDIS_KV_ISSUE>-redis-kv/canvas.md
+  # [Aligned]
+/spdd-generate docs/spdd/<REDIS_KV_ISSUE>-redis-kv/canvas.md
+  # O step 1: go-redis v9 dep → O step 2: redis_kv.go Set/Get/Delete/ListKeys
+  # → O step 3: MGet/MSet/DeleteNamespace + TTL → [PR J.3]
+
+# --- J.4: pgvector adapter ---
+/spdd-analysis <PGVECTOR_ISSUE>
+/spdd-reasons-canvas <PGVECTOR_ISSUE>
+  # Safeguards: pgvector schema is exclusively memory-service; no JOIN across service schemas
+/spdd-security-review docs/spdd/<PGVECTOR_ISSUE>-pgvector/canvas.md
+  # [Aligned]
+/spdd-generate docs/spdd/<PGVECTOR_ISSUE>-pgvector/canvas.md
+  # O step 1: pgvector migration + pgxpool → O step 2: StoreVector/QueryVector/DeleteVector
+  # → [PR J.4]
+
+# --- J.5: namespace TTL + isolation --- (follow same pattern)
+# --- J.6: gRPC handler wiring --- (follow same pattern)
+
+# --- J.7: BDD steps (test: — SPDD-exempt) ---
+# No Canvas needed. Directly implement testcontainers-go BDD steps for memory_service.feature.
+# test: PR → no /spdd-* commands required
+```
+
+**When requirements change mid-implementation (e.g., single-store evaluation in J.2 changes the store choice):**
+```
+/spdd-prompt-update docs/spdd/<MEMORY_SCAFFOLD_ISSUE>-memory-scaffold/canvas.md
+  # Describe the change (e.g., "switching to Redis Stack for both KV and vector planes")
+  # Updates R, E, A, S sections; resets Status to Draft; runs /spdd-security-review
+  # [human re-aligns] → /spdd-generate continues from affected O step
+```
+
+**After any refactoring that doesn't change logic (e.g., renaming files):**
+```
+/spdd-sync docs/spdd/<MEMORY_SCAFFOLD_ISSUE>-memory-scaffold/canvas.md
+  # Updates S-Structure file paths; sets Status: Synced
+```
+
+**SPDD-exempt story types (skip Canvas):**
+```
+# test: J.7  — BDD step implementations → no /spdd-* commands
+# ci:   H.1  — e2e smoke job → no /spdd-* commands
+# ci:   A.12 — helm lint gate → no /spdd-* commands
+# refactor: D.1 — stateless compiler (canvas already exists at #466) → use existing canvas
+# docs: A.13, F.4 → no /spdd-* commands
+```
+
+---
+
+## Section 7 — GitHub Bootstrap Commands (Deliverable 5)
+
+> **For human review and execution only — do NOT run these automatically.**
+> Labels and milestone title verified against live repo:
+>   - Milestone: `"K8s Production-Ready (M6)"` (confirmed from milestones API, #6)
+>   - `type: adr-proposal`, `type: feature`, `type: epic`, `type: docs`, `type: test`, `type: ci`, `type: chore`
+>   - `area: event-bus`, `area: memory-service`, `area: engine-adapter`, `area: infra`, `area: workflow-compiler`, `area: api-gateway`
+>   - `priority: high`, `priority: medium`
+>   - `milestone: M6` label (separate from GitHub Milestone — use both)
+>
+> Paste in order: (0) EBUS-DECISION → (1) epics → (2) stories
+
+---
+
+### (0) EBUS-DECISION Issue — Paste First (gates EPIC I)
+
+```bash
+gh issue create \
+  --title "decision(event-bus): ADR-022 — EventBusService gRPC vs CloudEvents library + direct NATS" \
+  --label "type: adr-proposal,type: docs,area: event-bus,priority: high,milestone: M6" \
+  --milestone "K8s Production-Ready (M6)" \
+  --body "$(cat <<'EOF'
+## Decision Needed
+
+ADR-022: Should EventBusService remain a gRPC wrapper over JetStream (Option 1),
+or should services use NATS/JetStream directly with a shared CloudEvents library (Option 2/3)?
+
+## Why Now
+
+M6 implements event-bus for real. This is a one-way door — ADR required per CLAUDE.md.
+It gates EPIC I scope and the e2e harness (EPIC G).
+
+## Pre-Commitment Evidence
+
+The repo has substantially pre-committed to Option 1:
+- `protos/zynax/v1/event_bus.proto` — gRPC EventBusService committed
+- `services/event-bus/tests/features/event_bus.feature` — 6 BDD scenarios committed
+- `services/event-bus/AGENTS.md` — describes gRPC service with NATSEventBus infrastructure adapter
+- ADR-001: all inter-service calls are gRPC; ADR-013: Python adapters use gRPC stubs only
+
+## Options
+
+1. **Full gRPC EventBusService** wrapping JetStream (recommended — repo pre-committed)
+2. **Shared CloudEvents library + direct NATS** (would require reverting proto + BDD)
+3. **Hybrid**: thin control-plane service + direct NATS for internal (partially violates ADR-001)
+
+## Required Output
+
+- `docs/adr/ADR-022-event-bus-architecture.md` recording the choice
+- EPIC I (#<EPIC_I_ISSUE>) unblocked after merge
+
+Assisted-by: Claude/claude-sonnet-4-6
+EOF
+)"
+```
+
+---
+
+### (1) New Epics — Paste After EBUS-DECISION
+
+```bash
+# EPIC A — Helm Charts + K8s Runtime Provider
+gh issue create \
+  --title "epic(infra): M6.Helm — Helm charts for all 7 services + cluster dependencies" \
+  --label "type: epic,area: infra,priority: high,milestone: M6" \
+  --milestone "K8s Production-Ready (M6)" \
+  --body "$(cat <<'EOF'
+## Scope
+
+Helm charts (Deployment, Service, ServiceAccount, HPA, PDB, NetworkPolicy) for all
+7 Go services: api-gateway, workflow-compiler, engine-adapter, task-broker,
+agent-registry, event-bus, memory-service.
+
+Cluster dependencies: Temporal (existing subchart), NATS JetStream (new), Postgres 16
+(Bitnami, for task-broker + agent-registry + memory-service schemas), Redis (dedicated
+to memory-service KV plane), cert-manager ClusterIssuer.
+
+memory-service chart uses StatefulSet/PVC for Redis. All Go service pods are
+stateless Deployments.
+
+## Stories
+
+- A.0: Shared _helpers.tpl library chart
+- A.1–A.7: One chart PR per service
+- A.8: NATS JetStream subchart
+- A.9: Postgres subchart
+- A.10: Temporal dependency
+- A.11: cert-manager certificates
+- A.12: helm lint CI gate (#242)
+- A.13: Environment parity manifest (#243)
+
+## References
+
+infra/AGENTS.md · docs/patterns/helm-charts.md · ADR-020 (mTLS) · ADR-021 (Postgres)
+
+Assisted-by: Claude/claude-sonnet-4-6
+EOF
+)"
+
+# EPIC B — ArgoEngine Adapter
+gh issue create \
+  --title "epic(engine-adapter): M6.Argo — ArgoEngine WorkflowEngine implementation" \
+  --label "type: epic,area: engine-adapter,priority: medium,milestone: M6" \
+  --milestone "K8s Production-Ready (M6)" \
+  --body "$(cat <<'EOF'
+## Scope
+
+Implement ArgoEngine as a second WorkflowEngine behind the existing WorkflowEngine
+interface (ADR-015). No engine name hardcoding.
+
+Stories:
+- B.1: Proto config message for Argo + .feature BDD scenarios
+- B.2: ArgoEngine Submit + Signal
+- B.3: ArgoEngine Query + Cancel + Watch
+- B.4: Multi-engine dispatch wiring + config flag
+
+## ADRs
+
+ADR-015 (pluggable engines) · ADR-016 (.feature before implementation)
+
+Assisted-by: Claude/claude-sonnet-4-6
+EOF
+)"
+
+# EPIC D — Multi-Namespace + Stateless Compiler (extends #466)
+gh issue create \
+  --title "epic(workflow-compiler): M6.NS — Multi-namespace support in workflow-compiler" \
+  --label "type: epic,area: workflow-compiler,priority: medium,milestone: M6" \
+  --milestone "K8s Production-Ready (M6)" \
+  --body "$(cat <<'EOF'
+## Scope
+
+Extends M6.D (#466 stateless compiler) with multi-namespace routing.
+
+Stories:
+- D.1: Drop in-memory IR store (#490) — use existing #466 canvas
+- D.2: Add namespace field to WorkflowIR proto + .feature
+- D.3: Namespace-scoped compilation in workflow-compiler
+- D.4: Propagate namespace from api-gateway request
+
+Assisted-by: Claude/claude-sonnet-4-6
+EOF
+)"
+
+# EPIC E — Policy Enforcement
+gh issue create \
+  --title "epic(api-gateway): M6.Policy — routing policies, rate limits, capability quotas" \
+  --label "type: epic,area: api-gateway,area: workflow-compiler,priority: medium,milestone: M6" \
+  --milestone "K8s Production-Ready (M6)" \
+  --body "$(cat <<'EOF'
+## Scope
+
+Policy enforcement layer: routing policies, per-IP rate limits, capability quotas.
+
+Stories:
+- E.1: Policy enforcement proto messages (RoutingPolicy, RateLimit, CapabilityQuota) + .feature
+- E.2: Per-IP token-bucket rate limit on POST /api/v1/apply (#580)
+- E.3: Routing policy + capability quota in workflow-compiler
+- E.4: Quota check in engine-adapter before DispatchCapabilityActivity
+
+Assisted-by: Claude/claude-sonnet-4-6
+EOF
+)"
+
+# EPIC F — zynax-sdk PyPI + Supply Chain
+gh issue create \
+  --title "epic(agents): M6.SDK — zynax-sdk PyPI publish + supply chain hardening" \
+  --label "type: epic,area: agents/sdk,area: ci,priority: medium,milestone: M6" \
+  --milestone "K8s Production-Ready (M6)" \
+  --body "$(cat <<'EOF'
+## Scope
+
+PyPI publish for zynax-sdk (pyproject.toml already has name + hatchling build backend).
+Plus supply chain hardening (#465 canvas exists).
+
+Stories:
+- F.1: Trusted publisher + TestPyPI dry-run
+- F.2: CI release-triggered PyPI publish workflow
+- F.3: cosign signing + SBOM (closes #489, #235, #239)
+- F.4: SDK docstrings step 2 (closes #376)
+
+Assisted-by: Claude/claude-sonnet-4-6
+EOF
+)"
+
+# EPIC G — e2e Harness
+gh issue create \
+  --title "epic(infra): M6.E2E — real end-to-end harness (kind/k3d + Helm + reference workflows)" \
+  --label "type: epic,area: infra,priority: high,milestone: M6" \
+  --milestone "K8s Production-Ready (M6)" \
+  --body "$(cat <<'EOF'
+## Scope
+
+kind/k3d cluster + Helm full-stack deployment running the reference workflows
+(code-review.yaml, ci-pipeline.yaml, research-task.yaml) end-to-end on both
+Temporal and Argo engines.
+
+Assert: emitted CloudEvents consumed off JetStream (not mocked) + memory-service
+reads returning what was written.
+
+Stories:
+- G.1: kind cluster bootstrap + helmfile
+- G.2: happy-path e2e via Temporal (assert CloudEvents off JetStream, memory reads)
+- G.3: Argo path e2e
+- G.4: failure-path e2e (timeout, guard-rejected, 5xx → workflow.failed)
+- G.5: Helm upgrade/rollback test (--atomic, Temporal↔Argo values matrix)
+
+## Scope NOT in M6
+
+Full observability (distributed traces, dashboards) — explicitly M7.
+
+Assisted-by: Claude/claude-sonnet-4-6
+EOF
+)"
+
+# EPIC H — e2e CI Gate
+gh issue create \
+  --title "epic(ci): M6.CI-E2E — e2e smoke + upgrade CI gate on infra/services changes" \
+  --label "type: epic,area: ci,priority: medium,milestone: M6" \
+  --milestone "K8s Production-Ready (M6)" \
+  --body "$(cat <<'EOF'
+## Scope
+
+GitHub Actions jobs running the kind+Helm e2e stack. Gated — not on every PR.
+Triggers on changes to infra/ or engine-adapter/.
+
+Stories:
+- H.1: e2e smoke job (kind + helm, gated on infra/services/ changes)
+- H.2: matrix values test (Temporal-backed vs Argo-backed helm values)
+
+Assisted-by: Claude/claude-sonnet-4-6
+EOF
+)"
+
+# EPIC I — event-bus Implementation (BLOCKED-ON EBUS-DECISION)
+gh issue create \
+  --title "epic(event-bus): M6.I — event-bus NATS JetStream implementation" \
+  --label "type: epic,area: event-bus,priority: high,milestone: M6" \
+  --milestone "K8s Production-Ready (M6)" \
+  --body "$(cat <<'EOF'
+## BLOCKED-ON: EBUS-DECISION
+
+This epic is blocked until ADR-022 is merged (see EBUS-DECISION issue).
+Do NOT write implementation-story REASONS Canvases until ADR-022 is resolved.
+
+## Assumed Scope (if Option 1 / gRPC EventBusService chosen)
+
+Stateless Go service wrapping NATS JetStream. Durability lives entirely in
+JetStream streams/consumers (retention, replay, DLQ). No separate database.
+
+Stories:
+- I.0: docs: ADR-022 (decision record)
+- I.1: Service scaffold (go.mod, cmd/, domain/, NATS client bootstrap)
+- I.2: Publish path (JetStream stream create + event publish)
+- I.3: Subscribe path (durable consumer group + gRPC server-streaming)
+- I.4: Unsubscribe + DLQ + retry-backoff
+- I.5: Wire engine-adapter PublishLifecycleEventActivity to EventBusService gRPC
+- I.6: BDD step implementations for event_bus.feature (6 scenarios)
+
+Assisted-by: Claude/claude-sonnet-4-6
+EOF
+)"
+
+# EPIC J — memory-service Implementation
+gh issue create \
+  --title "epic(memory-service): M6.J — memory-service KV + vector implementation" \
+  --label "type: epic,area: memory-service,priority: high,milestone: M6" \
+  --milestone "K8s Production-Ready (M6)" \
+  --body "$(cat <<'EOF'
+## Scope
+
+Implement MemoryService (10 RPCs) with Redis KV plane and pgvector vector plane.
+The ONLY stateful Go service in the control plane: Redis = dedicated StatefulSet/PVC.
+Postgres (pgvector schema) is shared at cluster level with task-broker/agent-registry
+schemas per ADR-008 (each service owns its schema exclusively).
+
+## State-Minimization Justification
+
+Agents must not hold shared state internally (twelve-factor principle).
+JetStream cannot substitute: it is message-passing, not a synchronous KV store
+with TTL enforcement and ANN similarity search. Redis+pgvector is the minimum
+viable store combination for the MemoryService contract.
+
+Before committing the J.2 Canvas, evaluate Redis Stack (vector module) as a
+single-store alternative to Redis+pgvector.
+
+## Stories
+
+- J.0: Postgres-backed task-broker repo (pgx/v5 + migrations) — prereq
+- J.1: Postgres-backed agent-registry repo — prereq
+- J.2: Service scaffold (go.mod, cmd/, domain interfaces)
+- J.3: Redis KV adapter (Set/Get/Delete/ListKeys/MGet/MSet/DeleteNamespace)
+- J.4: pgvector adapter (StoreVector/QueryVector/DeleteVector)
+- J.5: Namespace TTL enforcement + workflow_id isolation
+- J.6: gRPC handler wiring (all 10 RPCs, integration tests via testcontainers-go)
+- J.7: BDD step implementations for memory_service.feature (6 scenarios)
+
+## Dependencies
+
+#626 (M6.H Postgres-backed repos) is prerequisite for J.0–J.1 + J.4.
+EPIC A (A.9 Postgres chart) is prerequisite for K8s deployment.
+
+Assisted-by: Claude/claude-sonnet-4-6
+EOF
+)"
+```
+
+---
+
+### (2) Key Stories — Paste After Epics
+
+> Only the highest-priority and untracked stories are shown below.
+> Existing tracked stories (#487, #488, #489, #490, #491, #580, etc.) already exist — do NOT recreate.
+> Replace `<EPIC_A_ISSUE>`, `<EPIC_B_ISSUE>`, etc. with the issue numbers from step (1).
+
+```bash
+# A.0 — Shared helpers library chart (prerequisite for all service charts)
+gh issue create \
+  --title "feat(infra): shared Helm _helpers.tpl library chart for all Zynax services" \
+  --label "type: feature,area: infra,priority: high,milestone: M6,size/S" \
+  --milestone "K8s Production-Ready (M6)" \
+  --body "$(cat <<'EOF'
+## Story
+
+As a platform operator, I want a shared Helm library chart with canonical
+_helpers.tpl macros so that all service charts have consistent labels,
+selectors, and security contexts without duplication.
+
+## Acceptance Criteria
+
+- [ ] `helm/zynax-lib/Chart.yaml` with `type: library`
+- [ ] `_helpers.tpl` includes: `zynax.fullname`, `zynax.labels`, `zynax.selectorLabels`, `zynax.serviceAccountName`
+- [ ] Security context macro: `runAsNonRoot: true`, `allowPrivilegeEscalation: false`, `readOnlyRootFilesystem: true`, `capabilities.drop: ["ALL"]`, `seccompProfile.type: RuntimeDefault`
+- [ ] `ct lint` passes on the library chart
+- [ ] `docs/patterns/helm-charts.md` references the library chart
+
+## Out of Scope
+
+Individual service charts (A.1–A.7 each add their own chart depending on this library).
+
+## Size estimate: S (≤200 lines)
+## Dependencies: None — this is the first chart story
+
+Closes #<EPIC_A_ISSUE> (step A.0)
+Assisted-by: Claude/claude-sonnet-4-6
+EOF
+)"
+
+# B.1 — Argo proto + BDD feature (contracts first)
+gh issue create \
+  --title "feat(protos): ArgoEngine config message + BDD scenarios for Argo engine dispatch" \
+  --label "type: feature,area: engine-adapter,area: protos,priority: medium,milestone: M6,size/S,spdd: canvas-step" \
+  --milestone "K8s Production-Ready (M6)" \
+  --body "$(cat <<'EOF'
+## Story
+
+As a workflow author, I want to specify Argo Workflows as the execution engine in my
+WorkflowIR so that the engine-adapter can dispatch to Argo instead of Temporal.
+
+## Acceptance Criteria
+
+- [ ] `protos/zynax/v1/engine_adapter.proto`: `EngineConfig` oneof extended with `ArgoConfig` message
+- [ ] `ArgoConfig` includes: `argo_server_url`, `namespace`, `service_account_name`, `workflow_template_ref`
+- [ ] `.feature` file committed: `protos/tests/engine_adapter_service/features/argo_engine.feature` with ≥3 Gherkin scenarios (submit, query, cancel via Argo)
+- [ ] `make generate-protos` succeeds (Go + Python stubs regenerated)
+- [ ] `buf breaking` CI gate passes
+
+## Size estimate: S (≤200 lines, stub exclusions apply to *.pb.go)
+## Dependencies: None
+
+Closes #<EPIC_B_ISSUE> (step B.1)
+Assisted-by: Claude/claude-sonnet-4-6
+EOF
+)"
+
+# I.0 — ADR-022 (must be first I story; unblocks all EPIC I)
+gh issue create \
+  --title "docs: ADR-022 — EventBusService gRPC architecture decision record" \
+  --label "type: docs,type: adr-proposal,area: event-bus,priority: high,milestone: M6,size/S" \
+  --milestone "K8s Production-Ready (M6)" \
+  --body "$(cat <<'EOF'
+## Story
+
+Record the EBUS-DECISION outcome as ADR-022 in docs/adr/.
+
+## Acceptance Criteria
+
+- [ ] `docs/adr/ADR-022-event-bus-architecture.md` merged
+- [ ] `docs/adr/INDEX.md` updated with ADR-022 entry
+- [ ] ADR references: ADR-001 (gRPC), ADR-013 (adapter-first), ADR-014 (event-driven), ADR-016 (contracts)
+- [ ] Implementation scope for EPIC I confirmed in ADR (Option 1/2/3)
+- [ ] services/event-bus/AGENTS.md updated to reference ADR-022
+
+## Size estimate: S (≤200 lines — docs)
+## Depends on: EBUS-DECISION issue resolved by human
+
+Closes #<EPIC_I_ISSUE> (step I.0)
+Assisted-by: Claude/claude-sonnet-4-6
+EOF
+)"
+
+# J.2 — memory-service scaffold (first implementation story for EPIC J)
+gh issue create \
+  --title "feat(memory-service): service scaffold — go.mod, domain KV+Vector interfaces, cmd/" \
+  --label "type: feature,area: memory-service,priority: high,milestone: M6,size/S,spdd: canvas-step" \
+  --milestone "K8s Production-Ready (M6)" \
+  --body "$(cat <<'EOF'
+## Story
+
+As a platform developer, I want the memory-service Go module scaffolded with
+domain interfaces so that subsequent stories (Redis KV, pgvector) can implement
+them independently.
+
+## Acceptance Criteria
+
+- [ ] `services/memory-service/go.mod` with correct module path
+- [ ] `internal/domain/kv.go`: `KVStore` interface (Set/Get/Delete/ListKeys/MGet/MSet/DeleteNamespace)
+- [ ] `internal/domain/vector.go`: `VectorStore` interface (StoreVector/QueryVector/DeleteVector)
+- [ ] `internal/domain/errors.go`: `ErrKeyNotFound`, `ErrNamespaceNotFound`, `ErrDimensionMismatch`
+- [ ] `cmd/memory-service/main.go`: wiring-only skeleton (compiles; returns UNIMPLEMENTED on all RPCs)
+- [ ] `GOWORK=off go build ./...` succeeds
+- [ ] Canvas S-Safeguards records single-store evaluation (Redis Stack vs Redis+pgvector)
+- [ ] Canvas status: Aligned before PR opened
+
+## Size estimate: S (≤200 lines)
+## Dependencies: None (scaffold is independent)
+
+Closes #<EPIC_J_ISSUE> (step J.2)
+Assisted-by: Claude/claude-sonnet-4-6
+EOF
+)"
+
+# G.1 — e2e cluster bootstrap
+gh issue create \
+  --title "feat(infra): kind cluster bootstrap + helmfile for full Zynax stack e2e" \
+  --label "type: feature,area: infra,priority: high,milestone: M6,size/M,spdd: canvas-step" \
+  --milestone "K8s Production-Ready (M6)" \
+  --body "$(cat <<'EOF'
+## Story
+
+As a CI engineer, I want a reproducible script that spins up a kind/k3d cluster
+and deploys the full Zynax stack via Helm so that e2e tests can run against a
+real cluster in CI and locally.
+
+## Acceptance Criteria
+
+- [ ] `scripts/e2e/cluster-up.sh`: creates kind cluster with appropriate node config
+- [ ] `scripts/e2e/deploy-stack.sh`: runs helmfile/helm install for all charts (or umbrella)
+- [ ] All 7 Go services + NATS + Temporal + Postgres + Redis start healthy
+- [ ] `scripts/e2e/cluster-down.sh`: tears down cluster
+- [ ] Script works on CI Ubuntu-latest runner with Docker-in-Docker
+- [ ] Documented minimum resource requirements (RAM, CPU)
+
+## Size estimate: M (201–400 lines; scripts justified by e2e complexity)
+## Dependencies: All EPIC A charts merged (A.0–A.11)
+
+Closes #<EPIC_G_ISSUE> (step G.1)
+Assisted-by: Claude/claude-sonnet-4-6
+EOF
+)"
+```
+
+---
+
+## Section 8 — Open Questions for the Human
+
+> Ordered by urgency. Lead with the EBUS-DECISION.
+
+1. **EBUS-DECISION (blocks EPIC I):** The repo pre-commits to Option 1 (gRPC EventBusService wrapping JetStream), but confirm this as ADR-022 before any EPIC I implementation starts. Run the `gh issue create` from Deliverable 0 to open the decision issue; align on ADR-022; then EPIC I stories can proceed.
+
+2. **memory-service single-store question:** Should the J.2 Canvas evaluation recommend Redis Stack (single store for KV + vector) over the pre-decided Redis+pgvector (two stores)? This is an operational simplicity vs known-patterns tradeoff. Flag your preference before J.2 Canvas is written.
+
+3. **State-minimization vs ADR-021 conflict:** The prompt says "only memory-service is stateful." ADR-021 (accepted) adds Postgres for task-broker + agent-registry. Reconcile: all Go service Deployments ARE stateless; Postgres is a shared cluster StatefulSet with separate schemas (ADR-008 compliant). Confirm this interpretation is correct before starting EPIC A Postgres subchart (A.9).
+
+4. **Multi-namespace protocol design:** How should namespace context flow from the CLI user to the workflow-compiler? (a) HTTP header in api-gateway request → gRPC metadata, or (b) new field in YAML manifest → WorkflowIR namespace? Option (b) requires a proto change and new spec field. Decide before D.2 starts.
+
+5. **Policy enforcement priority:** EPIC E (policy enforcement) is on the roadmap but has no design. The per-IP rate limit (#580) is the most tractable story. Should the full routing-policy/capability-quota scope be M6 or deferred to M6.1? If M6, a proto design sprint (E.1) is needed early.
+
+6. **e2e harness timing:** EPIC G requires all EPIC A charts, EPIC I (event-bus), and EPIC J (memory-service) to be merged first. Given EPIC I is blocked on EBUS-DECISION, do you want EPIC G to start with a mock event bus stub and wire the real one in a later G iteration? Recommend: G.1–G.2 with Temporal + mocked events first; G.3 adds real JetStream after EPIC I.
+
+7. **ArgoEngine chart dependency:** EPIC B (ArgoEngine) requires the Argo Workflows cluster dependency, which has large CRD footprint. Should Argo Workflows be an optional/feature-flag chart dependency in M6, or mandatory for all deployments?
+
+8. **zynax-sdk version:** Should the first PyPI release be `0.1.0` (current pyproject.toml value) or `0.1.0.dev0` / `1.0.0a1`? This affects the PyPI stable channel vs pre-release distinction.
+
+9. **Platform config convergence ordering (#670):** Should #667 (shared config lib) and #668 (Dockerfile template) go BEFORE the Helm charts (since charts embed env var names) or in parallel? Recommend: #667 first (shared config defines env var grammar for all charts).
+
+---
+
+*Zynax — M6 Planning Document · Apache 2.0*
+*Generated 2026-06-02 from live repo state at commit 994efb7*


### PR DESCRIPTION
## Summary

Second half of `docs/milestones/M6-planning.md` (725 lines appended). Stacked on #777 — must merge after that PR.

## Sections included

| Section | Content |
|---------|---------|
| §6 SPDD command runbook | Full /spdd-* sequences for EPICs B (ArgoEngine), G (e2e harness), J (memory-service) |
| §7 GitHub bootstrap commands | `gh issue create` commands for EBUS-DECISION, 8 new epics, 5 key stories |
| §8 Open questions | 9 decisions for human review before implementation begins |

## Merge order

1. #777 (§1–5) → then this PR

## Size: 725 lines (1 file, pure Markdown)

Assisted-by: Claude/claude-sonnet-4-6