### PR TITLE
docs(milestones): align M6.Images canvas, fix /resume-m6 routing

### DIFF
--- a/.claude/commands/resume-m6.md
+++ b/.claude/commands/resume-m6.md
@@ -69,6 +69,7 @@ git fetch origin --prune && git checkout main && git pull --rebase origin main
 | Proto or BDD boundary touched | `protos/AGENTS.md` + `docs/patterns/bdd-contract-testing.md` |
 | Helm chart work | `infra/AGENTS.md` + `docs/patterns/helm-charts.md` |
 | Any ADR-governed decision | `docs/adr/INDEX.md` — ADR-022 (event-bus) Accepted; all 22 ADRs stable |
+| M6.Images work (#855) | `cmd/zynax-ci/AGENTS.md` + `images/images.yaml` (created in O1); O1 is `chore:` (implement directly); O2+O3 are the keystone cluster (`feat:`+`ci:`) |
 
 Run `/help` to confirm all SPDD commands are available.
 
@@ -118,7 +119,7 @@ Apply the **Resumption tree** (bottom) and report the matching row before taking
 | 1 | M6.Helm | #765 | canvas `Aligned` `docs/spdd/765-helm-charts/canvas.md`; children #779–#792 |
 | 2 | M6.H Postgres repos | #626 | canvas `Aligned` `docs/spdd/626-postgres-repos/canvas.md`; children #793 #794 |
 | 3 | M6.F Config convergence | #670 | refactor/ci — SPDD-exempt; children #667 #668 #669 |
-| 4 | M6.Images | #855 | canvas `Draft` `docs/spdd/855-images-sot/canvas.md`; children #856–#862; set canvas to Aligned before running O2 (`feat:`); O2+O3 ship as one cluster |
+| 4 | M6.Images | #855 | canvas `Aligned` `docs/spdd/855-images-sot/canvas.md`; children #856–#862; O1 (#856) `chore:` — implement directly (skip `/spdd-generate`); O2 (#857) `feat:` — use `/spdd-generate`; **O2+O3 (#857+#858) must ship as one cluster** |
 | 5 | M6.NS Multi-namespace | #767 | canvas `Aligned` `docs/spdd/767-multi-namespace/canvas.md`; children #799 #800; D.1 done (#774) |
 | 6 | M6.Argo | #766 | canvas `Aligned` `docs/spdd/766-argo-engine/canvas.md`; children #795–#798 |
 | 7 | M6.SDK PyPI | #769 | canvas `Aligned` `docs/spdd/769-sdk-pypi/canvas.md`; children #805–#808 |

--- a/docs/milestones/M6-planning.md
+++ b/docs/milestones/M6-planning.md
@@ -33,7 +33,7 @@
 | docs(contributing): record rebase-merge / branch-delete / no-reopen policy | [#846](https://github.com/zynax-io/zynax/issues/846) | Docs | #851 | ⬜ Open |
 | docs(adr): ADR-023 — restrict direct pushes to main; rebase-merge only | — | Docs/ADR | #847 | ⬜ Open |
 
-**M6.Images — Single source of truth for container-image references** (EPIC #855; canvas `docs/spdd/855-images-sot/canvas.md` — Status: Draft)
+**M6.Images — Single source of truth for container-image references** (EPIC #855; canvas `docs/spdd/855-images-sot/canvas.md` — Status: **Aligned**)
 
 | Story | Issue | Area | PR | Status |
 |-------|-------|------|-----|--------|

--- a/docs/spdd/855-images-sot/canvas.md
+++ b/docs/spdd/855-images-sot/canvas.md
@@ -7,7 +7,7 @@
 **Issue:** #855
 **Author:** Oscar Gómez Manresa
 **Date:** 2026-06-03
-**Status:** Draft
+**Status:** Aligned
 
 ---
 
@@ -200,7 +200,7 @@ neither is done without the other).
 - [x] No PII: no personal names in sensitive context, no non-public email addresses
 - [x] No prompt injection: no instruction-like phrasing that overrides AGENTS.md rules
 - [x] All entities in E section are public-safe abstractions
-- [ ] `/spdd-security-review` passed — result: **PENDING** (run before setting Status: Aligned)
+- [x] `/spdd-security-review` passed — result: **PASS**
 
 ### Feature Safeguards
 

--- a/state/current-milestone.md
+++ b/state/current-milestone.md
@@ -213,21 +213,20 @@ Canvas: `docs/spdd/464-mtls/canvas.md` — Status: Implemented
 
 Canvas: `docs/spdd/465-supply-chain/canvas.md` — Status: Implemented
 
-### M6.Images — Single Source of Truth for Container Image References (#855) — ⬜ IN PROGRESS
+### M6.Images — Single Source of Truth for Container Image References (#855) — ⬜ Canvas Aligned, not started
 
-Canvas: `docs/spdd/855-images-sot/canvas.md` — Status: **Draft** (set to Aligned before O2 implementation)
+Canvas: `docs/spdd/855-images-sot/canvas.md` — Status: **Aligned** ✅
 
 | Story | Issue | Status |
 |-------|-------|--------|
 | O1 chore(ci): images/images.yaml schema + initial population | [#856](https://github.com/zynax-io/zynax/issues/856) | ⬜ Open |
 | O2 feat(zynax-ci): images sync + check subcommands | [#857](https://github.com/zynax-io/zynax/issues/857) | ⬜ Open |
-| O3 ci: wire drift-check into CI | [#858](https://github.com/zynax-io/zynax/issues/858) | ⬜ Open (ships with O2) |
+| O3 ci: wire drift-check into CI | [#858](https://github.com/zynax-io/zynax/issues/858) | ⬜ Open (**ships with O2**) |
 | O4 chore(infra): Dockerfile ARG migration | [#859](https://github.com/zynax-io/zynax/issues/859) | ⬜ Open |
 | O5 chore(ci): bump flow rewrite (closes #844) | [#860](https://github.com/zynax-io/zynax/issues/860) | ⬜ Open |
 | O6 docs: propagation | [#861](https://github.com/zynax-io/zynax/issues/861) | ⬜ Open |
 | O7 docs: ADR-024 | [#862](https://github.com/zynax-io/zynax/issues/862) | ⬜ Open |
 
-**Active blocker**: Canvas must reach Status: Aligned before O2 (`feat:`) implementation starts (ADR-019).
 **Keystone**: O2 + O3 must ship in the same sprint; neither is done without the other.
 
 ### M6 Infra / Tooling — 🔄 In Progress


### PR DESCRIPTION
## Summary

- Sets `docs/spdd/855-images-sot/canvas.md` Status to **Aligned** (security review PASS)
- Fixes `/resume-m6` STEP 2 M6.Images entry: correct canvas status + per-O-step routing
  guidance so a fresh session can implement without further updates
- Adds read-when row for M6.Images context (`cmd/zynax-ci/AGENTS.md`)
- Updates `M6-planning.md` and `state/current-milestone.md` to reflect Aligned status
- Fixes EPIC #855 body: corrects canvas path placeholder and status

## Why

A fresh `/resume-m6` session needs to know: (1) canvas is Aligned so it goes to STEP
3C not 3A; (2) O1 is `chore:` so it implements directly, not via `/spdd-generate`;
(3) O2+O3 must ship as a cluster.

## Test plan

- [x] CI passes (docs-only)
- [x] `docs/spdd/855-images-sot/canvas.md` status reads `Aligned`
- [x] `/resume-m6` STEP 2 table M6.Images row correctly describes routing

🤖 Generated with [Claude Code](https://claude.com/claude-code)