### PR TITLE
docs(milestones): M6.D reconciliation — close #466, update delivery table

### DIFF
--- a/docs/milestones/M6-planning.md
+++ b/docs/milestones/M6-planning.md
@@ -2,7 +2,7 @@
 
 # Zynax M6 — K8s Production-Ready Planning
 
-> Generated: 2026-06-02 · Last updated: 2026-06-02 (ADR-022 accepted; EPIC I stories #823–#828 created)  
+> Generated: 2026-06-02 · Last updated: 2026-06-02 (M6.D #466 closed; delivery table updated)  
 > Based on live repo state at commit `994efb7` (main).  
 > GitHub Milestone: **"K8s Production-Ready (M6)"** (milestone #6, 30 open issues / 2 closed).  
 > All `gh` commands, file reads, and live issue data were gathered in this session — nothing assumed from memory.
@@ -11,7 +11,8 @@
 
 | Story | Issue | EPIC | PR | Status |
 |-------|-------|------|----|--------|
-| C.2 feat(api-gateway+engine-adapter): split startup/readiness/liveness probes | #487 | M6.A #463 | #821 | ✅ Merged |
+| A.1 feat(api-gateway): split startup/readiness/liveness probes | #487 | M6.A #463 | #821 | ✅ Merged |
+| D.1 refactor(workflow-compiler): drop in-memory IR store — stateless compiler | #490 | M6.D #466 | #774 | ✅ Merged |
 | I.0 docs: ADR-022 EventBus architecture decision | #764 | M6.I #772 | #822 | ✅ Merged |
 | I.1 feat(event-bus): service scaffold | #823 | M6.I #772 | — | ⬜ Pending canvas |
 | I.2 feat(event-bus): Publish path | #824 | M6.I #772 | — | ⬜ Pending I.1 |

--- a/docs/spdd/466-stateless-compiler/canvas.md
+++ b/docs/spdd/466-stateless-compiler/canvas.md
@@ -7,7 +7,7 @@
 **Issue:** #466
 **Author:** Oscar Gómez Manresa
 **Date:** 2026-05-18
-**Status:** Aligned
+**Status:** Implemented
 
 **Child issues:** #490 (drop in-memory IR store)
 

--- a/state/current-milestone.md
+++ b/state/current-milestone.md
@@ -179,15 +179,31 @@ Priority gaps to file immediately:
 
 | Story | Issue | Status |
 |-------|-------|--------|
-| C.2 split probes in api-gateway + engine-adapter | [#487](https://github.com/zynax-io/zynax/issues/487) | ✅ Merged (#821) |
+| A.1 split probes in api-gateway | [#487](https://github.com/zynax-io/zynax/issues/487) | ✅ Merged (#821) |
 
 Canvas: `docs/spdd/463-health-probes/canvas.md` — Status: Implemented
+
+### M6.D Stateless Compiler (#466) — ✅ COMPLETE
+
+| Story | Issue | Status |
+|-------|-------|--------|
+| D.1 drop in-memory IR store | [#490](https://github.com/zynax-io/zynax/issues/490) | ✅ Merged (#774) |
+
+Canvas: `docs/spdd/466-stateless-compiler/canvas.md` — Status: Implemented
 
 ### EBUS-DECISION (#764) — ✅ RESOLVED
 
 **ADR-022 accepted — Option 1: Full gRPC EventBusService wrapping NATS JetStream.** (PR #822)
 EPIC I (#772) unblocked. Stories created: #823 #824 #825 #826 #827 #828.
 Next: `/spdd-reasons-canvas 772` → canvas Aligned → implement I.1 (#823) first.
+
+### M6.B Inter-Service mTLS (#464) — 🚀 ACTIVE
+
+| Story | Issue | Status |
+|-------|-------|--------|
+| O1 mTLS env-var cert paths + credential wiring | [#488](https://github.com/zynax-io/zynax/issues/488) | ⬜ In progress |
+
+Canvas: `docs/spdd/464-mtls/canvas.md` — Status: Aligned
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds M6.D (#490, PR #774) row to `M6-planning.md` delivery table (was missing)
- Marks `docs/spdd/466-stateless-compiler/canvas.md` as `Status: Implemented`
- Closes epic #466 (story #490 merged 2026-06-02; epic was inadvertently left open)
- Adds M6.B as the new active EPIC in `state/current-milestone.md`

## Test plan

- [ ] `M6-planning.md` delivery table has D.1 row ✅
- [ ] `docs/spdd/466-stateless-compiler/canvas.md` → `Status: Implemented` ✅
- [ ] `state/current-milestone.md` → M6.D ✅ COMPLETE + M6.B 🚀 ACTIVE ✅
- [ ] Issue #466 closed in GitHub ✅
- [ ] No code changes, docs only

Closes #466

Assisted-by: Claude/claude-sonnet-4-6