### PR TITLE
chore(ci): add bump-ci-runner script and make target (#843)

### DIFF
--- a/.github/workflows/ai-context-budget.yml
+++ b/.github/workflows/ai-context-budget.yml
@@ -26,7 +26,7 @@ jobs:
     name: Count AI context lines
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:6dd8e55d433324656bdbbd2a46541c361498230f866f15be67863ac89ae81af1
+      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:f33e9a90f6ad8fdd6404c6e7f47811b6712e62d5be295493aa19fb730004666a
       options: --user root
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) \
 		| awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
-.PHONY: bootstrap check-docker build-tools
+.PHONY: bootstrap check-docker build-tools bump-ci-runner
 bootstrap: ensure-tools ## ★ Run once after clone — pulls tools image from GHCR and installs pre-commit hooks
 	@if command -v pre-commit >/dev/null 2>&1; then \
 	  pre-commit install && echo "✅ pre-commit hooks installed"; \
@@ -42,6 +42,10 @@ check-docker:
 build-tools: check-docker ## Build zynax/tools:local from source — use when editing Dockerfile.tools
 	docker build -f infra/docker/Dockerfile.tools -t $(TOOLS_IMAGE) .
 	@echo "✅ Tools image: $(TOOLS_IMAGE)"
+
+bump-ci-runner: ## Update ci-runner digest everywhere: make bump-ci-runner NEW_DIGEST=sha256:<hex>
+	@[ -n "$(NEW_DIGEST)" ] || (echo "❌ Usage: make bump-ci-runner NEW_DIGEST=sha256:<64-hex>"; exit 1)
+	scripts/bump-ci-runner.sh $(NEW_DIGEST)
 
 pull-tools: check-docker ## Pull tools image from GHCR (authenticates via `gh auth token`)
 	@echo "🔐 Authenticating to GHCR via gh..."

