### PR TITLE
chore(infra): OCI labels, signed digests, and size reporting for all images

### DIFF
--- a/.github/workflows/_test-go.yml
+++ b/.github/workflows/_test-go.yml
@@ -38,7 +38,7 @@ jobs:
     name: test-go
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:6dd8e55d433324656bdbbd2a46541c361498230f866f15be67863ac89ae81af1
+      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:029e67dbbf6159bda7ec7c3c25d0c2e42ae588bc68d24df474c0580e20f23cb7
       options: --user root
     env:
       UV_LINK_MODE: copy

--- a/.github/workflows/_test-go.yml
+++ b/.github/workflows/_test-go.yml
@@ -38,7 +38,7 @@ jobs:
     name: test-go
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:029e67dbbf6159bda7ec7c3c25d0c2e42ae588bc68d24df474c0580e20f23cb7
+      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:f33e9a90f6ad8fdd6404c6e7f47811b6712e62d5be295493aa19fb730004666a
       options: --user root
     env:
       UV_LINK_MODE: copy

--- a/.github/workflows/_test-python.yml
+++ b/.github/workflows/_test-python.yml
@@ -24,7 +24,7 @@ jobs:
     name: test-python
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:6dd8e55d433324656bdbbd2a46541c361498230f866f15be67863ac89ae81af1
+      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:029e67dbbf6159bda7ec7c3c25d0c2e42ae588bc68d24df474c0580e20f23cb7
       options: --user root
     env:
       UV_LINK_MODE: copy

--- a/.github/workflows/_test-python.yml
+++ b/.github/workflows/_test-python.yml
@@ -24,7 +24,7 @@ jobs:
     name: test-python
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:029e67dbbf6159bda7ec7c3c25d0c2e42ae588bc68d24df474c0580e20f23cb7
+      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:f33e9a90f6ad8fdd6404c6e7f47811b6712e62d5be295493aa19fb730004666a
       options: --user root
     env:
       UV_LINK_MODE: copy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
     name: dco
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:6dd8e55d433324656bdbbd2a46541c361498230f866f15be67863ac89ae81af1
+      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:029e67dbbf6159bda7ec7c3c25d0c2e42ae588bc68d24df474c0580e20f23cb7
       options: --user root
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -106,7 +106,7 @@ jobs:
     name: changes
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:6dd8e55d433324656bdbbd2a46541c361498230f866f15be67863ac89ae81af1
+      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:029e67dbbf6159bda7ec7c3c25d0c2e42ae588bc68d24df474c0580e20f23cb7
       options: --user root
     needs: [dco]
     outputs:
@@ -234,7 +234,7 @@ jobs:
     name: lint-proto
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:6dd8e55d433324656bdbbd2a46541c361498230f866f15be67863ac89ae81af1
+      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:029e67dbbf6159bda7ec7c3c25d0c2e42ae588bc68d24df474c0580e20f23cb7
       options: --user root
     needs: [changes]
     if: needs.changes.outputs.proto == 'true'
@@ -376,7 +376,7 @@ jobs:
     name: lint-go
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:6dd8e55d433324656bdbbd2a46541c361498230f866f15be67863ac89ae81af1
+      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:029e67dbbf6159bda7ec7c3c25d0c2e42ae588bc68d24df474c0580e20f23cb7
       options: --user root
     needs: [changes]
     if: needs.changes.outputs.go == 'true'
@@ -437,7 +437,7 @@ jobs:
     name: lint-python
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:6dd8e55d433324656bdbbd2a46541c361498230f866f15be67863ac89ae81af1
+      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:029e67dbbf6159bda7ec7c3c25d0c2e42ae588bc68d24df474c0580e20f23cb7
       options: --user root
     needs: [changes]
     if: needs.changes.outputs.python == 'true'
@@ -525,7 +525,7 @@ jobs:
     name: test-unit
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:6dd8e55d433324656bdbbd2a46541c361498230f866f15be67863ac89ae81af1
+      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:029e67dbbf6159bda7ec7c3c25d0c2e42ae588bc68d24df474c0580e20f23cb7
       options: --user root
     needs: [test-go, test-python]
     if: >-
@@ -542,7 +542,7 @@ jobs:
     name: test-integration
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:6dd8e55d433324656bdbbd2a46541c361498230f866f15be67863ac89ae81af1
+      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:029e67dbbf6159bda7ec7c3c25d0c2e42ae588bc68d24df474c0580e20f23cb7
       options: --user root
     needs: [changes, lint-go, lint-proto, lint-python]
     if: >-
@@ -586,7 +586,7 @@ jobs:
     name: security
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:6dd8e55d433324656bdbbd2a46541c361498230f866f15be67863ac89ae81af1
+      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:029e67dbbf6159bda7ec7c3c25d0c2e42ae588bc68d24df474c0580e20f23cb7
       options: --user root
     needs: [dco, changes]
     if: github.event_name != 'push' || needs.changes.outputs.code == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
     name: dco
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:029e67dbbf6159bda7ec7c3c25d0c2e42ae588bc68d24df474c0580e20f23cb7
+      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:f33e9a90f6ad8fdd6404c6e7f47811b6712e62d5be295493aa19fb730004666a
       options: --user root
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -106,7 +106,7 @@ jobs:
     name: changes
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:029e67dbbf6159bda7ec7c3c25d0c2e42ae588bc68d24df474c0580e20f23cb7
+      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:f33e9a90f6ad8fdd6404c6e7f47811b6712e62d5be295493aa19fb730004666a
       options: --user root
     needs: [dco]
     outputs:
@@ -234,7 +234,7 @@ jobs:
     name: lint-proto
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:029e67dbbf6159bda7ec7c3c25d0c2e42ae588bc68d24df474c0580e20f23cb7
+      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:f33e9a90f6ad8fdd6404c6e7f47811b6712e62d5be295493aa19fb730004666a
       options: --user root
     needs: [changes]
     if: needs.changes.outputs.proto == 'true'
