### PR TITLE
docs(milestones): M6.I story tracking — event-bus EPIC I decomposition (#823–#828)

### DIFF
--- a/docs/milestones/M6-planning.md
+++ b/docs/milestones/M6-planning.md
@@ -2,7 +2,7 @@
 
 # Zynax M6 — K8s Production-Ready Planning
 
-> Generated: 2026-06-02 · Last updated: 2026-06-02 (ADR-022 accepted; EPIC I unblocked)  
+> Generated: 2026-06-02 · Last updated: 2026-06-02 (ADR-022 accepted; EPIC I stories #823–#828 created)  
 > Based on live repo state at commit `994efb7` (main).  
 > GitHub Milestone: **"K8s Production-Ready (M6)"** (milestone #6, 30 open issues / 2 closed).  
 > All `gh` commands, file reads, and live issue data were gathered in this session — nothing assumed from memory.
@@ -12,7 +12,13 @@
 | Story | Issue | EPIC | PR | Status |
 |-------|-------|------|----|--------|
 | C.2 feat(api-gateway+engine-adapter): split startup/readiness/liveness probes | #487 | M6.A #463 | #821 | ✅ Merged |
-| I.0 docs: ADR-022 EventBus architecture decision | #764 | M6.I #772 | — | ✅ Decision: Option 1 (gRPC svc) |
+| I.0 docs: ADR-022 EventBus architecture decision | #764 | M6.I #772 | #822 | ✅ Merged |
+| I.1 feat(event-bus): service scaffold | #823 | M6.I #772 | — | ⬜ Pending canvas |
+| I.2 feat(event-bus): Publish path | #824 | M6.I #772 | — | ⬜ Pending I.1 |
+| I.3 feat(event-bus): Subscribe path | #825 | M6.I #772 | — | ⬜ Pending I.2 |
+| I.4 feat(event-bus): Unsubscribe + DLQ + retry | #826 | M6.I #772 | — | ⬜ Pending I.3 |
+| I.5 feat(engine-adapter): wire lifecycle activity | #827 | M6.I #772 | — | ⬜ Pending I.4 |
+| I.6 test: BDD steps for event_bus.feature | #828 | M6.I #772 | — | ⬜ Pending I.4 |
 
 ---
 

--- a/state/current-milestone.md
+++ b/state/current-milestone.md
@@ -185,8 +185,9 @@ Canvas: `docs/spdd/463-health-probes/canvas.md` — Status: Implemented
 
 ### EBUS-DECISION (#764) — ✅ RESOLVED
 
-**ADR-022 accepted — Option 1: Full gRPC EventBusService wrapping NATS JetStream.**
-EPIC I (#772) is unblocked. Canvas needed: run `/spdd-reasons-canvas 772` before implementation.
+**ADR-022 accepted — Option 1: Full gRPC EventBusService wrapping NATS JetStream.** (PR #822)
+EPIC I (#772) unblocked. Stories created: #823 #824 #825 #826 #827 #828.
+Next: `/spdd-reasons-canvas 772` → canvas Aligned → implement I.1 (#823) first.
 
 ---
 


### PR DESCRIPTION
## Summary

Records the 6 EPIC I story issues (#823–#828) in the M6 delivery progress table after ADR-022 was accepted and stories were created via `/spdd-story 772`.

## Changes

- `docs/milestones/M6-planning.md` — I.0–I.6 rows added to Delivery Progress table
- `state/current-milestone.md` — EPIC I story issue numbers recorded; next step noted

Assisted-by: Claude/claude-sonnet-4-6