### PR TITLE
docs(milestones): flip DevAuto.1 #874 to merged; add DevAuto section

### DIFF
--- a/docs/milestones/M6-planning.md
+++ b/docs/milestones/M6-planning.md
@@ -2,7 +2,7 @@
 
 # Zynax M6 — K8s Production-Ready Planning
 
-> Generated: 2026-06-02 · Last updated: 2026-06-03 (M6.DevAuto EPIC #873 added; issues #874–#883 created)  
+> Generated: 2026-06-02 · Last updated: 2026-06-03 (DevAuto.1 #874 ✅ merged in #884)  
 > Based on live repo state at commit `994efb7` (main).  
 > GitHub Milestone: **"K8s Production-Ready (M6)"** (milestone #6).  
 > All `gh` commands, file reads, and live issue data were gathered in this session — nothing assumed from memory.
@@ -87,7 +87,7 @@
 
 | Story | Issue | Area | PR | Status |
 |-------|-------|------|-----|--------|
-| DevAuto.1 docs(automation): STATUS-AND-DIRECTION.md | [#874](https://github.com/zynax-io/zynax/issues/874) | Docs | — | ⬜ Open |
+| DevAuto.1 docs(automation): STATUS-AND-DIRECTION.md | [#874](https://github.com/zynax-io/zynax/issues/874) | Docs | #884 | ✅ Merged |
 | DevAuto.2 chore(automation): expert mesh YAML configs (9 experts) | [#875](https://github.com/zynax-io/zynax/issues/875) | CI | — | ⬜ Open |
 | DevAuto.3 chore(automation): orchestrator config + aggregation protocol | [#876](https://github.com/zynax-io/zynax/issues/876) | CI | — | ⬜ Open |
 | DevAuto.4 ci: Wave 0 — GH Actions advisory workflow | [#877](https://github.com/zynax-io/zynax/issues/877) | CI | — | ⬜ Open |

--- a/state/current-milestone.md
+++ b/state/current-milestone.md
@@ -266,6 +266,20 @@ All PRs merged 2026-06-03.
 | docs(contributing): merge policy | [#846](https://github.com/zynax-io/zynax/issues/846) | #851 | ✅ Merged |
 | docs(milestones): tracking + ROADMAP expansion | — | #852 | ✅ Merged |
 
+### M6.DevAuto — Self-hosting dev-automation (#873) — 🔄 In Progress
+
+Canvas: SPDD-exempt (docs:/chore:/ci: stories only, until Wave 4 #881 which is BLOCKED on #626 + #772)
+
+| Story | Issue | Status |
+|-------|-------|--------|
+| DevAuto.1 docs(automation): STATUS-AND-DIRECTION.md | [#874](https://github.com/zynax-io/zynax/issues/874) | ✅ Merged (#884) |
+| DevAuto.2 chore(automation): expert mesh YAML configs | [#875](https://github.com/zynax-io/zynax/issues/875) | ⬜ Next |
+| DevAuto.3 chore(automation): orchestrator config | [#876](https://github.com/zynax-io/zynax/issues/876) | ⬜ Pending |
+| DevAuto.4–7 ci: Waves 0–3 | [#877](https://github.com/zynax-io/zynax/issues/877)–[#880](https://github.com/zynax-io/zynax/issues/880) | ⬜ Pending |
+| DevAuto.8 feat: Wave 4 aspirational | [#881](https://github.com/zynax-io/zynax/issues/881) | ⬜ **BLOCKED on #626 + #772** |
+| DevAuto.9 test: xfail gate | [#882](https://github.com/zynax-io/zynax/issues/882) | ⬜ Pending |
+| DevAuto.10 docs: AGENTS.md pointer + README | [#883](https://github.com/zynax-io/zynax/issues/883) | ⬜ Pending |
+
 ---
 
 ## Next Session Queue (priority order)


### PR DESCRIPTION
## Summary

#874 (DevAuto.1 STATUS-AND-DIRECTION.md) was closed by PR #884 on 2026-06-03, but the M6 planning table still showed it as ⬜ Open. This PR reconciles the discrepancy per the /resume-m6 STEP 1.3 protocol.

**Changes:**
- `docs/milestones/M6-planning.md`: flip DevAuto.1 row `⬜ Open` → `✅ Merged (#884)`; update "Last updated" annotation
- `state/current-milestone.md`: add M6.DevAuto subsection showing #874 ✅ and #875 as next

## Test plan

- [x] `make lint` — pre-commit hooks pass (docs only)
- [x] #874 is CLOSED in GitHub (verified via `gh issue view 874`)
- [x] PR #884 mergedAt = 2026-06-03T13:25:37Z (confirmed)
- [x] No out-of-scope edits

## Engineering hygiene

- [x] docs: type — SPDD-exempt
- [x] `Signed-off-by` + `Assisted-by` trailers on commit
- [x] Branched from fresh `origin/main`

Assisted-by: Claude/claude-sonnet-4-6