### PR TITLE
ci(zynax-ci): add go.mod version-alignment gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,7 +195,7 @@ jobs:
             if echo "$f" | grep -qE '^(protos/|spec/|CLAUDE\.md|AGENTS\.md|.*/AGENTS\.md|docs/ai-assistant-setup\.md|\.ai/|\.claude/)'; then
               proto=true
             fi
-            if echo "$f" | grep -qE '^(services/|protos/|cmd/|agents/adapters/)'; then
+            if echo "$f" | grep -qE '^(services/|protos/|cmd/|agents/adapters/|libs/|go\.work(\.sum)?$)'; then
               go=true
             fi
             if echo "$f" | grep -qE '^agents/' && ! echo "$f" | grep -qE '^agents/adapters/'; then
@@ -431,6 +431,12 @@ jobs:
             fi
           done
           $failed && exit 1 || echo "✅ CLI tool lint passed"
+
+      - name: zynax-ci check deps (go.mod version alignment)
+        run: |
+          cd cmd/zynax-ci
+          GOWORK=off go run . check deps --root "$GITHUB_WORKSPACE"
+          echo "✅ go.mod version alignment check passed"
 
 # ── Lint: Python agents and SDK ───────────────────────────────────────────────
   lint-python:

--- a/cmd/zynax-ci/AGENTS.md
+++ b/cmd/zynax-ci/AGENTS.md
@@ -34,6 +34,7 @@ cmd/zynax-ci/
     validate_capabilities.go  zynax-ci validate capabilities <dir>
     validate_policies.go   zynax-ci validate policies <dir>
     check_ai_context.go    zynax-ci check ai-context
+    check_deps.go          zynax-ci check deps
   validate/
     canvas.go              Canvas validator (seven REASONS sections, header fields, Status)
     canvas_test.go
@@ -43,6 +44,7 @@ cmd/zynax-ci/
     helpers.go             Shared ValidationError helpers
   check/
     context.go             AI context line-count reporter (advisory, always exits 0)