--- a/scripts/bump-ci-runner.sh
+++ b/scripts/bump-ci-runner.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# bump-ci-runner.sh — update every ci-runner digest reference in the repo.
+#
+# Usage:
+#   scripts/bump-ci-runner.sh <new-digest>
+#   scripts/bump-ci-runner.sh --check <expected-digest>
+#
+# Arguments:
+#   <new-digest>       New digest in the form sha256:<64-hex-chars>
+#   --check <digest>   Dry-run: exit 0 if all refs already match <digest>,
+#                      exit 1 if any ref is stale (prints differing files)
+#
+# Files updated (18 occurrences total):
+#   config/ci-runner-digest.txt
+#   .github/workflows/ci.yml              (8 refs)
+#   .github/workflows/pr-checks.yml       (7 refs)
+#   .github/workflows/_test-go.yml        (1 ref)
+#   .github/workflows/_test-python.yml    (1 ref)
+#   .github/workflows/ai-context-budget.yml (1 ref)
+#
+# The script is idempotent: running it twice with the same digest is a no-op.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+IMAGE_PREFIX="ghcr.io/zynax-io/zynax/ci-runner@"
+
+WORKFLOW_FILES=(
+  ".github/workflows/ci.yml"
+  ".github/workflows/pr-checks.yml"
+  ".github/workflows/_test-go.yml"
+  ".github/workflows/_test-python.yml"
+  ".github/workflows/ai-context-budget.yml"
+)
+DIGEST_FILE="config/ci-runner-digest.txt"
+
+usage() {
+  echo "Usage: $0 <sha256:hex>" >&2
+  echo "       $0 --check <sha256:hex>" >&2
+  exit 1
+}
+
+# ── argument parsing ───────────────────────────────────────────────────────────
+
+CHECK_MODE=false
+if [[ "${1:-}" == "--check" ]]; then
+  CHECK_MODE=true
+  NEW_DIGEST="${2:-}"
+else
+  NEW_DIGEST="${1:-}"
+fi
+
+[[ -z "$NEW_DIGEST" ]] && usage
+
+if [[ ! "$NEW_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+  echo "❌ digest must match sha256:<64 lowercase hex chars>, got: $NEW_DIGEST" >&2
+  exit 1
+fi
+
+# ── helpers ────────────────────────────────────────────────────────────────────
+
+# Pattern that matches any existing ci-runner digest in workflow files.
+# Captures: ghcr.io/zynax-io/zynax/ci-runner@sha256:<64 hex>
+CI_RUNNER_PATTERN="${IMAGE_PREFIX}sha256:[0-9a-f]{64}"
+
+stale_files=()
+
+check_file() {
+  local rel="$1"
+  local file="${REPO_ROOT}/${rel}"
+  if grep -qE "${CI_RUNNER_PATTERN}" "$file" 2>/dev/null; then
+    if ! grep -qF "${IMAGE_PREFIX}${NEW_DIGEST}" "$file"; then
+      stale_files+=("$rel")
+    fi
+  fi
+}
+
+update_file() {
+  local rel="$1"
+  local file="${REPO_ROOT}/${rel}"
+  # Replace any existing ci-runner digest with the new one (portable sed)
+  sed -i "s|${IMAGE_PREFIX}sha256:[0-9a-f]*|${IMAGE_PREFIX}${NEW_DIGEST}|g" "$file"
+}
+
+# ── check digest file separately (different pattern) ──────────────────────────
+
+DIGEST_PATH="${REPO_ROOT}/${DIGEST_FILE}"
+if [[ -f "$DIGEST_PATH" ]]; then
+  current=$(grep -E '^sha256:[0-9a-f]{64}$' "$DIGEST_PATH" | head -1 || true)
+  if [[ "$current" != "$NEW_DIGEST" ]]; then
+    stale_files+=("$DIGEST_FILE")
+  fi
+fi
+
+# ── check workflow files ───────────────────────────────────────────────────────
+
+for rel in "${WORKFLOW_FILES[@]}"; do
+  check_file "$rel"
+done
+
+# ── report / exit in check mode ───────────────────────────────────────────────
+
+if $CHECK_MODE; then
+  if [[ ${#stale_files[@]} -eq 0 ]]; then
+    echo "✅ All ci-runner refs already match ${NEW_DIGEST}"
+    exit 0
+  else
+    echo "❌ Stale ci-runner refs found (run: make bump-ci-runner NEW_DIGEST=${NEW_DIGEST}):" >&2
+    for f in "${stale_files[@]}"; do
+      echo "   $f" >&2
+    done
+    exit 1
+  fi
+fi
+
+# ── apply updates ─────────────────────────────────────────────────────────────
+
+if [[ ${#stale_files[@]} -eq 0 ]]; then
+  echo "✅ All refs already up to date — nothing to do."
+  exit 0
+fi
+
+echo "🔄 Updating ci-runner digest to ${NEW_DIGEST} in ${#stale_files[@]} file(s)…"
+
+# Update digest file
+if [[ -f "$DIGEST_PATH" ]]; then
+  sed -i "s|^sha256:[0-9a-f]*$|${NEW_DIGEST}|" "$DIGEST_PATH"
+  echo "   ✓ ${DIGEST_FILE}"
+fi
+
+# Update workflow files
+for rel in "${WORKFLOW_FILES[@]}"; do
+  file="${REPO_ROOT}/${rel}"
+  if [[ -f "$file" ]] && grep -qE "${CI_RUNNER_PATTERN}" "$file" 2>/dev/null; then
+    update_file "$rel"
+    count=$(grep -cF "${IMAGE_PREFIX}${NEW_DIGEST}" "$file" || true)
+    echo "   ✓ ${rel} (${count} ref(s))"
+  fi
+done
+
+echo "✅ Done. Verify with: scripts/bump-ci-runner.sh --check ${NEW_DIGEST}"


### PR DESCRIPTION
## Summary

- Adds `scripts/bump-ci-runner.sh` — idempotent script that updates all 18
  `ci-runner@sha256:` refs across workflow files and `config/ci-runner-digest.txt`
- Adds `make bump-ci-runner NEW_DIGEST=sha256:<hex>` (visible in `make help`)
- Supports `--check` / dry-run mode (exits 1 if any ref is stale)
- First run also fixes the stale `ai-context-budget.yml` ref missed by PR #836

## Usage

```bash
# After a ci-runner rebuild:
make bump-ci-runner NEW_DIGEST=sha256:<new-digest>

# Verify all refs are current:
scripts/bump-ci-runner.sh --check sha256:<expected-digest>
```

## Scope

Covers all 18 occurrences identified in Phase 0 discovery:
- `config/ci-runner-digest.txt` (1 ref)
- `.github/workflows/ci.yml` (8 refs)
- `.github/workflows/pr-checks.yml` (7 refs)
- `.github/workflows/_test-go.yml` (1 ref)
- `.github/workflows/_test-python.yml` (1 ref)
- `.github/workflows/ai-context-budget.yml` (1 ref — was stale, now fixed)

## Test plan

- [x] `scripts/bump-ci-runner.sh --check sha256:f33e9a90...` exits 0 after run
- [x] Script syntax valid (`bash -n`)
- [x] Idempotency verified: second run with same digest → "nothing to do"
- [x] `--check` with wrong digest exits 1 and lists stale files
- [x] New `bump-ci-runner` target appears in `make help` output
- [x] `make lint` — exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)