### PR TITLE
docs(milestones): reconcile M6 planning table — infra/tooling PRs all merged

### DIFF
--- a/docs/milestones/M6-planning.md
+++ b/docs/milestones/M6-planning.md
@@ -2,9 +2,9 @@
 
 # Zynax M6 — K8s Production-Ready Planning
 
-> Generated: 2026-06-02 · Last updated: 2026-06-03 (GHCR hygiene issues #865–#869 + M6.Build #837 wired)  
+> Generated: 2026-06-02 · Last updated: 2026-06-03 (infra/tooling PRs #847–#852 all merged)  
 > Based on live repo state at commit `994efb7` (main).  
-> GitHub Milestone: **"K8s Production-Ready (M6)"** (milestone #6, 30 open issues / 2 closed).  
+> GitHub Milestone: **"K8s Production-Ready (M6)"** (milestone #6).  
 > All `gh` commands, file reads, and live issue data were gathered in this session — nothing assumed from memory.
 
 ## Delivery Progress
@@ -27,11 +27,11 @@
 
 | Story | Issue | Area | PR | Status |
 |-------|-------|------|-----|--------|
-| chore(ci): add bump-ci-runner script and make target | [#843](https://github.com/zynax-io/zynax/issues/843) | CI tooling | #848 | ⬜ Open |
-| ci(infra): open ci-runner bump issue after tools-image build | [#844](https://github.com/zynax-io/zynax/issues/844) | CI automation | #849 | ⬜ Open |
-| chore(claude): rewrite /resume-m6 — FF discipline, doc-PR path, branch cleanup | [#845](https://github.com/zynax-io/zynax/issues/845) | Slash commands | #850 | ⬜ Open |
-| docs(contributing): record rebase-merge / branch-delete / no-reopen policy | [#846](https://github.com/zynax-io/zynax/issues/846) | Docs | #851 | ⬜ Open |
-| docs(adr): ADR-023 — restrict direct pushes to main; rebase-merge only | — | Docs/ADR | #847 | ⬜ Open |
+| chore(ci): add bump-ci-runner script and make target | [#843](https://github.com/zynax-io/zynax/issues/843) | CI tooling | #848 | ✅ Merged |
+| ci(infra): open ci-runner bump issue after tools-image build | [#844](https://github.com/zynax-io/zynax/issues/844) | CI automation | #849 | ✅ Merged |
+| chore(claude): rewrite /resume-m6 — FF discipline, doc-PR path, branch cleanup | [#845](https://github.com/zynax-io/zynax/issues/845) | Slash commands | #850 | ✅ Merged |
+| docs(contributing): record rebase-merge / branch-delete / no-reopen policy | [#846](https://github.com/zynax-io/zynax/issues/846) | Docs | #851 | ✅ Merged |
+| docs(adr): ADR-023 — restrict direct pushes to main; rebase-merge only | — | Docs/ADR | #847 | ✅ Merged |
 
 **M6.Images — Single source of truth for container-image references** (EPIC #855; canvas `docs/spdd/855-images-sot/canvas.md` — Status: **Aligned**)
 

--- a/state/current-milestone.md
+++ b/state/current-milestone.md
@@ -243,19 +243,19 @@ Delivery order (each is its own PR):
 | chore(ci): GHCR retention cap (last 5 builds) | [#867](https://github.com/zynax-io/zynax/issues/867) | ⬜ Open |
 | docs: document unknown/unknown attestation manifests | [#869](https://github.com/zynax-io/zynax/issues/869) | ⬜ Open — depends on #868 |
 
-### M6 Infra / Tooling — 🔄 In Progress
+### M6 Infra / Tooling — ✅ Complete
 
 Process-health work (ADR-023, merge-policy, image-bump tooling, /resume-m6 fix).
-SPDD-exempt (chore/docs/ci — not feat: EPICs).
+All PRs merged 2026-06-03.
 
 | Work Item | Issue | PR | Status |
 |-----------|-------|-----|--------|
-| ADR-023 — restrict direct pushes to main | — | #847 | ⬜ CI running |
-| chore(ci): bump-ci-runner script + make target | [#843](https://github.com/zynax-io/zynax/issues/843) | #848 | ⬜ CI running |
-| ci(infra): post-build bump issue from tools-image.yml | [#844](https://github.com/zynax-io/zynax/issues/844) | #849 | ⬜ CI running |
-| chore(claude): /resume-m6 rewrite — FF discipline | [#845](https://github.com/zynax-io/zynax/issues/845) | #850 | ⬜ CI running |
-| docs(contributing): merge policy | [#846](https://github.com/zynax-io/zynax/issues/846) | #851 | ⬜ CI running |
-| docs(milestones): this tracking PR | — | #852 | ⬜ Open |
+| ADR-023 — restrict direct pushes to main | — | #847 | ✅ Merged |
+| chore(ci): bump-ci-runner script + make target | [#843](https://github.com/zynax-io/zynax/issues/843) | #848 | ✅ Merged |
+| ci(infra): post-build bump issue from tools-image.yml | [#844](https://github.com/zynax-io/zynax/issues/844) | #849 | ✅ Merged |
+| chore(claude): /resume-m6 rewrite — FF discipline | [#845](https://github.com/zynax-io/zynax/issues/845) | #850 | ✅ Merged |
+| docs(contributing): merge policy | [#846](https://github.com/zynax-io/zynax/issues/846) | #851 | ✅ Merged |
+| docs(milestones): tracking + ROADMAP expansion | — | #852 | ✅ Merged |
 
 ---
 


### PR DESCRIPTION
## Summary

PRs #847–#852 (ADR-023, bump-ci-runner, post-build bump, /resume-m6 rewrite, merge policy, milestone tracking) all merged 2026-06-03. Flip 6 rows ⬜→✅ in M6-planning.md and mark the infra/tooling track Complete in current-milestone.md.

## Changes
- `docs/milestones/M6-planning.md` — 5 infra rows ⬜ Open → ✅ Merged; update header date
- `state/current-milestone.md` — M6 Infra/Tooling section 🔄 In Progress → ✅ Complete; all 6 PR rows flipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)