+    deps.go                go.mod version alignment checker (exits 1 on divergence)
 ```
 
 ## Hard Constraints

--- a/cmd/zynax-ci/check/deps.go
+++ b/cmd/zynax-ci/check/deps.go
@@ -1,0 +1,215 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package check
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// mustMatchModules lists shared deps that must pin identical versions across
+// every go.mod that declares them. "go" is the toolchain directive and must
+// match in ALL go.mod files.
+var mustMatchModules = []string{
+	"go", // Go toolchain directive — must match in every module
+	"github.com/kelseyhightower/envconfig",
+	"google.golang.org/grpc",
+	"google.golang.org/protobuf",
+	"gopkg.in/yaml.v3",
+}
+
+// DepsViolation records a module whose version differs across go.mod files.
+type DepsViolation struct {
+	Module   string            // dependency path ("go" for toolchain directive)
+	Versions map[string]string // go.mod file path → version string
+}
+
+// DepsReport is the result of a Deps check.
+type DepsReport struct {
+	GoModFiles []string        // all go.mod files found
+	Violations []DepsViolation // non-empty when versions diverge
+}
+
+// Deps scans repoRoot for all go.mod files and verifies that each module in
+// mustMatchModules pins the same version across all files that declare it.
+// The "go" directive is checked across ALL go.mod files.
+// Other modules are only compared where they appear (absent = skip).
+func Deps(repoRoot string) (DepsReport, error) {
+	modFiles, err := findGoModFiles(repoRoot)
+	if err != nil {
+		return DepsReport{}, err
+	}
+
+	versions, err := collectVersions(repoRoot, modFiles)
+	if err != nil {
+		return DepsReport{}, err
+	}
+
+	report := DepsReport{GoModFiles: make([]string, len(modFiles))}
+	for i, p := range modFiles {
+		report.GoModFiles[i] = relPath(repoRoot, p)
+	}
+	for _, mod := range mustMatchModules {
+		vmap := versions[mod]
+		if len(vmap) < 2 {
+			continue
+		}
+		if len(uniqueVersions(vmap)) > 1 {
+			report.Violations = append(report.Violations, DepsViolation{
+				Module:   mod,
+				Versions: copyMap(vmap),
+			})
+		}
+	}
+	return report, nil
+}
+
+// findGoModFiles walks repoRoot and returns all go.mod paths, skipping vendor/.git/hidden dirs.
+func findGoModFiles(repoRoot string) ([]string, error) {
+	var modFiles []string
+	err := filepath.WalkDir(repoRoot, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if d.IsDir() {
+			base := d.Name()
+			if base == "vendor" || base == ".git" || strings.HasPrefix(base, ".") {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if d.Name() == "go.mod" {
+			modFiles = append(modFiles, path)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("check deps: walk %s: %w", repoRoot, err)
+	}
+	sort.Strings(modFiles)
+	return modFiles, nil
+}
+
+// collectVersions parses each go.mod file and builds a versions[module][path]=version map.
+func collectVersions(repoRoot string, modFiles []string) (map[string]map[string]string, error) {
+	versions := make(map[string]map[string]string, len(mustMatchModules))
+	for _, mod := range mustMatchModules {
+		versions[mod] = make(map[string]string)
+	}
+	for _, modPath := range modFiles {
+		parsed, err := parseGoMod(modPath)
+		if err != nil {
+			return nil, fmt.Errorf("check deps: parse %s: %w", modPath, err)
+		}
+		rel := relPath(repoRoot, modPath)
+		for mod, vmap := range versions {
+			if v, ok := parsed[mod]; ok {
+				vmap[rel] = v
+			}
+		}
+	}
+	return versions, nil
+}
+
+// PrintDepsReport writes the report to w. Returns true if all versions agree.
+func PrintDepsReport(w *os.File, r DepsReport) bool {
+	if len(r.Violations) == 0 {
+		_, _ = fmt.Fprintf(w, "✅  All %d go.mod files agree on shared dependency versions.\n", len(r.GoModFiles))
+		return true
+	}
+	_, _ = fmt.Fprintf(w, "❌  Shared dependency version mismatch found in %d module(s):\n\n", len(r.Violations))
+	for _, v := range r.Violations {
+		_, _ = fmt.Fprintf(w, "  %s\n", v.Module)
+		files := sortedKeys(v.Versions)
+		for _, f := range files {
+			_, _ = fmt.Fprintf(w, "    %-60s %s\n", f, v.Versions[f])
+		}
+		_, _ = fmt.Fprintln(w)
+	}
+	_, _ = fmt.Fprintln(w, "Fix: align all go.mod files to the same version before merging.")
+	return false
+}
+
+// parseGoMod reads a go.mod file and returns a map of module path → version
+// for the "go" directive and all require entries.
+func parseGoMod(path string) (map[string]string, error) {
+	f, err := os.Open(path) //nolint:gosec
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+
+	result := make(map[string]string)
+	scanner := bufio.NewScanner(f)
+	inRequire := false
+
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "//") {
+			continue
+		}
+		// toolchain directive: "go 1.26.4"
+		if strings.HasPrefix(line, "go ") {
+			parts := strings.Fields(line)
+			if len(parts) == 2 {
+				result["go"] = parts[1]
+			}
+			continue
+		}
+		// require block start
+		if line == "require (" {
+			inRequire = true
+			continue
+		}
+		// require block end
+		if inRequire && line == ")" {
+			inRequire = false
+			continue
+		}
+		// single-line require: "require foo v1.2.3"
+		if strings.HasPrefix(line, "require ") {
+			parts := strings.Fields(strings.TrimPrefix(line, "require "))
+			if len(parts) >= 2 {
+				result[parts[0]] = parts[1]
+			}
+			continue
+		}
+		// require block entry: "foo v1.2.3" or "foo v1.2.3 // indirect"
+		if inRequire {
+			parts := strings.Fields(line)
+			if len(parts) >= 2 {
+				result[parts[0]] = parts[1]
+			}
+		}
+	}
+	return result, scanner.Err()
+}
+
+func uniqueVersions(m map[string]string) map[string]struct{} {
+	u := make(map[string]struct{})
+	for _, v := range m {
+		u[v] = struct{}{}
+	}
+	return u
+}
+
+func copyMap(m map[string]string) map[string]string {
+	c := make(map[string]string, len(m))
+	for k, v := range m {
+		c[k] = v
+	}
+	return c
+}
+
+func sortedKeys(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/cmd/zynax-ci/check/deps_test.go
+++ b/cmd/zynax-ci/check/deps_test.go
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package check_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/zynax-io/zynax/cmd/zynax-ci/check"
+)
+
+func writeGoMod(t *testing.T, dir, content string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDeps_AllMatch(t *testing.T) {
+	root := t.TempDir()
+	mod := "module github.com/example/a\n\ngo 1.26.4\n\nrequire (\n\tgoogle.golang.org/grpc v1.81.1\n\tgopkg.in/yaml.v3 v3.0.1\n)\n"
+	writeGoMod(t, filepath.Join(root, "a"), mod)
+	writeGoMod(t, filepath.Join(root, "b"), mod)
+
+	r, err := check.Deps(root)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(r.Violations) != 0 {
+		t.Errorf("expected no violations, got %d: %+v", len(r.Violations), r.Violations)
+	}
+	if len(r.GoModFiles) != 2 {
+		t.Errorf("expected 2 go.mod files, got %d", len(r.GoModFiles))
+	}
+}
+
+func TestDeps_GrpcMismatch(t *testing.T) {
+	root := t.TempDir()
+	writeGoMod(t, filepath.Join(root, "a"), "module github.com/example/a\n\ngo 1.26.4\n\nrequire google.golang.org/grpc v1.81.1\n")
+	writeGoMod(t, filepath.Join(root, "b"), "module github.com/example/b\n\ngo 1.26.4\n\nrequire google.golang.org/grpc v1.80.0\n")
+
+	r, err := check.Deps(root)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(r.Violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d: %+v", len(r.Violations), r.Violations)
+	}
+	if r.Violations[0].Module != "google.golang.org/grpc" {
+		t.Errorf("expected grpc violation, got %s", r.Violations[0].Module)
+	}
+}
+
+func TestDeps_GoDirectiveMismatch(t *testing.T) {
+	root := t.TempDir()
+	writeGoMod(t, filepath.Join(root, "a"), "module github.com/example/a\n\ngo 1.26.4\n")
+	writeGoMod(t, filepath.Join(root, "b"), "module github.com/example/b\n\ngo 1.25.0\n")
+
+	r, err := check.Deps(root)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	found := false
+	for _, v := range r.Violations {
+		if v.Module == "go" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected go directive violation, none found")
+	}
+}
+
+func TestDeps_AbsentModuleNotViolation(t *testing.T) {
+	root := t.TempDir()
+	// Only "a" has grpc; "b" doesn't — no violation (only one occurrence).
+	writeGoMod(t, filepath.Join(root, "a"), "module github.com/example/a\n\ngo 1.26.4\n\nrequire google.golang.org/grpc v1.81.1\n")
+	writeGoMod(t, filepath.Join(root, "b"), "module github.com/example/b\n\ngo 1.26.4\n")
+
+	r, err := check.Deps(root)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, v := range r.Violations {
+		if v.Module == "google.golang.org/grpc" {
+			t.Errorf("grpc should not be a violation when only one module declares it; got %+v", v)
+		}
+	}
+}
+
+func TestDeps_VendorSkipped(t *testing.T) {
+	root := t.TempDir()
+	writeGoMod(t, filepath.Join(root, "a"), "module github.com/example/a\n\ngo 1.26.4\n")
+	writeGoMod(t, filepath.Join(root, "a", "vendor", "something"), "module vendor/something\n\ngo 1.20.0\n")
+
+	r, err := check.Deps(root)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// vendor go.mod should be skipped — only "a/go.mod" found
+	if len(r.GoModFiles) != 1 {
+		t.Errorf("expected 1 go.mod file (vendor skipped), got %d: %v", len(r.GoModFiles), r.GoModFiles)
+	}
+	if len(r.Violations) != 0 {
+		t.Errorf("expected no violations, got %d", len(r.Violations))
+	}
+}

--- a/cmd/zynax-ci/cmd/check_deps.go
+++ b/cmd/zynax-ci/cmd/check_deps.go
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/zynax-io/zynax/cmd/zynax-ci/check"
+)
+
+var depsRoot string
+
+var checkDepsCmd = &cobra.Command{
+	Use:   "deps",
+	Short: "Verify all go.mod files agree on shared dependency versions",
+	Long: `Walk the repository and check that each module in the must-match list
+pins the same version across every go.mod file that declares it.
+
+Must-match modules:
+  go (toolchain directive)
+  github.com/kelseyhightower/envconfig
+  google.golang.org/grpc
+  google.golang.org/protobuf
+  gopkg.in/yaml.v3
+
+Exits 0 when all versions agree; exits 1 on any divergence.`,
+	Args: cobra.NoArgs,
+	RunE: runCheckDeps,
+}
+
+func init() {
+	checkDepsCmd.Flags().StringVar(&depsRoot, "root", ".", "repository root directory")
+	checkCmd.AddCommand(checkDepsCmd)
+}
+
+func runCheckDeps(_ *cobra.Command, _ []string) error {
+	root := depsRoot
+	if root == "." {
+		var err error
+		root, err = os.Getwd()
+		if err != nil {
+			return fmt.Errorf("check deps: get working directory: %w", err)
+		}
+	}
+
+	report, err := check.Deps(root)
+	if err != nil {
+		return err
+	}
+
+	ok := check.PrintDepsReport(os.Stdout, report)
+	if !ok {
+		return fmt.Errorf("go.mod version alignment check failed")
+	}
+	return nil
+}

--- a/docs/milestones/M6-planning.md
+++ b/docs/milestones/M6-planning.md
@@ -2,7 +2,7 @@
 
 # Zynax M6 — K8s Production-Ready Planning
 
-> Generated: 2026-06-02 · Last updated: 2026-06-06 (M6.F #667 PR#907 MERGED — reconcile "PR pending" → Merged)
+> Generated: 2026-06-02 · Last updated: 2026-06-06 (M6.F #668 PR#909 Merged, #669 ⬜→✅)
 > Based on live repo state at commit `994efb7` (main).  
 > GitHub Milestone: **"K8s Production-Ready (M6)"** (milestone #6).  
 > All `gh` commands, file reads, and live issue data were gathered in this session — nothing assumed from memory.
@@ -115,8 +115,8 @@ DevAuto.8 is aspirational (Zynax AgentDef workflows) — gated by `automation/te
 | Story | Issue | Area | PR | Status |
 |-------|-------|------|-----|--------|
 | refactor: introduce libs/zynaxconfig shared config package — migrate task-broker | [#667](https://github.com/zynax-io/zynax/issues/667) | infra/libs | #907 | ✅ Merged |
-| chore(infra): consolidate five service Dockerfiles into single parameterized template | [#668](https://github.com/zynax-io/zynax/issues/668) | Infra | — | ✅ Implemented |
-| ci: add go.mod version-alignment gate | [#669](https://github.com/zynax-io/zynax/issues/669) | CI | — | ⬜ Open |
+| chore(infra): consolidate five service Dockerfiles into single parameterized template | [#668](https://github.com/zynax-io/zynax/issues/668) | Infra | #909 | ✅ Merged |
+| ci: add go.mod version-alignment gate | [#669](https://github.com/zynax-io/zynax/issues/669) | CI | — | ✅ Implemented |
 
 
 ---

--- a/state/current-milestone.md
+++ b/state/current-milestone.md
@@ -277,8 +277,8 @@ All PRs merged 2026-06-03.
 | Story | Issue | Status |
 |-------|-------|--------|
 | refactor: libs/zynaxconfig shared config + task-broker migration | [#667](https://github.com/zynax-io/zynax/issues/667) | ✅ Merged (PR #907) |
-| chore(infra): Dockerfile template consolidation | [#668](https://github.com/zynax-io/zynax/issues/668) | ✅ Implemented |
-| ci: go.mod version-alignment gate | [#669](https://github.com/zynax-io/zynax/issues/669) | ⬜ Pending |
+| chore(infra): Dockerfile template consolidation | [#668](https://github.com/zynax-io/zynax/issues/668) | ✅ Merged (PR #909) |
+| ci: go.mod version-alignment gate | [#669](https://github.com/zynax-io/zynax/issues/669) | ✅ Implemented |
 
 ### M6.DevAuto — Self-hosting dev-automation (#873) — 🔄 In Progress
 


### PR DESCRIPTION
## Summary

- Adds `zynax-ci check deps` subcommand (`check/deps.go`, `cmd/check_deps.go`) that walks the repo tree, parses all `go.mod` files, and asserts that five shared dependencies pin identical versions across every module that declares them.
- Wires the check into `ci.yml` `lint-go` job so it runs on every PR touching Go modules.
- Adds `libs/` to the `go=true` change-detection pattern (needed for any future shared-lib `go.mod` edits).

## Checked modules

- `go` (toolchain directive — checked in ALL go.mod files)
- `google.golang.org/grpc`
- `google.golang.org/protobuf`
- `gopkg.in/yaml.v3`
- `github.com/kelseyhightower/envconfig`

## Test plan

- [x] `GOWORK=off go test ./... -race` passes in `cmd/zynax-ci/`
- [x] `golangci-lint run ./...` — 0 issues
- [x] `zynax-ci check deps --root .` exits 0 against the repo (all 14 go.mod files agree)
- [x] Unit tests cover: all-match, grpc mismatch, go-directive mismatch, absent-module no-violation, vendor skipped

Closes #669

Assisted-by: Claude/claude-sonnet-4-6