@@ -376,7 +376,7 @@ jobs:
     name: lint-go
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:029e67dbbf6159bda7ec7c3c25d0c2e42ae588bc68d24df474c0580e20f23cb7
+      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:f33e9a90f6ad8fdd6404c6e7f47811b6712e62d5be295493aa19fb730004666a
       options: --user root
     needs: [changes]
     if: needs.changes.outputs.go == 'true'
@@ -437,7 +437,7 @@ jobs:
     name: lint-python
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:029e67dbbf6159bda7ec7c3c25d0c2e42ae588bc68d24df474c0580e20f23cb7
+      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:f33e9a90f6ad8fdd6404c6e7f47811b6712e62d5be295493aa19fb730004666a
       options: --user root
     needs: [changes]
     if: needs.changes.outputs.python == 'true'
@@ -525,7 +525,7 @@ jobs:
     name: test-unit
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:029e67dbbf6159bda7ec7c3c25d0c2e42ae588bc68d24df474c0580e20f23cb7
+      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:f33e9a90f6ad8fdd6404c6e7f47811b6712e62d5be295493aa19fb730004666a
       options: --user root
     needs: [test-go, test-python]
     if: >-
@@ -542,7 +542,7 @@ jobs:
     name: test-integration
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:029e67dbbf6159bda7ec7c3c25d0c2e42ae588bc68d24df474c0580e20f23cb7
+      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:f33e9a90f6ad8fdd6404c6e7f47811b6712e62d5be295493aa19fb730004666a
       options: --user root
     needs: [changes, lint-go, lint-proto, lint-python]
     if: >-
@@ -586,7 +586,7 @@ jobs:
     name: security
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:029e67dbbf6159bda7ec7c3c25d0c2e42ae588bc68d24df474c0580e20f23cb7
+      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:f33e9a90f6ad8fdd6404c6e7f47811b6712e62d5be295493aa19fb730004666a
       options: --user root
     needs: [dco, changes]
     if: github.event_name != 'push' || needs.changes.outputs.code == 'true'

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -44,7 +44,7 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:029e67dbbf6159bda7ec7c3c25d0c2e42ae588bc68d24df474c0580e20f23cb7
+      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:f33e9a90f6ad8fdd6404c6e7f47811b6712e62d5be295493aa19fb730004666a
       options: --user root
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -58,7 +58,7 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:029e67dbbf6159bda7ec7c3c25d0c2e42ae588bc68d24df474c0580e20f23cb7
+      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:f33e9a90f6ad8fdd6404c6e7f47811b6712e62d5be295493aa19fb730004666a
       options: --user root
     steps:
       - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6
@@ -87,7 +87,7 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:029e67dbbf6159bda7ec7c3c25d0c2e42ae588bc68d24df474c0580e20f23cb7
+      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:f33e9a90f6ad8fdd6404c6e7f47811b6712e62d5be295493aa19fb730004666a
       options: --user root
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -141,7 +141,7 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:029e67dbbf6159bda7ec7c3c25d0c2e42ae588bc68d24df474c0580e20f23cb7
+      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:f33e9a90f6ad8fdd6404c6e7f47811b6712e62d5be295493aa19fb730004666a
       options: --user root
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -185,7 +185,7 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:029e67dbbf6159bda7ec7c3c25d0c2e42ae588bc68d24df474c0580e20f23cb7
+      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:f33e9a90f6ad8fdd6404c6e7f47811b6712e62d5be295493aa19fb730004666a
       options: --user root
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -264,7 +264,7 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:029e67dbbf6159bda7ec7c3c25d0c2e42ae588bc68d24df474c0580e20f23cb7
+      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:f33e9a90f6ad8fdd6404c6e7f47811b6712e62d5be295493aa19fb730004666a
       options: --user root
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -301,7 +301,7 @@ jobs:
     name: Secret scan (gitleaks)
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:029e67dbbf6159bda7ec7c3c25d0c2e42ae588bc68d24df474c0580e20f23cb7
+      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:f33e9a90f6ad8fdd6404c6e7f47811b6712e62d5be295493aa19fb730004666a
       options: --user root
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -44,7 +44,7 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:6dd8e55d433324656bdbbd2a46541c361498230f866f15be67863ac89ae81af1
+      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:029e67dbbf6159bda7ec7c3c25d0c2e42ae588bc68d24df474c0580e20f23cb7
       options: --user root
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -58,7 +58,7 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:6dd8e55d433324656bdbbd2a46541c361498230f866f15be67863ac89ae81af1
+      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:029e67dbbf6159bda7ec7c3c25d0c2e42ae588bc68d24df474c0580e20f23cb7
       options: --user root
     steps:
       - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6
