### PR TITLE
docs(milestones): wire GHCR hygiene issues #865–#869 + M6.Build #837 into M6 plan

### DIFF
--- a/.claude/commands/resume-m6.md
+++ b/.claude/commands/resume-m6.md
@@ -69,7 +69,9 @@ git fetch origin --prune && git checkout main && git pull --rebase origin main
 | Proto or BDD boundary touched | `protos/AGENTS.md` + `docs/patterns/bdd-contract-testing.md` |
 | Helm chart work | `infra/AGENTS.md` + `docs/patterns/helm-charts.md` |
 | Any ADR-governed decision | `docs/adr/INDEX.md` — ADR-022 (event-bus) Accepted; all 22 ADRs stable |
-| M6.Images work (#855) | `cmd/zynax-ci/AGENTS.md` + `images/images.yaml` (created in O1); O1 is `chore:` (implement directly); O2+O3 are the keystone cluster (`feat:`+`ci:`) |
+| M6.Images SoT work (#855, #856–#862) | `cmd/zynax-ci/AGENTS.md` + `images/images.yaml` (created in O1); O1 is `chore:` (implement directly); O2+O3 are the keystone cluster (`feat:`+`ci:`) |
+| M6.Images GHCR hygiene (#865–#869) | Root cause confirmed: all images have `"annotations": null` on OCI index (no description shown); `unknown/unknown` = SLSA provenance attestation (expected, do NOT disable); deliver #868 ADR-025 first, then #865 annotations, then #866 gate, #867 retention, #869 docs |
+| M6.Build work (#837, #841) | Native arm64 runners; B.1–B.3 story issues must be created from EPIC body before implementing |
 
 Run `/help` to confirm all SPDD commands are available.
 
@@ -119,7 +121,8 @@ Apply the **Resumption tree** (bottom) and report the matching row before taking
 | 1 | M6.Helm | #765 | canvas `Aligned` `docs/spdd/765-helm-charts/canvas.md`; children #779–#792 |
 | 2 | M6.H Postgres repos | #626 | canvas `Aligned` `docs/spdd/626-postgres-repos/canvas.md`; children #793 #794 |
 | 3 | M6.F Config convergence | #670 | refactor/ci — SPDD-exempt; children #667 #668 #669 |
-| 4 | M6.Images | #855 | canvas `Aligned` `docs/spdd/855-images-sot/canvas.md`; children #856–#862; O1 (#856) `chore:` — implement directly (skip `/spdd-generate`); O2 (#857) `feat:` — use `/spdd-generate`; **O2+O3 (#857+#858) must ship as one cluster** |
+| 4 | M6.Images — SoT | #855 | canvas `Aligned` `docs/spdd/855-images-sot/canvas.md`; SoT children: #856–#862 (O1 `chore:` direct; O2+O3 keystone cluster); **GHCR hygiene children: #865–#869 — SPDD-exempt; deliver in order #868 → #865 → #866 → #867 → #869** |
+| 4a | M6.Build | #837 | SPDD-exempt (ci:/chore:); B.1–B.3 story issues not yet created — create from EPIC body; B.4 = #841 (image size audit); goal: zero QEMU, native arm64 runners, Python adapters in release pipeline |
 | 5 | M6.NS Multi-namespace | #767 | canvas `Aligned` `docs/spdd/767-multi-namespace/canvas.md`; children #799 #800; D.1 done (#774) |
 | 6 | M6.Argo | #766 | canvas `Aligned` `docs/spdd/766-argo-engine/canvas.md`; children #795–#798 |
 | 7 | M6.SDK PyPI | #769 | canvas `Aligned` `docs/spdd/769-sdk-pypi/canvas.md`; children #805–#808 |

--- a/docs/milestones/M6-planning.md
+++ b/docs/milestones/M6-planning.md
@@ -2,7 +2,7 @@
 
 # Zynax M6 — K8s Production-Ready Planning
 
-> Generated: 2026-06-02 · Last updated: 2026-06-03 (M6.Images EPIC #855 + stories #856–#862 added)  
+> Generated: 2026-06-02 · Last updated: 2026-06-03 (GHCR hygiene issues #865–#869 + M6.Build #837 wired)  
 > Based on live repo state at commit `994efb7` (main).  
 > GitHub Milestone: **"K8s Production-Ready (M6)"** (milestone #6, 30 open issues / 2 closed).  
 > All `gh` commands, file reads, and live issue data were gathered in this session — nothing assumed from memory.
@@ -44,6 +44,25 @@
 | O5 chore(ci): bump flow rewrite | [#860](https://github.com/zynax-io/zynax/issues/860) | CI tooling | — | ⬜ Open |
 | O6 docs: single source of truth propagation | [#861](https://github.com/zynax-io/zynax/issues/861) | Docs | — | ⬜ Open |
 | O7 docs: ADR-024 | [#862](https://github.com/zynax-io/zynax/issues/862) | Docs/ADR | — | ⬜ Open |
+
+**M6.Images — GHCR Package Hygiene** (attached to EPIC #855; SPDD-exempt; delivery order: #868 → #865 → #866 → #867 → #869)
+
+| Story | Issue | Area | PR | Status |
+|-------|-------|------|-----|--------|
+| docs(adr): ADR-025 — SLSA provenance attestation keep vs disable | [#868](https://github.com/zynax-io/zynax/issues/868) | Docs/ADR | — | ⬜ Open |
+| ci: add OCI manifest annotations — fix "no description" on GHCR | [#865](https://github.com/zynax-io/zynax/issues/865) | CI/Infra | — | ⬜ Open |
+| ci: description-present gate + size-budget check in publish steps | [#866](https://github.com/zynax-io/zynax/issues/866) | CI | — | ⬜ Open |
+| chore(ci): GHCR retention cap — keep last 5 builds per image | [#867](https://github.com/zynax-io/zynax/issues/867) | CI | — | ⬜ Open |
+| docs: document unknown/unknown — expected SLSA provenance | [#869](https://github.com/zynax-io/zynax/issues/869) | Docs/Infra | — | ⬜ Open |
+
+**M6.Build — Native multi-arch build pipeline** (EPIC [#837](https://github.com/zynax-io/zynax/issues/837); SPDD-exempt; no canvas required)
+
+| Story | Issue | Area | PR | Status |
+|-------|-------|------|-----|--------|
+| ci(infra): migrate release.yml service builds to native arm64 — no QEMU | — | CI | — | ⬜ Open |
+| ci(infra): migrate tools-image.yml to native arm64 — no QEMU | — | CI | — | ⬜ Open |
+| ci(infra): add Python adapter images to multi-arch release pipeline | — | CI/Infra | — | ⬜ Open |
+| ci(infra): audit and minimize final image sizes | [#841](https://github.com/zynax-io/zynax/issues/841) | CI/Infra | — | ⬜ Open |
 
 ---
 

--- a/state/current-milestone.md
+++ b/state/current-milestone.md
@@ -229,6 +229,20 @@ Canvas: `docs/spdd/855-images-sot/canvas.md` — Status: **Aligned** ✅
 
 **Keystone**: O2 + O3 must ship in the same sprint; neither is done without the other.
 
+### M6.Images — GHCR Package Hygiene — ⬜ Ready to implement
+
+Investigation confirmed (2026-06-03): all 8 GHCR images have `"annotations": null` on their OCI index manifests → "No description" in GHCR UI. Two `unknown/unknown` rows per image are SLSA provenance attestations (expected). No retention policy exists.
+
+Delivery order (each is its own PR):
+
+| Story | Issue | Status |
+|-------|-------|--------|
+| docs(adr): ADR-025 — keep vs disable SLSA attestations | [#868](https://github.com/zynax-io/zynax/issues/868) | ⬜ Open |
+| ci: OCI manifest annotations (fix "no description") | [#865](https://github.com/zynax-io/zynax/issues/865) | ⬜ Open — depends on #868 |
+| ci: description-present gate + size-budget check | [#866](https://github.com/zynax-io/zynax/issues/866) | ⬜ Open — depends on #865 |
+| chore(ci): GHCR retention cap (last 5 builds) | [#867](https://github.com/zynax-io/zynax/issues/867) | ⬜ Open |
+| docs: document unknown/unknown attestation manifests | [#869](https://github.com/zynax-io/zynax/issues/869) | ⬜ Open — depends on #868 |
+
 ### M6 Infra / Tooling — 🔄 In Progress
 
 Process-health work (ADR-023, merge-policy, image-bump tooling, /resume-m6 fix).


### PR DESCRIPTION
## Summary

- Adds 5 new GHCR package-hygiene stories (#865–#869) to the M6.Images section of the delivery table, with the confirmed delivery order (ADR-025 → annotations → gate → retention → docs).
- Adds the previously-untracked M6.Build EPIC (#837) to both the delivery table and the `/resume-m6` priority order.
- Updates `state/current-milestone.md` with the GHCR hygiene section so `/resume-m6` can orient from it.
- Updates `.claude/commands/resume-m6.md` STEP 2 priority table to split M6.Images into SoT children (#856–#862) and GHCR hygiene children (#865–#869), and adds M6.Build as priority 4a.
- Adds GHCR hygiene and M6.Build context rows to the "Read when" table.

## Context

Phase 0 investigation (2026-06-03) confirmed:
- All 8 published GHCR images have `"annotations": null` on their OCI index manifests → "No description" in GHCR UI.
- Two `unknown/unknown` rows per image are SLSA provenance attestation manifests (one per platform) — NOT defects.
- No retention policy exists; images accumulate indefinitely.

## Test plan

- [x] `make lint` — exit 0 (pre-commit passed)
- [x] All 5 issues #865–#869 created in GitHub with correct labels, milestone, and body
- [x] M6.Build #837 surfaced in delivery table and `/resume-m6` priority order
- [x] No implementation changes — docs/planning only

🤖 Generated with [Claude Code](https://claude.ai/claude-code)