### PR TITLE
docs(event-bus): ADR-022 — EventBusService gRPC over NATS JetStream

### DIFF
--- a/.claude/commands/resume-m6.md
+++ b/.claude/commands/resume-m6.md
@@ -43,11 +43,11 @@ git fetch origin --prune && git checkout main && git pull --rebase origin main
 
 | Read when | File |
 |---|---|
-| Any EPIC touching event-bus | Wait for ADR-022 decision (#764) — EPIC I (#772) is BLOCKED |
+| Any EPIC touching event-bus | ADR-022 Accepted (#764 closed) — EPIC I (#772) needs canvas via `/spdd-reasons-canvas 772` |
 | Any memory-service work | Confirm single-store choice is in J.2 canvas safeguards |
 | Proto or BDD boundary touched | `protos/AGENTS.md` + `docs/patterns/bdd-contract-testing.md` |
 | Helm chart work | `infra/AGENTS.md` + `docs/patterns/helm-charts.md` |
-| Any ADR-governed decision | `docs/adr/INDEX.md` — ADR-022 (event-bus) is still open |
+| Any ADR-governed decision | `docs/adr/INDEX.md` — ADR-022 (event-bus) Accepted; all 22 ADRs stable |
 
 Run `/help` to confirm all SPDD commands are available.
 
@@ -74,20 +74,20 @@ Apply the **Resumption tree** (bottom) and report the matching row before taking
 
 | Priority | EPIC | Issue | Status gate |
 |---|---|---|---|
-| 1 | M6.A Health probes | #463 | canvas `Aligned`; child #487 |
-| 2 | M6.D Stateless compiler | #466 | canvas `Aligned`; child #490 — **#774 merged** ✅ |
-| 3 | M6.B mTLS | #464 | canvas `Aligned`; child #488 |
-| 4 | M6.C Supply chain | #465 | canvas `Aligned`; child #489 |
-| 5 | M6.Helm | #765 | canvas `Aligned` `docs/spdd/765-helm-charts/canvas.md`; children #779–#792 |
-| 6 | M6.H Postgres repos | #626 | canvas `Aligned` `docs/spdd/626-postgres-repos/canvas.md`; children #793 #794 |
-| 7 | M6.F Config convergence | #670 | refactor/ci — SPDD-exempt; children #667 #668 #669 |
-| 8 | M6.NS Multi-namespace | #767 | canvas `Aligned` `docs/spdd/767-multi-namespace/canvas.md`; children #799 #800; D.1 done (#774) |
-| 9 | M6.Argo | #766 | canvas `Aligned` `docs/spdd/766-argo-engine/canvas.md`; children #795–#798 |
-| 10 | M6.SDK PyPI | #769 | canvas `Aligned` `docs/spdd/769-sdk-pypi/canvas.md`; children #805–#808 |
-| 11 | M6.Policy | #768 | canvas `Aligned` `docs/spdd/768-policy-enforcement/canvas.md`; children #801–#804 |
-| 12 | M6.J memory-service | #773 | canvas `Aligned` `docs/spdd/773-memory-service/canvas.md`; children #814–#819; **BLOCKED on #626** |
-| 13 | M6.I event-bus | #772 | **BLOCKED on #764 (EBUS-DECISION)** — no canvas until ADR-022 merged |
-| 14 | M6.G e2e harness | #770 | canvas `Aligned` `docs/spdd/770-e2e-harness/canvas.md`; children #809–#813; BLOCKED on EPIC A + I + J + B |
+| ✅ | M6.A Health probes | #463 | **COMPLETE** — #487 merged in PR #821 |
+| ✅ | M6.D Stateless compiler | #466 | **COMPLETE** — #490 merged in PR #774 |
+| 1 | M6.B mTLS | #464 | canvas `Aligned`; child #488 |
+| 2 | M6.C Supply chain | #465 | canvas `Aligned`; child #489 |
+| 3 | M6.Helm | #765 | canvas `Aligned` `docs/spdd/765-helm-charts/canvas.md`; children #779–#792 |
+| 4 | M6.H Postgres repos | #626 | canvas `Aligned` `docs/spdd/626-postgres-repos/canvas.md`; children #793 #794 |
+| 5 | M6.F Config convergence | #670 | refactor/ci — SPDD-exempt; children #667 #668 #669 |
+| 6 | M6.NS Multi-namespace | #767 | canvas `Aligned` `docs/spdd/767-multi-namespace/canvas.md`; children #799 #800; D.1 done (#774) |
+| 7 | M6.Argo | #766 | canvas `Aligned` `docs/spdd/766-argo-engine/canvas.md`; children #795–#798 |
+| 8 | M6.SDK PyPI | #769 | canvas `Aligned` `docs/spdd/769-sdk-pypi/canvas.md`; children #805–#808 |
+| 9 | M6.Policy | #768 | canvas `Aligned` `docs/spdd/768-policy-enforcement/canvas.md`; children #801–#804 |
+| 10 | M6.J memory-service | #773 | canvas `Aligned` `docs/spdd/773-memory-service/canvas.md`; children #814–#819; **BLOCKED on #626** |
+| 11 | M6.I event-bus | #772 | ADR-022 Accepted (#764 closed) — no canvas yet; run `/spdd-reasons-canvas 772` first |
+| 12 | M6.G e2e harness | #770 | canvas `Aligned` `docs/spdd/770-e2e-harness/canvas.md`; children #809–#813; BLOCKED on EPIC A + I + J + B |
 
 ```bash
 gh issue view <EPIC_N> --json number,title,body,labels,state,milestone,comments

--- a/docs/adr/ADR-022-event-bus-architecture.md
+++ b/docs/adr/ADR-022-event-bus-architecture.md
@@ -1,0 +1,101 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# ADR-022 — EventBusService gRPC wrapper over NATS JetStream
+
+| Field | Value |
+|-------|-------|
+| **Status** | Accepted |
+| **Date** | 2026-06-02 |
+| **Deciders** | Oscar Gómez Manresa |
+| **Governs** | `services/event-bus/`, `protos/zynax/v1/event_bus.proto`, all producer/consumer wiring |
+
+---
+
+## Context
+
+The repo needed a formal decision on whether to implement the event bus as:
+
+- **Option 1** — a full gRPC `EventBusService` wrapping NATS JetStream (stateless Go service).
+- **Option 2** — a shared CloudEvents library + direct NATS access (no service).
+- **Option 3** — a hybrid thin control-plane service + direct NATS for internal paths.
+
+This is a one-way door: the proto contract (`event_bus.proto`) and BDD feature file were committed before this ADR (ADR-016: contracts before code). Reversing to Option 2 or 3 would require reverting accepted contracts.
+
+### Pre-commitment evidence at decision time
+
+| Artifact | Status |
+|----------|--------|
+| `protos/zynax/v1/event_bus.proto` — `EventBusService` with `Publish`, `Subscribe`, `Unsubscribe` | Committed |
+| `services/event-bus/tests/features/event_bus.feature` — 6 BDD scenarios | Committed |
+| `services/event-bus/AGENTS.md` — describes gRPC service with `NATSEventBus` adapter | Committed |
+| ADR-001 — all inter-service calls are gRPC; no direct cross-service imports | Accepted |
+| ADR-013 — Python adapters use gRPC stubs only; no NATS client library in agents | Accepted |
+
+---
+
+## Decision
+
+**Option 1 — Full gRPC EventBusService wrapping NATS JetStream.**
+
+The `event-bus` Go service is a **stateless Deployment** that wraps JetStream. All durability (stream retention, consumer groups, DLQ) lives entirely in JetStream — the Go service itself holds no persistent state.
+
+All producers (engine-adapter, task-broker, agent-registry) call `EventBusService.Publish` via gRPC.  
+All consumers (future observability, memory-service event triggers) call `EventBusService.Subscribe` via gRPC server-streaming.  
+The `PublishLifecycleEventActivity` stub in `services/engine-adapter/internal/infrastructure/activities.go` will be wired to the `EventBusService` gRPC stub when this service ships (EPIC I).
+
+---
+
+## Rationale
+
+1. **ADR-001 compliance** — All inter-service communication must be gRPC. Directing services or Python adapters to a NATS client library would violate ADR-001 and ADR-013.
+2. **Proto/BDD irreversibility** — Reverting the committed proto + BDD contracts to adopt a library approach would violate the ADR-016 "contracts before code" invariant in reverse (removing accepted contracts is a one-way door in the other direction).
+3. **Natural policy chokepoint** — The gRPC service boundary is the right place to enforce topic authorization, namespace isolation, and rate limits (planned for M7). A shared library has no natural enforcement point.
+4. **Stateless service** — The extra gRPC hop (~0.1–1 ms per publish on local network) is acceptable for async event delivery. The service itself is stateless; scaling is a Deployment replica-count change.
+5. **CNCF alignment** — A clean versioned gRPC contract (`zynax.v1.EventBusService`) is more portable than a shared library dependency.
+
+---
+
+## Consequences
+
+**Positive**
+- ADR-001 and ADR-013 compliance: zero exceptions needed.
+- Policy, quota, and multi-namespace isolation fit naturally as gRPC middleware (M7).
+- Horizontal scaling is trivial (stateless Deployment).
+- BDD contract tests (`event_bus.feature`) can be run without NATS in test doubles.
+
+**Negative**
+- One extra network hop per `Publish` call vs direct JetStream.
+- One additional service to deploy, monitor, and maintain.
+
+**Neutral**
+- NATS JetStream is a cluster-level StatefulSet. The event-bus Go service is a stateless Deployment.
+- The Helm chart for event-bus (EPIC A, step A.6) is gated on this ADR (now unblocked).
+
+---
+
+## Implementation scope (EPIC I — #772)
+
+Story decomposition (O-steps, to be created via `/spdd-story 772`):
+
+| Step | Story | Notes |
+|------|-------|-------|
+| I.1 | Service scaffold — `go.mod`, `cmd/`, domain types, NATS JetStream client bootstrap | No external deps beyond NATS Go SDK |
+| I.2 | Publish path — JetStream stream create + event publish | Domain: `EventBus.Publish` |
+| I.3 | Subscribe path — durable consumer group + gRPC server-streaming | Domain: `EventBus.Subscribe` |
+| I.4 | Unsubscribe + DLQ + retry-backoff wiring | Completes the EventBus interface |
+| I.5 | Wire engine-adapter `PublishLifecycleEventActivity` to EventBusService gRPC | Removes the log-only stub |
+| I.6 | BDD step implementations for `event_bus.feature` (6 scenarios) | `test:` type — SPDD-exempt |
+
+Canvas must be created via `/spdd-reasons-canvas 772` before any implementation PR is opened.
+
+---
+
+## References
+
+- ADR-001: gRPC as the inter-service protocol
+- ADR-008: No shared databases — event durability lives in JetStream, not a service DB
+- ADR-013: Adapter-first — Python adapters use gRPC stubs only
+- ADR-014: Event-driven state machine workflow model
+- ADR-016: Layered testing — BDD contracts before implementation
+- Decision issue: [#764](https://github.com/zynax-io/zynax/issues/764)
+- EPIC I: [#772](https://github.com/zynax-io/zynax/issues/772)

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -32,6 +32,7 @@ a PR against `docs/adr/`.
 | [ADR-019](ADR-019-spdd-prompt-governance.md) | Structured Prompt-Driven Development (SPDD) | Accepted | 2026-04-30 | `feat:` PRs — Canvas before code, `docs/spdd/`, slash commands |
 | [ADR-020](ADR-020-zero-trust-auth.md) | mTLS with cert-manager for inter-service gRPC auth | Accepted | 2026-05-21 | All inter-service gRPC in K8s — #240 #488 |
 | [ADR-021](ADR-021-horizontal-scale.md) | Postgres-backed repositories for horizontal scaling | Accepted | 2026-05-21 | task-broker + agent-registry repos — #578 #626 |
+| [ADR-022](ADR-022-event-bus-architecture.md) | EventBusService gRPC wrapper over NATS JetStream | Accepted | 2026-06-02 | `services/event-bus/`, `protos/zynax/v1/event_bus.proto`, EPIC I (#772) |
 
 ---
 

--- a/docs/milestones/M6-planning.md
+++ b/docs/milestones/M6-planning.md
@@ -2,7 +2,7 @@
 
 # Zynax M6 — K8s Production-Ready Planning
 
-> Generated: 2026-06-02 · Last updated: 2026-06-02  
+> Generated: 2026-06-02 · Last updated: 2026-06-02 (ADR-022 accepted; EPIC I unblocked)  
 > Based on live repo state at commit `994efb7` (main).  
 > GitHub Milestone: **"K8s Production-Ready (M6)"** (milestone #6, 30 open issues / 2 closed).  
 > All `gh` commands, file reads, and live issue data were gathered in this session — nothing assumed from memory.
@@ -11,7 +11,8 @@
 
 | Story | Issue | EPIC | PR | Status |
 |-------|-------|------|----|--------|
-| C.2 feat(api-gateway+engine-adapter): split startup/readiness/liveness probes | #487 | M6.A #463 | — | ✅ Merged |
+| C.2 feat(api-gateway+engine-adapter): split startup/readiness/liveness probes | #487 | M6.A #463 | #821 | ✅ Merged |
+| I.0 docs: ADR-022 EventBus architecture decision | #764 | M6.I #772 | — | ✅ Decision: Option 1 (gRPC svc) |
 
 ---
 

--- a/services/event-bus/AGENTS.md
+++ b/services/event-bus/AGENTS.md
@@ -1,7 +1,7 @@
 # services/event-bus — AGENTS.md
 
 > Go 1.22+. Inherits rules from root `AGENTS.md` and `services/AGENTS.md`.
-> **Status: M6+ (not yet implemented).** BDD contract tests exist in `protos/tests/`. NATS JetStream backend; `PublishLifecycleEventActivity` in engine-adapter is a log-only stub until this service ships.
+> **Status: M6 EPIC I (#772) — implementation pending.** Architecture decided by ADR-022: full gRPC `EventBusService` wrapping NATS JetStream; the service is a stateless Deployment (all durability in JetStream). BDD contract tests exist in `protos/tests/`. `PublishLifecycleEventActivity` in engine-adapter is a log-only stub until EPIC I ships.
 
 ---
 

--- a/state/current-milestone.md
+++ b/state/current-milestone.md
@@ -175,13 +175,18 @@ Priority gaps to file immediately:
 
 ## M6 — Active Work
 
-### M6.A Health Probe Semantics (#463)
+### M6.A Health Probe Semantics (#463) — ✅ COMPLETE
 
 | Story | Issue | Status |
 |-------|-------|--------|
-| C.2 split probes in api-gateway + engine-adapter | [#487](https://github.com/zynax-io/zynax/issues/487) | ✅ PR open |
+| C.2 split probes in api-gateway + engine-adapter | [#487](https://github.com/zynax-io/zynax/issues/487) | ✅ Merged (#821) |
 
 Canvas: `docs/spdd/463-health-probes/canvas.md` — Status: Implemented
+
+### EBUS-DECISION (#764) — ✅ RESOLVED
+
+**ADR-022 accepted — Option 1: Full gRPC EventBusService wrapping NATS JetStream.**
+EPIC I (#772) is unblocked. Canvas needed: run `/spdd-reasons-canvas 772` before implementation.
 
 ---
 


### PR DESCRIPTION
## Summary

Records the EBUS-DECISION (#764): **Option 1 — Full gRPC EventBusService wrapping NATS JetStream.**

The EventBusService is a stateless Go Deployment. All durability (stream retention, consumer groups, DLQ) lives in JetStream. All producers and consumers use gRPC — no direct NATS access from other services or Python adapters (ADR-001 + ADR-013).

## Changes

- `docs/adr/ADR-022-event-bus-architecture.md` (new) — full decision record with rationale, consequences, and EPIC I implementation scope
- `docs/adr/INDEX.md` — ADR-022 row added (Accepted, 2026-06-02)
- `services/event-bus/AGENTS.md` — status updated; references ADR-022
- `.claude/commands/resume-m6.md` — M6.A/D marked ✅; EPIC I unblocked; priority table updated
- `docs/milestones/M6-planning.md` — I.0 delivery row; last-updated bump
- `state/current-milestone.md` — EBUS-DECISION resolved; EPIC I next step noted

## What this unblocks

- **EPIC I (#772)** — event-bus implementation can start once canvas is created (`/spdd-reasons-canvas 772`)
- **EPIC A step A.6** — Helm chart for event-bus (required ADR-022 to confirm service exists)
- **EPIC G** — e2e harness (requires real event-bus wired, but G.1/G.2 can now plan around real JetStream)

Closes #764

Assisted-by: Claude/claude-sonnet-4-6