### PR TITLE
chore(ci): bump ci-runner digest to 35e84a949a1148a0 (#853)

### DIFF
--- a/.github/workflows/_test-go.yml
+++ b/.github/workflows/_test-go.yml
@@ -38,7 +38,7 @@ jobs:
     name: test-go
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:f33e9a90f6ad8fdd6404c6e7f47811b6712e62d5be295493aa19fb730004666a
+      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:35e84a949a1148a07e3e036afd8f94e5410b025beaf84e323286883ad39f5abc
       options: --user root
     env:
       UV_LINK_MODE: copy

--- a/.github/workflows/_test-python.yml
+++ b/.github/workflows/_test-python.yml
@@ -24,7 +24,7 @@ jobs:
     name: test-python
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:f33e9a90f6ad8fdd6404c6e7f47811b6712e62d5be295493aa19fb730004666a
+      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:35e84a949a1148a07e3e036afd8f94e5410b025beaf84e323286883ad39f5abc
       options: --user root
     env:
       UV_LINK_MODE: copy

--- a/.github/workflows/ai-context-budget.yml
+++ b/.github/workflows/ai-context-budget.yml
@@ -26,7 +26,7 @@ jobs:
     name: Count AI context lines
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:f33e9a90f6ad8fdd6404c6e7f47811b6712e62d5be295493aa19fb730004666a
+      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:35e84a949a1148a07e3e036afd8f94e5410b025beaf84e323286883ad39f5abc
       options: --user root
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
     name: dco
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:f33e9a90f6ad8fdd6404c6e7f47811b6712e62d5be295493aa19fb730004666a
+      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:35e84a949a1148a07e3e036afd8f94e5410b025beaf84e323286883ad39f5abc
       options: --user root
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -106,7 +106,7 @@ jobs:
     name: changes
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:f33e9a90f6ad8fdd6404c6e7f47811b6712e62d5be295493aa19fb730004666a
+      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:35e84a949a1148a07e3e036afd8f94e5410b025beaf84e323286883ad39f5abc
       options: --user root
     needs: [dco]
     outputs:
@@ -234,7 +234,7 @@ jobs:
     name: lint-proto
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:f33e9a90f6ad8fdd6404c6e7f47811b6712e62d5be295493aa19fb730004666a
+      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:35e84a949a1148a07e3e036afd8f94e5410b025beaf84e323286883ad39f5abc
       options: --user root
     needs: [changes]
     if: needs.changes.outputs.proto == 'true'
@@ -376,7 +376,7 @@ jobs:
     name: lint-go
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:f33e9a90f6ad8fdd6404c6e7f47811b6712e62d5be295493aa19fb730004666a
+      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:35e84a949a1148a07e3e036afd8f94e5410b025beaf84e323286883ad39f5abc
       options: --user root
     needs: [changes]
     if: needs.changes.outputs.go == 'true'
@@ -437,7 +437,7 @@ jobs:
     name: lint-python
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:f33e9a90f6ad8fdd6404c6e7f47811b6712e62d5be295493aa19fb730004666a
+      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:35e84a949a1148a07e3e036afd8f94e5410b025beaf84e323286883ad39f5abc
       options: --user root
     needs: [changes]
     if: needs.changes.outputs.python == 'true'
@@ -525,7 +525,7 @@ jobs:
     name: test-unit
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:f33e9a90f6ad8fdd6404c6e7f47811b6712e62d5be295493aa19fb730004666a
+      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:35e84a949a1148a07e3e036afd8f94e5410b025beaf84e323286883ad39f5abc
       options: --user root
     needs: [test-go, test-python]
     if: >-
@@ -542,7 +542,7 @@ jobs:
     name: test-integration
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:f33e9a90f6ad8fdd6404c6e7f47811b6712e62d5be295493aa19fb730004666a
+      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:35e84a949a1148a07e3e036afd8f94e5410b025beaf84e323286883ad39f5abc
       options: --user root
     needs: [changes, lint-go, lint-proto, lint-python]
     if: >-
@@ -586,7 +586,7 @@ jobs:
     name: security
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:f33e9a90f6ad8fdd6404c6e7f47811b6712e62d5be295493aa19fb730004666a
+      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:35e84a949a1148a07e3e036afd8f94e5410b025beaf84e323286883ad39f5abc
       options: --user root
     needs: [dco, changes]
     if: github.event_name != 'push' || needs.changes.outputs.code == 'true'

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -44,7 +44,7 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:f33e9a90f6ad8fdd6404c6e7f47811b6712e62d5be295493aa19fb730004666a
+      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:35e84a949a1148a07e3e036afd8f94e5410b025beaf84e323286883ad39f5abc
       options: --user root
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -58,7 +58,7 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:f33e9a90f6ad8fdd6404c6e7f47811b6712e62d5be295493aa19fb730004666a
+      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:35e84a949a1148a07e3e036afd8f94e5410b025beaf84e323286883ad39f5abc
       options: --user root
     steps:
       - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6
@@ -87,7 +87,7 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:f33e9a90f6ad8fdd6404c6e7f47811b6712e62d5be295493aa19fb730004666a
+      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:35e84a949a1148a07e3e036afd8f94e5410b025beaf84e323286883ad39f5abc
       options: --user root
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -141,7 +141,7 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:f33e9a90f6ad8fdd6404c6e7f47811b6712e62d5be295493aa19fb730004666a
+      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:35e84a949a1148a07e3e036afd8f94e5410b025beaf84e323286883ad39f5abc
       options: --user root
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -185,7 +185,7 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:f33e9a90f6ad8fdd6404c6e7f47811b6712e62d5be295493aa19fb730004666a
+      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:35e84a949a1148a07e3e036afd8f94e5410b025beaf84e323286883ad39f5abc
       options: --user root
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -264,7 +264,7 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:f33e9a90f6ad8fdd6404c6e7f47811b6712e62d5be295493aa19fb730004666a
+      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:35e84a949a1148a07e3e036afd8f94e5410b025beaf84e323286883ad39f5abc
       options: --user root
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -301,7 +301,7 @@ jobs:
     name: Secret scan (gitleaks)
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:f33e9a90f6ad8fdd6404c6e7f47811b6712e62d5be295493aa19fb730004666a
+      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:35e84a949a1148a07e3e036afd8f94e5410b025beaf84e323286883ad39f5abc
       options: --user root
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/config/ci-runner-digest.txt
+++ b/config/ci-runner-digest.txt
@@ -8,4 +8,4 @@
 #     image: ghcr.io/zynax-io/zynax/ci-runner@<digest>
 #
 # Digest from last build (update after each tools-image.yml run):
-sha256:f33e9a90f6ad8fdd6404c6e7f47811b6712e62d5be295493aa19fb730004666a
+sha256:35e84a949a1148a07e3e036afd8f94e5410b025beaf84e323286883ad39f5abc


### PR DESCRIPTION
## Summary

- Bumps `ci-runner` digest across all workflow files and `config/ci-runner-digest.txt`
- New digest: `sha256:35e84a949a1148a07e3e036afd8f94e5410b025beaf84e323286883ad39f5abc`
- Built by: https://github.com/zynax-io/zynax/actions/runs/26879231298

## Closes

Closes #853

## Checklist (from issue #853)

- [x] `make bump-ci-runner NEW_DIGEST=sha256:35e84a949a1148a07e3e036afd8f94e5410b025beaf84e323286883ad39f5abc` ran
- [x] `--check` exits 0 — all 6 files verified clean
- [x] PR opened

## Files changed (6, 19 substitutions)

| File | Refs updated |
|------|-------------|
| `config/ci-runner-digest.txt` | 1 |
| `.github/workflows/ci.yml` | 8 |
| `.github/workflows/pr-checks.yml` | 7 |
| `.github/workflows/_test-go.yml` | 1 |
| `.github/workflows/_test-python.yml` | 1 |
| `.github/workflows/ai-context-budget.yml` | 1 |

Assisted-by: Claude/claude-sonnet-4-6