### PR TITLE
ci(infra): helm ct lint gate on helm/ and infra/ changes (#765, step 13)

### DIFF
--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: Apache-2.0
+# Helm chart linting gate — runs ct lint on every PR or push touching helm/ or infra/.
+# Closes #242.
+#
+# ct lint validates chart structure, required resources, and YAML syntax.
+# It does NOT install charts (that is the EPIC G e2e harness, #770).
+#
+# All actions pinned to SHA (project standard — see CONTRIBUTING.md §CI Rules).
+
+name: Helm Lint
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "helm/**"
+      - "infra/**"
+  push:
+    branches: [main]
+    paths:
+      - "helm/**"
+      - "infra/**"
+  workflow_dispatch:
+
+concurrency:
+  group: helm-lint-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  helm-lint:
+    name: ct lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4.3.1
+        with:
+          version: v3.17.0
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@0d27833985e9ab9b3b0fddf0afd58c7843f2c3e4 # v2.7.0
+
+      - name: Add Helm repositories
+        run: |
+          helm repo add bitnami https://charts.bitnami.com/bitnami
+          helm repo add nats https://nats-io.github.io/k8s/helm/charts
+          helm repo add temporalio https://temporalio.github.io/helm-charts
+          helm repo add jetstack https://charts.jetstack.io
+          helm repo update
+
+      - name: Build chart dependencies
+        run: |
+          # Build dependencies for charts that reference local file:// charts so
+          # that ct lint can resolve them. The .tgz files are already committed;
+          # this step is a no-op if all deps are satisfied.
+          for dir in helm/zynax-*/; do
+            if [ -f "$dir/Chart.yaml" ] && grep -q "file://" "$dir/Chart.yaml" 2>/dev/null; then
+              echo "Building deps for $dir"
+              helm dependency build "$dir" 2>&1 || true
+            fi
+          done
+          if grep -q "file://" helm/zynax-umbrella/Chart.yaml 2>/dev/null; then
+            echo "Building deps for helm/zynax-umbrella/"
+            helm dependency build helm/zynax-umbrella/ 2>&1 || true
+          fi
+
+      - name: Run ct lint
+        run: |
+          ct lint \
+            --chart-dirs helm \
+            --validate-maintainers false \
+            --all \
+            --debug

--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -22,6 +22,9 @@ on:
       - "infra/**"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: helm-lint-${{ github.ref }}
   cancel-in-progress: true

--- a/docs/milestones/M6-planning.md
+++ b/docs/milestones/M6-planning.md
@@ -2,7 +2,7 @@
 
 # Zynax M6 — K8s Production-Ready Planning
 
-> Generated: 2026-06-02 · Last updated: 2026-06-04 (A.11 #790 merged — cert-manager ClusterIssuer + Certificates)
+> Generated: 2026-06-02 · Last updated: 2026-06-04 (A.12 #791 merged — helm lint CI gate)
 > Based on live repo state at commit `994efb7` (main).  
 > GitHub Milestone: **"K8s Production-Ready (M6)"** (milestone #6).  
 > All `gh` commands, file reads, and live issue data were gathered in this session — nothing assumed from memory.
@@ -70,8 +70,8 @@
 | A.8 feat(infra): NATS JetStream subchart | [#787](https://github.com/zynax-io/zynax/issues/787) | Infra | — | ✅ Merged |
 | A.9 feat(infra): Postgres 16 subchart | [#788](https://github.com/zynax-io/zynax/issues/788) | Infra | — | ✅ Merged |
 | A.10 feat(infra): Temporal + zynax-umbrella chart | [#789](https://github.com/zynax-io/zynax/issues/789) | Infra | — | ✅ Merged |
-| A.11 feat(infra): cert-manager ClusterIssuer + Certificates | [#790](https://github.com/zynax-io/zynax/issues/790) | Infra | — | ✅ Merged |
-| A.12 ci: helm lint gate | [#791](https://github.com/zynax-io/zynax/issues/791) | CI | — | ⬜ Open |
+| A.11 feat(infra): cert-manager ClusterIssuer + Certificates | [#790](https://github.com/zynax-io/zynax/issues/790) | Infra | #896 | ✅ Merged |
+| A.12 ci: helm lint gate | [#791](https://github.com/zynax-io/zynax/issues/791) | CI | — | ✅ Merged |
 | A.13 docs(infra): environment parity manifest | [#792](https://github.com/zynax-io/zynax/issues/792) | Docs | — | ⬜ Open |
 
 **M6.Build — Native multi-arch build pipeline** (EPIC [#837](https://github.com/zynax-io/zynax/issues/837); SPDD-exempt; no canvas required)

--- a/docs/spdd/765-helm-charts/canvas.md
+++ b/docs/spdd/765-helm-charts/canvas.md
@@ -141,7 +141,7 @@ Each O-step ships as its own PR. A.0 must merge first; A.1–A.11 may proceed in
 
 12. **[A.11]** ✅ Create cert-manager `ClusterIssuer` + per-service `Certificate` resources in `helm/charts/cert-manager/`; update `infra/AGENTS.md` Helm section with cert-manager prerequisite note; integrates with ADR-020 mTLS wiring (#488).
 
-13. **[A.12]** Add `.github/workflows/helm-lint.yml`: runs `ct lint` on PRs touching `helm/` or `infra/`; pinned SHA for `helm/chart-testing-action`; closes #242.
+13. **[A.12]** ✅ Add `.github/workflows/helm-lint.yml`: runs `ct lint` on PRs touching `helm/` or `infra/`; pinned SHA for `helm/chart-testing-action`; closes #242.
 
 14. **[A.13]** Add `docs/infra/environment-parity.md`: table of dev/staging/prod value differences (replica counts, resource limits, image tag strategy, TLS disabled vs enabled); closes #243.
 

--- a/state/current-milestone.md
+++ b/state/current-milestone.md
@@ -231,7 +231,7 @@ Canvas: `docs/spdd/765-helm-charts/canvas.md` — Status: **Aligned** ✅
 | A.9 feat(infra): Postgres 16 subchart | [#788](https://github.com/zynax-io/zynax/issues/788) | ✅ Merged |
 | A.10 feat(infra): Temporal + zynax-umbrella chart | [#789](https://github.com/zynax-io/zynax/issues/789) | ✅ Merged |
 | A.11 feat(infra): cert-manager ClusterIssuer + Certificates | [#790](https://github.com/zynax-io/zynax/issues/790) | ✅ Merged |
-| A.12 ci: helm lint gate | [#791](https://github.com/zynax-io/zynax/issues/791) | ⬜ Pending |
+| A.12 ci: helm lint gate | [#791](https://github.com/zynax-io/zynax/issues/791) | ✅ Merged |
 | A.13 docs: environment parity manifest | [#792](https://github.com/zynax-io/zynax/issues/792) | ⬜ Pending |
 
 ### M6.Images — Single Source of Truth for Container Image References (#855) — ⬜ Canvas Aligned, not started


### PR DESCRIPTION
## Summary

- Add `.github/workflows/helm-lint.yml` running `ct lint --all` on every PR/push touching `helm/**` or `infra/**`
- All GitHub Actions pinned to SHA
- Closes #242

## EPIC canvas
`docs/spdd/765-helm-charts/canvas.md` — O-step 13 (A.12)

## Acceptance criteria
- [x] Workflow triggers on `helm/**` and `infra/**` path changes
- [x] `ct lint` runs against all charts in `helm/`
- [x] `helm/chart-testing-action` is pinned to SHA
- [x] Workflow runs `helm dependency build` for file:// deps before linting
- [x] Closes #242

## Out of scope
Full chart-testing (install + test) — that is the EPIC G / #770 e2e harness.

## Test plan

### Engineering hygiene
- [x] **`M6-planning.md` row ⬜→✅ in this diff** (mandatory)
- [x] **`current-milestone.md` updated in this diff** (mandatory)
- [x] Canvas O-step 13 marked ✅
- [x] Branched from fresh `origin/main` · PR XS size · trailers on every commit

**SHA verification needed:** `azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4.3.1` and `helm/chart-testing-action@0d27833985e9ab9b3b0fddf0afd58c7843f2c3e4 # v2.7.0` — please verify these SHAs match the tagged releases before merging.

Assisted-by: Claude/claude-sonnet-4-6
