### PR TITLE
docs(milestones): M6.H #626 COMPLETE — both Postgres repos merged

### DIFF
--- a/docs/milestones/M6-planning.md
+++ b/docs/milestones/M6-planning.md
@@ -2,7 +2,7 @@
 
 # Zynax M6 — K8s Production-Ready Planning
 
-> Generated: 2026-06-02 · Last updated: 2026-06-05 (M6.H O2 #794 in progress — agent-registry Postgres repo)
+> Generated: 2026-06-02 · Last updated: 2026-06-05 (M6.H COMPLETE — #626 closed; PRs #900 + #901 merged)
 > Based on live repo state at commit `994efb7` (main).  
 > GitHub Milestone: **"K8s Production-Ready (M6)"** (milestone #6).  
 > All `gh` commands, file reads, and live issue data were gathered in this session — nothing assumed from memory.
@@ -33,12 +33,14 @@
 | docs(contributing): record rebase-merge / branch-delete / no-reopen policy | [#846](https://github.com/zynax-io/zynax/issues/846) | Docs | #851 | ✅ Merged |
 | docs(adr): ADR-023 — restrict direct pushes to main; rebase-merge only | — | Docs/ADR | #847 | ✅ Merged |
 
-**M6.H — Postgres-backed repositories for task-broker + agent-registry** (EPIC [#626](https://github.com/zynax-io/zynax/issues/626); canvas `docs/spdd/626-postgres-repos/canvas.md` — Status: **Aligned**)
+**M6.H — Postgres-backed repositories for task-broker + agent-registry** (EPIC [#626](https://github.com/zynax-io/zynax/issues/626); canvas `docs/spdd/626-postgres-repos/canvas.md` — Status: **Implemented** ✅)
+
+All 2 O-steps merged. ✅ EPIC COMPLETE.
 
 | Story | Issue | Area | PR | Status |
 |-------|-------|------|-----|--------|
 | O1 feat(task-broker): Postgres TaskRepository — pgx/v5 + migrations | [#793](https://github.com/zynax-io/zynax/issues/793) | task-broker | #900 | ✅ Merged |
-| O2 feat(agent-registry): Postgres AgentRepository — pgx/v5 + migrations | [#794](https://github.com/zynax-io/zynax/issues/794) | agent-registry | — | 🔄 PR open |
+| O2 feat(agent-registry): Postgres AgentRepository — pgx/v5 + migrations | [#794](https://github.com/zynax-io/zynax/issues/794) | agent-registry | #901 | ✅ Merged |
 
 **M6.Images — Single source of truth for container-image references** (EPIC #855; canvas `docs/spdd/855-images-sot/canvas.md` — Status: **Aligned**)
 

--- a/docs/spdd/626-postgres-repos/canvas.md
+++ b/docs/spdd/626-postgres-repos/canvas.md
@@ -7,7 +7,7 @@
 **Issue:** #626
 **Author:** Oscar Gómez Manresa
 **Date:** 2026-06-02
-**Status:** Aligned
+**Status:** Implemented
 
 **Child issues:** #793 (J.0 task-broker Postgres repo) · #794 (J.1 agent-registry Postgres repo)
 

--- a/state/current-milestone.md
+++ b/state/current-milestone.md
@@ -219,14 +219,14 @@ Canvas: `docs/spdd/765-helm-charts/canvas.md` — Status: **Implemented** ✅
 
 All 14 O-steps merged. ✅ EPIC COMPLETE.
 
-### M6.H — Postgres-Backed Repositories (#626) — 🔄 In Progress
+### M6.H — Postgres-Backed Repositories (#626) — ✅ COMPLETE
 
-Canvas: `docs/spdd/626-postgres-repos/canvas.md` — Status: **Aligned**
+Canvas: `docs/spdd/626-postgres-repos/canvas.md` — Status: Implemented
 
 | Story | Issue | Status |
 |-------|-------|--------|
 | O1 feat(task-broker): Postgres TaskRepository | [#793](https://github.com/zynax-io/zynax/issues/793) | ✅ Merged (#900) |
-| O2 feat(agent-registry): Postgres AgentRepository | [#794](https://github.com/zynax-io/zynax/issues/794) | 🔄 PR open |
+| O2 feat(agent-registry): Postgres AgentRepository | [#794](https://github.com/zynax-io/zynax/issues/794) | ✅ Merged (#901) |
 
 ### M6.Images — Single Source of Truth for Container Image References (#855) — ⬜ Canvas Aligned, not started
 


### PR DESCRIPTION
Marks M6.H EPIC #626 complete, updates canvas to Implemented. Follows #900 (task-broker) and #901 (agent-registry) merges.

Assisted-by: Claude/claude-sonnet-4-6