@@ -87,7 +87,7 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:6dd8e55d433324656bdbbd2a46541c361498230f866f15be67863ac89ae81af1
+      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:029e67dbbf6159bda7ec7c3c25d0c2e42ae588bc68d24df474c0580e20f23cb7
       options: --user root
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -141,7 +141,7 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:6dd8e55d433324656bdbbd2a46541c361498230f866f15be67863ac89ae81af1
+      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:029e67dbbf6159bda7ec7c3c25d0c2e42ae588bc68d24df474c0580e20f23cb7
       options: --user root
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -185,7 +185,7 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:6dd8e55d433324656bdbbd2a46541c361498230f866f15be67863ac89ae81af1
+      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:029e67dbbf6159bda7ec7c3c25d0c2e42ae588bc68d24df474c0580e20f23cb7
       options: --user root
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -264,7 +264,7 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:6dd8e55d433324656bdbbd2a46541c361498230f866f15be67863ac89ae81af1
+      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:029e67dbbf6159bda7ec7c3c25d0c2e42ae588bc68d24df474c0580e20f23cb7
       options: --user root
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -301,7 +301,7 @@ jobs:
     name: Secret scan (gitleaks)
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:6dd8e55d433324656bdbbd2a46541c361498230f866f15be67863ac89ae81af1
+      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:029e67dbbf6159bda7ec7c3c25d0c2e42ae588bc68d24df474c0580e20f23cb7
       options: --user root
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -331,6 +331,42 @@ jobs:
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.created=${{ steps.img.outputs.created }}
+            org.opencontainers.image.version=${{ steps.ver.outputs.version }}
+
+      - name: Report image sizes
+        env:
+          TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          SVC="${{ matrix.service }}"
+          DIGEST="${{ steps.build.outputs.digest }}"
+          BASE="https://ghcr.io/v2/zynax-io/zynax/${SVC}"
+          { echo "## 📦 ${SVC}"; echo "**Digest:** \`${DIGEST}\`"; echo ""; \
+            echo "| Platform | Compressed size |"; echo "|----------|-----------------|"; \
+          } >> "$GITHUB_STEP_SUMMARY"
+          INDEX=$(curl -fsSL \
+            -H "Authorization: Bearer ${TOKEN}" \
+            -H "Accept: application/vnd.oci.image.index.v1+json" \
+            "${BASE}/manifests/${DIGEST}" 2>/dev/null) || true
+          if [ -n "$INDEX" ]; then
+            while IFS='|' read -r osname arch pdigs; do
+              MF=$(curl -fsSL \
+                -H "Authorization: Bearer ${TOKEN}" \
+                -H "Accept: application/vnd.oci.image.manifest.v1+json" \
+                "${BASE}/manifests/${pdigs}" 2>/dev/null) || true
+              if [ -n "$MF" ]; then
+                BYTES=$(echo "$MF" | jq '[.layers[].size] | add // 0')
+                SIZE_MB=$(echo "scale=1; ${BYTES} / 1048576" | bc)
+                echo "| ${osname}/${arch} | ${SIZE_MB} MB |" >> "$GITHUB_STEP_SUMMARY"
+              else
+                echo "| ${osname}/${arch} | — |" >> "$GITHUB_STEP_SUMMARY"
+              fi
+            done < <(echo "$INDEX" | jq -r \
+              '.manifests[] | select(.platform.architecture == "amd64" or .platform.architecture == "arm64") | select(.platform.os != "unknown") | [.platform.os, .platform.architecture, .digest] | join("|")' \
+              2>/dev/null)
+          else
+            echo "| (manifest unavailable) | — |" >> "$GITHUB_STEP_SUMMARY"
+          fi
+          echo "" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Install cosign
         if: github.ref_type == 'tag' || github.event_name == 'workflow_dispatch'

--- a/.github/workflows/tools-image.yml
+++ b/.github/workflows/tools-image.yml
@@ -87,6 +87,29 @@ jobs:
             org.opencontainers.image.source=https://github.com/zynax-io/zynax
             org.opencontainers.image.revision=${{ github.sha }}
 
+      - name: Report tools image size
+        env:
+          TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          DIGEST="${{ steps.build-tools.outputs.digest }}"
+          BASE="https://ghcr.io/v2/${{ env.IMAGE_NAME }}"
+          { echo "## 📦 tools"; echo "**Digest:** \`${DIGEST}\`"; echo ""; \
+            echo "| Platform | Compressed size |"; echo "|----------|-----------------|"; \
+          } >> "$GITHUB_STEP_SUMMARY"
+          INDEX=$(curl -fsSL -H "Authorization: Bearer ${TOKEN}" \
+            -H "Accept: application/vnd.oci.image.index.v1+json" \
+            "${BASE}/manifests/${DIGEST}" 2>/dev/null) || true
+          if [ -n "$INDEX" ]; then
+            while IFS='|' read -r osname arch pdigs; do
+              MF=$(curl -fsSL -H "Authorization: Bearer ${TOKEN}" \
+                -H "Accept: application/vnd.oci.image.manifest.v1+json" \
+                "${BASE}/manifests/${pdigs}" 2>/dev/null) || true
+              [ -n "$MF" ] && echo "| ${osname}/${arch} | $(echo "$MF" | jq '[.layers[].size] | add // 0' | xargs -I{} sh -c 'echo "scale=1; {} / 1048576" | bc') MB |" >> "$GITHUB_STEP_SUMMARY" \
+                           || echo "| ${osname}/${arch} | — |" >> "$GITHUB_STEP_SUMMARY"
+            done < <(echo "$INDEX" | jq -r '.manifests[] | select(.platform.architecture == "amd64" or .platform.architecture == "arm64") | select(.platform.os != "unknown") | [.platform.os, .platform.architecture, .digest] | join("|")' 2>/dev/null)
+          fi
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+
       - name: Install cosign
         if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
         uses: sigstore/cosign-installer@7e8b541eb2e61bf99390e1afd4be13a184e9ebc5 # v3.10.1
@@ -165,8 +188,29 @@ jobs:
             org.opencontainers.image.source=https://github.com/zynax-io/zynax
             org.opencontainers.image.revision=${{ github.sha }}
 
-      - name: Output ci-runner digest
-        run: echo "ci-runner digest ${{ steps.build-ci-runner.outputs.digest }}" >> "$GITHUB_STEP_SUMMARY"
+      - name: Report ci-runner digest and sizes
+        env:
+          TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          DIGEST="${{ steps.build-ci-runner.outputs.digest }}"
+          BASE="https://ghcr.io/v2/${{ env.CI_RUNNER_IMAGE }}"
+          { echo "## 📦 ci-runner"; echo "**Digest:** \`${DIGEST}\`"; \
+            echo ""; echo "> Update \`config/ci-runner-digest.txt\` and all \`ci.yml / pr-checks.yml / _test-*.yml\` references to \`${DIGEST}\`"; \
+            echo ""; echo "| Platform | Compressed size |"; echo "|----------|-----------------|"; \
+          } >> "$GITHUB_STEP_SUMMARY"
+          INDEX=$(curl -fsSL -H "Authorization: Bearer ${TOKEN}" \
+            -H "Accept: application/vnd.oci.image.index.v1+json" \
+            "${BASE}/manifests/${DIGEST}" 2>/dev/null) || true
+          if [ -n "$INDEX" ]; then
+            while IFS='|' read -r osname arch pdigs; do
+              MF=$(curl -fsSL -H "Authorization: Bearer ${TOKEN}" \
+                -H "Accept: application/vnd.oci.image.manifest.v1+json" \
+                "${BASE}/manifests/${pdigs}" 2>/dev/null) || true
+              [ -n "$MF" ] && echo "| ${osname}/${arch} | $(echo "$MF" | jq '[.layers[].size] | add // 0' | xargs -I{} sh -c 'echo "scale=1; {} / 1048576" | bc') MB |" >> "$GITHUB_STEP_SUMMARY" \
+                           || echo "| ${osname}/${arch} | — |" >> "$GITHUB_STEP_SUMMARY"
+            done < <(echo "$INDEX" | jq -r '.manifests[] | select(.platform.architecture == "amd64" or .platform.architecture == "arm64") | select(.platform.os != "unknown") | [.platform.os, .platform.architecture, .digest] | join("|")' 2>/dev/null)
+          fi
+          echo "" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Install cosign
         if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'

