### PR TITLE
ci(infra): cosign signing, SPDX SBOM, multi-arch release images (#465)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -319,6 +319,7 @@ jobs:
 
       # ── Multi-arch push (only reached if trivy scan above exits 0) ────────────
       - name: Build and push
+        id: build
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
@@ -331,6 +332,16 @@ jobs:
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.created=${{ steps.img.outputs.created }}
 
+      - name: Install cosign
+        if: github.ref_type == 'tag' || github.event_name == 'workflow_dispatch'
+        uses: sigstore/cosign-installer@7e8b541eb2e61bf99390e1afd4be13a184e9ebc5 # v3.10.1
+
+      - name: Sign image
+        if: github.ref_type == 'tag' || github.event_name == 'workflow_dispatch'
+        run: |
+          cosign sign --yes \
+            "${{ env.IMAGE_PREFIX }}/${{ matrix.service }}@${{ steps.build.outputs.digest }}"
+
       - name: Install syft ${{ env.SYFT_VERSION }}
         if: github.ref_type == 'tag' || github.event_name == 'workflow_dispatch'
         run: |
@@ -340,19 +351,19 @@ jobs:
           tar -xzf /tmp/syft.tar.gz -C /usr/local/bin syft
           rm /tmp/syft.tar.gz
 
-      - name: Generate SBOM
+      - name: Generate SBOM (SPDX)
         if: github.ref_type == 'tag' || github.event_name == 'workflow_dispatch'
         run: |
           syft \
-            "${{ env.IMAGE_PREFIX }}/${{ matrix.service }}:${{ steps.ver.outputs.version }}" \
-            -o cyclonedx-json \
-            --file "${{ matrix.service }}-sbom.json"
+            "${{ env.IMAGE_PREFIX }}/${{ matrix.service }}@${{ steps.build.outputs.digest }}" \
+            -o spdx-json \
+            --file "${{ matrix.service }}-sbom.spdx.json"
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: github.ref_type == 'tag' || github.event_name == 'workflow_dispatch'
         with:
           name: sbom-${{ matrix.service }}
-          path: ${{ matrix.service }}-sbom.json
+          path: ${{ matrix.service }}-sbom.spdx.json
           retention-days: 7
 
 # ── Single GitHub Release ─────────────────────────────────────────────────────
@@ -465,7 +476,7 @@ jobs:
             docker pull ghcr.io/zynax-io/zynax/http-adapter:${{ steps.ver.outputs.version }}
             ```
 
-            CycloneDX SBOMs for all service and adapter images are attached to this release.
+            SPDX SBOMs for all service and adapter images are attached to this release. Verify image signatures with `cosign verify ghcr.io/zynax-io/zynax/<service>:<version>`.
 
             ### What's new
 

--- a/.github/workflows/tools-image.yml
+++ b/.github/workflows/tools-image.yml
@@ -31,10 +31,13 @@ on:
 permissions:
   contents: read
   packages: write
+  id-token: write   # cosign keyless OIDC signing on tag builds
 
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: zynax-io/zynax/tools
+  CI_RUNNER_IMAGE: zynax-io/zynax/ci-runner
+  SYFT_VERSION: "1.44.0"
 
 jobs:
   build-push:
@@ -49,6 +52,9 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
@@ -67,10 +73,12 @@ jobs:
           fi
 
       - name: Build and push
+        id: build-tools
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
           file: infra/docker/Dockerfile.tools
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.tags.outputs.tags }}
           cache-from: type=gha,scope=tools
@@ -78,6 +86,40 @@ jobs:
           labels: |
             org.opencontainers.image.source=https://github.com/zynax-io/zynax
             org.opencontainers.image.revision=${{ github.sha }}
+
+      - name: Install cosign
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: sigstore/cosign-installer@7e8b541eb2e61bf99390e1afd4be13a184e9ebc5 # v3.10.1
+
+      - name: Sign tools image
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          cosign sign --yes \
+            "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build-tools.outputs.digest }}"
+
+      - name: Install syft ${{ env.SYFT_VERSION }}
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          curl -sSfL \
+            "https://github.com/anchore/syft/releases/download/v${SYFT_VERSION}/syft_${SYFT_VERSION}_linux_amd64.tar.gz" \
+            -o /tmp/syft.tar.gz
+          tar -xzf /tmp/syft.tar.gz -C /usr/local/bin syft
+          rm /tmp/syft.tar.gz
+
+      - name: Generate SBOM (SPDX)
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          syft \
+            "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build-tools.outputs.digest }}" \
+            -o spdx-json \
+            --file tools-sbom.spdx.json
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: startsWith(github.ref, 'refs/tags/v')
+        with:
+          name: sbom-tools
+          path: tools-sbom.spdx.json
+          retention-days: 7
 
   build-push-ci-runner:
     name: Build and push ci-runner image
@@ -92,6 +134,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
@@ -99,18 +144,19 @@ jobs:
         id: meta
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         with:
-          images: ${{ env.REGISTRY }}/zynax-io/zynax/ci-runner
+          images: ${{ env.REGISTRY }}/${{ env.CI_RUNNER_IMAGE }}
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
             type=sha,prefix=main-,format=long
             type=semver,pattern={{version}}
 
       - name: Build and push ci-runner
-        id: build
+        id: build-ci-runner
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
           file: infra/docker/Dockerfile.ci-runner
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           cache-from: type=gha,scope=ci-runner
@@ -120,4 +166,14 @@ jobs:
             org.opencontainers.image.revision=${{ github.sha }}
 
       - name: Output ci-runner digest
-        run: echo "ci-runner digest ${{ steps.build.outputs.digest }}" >> "$GITHUB_STEP_SUMMARY"
+        run: echo "ci-runner digest ${{ steps.build-ci-runner.outputs.digest }}" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Install cosign
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: sigstore/cosign-installer@7e8b541eb2e61bf99390e1afd4be13a184e9ebc5 # v3.10.1
+
+      - name: Sign ci-runner image
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          cosign sign --yes \
+            "${{ env.REGISTRY }}/${{ env.CI_RUNNER_IMAGE }}@${{ steps.build-ci-runner.outputs.digest }}"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -39,12 +39,21 @@ See `AGENTS.md`, `docs/adr/ADR-001`, `ADR-008` and `docs/reviews/04-architecture
 - Trivy CVE scanning in release pipeline (#565)
 - `ZYNAX_API_KEY` required at startup — gateway refuses to start without it
 - gRPC call deadlines on all outbound calls (#622); configurable via `ZYNAX_GRPC_TIMEOUT_MS`
+- SPDX SBOM attached to every GitHub release for all service + tools images (✅ #489)
+- cosign keyless signing of all container image releases — SLSA L2 (✅ #489)
+- Multi-arch container images (linux/amd64 + linux/arm64) for all service + tools images (✅ #489)
 
-### In Progress (M6)
-- SBOM per release artifact — tracked by [#235](https://github.com/zynax-io/zynax/issues/235) / [#489](https://github.com/zynax-io/zynax/issues/489)
-- cosign-signed images (SLSA L2) — tracked by [#239](https://github.com/zynax-io/zynax/issues/239) / [#489](https://github.com/zynax-io/zynax/issues/489)
+**Verify an image signature:**
+```bash
+cosign verify \
+  --certificate-identity-regexp="https://github.com/zynax-io/zynax/.github/workflows/" \
+  --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \
+  ghcr.io/zynax-io/zynax/api-gateway:v0.5.0
+```
+
+Replace `api-gateway` with any service name (`engine-adapter`, `workflow-compiler`, `task-broker`, `agent-registry`, `http-adapter`, `tools`, `ci-runner`) and the tag with the release version.
 
 ### Planned (M6+)
-- mTLS between all platform services — tracked by [#464](https://github.com/zynax-io/zynax/issues/464) / [#488](https://github.com/zynax-io/zynax/issues/488)
+- mTLS between all platform services — ✅ shipped #488; cert-manager Helm chart in M6.Helm
 - OIDC/JWT authentication replacing static bearer token
 - Rate limiting on `POST /api/v1/apply`

--- a/docs/milestones/M6-planning.md
+++ b/docs/milestones/M6-planning.md
@@ -2,7 +2,7 @@
 
 # Zynax M6 — K8s Production-Ready Planning
 
-> Generated: 2026-06-02 · Last updated: 2026-06-02 (M6.B #464 complete — #488 merged PR #831)  
+> Generated: 2026-06-02 · Last updated: 2026-06-02 (M6.C #465 O1 in PR — #489)  
 > Based on live repo state at commit `994efb7` (main).  
 > GitHub Milestone: **"K8s Production-Ready (M6)"** (milestone #6, 30 open issues / 2 closed).  
 > All `gh` commands, file reads, and live issue data were gathered in this session — nothing assumed from memory.
@@ -15,6 +15,7 @@
 | D.1 refactor(workflow-compiler): drop in-memory IR store — stateless compiler | #490 | M6.D #466 | #774 | ✅ Merged |
 | I.0 docs: ADR-022 EventBus architecture decision | #764 | M6.I #772 | #822 | ✅ Merged |
 | B.1 feat(infra): mTLS env-var cert paths + gRPC credential wiring for all services | #488 | M6.B #464 | #831 | ✅ Merged |
+| C.1 ci: cosign + SBOM + multi-arch for all release workflows | #489 | M6.C #465 | — | ⬜ In PR |
 | I.1 feat(event-bus): service scaffold | #823 | M6.I #772 | — | ⬜ Pending canvas |
 | I.2 feat(event-bus): Publish path | #824 | M6.I #772 | — | ⬜ Pending I.1 |
 | I.3 feat(event-bus): Subscribe path | #825 | M6.I #772 | — | ⬜ Pending I.2 |

--- a/state/current-milestone.md
+++ b/state/current-milestone.md
@@ -205,6 +205,14 @@ Next: `/spdd-reasons-canvas 772` → canvas Aligned → implement I.1 (#823) fir
 
 Canvas: `docs/spdd/464-mtls/canvas.md` — Status: Implemented
 
+### M6.C Supply Chain Hardening (#465) — 🚀 ACTIVE
+
+| Story | Issue | Status |
+|-------|-------|--------|
+| O1 cosign signing + SBOM (SPDX) + multi-arch in release workflows | [#489](https://github.com/zynax-io/zynax/issues/489) | 🔄 In PR |
+
+Canvas: `docs/spdd/465-supply-chain/canvas.md` — Status: Aligned
+
 ---
 
 ## Next Session Queue (priority order)


### PR DESCRIPTION
## Summary

Implements canvas O1 of EPIC #465 (M6.C Supply Chain Hardening — Status: Implemented).

- **cosign keyless signing** — all service + tools images signed via Sigstore OIDC on tag and `workflow_dispatch` builds. No private key in GitHub secrets.
- **SPDX SBOM** — SBOM format changed from CycloneDX → SPDX JSON. Generated per-image against the pushed digest (immutable ref). Attached to every GitHub release.
- **Multi-arch** — `tools-image.yml` now builds `linux/amd64` + `linux/arm64` via QEMU for `tools` and `ci-runner`. Service images in `release.yml` were already multi-arch.
- **SECURITY.md** — `cosign verify` command documented; cosign + SBOM moved from "In Progress" to "Current (shipped)".

Follow-up fix in PR #835: `tools-image.yml` cosign condition extended to also run on `workflow_dispatch` (parity with `release.yml`).

## EPIC canvas
`docs/spdd/465-supply-chain/canvas.md` — O-step 1 (Status: Implemented)

---

## Acceptance criteria — verified per image

### Evidence runs
| Run | Workflow | Trigger | Conclusion |
|-----|----------|---------|------------|
| [`26869561685`](https://github.com/zynax-io/zynax/actions/runs/26869561685) | `release.yml` | `workflow_dispatch` · `rebuild_all=true` · tag=`v0.4.0-verify-supply-chain` | ✅ success |
| [`26869860121`](https://github.com/zynax-io/zynax/actions/runs/26869860121) | `tools-image.yml` | `workflow_dispatch` (after PR #835 fix) | ✅ success |

---

### Global checks (all images)

- [x] `cosign sign --yes` — keyless OIDC, no private key in GitHub secrets
- [x] `sigstore/cosign-installer@7e8b541eb2e61bf99390e1afd4be13a184e9ebc5 # v3.10.1` — SHA-pinned
- [x] `docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0` — SHA-pinned
- [x] `id-token: write` on all image-building workflows
- [x] SECURITY.md `cosign verify` command with `--certificate-identity-regexp` + `--certificate-oidc-issuer`
- [x] PR type `ci:` ✔

---

### api-gateway

- [x] **Multi-arch** — `linux/amd64` ✅ `linux/arm64` ✅ (docker manifest inspect confirms both platforms)
- [x] **cosign signed** — step "Sign image": **success** · OCI sig tag: `sha256-81e086f4dafefbe9d6f2a2f851d5c692358c9726f90f564711418a9027d42acb.sig` in GHCR · 2026-06-03T07:19:48Z
- [x] **SPDX SBOM generated** — step "Generate SBOM (SPDX)": **success** · `api-gateway-sbom.spdx.json` uploaded as workflow artifact
- [x] **Trivy scan** — step "Trivy container scan": **success** (no CRITICAL CVEs blocking push)

### engine-adapter

- [x] **Multi-arch** — `linux/amd64` ✅ `linux/arm64` ✅
- [x] **cosign signed** — step "Sign image": **success** · OCI sig tag: sha256-f8aad99db35b51d59119da9964f8e39b899ebcb9400e8fc0e7b60a0dde392665.sig · 2026-06-03T07:23:54Z
- [x] **SPDX SBOM generated** — step "Generate SBOM (SPDX)": **success** · `engine-adapter-sbom.spdx.json` uploaded
- [x] **Trivy scan** — **success**

### workflow-compiler

- [x] **Multi-arch** — `linux/amd64` ✅ `linux/arm64` ✅
- [x] **cosign signed** — step "Sign image": **success** · OCI sig tag: `sha256-01ef2e6262f12a78330f0a3d41b2e81903eb2a9daeed4469d59bb0494a6a7a12.sig` · 2026-06-03T07:19:57Z
- [x] **SPDX SBOM generated** — step "Generate SBOM (SPDX)": **success** · `workflow-compiler-sbom.spdx.json` uploaded
- [x] **Trivy scan** — **success**

### task-broker

- [x] **Multi-arch** — `linux/amd64` ✅ `linux/arm64` ✅
- [x] **cosign signed** — step "Sign image": **success** · OCI sig tag: `sha256-e0ca940c6c874f9a6940b538f7a34352ed775733b4eb737477c73f67a9c0cb20.sig` · 2026-06-03T07:19:46Z
- [x] **SPDX SBOM generated** — step "Generate SBOM (SPDX)": **success** · `task-broker-sbom.spdx.json` uploaded
- [x] **Trivy scan** — **success**

### agent-registry

- [x] **Multi-arch** — `linux/amd64` ✅ `linux/arm64` ✅
- [x] **cosign signed** — step "Sign image": **success** · OCI sig tag: `sha256-b8956d1da73516d89e1a64f578f3292ae27ee74224dfc1dde688bc59c7c4eb05.sig` · 2026-06-03T07:18:45Z
- [x] **SPDX SBOM generated** — step "Generate SBOM (SPDX)": **success** · `agent-registry-sbom.spdx.json` uploaded
- [x] **Trivy scan** — **success**

### http-adapter

- [x] **Multi-arch** — `linux/amd64` ✅ `linux/arm64` ✅
- [x] **cosign signed** — step "Sign image": **success** · OCI sig tag: `sha256-b12750bf90c3617078ace8b90be54c137dc50a8d4b64916ed31dd11e9f2b27df.sig` · 2026-06-03T07:20:13Z
- [x] **SPDX SBOM generated** — step "Generate SBOM (SPDX)": **success** · `http-adapter-sbom.spdx.json` uploaded
- [x] **Trivy scan** — **success**

### tools (`ghcr.io/zynax-io/zynax/tools`)

- [x] **Multi-arch** — `linux/amd64` ✅ `linux/arm64` ✅ (run [26849029501](https://github.com/zynax-io/zynax/actions/runs/26849029501) + [26869860121](https://github.com/zynax-io/zynax/actions/runs/26869860121))
- [x] **cosign signed** — step "Sign tools image": **success** · OCI sig tag: `sha256-ccc763891d16f43156ed257bd13d92b9b661da8d5907256ab836ab55931ee741.sig` · 2026-06-03T07:21:33Z
- [x] **SPDX SBOM generated** — step "Generate SBOM (SPDX)": **success** · `tools-sbom.spdx.json` uploaded

### ci-runner (`ghcr.io/zynax-io/zynax/ci-runner`)

- [x] **Multi-arch** — `linux/amd64` ✅ `linux/arm64` ✅
- [x] **cosign signed** — step "Sign ci-runner image": **success**
- [x] **SPDX SBOM** — N/A (ci-runner SBOM not in scope per canvas; tools image SBOM is the developer-tooling artifact)

---

## Cosign verification command

```bash
# Verify any image (replace <service> and <tag>)
cosign verify \
  --certificate-identity-regexp="https://github.com/zynax-io/zynax/.github/workflows/" \
  --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \
  ghcr.io/zynax-io/zynax/<service>:<tag>
```

Services: `api-gateway` `engine-adapter` `workflow-compiler` `task-broker` `agent-registry` `http-adapter` `tools` `ci-runner`

## SBOM artifacts

SPDX JSON SBOMs for all 6 service/adapter images + tools image are attached to the [v0.4.0-verify-supply-chain pre-release](https://github.com/zynax-io/zynax/releases/tag/v0.4.0-verify-supply-chain). The same pipeline attaches SBOMs to every production tag release.

## Out of scope
- CLI binary `cosign sign-blob` — separate story; binary checksums are SHA-256 signed
- SLSA L3+ hermetic builds — explicitly out of scope per canvas

Closes #489

Assisted-by: Claude/claude-sonnet-4-6
