### PR TITLE
chore(claude): self-managed worktree in /m6-issue-generate

### DIFF
--- a/.claude/commands/m6-issue-generate.md
+++ b/.claude/commands/m6-issue-generate.md
@@ -89,6 +89,32 @@ echo "Claimed issue #$ISSUE_N (label added, self-assigned)."
 
 ---
 
+## STEP 2.5 — Create isolated worktree
+
+Create a throw-away checkout so the rest of the skill runs on a guaranteed clean tree,
+completely isolated from the caller's working directory.
+
+```bash
+WORKTREE_PATH="/tmp/zynax-auto-${ISSUE_N}"
+
+# Remove any leftover from a previous crashed run
+git worktree remove "$WORKTREE_PATH" --force 2>/dev/null || true
+rm -rf "$WORKTREE_PATH" 2>/dev/null || true
+
+# Create a fresh worktree based on current origin/main
+git fetch origin --prune
+git worktree add "$WORKTREE_PATH" origin/main
+
+# All subsequent steps run from this directory
+cd "$WORKTREE_PATH"
+echo "Worktree ready: $WORKTREE_PATH"
+```
+
+> Every file read, edit, build, and commit from this point on happens inside
+> `$WORKTREE_PATH`. The caller's workspace is untouched.
+
+---
+
 ## STEP 3 — Read the issue
 
 ```bash
@@ -210,20 +236,7 @@ STORY_COUNT=$(gh issue list --milestone "K8s Production-Ready (M6)" --state all 
 ## STEP 5 — Sync main + create branch (atomic hard claim)
 
 ```bash
-git fetch origin --prune
-git checkout main
-git pull --rebase origin main
-[ "$(git rev-parse main)" = "$(git rev-parse origin/main)" ] || {
-  echo "main diverged — STOP"
-  gh issue edit "$ISSUE_N" --remove-label "status: in-progress"
-  exit 1
-}
-[ -z "$(git status --porcelain)" ] || {
-  echo "dirty working tree — STOP"
-  git status
-  gh issue edit "$ISSUE_N" --remove-label "status: in-progress"
-  exit 1
-}
+# Worktree was created from origin/main in STEP 2.5 — already clean and up to date.
 
 # Derive branch name from issue title: <type>/<N>-<slug>
 SLUG=$(echo "$ISSUE_TITLE" | sed 's|[^a-zA-Z0-9 ]||g' | tr '[:upper:]' '[:lower:]' \
@@ -569,6 +582,12 @@ Artifacts:   $([ "$TOUCHES_IMAGE" -gt 0 ] && echo "Docker images verified ✓" |
 Issue state: CLOSED ✓
 Next:        Run /m6-plan to see what to pick up next.
 EOF
+
+# Remove the isolated worktree — all work is merged, nothing to keep
+cd /tmp   # leave the worktree directory before removing it
+git -C "$OLDPWD" worktree remove "$WORKTREE_PATH" --force 2>/dev/null || true
+rm -rf "$WORKTREE_PATH" 2>/dev/null || true
+echo "Worktree $WORKTREE_PATH removed."
 ```
 
 ---


### PR DESCRIPTION
## Summary

- Adds **STEP 2.5** that creates `/tmp/zynax-auto-<N>` as an isolated git worktree from `origin/main` before any code is written.
- Removes the dirty-tree guard from STEP 5 — it's redundant because the worktree is always clean.
- Adds worktree teardown at the end of STEP 14, after the PR is merged and all cleanup is done.

The command can now be invoked from any workspace state (dirty tree, mid-feature branch, etc.) without interrupting the caller's in-progress work.

## Test plan
- [ ] Slash command file only — no build artefacts changed.
- [ ] CI: conventional commit, secret scan, size label.

Assisted-by: Claude/claude-sonnet-4-6