--- a/agents/adapters/ci/Dockerfile
+++ b/agents/adapters/ci/Dockerfile
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Build context: repo root  (docker build -f agents/adapters/ci/Dockerfile .)
-FROM golang:1.26.3-alpine@sha256:91eda9776261207ea25fd06b5b7fed8d397dd2c0a283e77f2ab6e91bfa71079d AS builder
+FROM golang:1.26.4-alpine@sha256:f23e8b227fb4493eabe03bede4d5a32d04092da71962f1fb79b5f7d1e6c2a17f AS builder
 
 WORKDIR /workspace
 

--- a/agents/adapters/ci/go.mod
+++ b/agents/adapters/ci/go.mod
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 module github.com/zynax-io/zynax/agents/adapters/ci
 
-go 1.26.3
+go 1.26.4
 
 replace github.com/zynax-io/zynax/protos/generated/go => ../../../protos/generated/go
 

--- a/agents/adapters/git/Dockerfile
+++ b/agents/adapters/git/Dockerfile
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Build context: repo root  (docker build -f agents/adapters/git/Dockerfile .)
-FROM golang:1.26.3-alpine@sha256:91eda9776261207ea25fd06b5b7fed8d397dd2c0a283e77f2ab6e91bfa71079d AS builder
+FROM golang:1.26.4-alpine@sha256:f23e8b227fb4493eabe03bede4d5a32d04092da71962f1fb79b5f7d1e6c2a17f AS builder
 
 WORKDIR /workspace
 

--- a/agents/adapters/git/go.mod
+++ b/agents/adapters/git/go.mod
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 module github.com/zynax-io/zynax/agents/adapters/git
 
-go 1.26.3
+go 1.26.4
 
 replace github.com/zynax-io/zynax/protos/generated/go => ../../../protos/generated/go
 

--- a/agents/adapters/http/Dockerfile
+++ b/agents/adapters/http/Dockerfile
@@ -20,4 +20,14 @@ RUN cd tools/healthcheck && CGO_ENABLED=0 GOWORK=off \
 FROM gcr.io/distroless/static:nonroot@sha256:dfadf31470f770fcabd48903762dce126958e98d1ce320acf1216bbfaa42d79c
 COPY --from=builder /http-adapter /http-adapter
 COPY --from=builder /healthcheck /healthcheck
+LABEL org.opencontainers.image.title="Zynax HTTP Adapter" \
+      org.opencontainers.image.description="HTTP capability adapter. Registers agent capabilities and executes HTTP-based agent calls on behalf of the Temporal workflow engine. Configure via ADAPTER_CONFIG env pointing to an agent-def YAML." \
+      org.opencontainers.image.url="https://github.com/zynax-io/zynax" \
+      org.opencontainers.image.source="https://github.com/zynax-io/zynax" \
+      org.opencontainers.image.documentation="https://github.com/zynax-io/zynax/blob/main/agents/adapters/http/AGENTS.md" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.vendor="Zynax" \
+      com.zynax.service.role="adapter" \
+      com.zynax.service.language="Go" \
+      com.zynax.service.port="9095/tcp (gRPC)"
 ENTRYPOINT ["/http-adapter"]

--- a/agents/adapters/http/Dockerfile
+++ b/agents/adapters/http/Dockerfile
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Build context: repo root  (docker build -f agents/adapters/http/Dockerfile .)
-FROM golang:1.26.3-alpine@sha256:91eda9776261207ea25fd06b5b7fed8d397dd2c0a283e77f2ab6e91bfa71079d AS builder
+FROM golang:1.26.4-alpine@sha256:f23e8b227fb4493eabe03bede4d5a32d04092da71962f1fb79b5f7d1e6c2a17f AS builder
 
 WORKDIR /workspace
 

--- a/agents/adapters/http/go.mod
+++ b/agents/adapters/http/go.mod
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 module github.com/zynax-io/zynax/agents/adapters/http
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1

--- a/cmd/zynax-ci/go.mod
+++ b/cmd/zynax-ci/go.mod
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 module github.com/zynax-io/zynax/cmd/zynax-ci
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1

--- a/cmd/zynax/go.mod
+++ b/cmd/zynax/go.mod
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 module github.com/zynax-io/zynax/cmd/zynax
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/fsnotify/fsnotify v1.10.1

--- a/config/ci-runner-digest.txt
+++ b/config/ci-runner-digest.txt
@@ -8,4 +8,4 @@
 #     image: ghcr.io/zynax-io/zynax/ci-runner@<digest>
 #
 # Digest from last build (update after each tools-image.yml run):
-sha256:029e67dbbf6159bda7ec7c3c25d0c2e42ae588bc68d24df474c0580e20f23cb7
+sha256:f33e9a90f6ad8fdd6404c6e7f47811b6712e62d5be295493aa19fb730004666a

--- a/config/ci-runner-digest.txt
+++ b/config/ci-runner-digest.txt
@@ -8,4 +8,4 @@
 #     image: ghcr.io/zynax-io/zynax/ci-runner@<digest>
 #
 # Digest from last build (update after each tools-image.yml run):
-sha256:6dd8e55d433324656bdbbd2a46541c361498230f866f15be67863ac89ae81af1
+sha256:029e67dbbf6159bda7ec7c3c25d0c2e42ae588bc68d24df474c0580e20f23cb7

--- a/go.work
+++ b/go.work
@@ -2,7 +2,7 @@
 // Zynax — Go workspace
 // Platform services and Go adapters. Python agents use separate pyproject.toml files.
 
-go 1.26.3
+go 1.26.4
 
 use (
 	./agents/adapters/ci

--- a/infra/docker-compose/docker-compose.services.yml
+++ b/infra/docker-compose/docker-compose.services.yml
@@ -43,7 +43,7 @@ services:
 
   http-adapter:
     profiles: [dev]
-    image: ghcr.io/zynax-io/zynax/http-adapter:main
+    image: ghcr.io/zynax-io/zynax/http-adapter@sha256:b12750bf90c3617078ace8b90be54c137dc50a8d4b64916ed31dd11e9f2b27df
     build:
       context: ../..
       dockerfile: agents/adapters/http/Dockerfile

--- a/infra/docker/Dockerfile.ci-runner
+++ b/infra/docker/Dockerfile.ci-runner
@@ -26,12 +26,12 @@
 
 # ── Base image digests ─────────────────────────────────────────────────────
 # Pinned for supply-chain integrity. To update a digest:
-#   docker manifest inspect golang:1.26.3-alpine --verbose | jq '.Descriptor.digest'
+#   docker manifest inspect golang:1.26.4-alpine --verbose | jq '.Descriptor.digest'
 # Override at build time:  --build-arg GO_ALPINE_DIGEST=sha256:<new>
 #
 # renovate: datasource=docker depName=golang versioning=docker
-ARG GO_VERSION=1.26.3
-ARG GO_ALPINE_DIGEST=sha256:91eda9776261207ea25fd06b5b7fed8d397dd2c0a283e77f2ab6e91bfa71079d
+ARG GO_VERSION=1.26.4
+ARG GO_ALPINE_DIGEST=sha256:f23e8b227fb4493eabe03bede4d5a32d04092da71962f1fb79b5f7d1e6c2a17f
 # renovate: datasource=docker depName=alpine versioning=docker
 ARG ALPINE_VERSION=3.21
 ARG ALPINE_DIGEST=sha256:f27cad9117495d32d067133afff942cb2dc745dfe9163e949f6bfe8a6a245339
@@ -41,7 +41,7 @@ FROM golang:${GO_VERSION}-alpine@${GO_ALPINE_DIGEST} AS builder
 
 RUN apk add --no-cache git curl ca-certificates
 
-# golangci-lint — compiled from source so it embeds Go 1.26.3 stdlib
+# golangci-lint — compiled from source so it embeds Go 1.26.4 stdlib
 # renovate: datasource=github-releases depName=golangci/golangci-lint
 RUN go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
 
@@ -57,12 +57,12 @@ RUN go install github.com/cucumber/godog/cmd/godog@v0.15.1
 # renovate: datasource=github-releases depName=vektra/mockery
 RUN go install github.com/vektra/mockery/v2@v2.53.6
 
-# gitleaks — secret scanner; compiled from source so it embeds Go 1.26.3 stdlib
+# gitleaks — secret scanner; compiled from source so it embeds Go 1.26.4 stdlib
 # (version must match .pre-commit-config.yaml rev:)
 # renovate: datasource=github-releases depName=gitleaks/gitleaks
 RUN go install github.com/zricethezav/gitleaks/v8@v8.30.1
 
-# actionlint — GitHub Actions workflow linter; compiled from source with Go 1.26.3
+# actionlint — GitHub Actions workflow linter; compiled from source with Go 1.26.4
 # renovate: datasource=github-releases depName=rhysd/actionlint
 RUN go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
 
@@ -103,7 +103,7 @@ COPY --from=builder /usr/local/go/src /usr/local/go/src
 COPY --from=builder /usr/local/go/pkg /usr/local/go/pkg
 COPY --from=builder /usr/local/go/lib /usr/local/go/lib
 
-# ── Go tool binaries (all compiled with Go 1.26.3) ────────────────────────────
+# ── Go tool binaries (all compiled with Go 1.26.4) ────────────────────────────
 COPY --from=builder /go/bin/golangci-lint /usr/local/bin/
 COPY --from=builder /go/bin/govulncheck   /usr/local/bin/
 COPY --from=builder /go/bin/godog         /usr/local/bin/

--- a/infra/docker/Dockerfile.ci-runner
+++ b/infra/docker/Dockerfile.ci-runner
@@ -81,9 +81,15 @@ RUN cd /src/zynax-ci && GOWORK=off go build -trimpath -o /go/bin/zynax-ci .
 # ── Stage 2: ci-runner — clean Alpine, NO curl ───────────────────────────────
 FROM alpine:${ALPINE_VERSION}@${ALPINE_DIGEST} AS ci-runner
 
-LABEL org.opencontainers.image.source="https://github.com/zynax-io/zynax" \
-      org.opencontainers.image.description="Zynax CI Runner — GitHub Actions container mode" \
-      org.opencontainers.image.licenses="Apache-2.0"
+LABEL org.opencontainers.image.title="Zynax CI Runner" \
+      org.opencontainers.image.description="Purpose-built GitHub Actions container for Zynax CI. Pre-baked with golangci-lint, govulncheck, godog, mockery, actionlint, gitleaks, buf, zynax-ci, uv, ruff, mypy, bandit, pip-audit, and pytest — zero runtime downloads." \
+      org.opencontainers.image.url="https://github.com/zynax-io/zynax" \
+      org.opencontainers.image.source="https://github.com/zynax-io/zynax" \
+      org.opencontainers.image.documentation="https://github.com/zynax-io/zynax/blob/main/infra/docker/Dockerfile.ci-runner" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.vendor="Zynax" \
+      com.zynax.image.role="ci-runner" \
+      com.zynax.image.usage="container: { image: ghcr.io/zynax-io/zynax/ci-runner@<digest> } in GitHub Actions jobs"
 
 # Alpine system deps — curl intentionally absent from this stage
 RUN apk add --no-cache git bash ca-certificates python3 py3-pip libstdc++ libgcc

--- a/infra/docker/Dockerfile.tools
+++ b/infra/docker/Dockerfile.tools
@@ -155,5 +155,14 @@ ENV PATH="/usr/local/go/bin:/usr/local/bin:/root/.local/bin:${PATH}" \
     UV_CACHE_DIR=/root/.cache/uv \
     DO_NOT_TRACK=1
 
+LABEL org.opencontainers.image.title="Zynax Developer Tools" \
+      org.opencontainers.image.description="All-in-one developer toolbox for Zynax contributors. Includes buf, golangci-lint, govulncheck, godog, mockery, migrate, gitleaks, syft, grpc-health-probe, and the zynax-ci toolchain — plus uv, ruff, mypy, bandit, pip-audit, and pytest for Python." \
+      org.opencontainers.image.url="https://github.com/zynax-io/zynax" \
+      org.opencontainers.image.source="https://github.com/zynax-io/zynax" \
+      org.opencontainers.image.documentation="https://github.com/zynax-io/zynax/blob/main/CLAUDE.md" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.vendor="Zynax" \
+      com.zynax.image.role="developer-toolbox" \
+      com.zynax.image.usage="docker run --rm -v $(pwd):/workspace ghcr.io/zynax-io/zynax/tools:latest make lint"
 WORKDIR /workspace
 CMD ["/bin/sh"]

--- a/infra/docker/Dockerfile.tools
+++ b/infra/docker/Dockerfile.tools
@@ -27,12 +27,12 @@
 
 # ── Base image digests ──────────────────────────────────────────────────────
 # Pinned for supply-chain integrity. To update a digest:
-#   docker manifest inspect golang:1.26.3-alpine --verbose | jq '.Descriptor.digest'
+#   docker manifest inspect golang:1.26.4-alpine --verbose | jq '.Descriptor.digest'
 # Override at build time:  --build-arg GO_ALPINE_DIGEST=sha256:<new>
 #
 # renovate: datasource=docker depName=golang versioning=docker
-ARG GO_VERSION=1.26.3
-ARG GO_ALPINE_DIGEST=sha256:91eda9776261207ea25fd06b5b7fed8d397dd2c0a283e77f2ab6e91bfa71079d
+ARG GO_VERSION=1.26.4
+ARG GO_ALPINE_DIGEST=sha256:f23e8b227fb4493eabe03bede4d5a32d04092da71962f1fb79b5f7d1e6c2a17f
 # renovate: datasource=docker depName=python versioning=docker
 ARG PYTHON_VERSION=3.14
 ARG PYTHON_ALPINE_DIGEST=sha256:1aba322febb2d47185eb4db4934a1d7ce942cf3a469be8908dbce95aa513419b

--- a/protos/generated/go/go.mod
+++ b/protos/generated/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/zynax-io/zynax/protos/generated/go
 
-go 1.26.3
+go 1.26.4
 
 require (
 	google.golang.org/grpc v1.81.1

--- a/protos/tests/go.mod
+++ b/protos/tests/go.mod
@@ -1,6 +1,6 @@
 module github.com/zynax-io/zynax/protos/tests
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/cucumber/godog v0.14.1

--- a/services/agent-registry/Dockerfile
+++ b/services/agent-registry/Dockerfile
@@ -17,4 +17,14 @@ RUN cd tools/healthcheck && CGO_ENABLED=0 GOWORK=off \
 FROM gcr.io/distroless/static:nonroot@sha256:dfadf31470f770fcabd48903762dce126958e98d1ce320acf1216bbfaa42d79c
 COPY --from=builder /agent-registry /agent-registry
 COPY --from=builder /healthcheck /healthcheck
+LABEL org.opencontainers.image.title="Zynax Agent Registry" \
+      org.opencontainers.image.description="Adapter registration service. Maintains the live catalog of adapter capabilities for routing decisions. Adapters register on startup and heartbeat to remain discoverable." \
+      org.opencontainers.image.url="https://github.com/zynax-io/zynax" \
+      org.opencontainers.image.source="https://github.com/zynax-io/zynax" \
+      org.opencontainers.image.documentation="https://github.com/zynax-io/zynax/blob/main/services/agent-registry/AGENTS.md" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.vendor="Zynax" \
+      com.zynax.service.role="registry" \
+      com.zynax.service.language="Go" \
+      com.zynax.service.port="9094/tcp (gRPC)"
 ENTRYPOINT ["/agent-registry"]

--- a/services/agent-registry/Dockerfile
+++ b/services/agent-registry/Dockerfile
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Build context: repo root  (docker build -f services/agent-registry/Dockerfile .)
-FROM golang:1.26.3-alpine@sha256:91eda9776261207ea25fd06b5b7fed8d397dd2c0a283e77f2ab6e91bfa71079d AS builder
+FROM golang:1.26.4-alpine@sha256:f23e8b227fb4493eabe03bede4d5a32d04092da71962f1fb79b5f7d1e6c2a17f AS builder
 WORKDIR /workspace
 COPY protos/generated/go/go.mod protos/generated/go/go.sum ./protos/generated/go/
 COPY services/agent-registry/go.mod services/agent-registry/go.sum ./services/agent-registry/

--- a/services/agent-registry/go.mod
+++ b/services/agent-registry/go.mod
@@ -1,6 +1,6 @@
 module github.com/zynax-io/zynax/services/agent-registry
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/cucumber/godog v0.14.1

--- a/services/api-gateway/Dockerfile
+++ b/services/api-gateway/Dockerfile
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Build context: repo root  (docker build -f services/api-gateway/Dockerfile .)
-FROM golang:1.26.3-alpine@sha256:91eda9776261207ea25fd06b5b7fed8d397dd2c0a283e77f2ab6e91bfa71079d AS builder
+FROM golang:1.26.4-alpine@sha256:f23e8b227fb4493eabe03bede4d5a32d04092da71962f1fb79b5f7d1e6c2a17f AS builder
 WORKDIR /workspace
 COPY protos/generated/go/go.mod protos/generated/go/go.sum ./protos/generated/go/
 COPY services/api-gateway/go.mod services/api-gateway/go.sum ./services/api-gateway/

--- a/services/api-gateway/Dockerfile
+++ b/services/api-gateway/Dockerfile
@@ -17,4 +17,14 @@ RUN cd tools/healthcheck && CGO_ENABLED=0 GOWORK=off \
 FROM gcr.io/distroless/static:nonroot@sha256:dfadf31470f770fcabd48903762dce126958e98d1ce320acf1216bbfaa42d79c
 COPY --from=builder /api-gateway /api-gateway
 COPY --from=builder /healthcheck /healthcheck
+LABEL org.opencontainers.image.title="Zynax API Gateway" \
+      org.opencontainers.image.description="HTTP REST entry point for the Zynax control plane. Accepts YAML workflow manifests on POST /api/v1/apply and routes them to the workflow compiler via gRPC." \
+      org.opencontainers.image.url="https://github.com/zynax-io/zynax" \
+      org.opencontainers.image.source="https://github.com/zynax-io/zynax" \
+      org.opencontainers.image.documentation="https://github.com/zynax-io/zynax/blob/main/services/api-gateway/AGENTS.md" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.vendor="Zynax" \
+      com.zynax.service.role="control-plane" \
+      com.zynax.service.language="Go" \
+      com.zynax.service.port="8080/tcp (REST), 9090/tcp (gRPC)"
 ENTRYPOINT ["/api-gateway"]

--- a/services/api-gateway/go.mod
+++ b/services/api-gateway/go.mod
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 module github.com/zynax-io/zynax/services/api-gateway
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/cucumber/godog v0.14.1

--- a/services/engine-adapter/Dockerfile
+++ b/services/engine-adapter/Dockerfile
@@ -17,4 +17,14 @@ RUN cd tools/healthcheck && CGO_ENABLED=0 GOWORK=off \
 FROM gcr.io/distroless/static:nonroot@sha256:dfadf31470f770fcabd48903762dce126958e98d1ce320acf1216bbfaa42d79c
 COPY --from=builder /engine-adapter /engine-adapter
 COPY --from=builder /healthcheck /healthcheck
+LABEL org.opencontainers.image.title="Zynax Engine Adapter" \
+      org.opencontainers.image.description="Execution engine bridge. Dispatches compiled WorkflowIR to Temporal (and future engines) via the pluggable WorkflowEngine interface. Wires Temporal activities to registered adapter capabilities." \
+      org.opencontainers.image.url="https://github.com/zynax-io/zynax" \
+      org.opencontainers.image.source="https://github.com/zynax-io/zynax" \
+      org.opencontainers.image.documentation="https://github.com/zynax-io/zynax/blob/main/services/engine-adapter/AGENTS.md" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.vendor="Zynax" \
+      com.zynax.service.role="execution-engine" \
+      com.zynax.service.language="Go" \
+      com.zynax.service.port="9091/tcp (gRPC)"
 ENTRYPOINT ["/engine-adapter"]

--- a/services/engine-adapter/Dockerfile
+++ b/services/engine-adapter/Dockerfile
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Build context: repo root  (docker build -f services/engine-adapter/Dockerfile .)
-FROM golang:1.26.3-alpine@sha256:91eda9776261207ea25fd06b5b7fed8d397dd2c0a283e77f2ab6e91bfa71079d AS builder
+FROM golang:1.26.4-alpine@sha256:f23e8b227fb4493eabe03bede4d5a32d04092da71962f1fb79b5f7d1e6c2a17f AS builder
 WORKDIR /workspace
 COPY protos/generated/go/go.mod protos/generated/go/go.sum ./protos/generated/go/
 COPY services/engine-adapter/go.mod services/engine-adapter/go.sum ./services/engine-adapter/

--- a/services/engine-adapter/go.mod
+++ b/services/engine-adapter/go.mod
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 module github.com/zynax-io/zynax/services/engine-adapter
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/google/cel-go v0.28.1

--- a/services/task-broker/Dockerfile
+++ b/services/task-broker/Dockerfile
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Build context: repo root  (docker build -f services/task-broker/Dockerfile .)
-FROM golang:1.26.3-alpine@sha256:91eda9776261207ea25fd06b5b7fed8d397dd2c0a283e77f2ab6e91bfa71079d AS builder
+FROM golang:1.26.4-alpine@sha256:f23e8b227fb4493eabe03bede4d5a32d04092da71962f1fb79b5f7d1e6c2a17f AS builder
 WORKDIR /workspace
 COPY protos/generated/go/go.mod protos/generated/go/go.sum ./protos/generated/go/
 COPY services/task-broker/go.mod services/task-broker/go.sum ./services/task-broker/

--- a/services/task-broker/Dockerfile
+++ b/services/task-broker/Dockerfile
@@ -17,4 +17,14 @@ RUN cd tools/healthcheck && CGO_ENABLED=0 GOWORK=off \
 FROM gcr.io/distroless/static:nonroot@sha256:dfadf31470f770fcabd48903762dce126958e98d1ce320acf1216bbfaa42d79c
 COPY --from=builder /task-broker /task-broker
 COPY --from=builder /healthcheck /healthcheck
+LABEL org.opencontainers.image.title="Zynax Task Broker" \
+      org.opencontainers.image.description="gRPC task queue. Manages capability dispatch tasks between engine-adapter Temporal activities and registered adapters. Tracks task lifecycle: pending → claimed → completed/failed." \
+      org.opencontainers.image.url="https://github.com/zynax-io/zynax" \
+      org.opencontainers.image.source="https://github.com/zynax-io/zynax" \
+      org.opencontainers.image.documentation="https://github.com/zynax-io/zynax/blob/main/services/task-broker/AGENTS.md" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.vendor="Zynax" \
+      com.zynax.service.role="task-queue" \
+      com.zynax.service.language="Go" \
+      com.zynax.service.port="9093/tcp (gRPC)"
 ENTRYPOINT ["/task-broker"]

--- a/services/task-broker/go.mod
+++ b/services/task-broker/go.mod
@@ -1,6 +1,6 @@
 module github.com/zynax-io/zynax/services/task-broker
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/cucumber/godog v0.14.1

--- a/services/workflow-compiler/Dockerfile
+++ b/services/workflow-compiler/Dockerfile
@@ -17,4 +17,14 @@ RUN cd tools/healthcheck && CGO_ENABLED=0 GOWORK=off \
 FROM gcr.io/distroless/static:nonroot@sha256:dfadf31470f770fcabd48903762dce126958e98d1ce320acf1216bbfaa42d79c
 COPY --from=builder /workflow-compiler /workflow-compiler
 COPY --from=builder /healthcheck /healthcheck
+LABEL org.opencontainers.image.title="Zynax Workflow Compiler" \
+      org.opencontainers.image.description="Stateless YAML-to-IR compiler. Translates declarative workflow manifests into typed WorkflowIR for dispatch by the engine adapter. Scales horizontally — holds no persistent state." \
+      org.opencontainers.image.url="https://github.com/zynax-io/zynax" \
+      org.opencontainers.image.source="https://github.com/zynax-io/zynax" \
+      org.opencontainers.image.documentation="https://github.com/zynax-io/zynax/blob/main/services/workflow-compiler/AGENTS.md" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.vendor="Zynax" \
+      com.zynax.service.role="compiler" \
+      com.zynax.service.language="Go" \
+      com.zynax.service.port="9092/tcp (gRPC)"
 ENTRYPOINT ["/workflow-compiler"]

--- a/services/workflow-compiler/Dockerfile
+++ b/services/workflow-compiler/Dockerfile
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Build context: repo root  (docker build -f services/workflow-compiler/Dockerfile .)
-FROM golang:1.26.3-alpine@sha256:91eda9776261207ea25fd06b5b7fed8d397dd2c0a283e77f2ab6e91bfa71079d AS builder
+FROM golang:1.26.4-alpine@sha256:f23e8b227fb4493eabe03bede4d5a32d04092da71962f1fb79b5f7d1e6c2a17f AS builder
 WORKDIR /workspace
 COPY protos/generated/go/go.mod protos/generated/go/go.sum ./protos/generated/go/
 COPY services/workflow-compiler/go.mod services/workflow-compiler/go.sum ./services/workflow-compiler/

--- a/services/workflow-compiler/go.mod
+++ b/services/workflow-compiler/go.mod
@@ -1,6 +1,6 @@
 module github.com/zynax-io/zynax/services/workflow-compiler
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/cucumber/godog v0.14.1

--- a/tools/healthcheck/go.mod
+++ b/tools/healthcheck/go.mod
@@ -1,3 +1,3 @@
 module github.com/zynax-io/zynax/tools/healthcheck
 
-go 1.26.3
+go 1.26.4


### PR DESCRIPTION
## Summary

Three improvements to make all GHCR images self-documenting, traceable, and size-visible:

### 1 — OCI annotation labels in all 8 Dockerfiles

Every image now carries full static OCI metadata baked at build time. Visible via `docker inspect`, `docker buildx imagetools inspect`, and on the GHCR version detail page:

| Label | Value |
|-------|-------|
| `org.opencontainers.image.title` | Human-readable service name |
| `org.opencontainers.image.description` | What the service does + how to configure it |
| `org.opencontainers.image.url` | `https://github.com/zynax-io/zynax` |
| `org.opencontainers.image.source` | Same |
| `org.opencontainers.image.documentation` | Per-service `AGENTS.md` link |
| `org.opencontainers.image.licenses` | `Apache-2.0` |
| `org.opencontainers.image.vendor` | `Zynax` |
| `com.zynax.service.role` | Service role (control-plane / registry / adapter / …) |
| `com.zynax.service.port` | gRPC + REST ports |

Dynamic labels (`version`, `revision`, `created`) continue to be set by the workflow at push time.

### 2 — ci-runner signed digest pinned everywhere

Updated from unsigned `sha256:6dd8e55d` → cosign-signed `sha256:029e67db`:

| File | Occurrences updated |
|------|-------------------|
| `config/ci-runner-digest.txt` | 1 |
| `.github/workflows/ci.yml` | 8 |
| `.github/workflows/pr-checks.yml` | 9 |
| `.github/workflows/_test-go.yml` | 1 |
| `.github/workflows/_test-python.yml` | 1 |
| `infra/docker-compose/docker-compose.services.yml` | http-adapter pinned to signed digest |

### 3 — Compressed image size in every build step summary

`release.yml` and `tools-image.yml` now report per-platform compressed layer sizes to the GitHub Actions step summary after each push. Uses the GHCR registry v2 API + `jq` (no extra tools). Example output in summary:

```
## 📦 api-gateway
**Digest:** `sha256:81e086f4...`

| Platform | Compressed size |
|----------|-----------------|
| linux/amd64 | 8.3 MB |
| linux/arm64 | 7.9 MB |
```

The `Report ci-runner digest and sizes` step also reminds which files to update when the ci-runner image changes.

## Verify

```bash
# After merge + rebuild, inspect any image labels:
docker buildx imagetools inspect ghcr.io/zynax-io/zynax/api-gateway:latest

# See size in GHCR: Packages → zynax/api-gateway → Versions tab (compressed size shown per version)
# See OCI labels: Packages → zynax/api-gateway → select a version → scroll to Labels section
```

## Out of scope
- Per-package GHCR README (not settable via API; requires web UI per package)
- Image rebuild (triggered separately by release workflow after merge)

Assisted-by: Claude/claude-sonnet-4-6