### PR TITLE
chore(infra): migrate Dockerfiles to ARG+banner image digest pattern

### DIFF
--- a/agents/adapters/ci/Dockerfile
+++ b/agents/adapters/ci/Dockerfile
@@ -1,6 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # Build context: repo root  (docker build -f agents/adapters/ci/Dockerfile .)
-FROM golang:1.26.4-alpine@sha256:f23e8b227fb4493eabe03bede4d5a32d04092da71962f1fb79b5f7d1e6c2a17f AS builder
+# BEGIN zynax-ci:images:golang-alpine
+ARG GO_ALPINE_DIGEST=sha256:f23e8b227fb4493eabe03bede4d5a32d04092da71962f1fb79b5f7d1e6c2a17f
+# END zynax-ci:images:golang-alpine
+# BEGIN zynax-ci:images:distroless-static
+ARG DISTROLESS_DIGEST=sha256:dfadf31470f770fcabd48903762dce126958e98d1ce320acf1216bbfaa42d79c
+# END zynax-ci:images:distroless-static
+FROM golang:1.26.4-alpine@${GO_ALPINE_DIGEST} AS builder
 
 WORKDIR /workspace
 
@@ -17,7 +23,7 @@ RUN cd tools/healthcheck && CGO_ENABLED=0 GOWORK=off \
     go build -trimpath -ldflags "-s -w" -o /healthcheck .
 
 # renovate: datasource=docker depName=gcr.io/distroless/static
-FROM gcr.io/distroless/static:nonroot@sha256:dfadf31470f770fcabd48903762dce126958e98d1ce320acf1216bbfaa42d79c
+FROM gcr.io/distroless/static:nonroot@${DISTROLESS_DIGEST}
 COPY --from=builder /ci-adapter /ci-adapter
 COPY --from=builder /healthcheck /healthcheck
 COPY --from=builder /workspace/agents/adapters/ci/agent-def.yaml.example /etc/ci-adapter/config.yaml

--- a/agents/adapters/git/Dockerfile
+++ b/agents/adapters/git/Dockerfile
@@ -1,6 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # Build context: repo root  (docker build -f agents/adapters/git/Dockerfile .)
-FROM golang:1.26.4-alpine@sha256:f23e8b227fb4493eabe03bede4d5a32d04092da71962f1fb79b5f7d1e6c2a17f AS builder
+# BEGIN zynax-ci:images:golang-alpine
+ARG GO_ALPINE_DIGEST=sha256:f23e8b227fb4493eabe03bede4d5a32d04092da71962f1fb79b5f7d1e6c2a17f
+# END zynax-ci:images:golang-alpine
+# BEGIN zynax-ci:images:distroless-static
+ARG DISTROLESS_DIGEST=sha256:dfadf31470f770fcabd48903762dce126958e98d1ce320acf1216bbfaa42d79c
+# END zynax-ci:images:distroless-static
+FROM golang:1.26.4-alpine@${GO_ALPINE_DIGEST} AS builder
 
 WORKDIR /workspace
 
@@ -17,7 +23,7 @@ RUN cd tools/healthcheck && CGO_ENABLED=0 GOWORK=off \
     go build -trimpath -ldflags "-s -w" -o /healthcheck .
 
 # renovate: datasource=docker depName=gcr.io/distroless/static
-FROM gcr.io/distroless/static:nonroot@sha256:dfadf31470f770fcabd48903762dce126958e98d1ce320acf1216bbfaa42d79c
+FROM gcr.io/distroless/static:nonroot@${DISTROLESS_DIGEST}
 COPY --from=builder /git-adapter /git-adapter
 COPY --from=builder /healthcheck /healthcheck
 COPY --from=builder /workspace/agents/adapters/git/agent-def.yaml.example /etc/git-adapter/config.yaml

--- a/agents/adapters/http/Dockerfile
+++ b/agents/adapters/http/Dockerfile
@@ -1,6 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # Build context: repo root  (docker build -f agents/adapters/http/Dockerfile .)
-FROM golang:1.26.4-alpine@sha256:f23e8b227fb4493eabe03bede4d5a32d04092da71962f1fb79b5f7d1e6c2a17f AS builder
+# BEGIN zynax-ci:images:golang-alpine
+ARG GO_ALPINE_DIGEST=sha256:f23e8b227fb4493eabe03bede4d5a32d04092da71962f1fb79b5f7d1e6c2a17f
+# END zynax-ci:images:golang-alpine
+# BEGIN zynax-ci:images:distroless-static
+ARG DISTROLESS_DIGEST=sha256:dfadf31470f770fcabd48903762dce126958e98d1ce320acf1216bbfaa42d79c
+# END zynax-ci:images:distroless-static
+FROM golang:1.26.4-alpine@${GO_ALPINE_DIGEST} AS builder
 
 WORKDIR /workspace
 
@@ -17,7 +23,7 @@ RUN cd tools/healthcheck && CGO_ENABLED=0 GOWORK=off \
     go build -trimpath -ldflags "-s -w" -o /healthcheck .
 
 # renovate: datasource=docker depName=gcr.io/distroless/static
-FROM gcr.io/distroless/static:nonroot@sha256:dfadf31470f770fcabd48903762dce126958e98d1ce320acf1216bbfaa42d79c
+FROM gcr.io/distroless/static:nonroot@${DISTROLESS_DIGEST}
 COPY --from=builder /http-adapter /http-adapter
 COPY --from=builder /healthcheck /healthcheck
 LABEL org.opencontainers.image.title="Zynax HTTP Adapter" \

--- a/agents/adapters/langgraph/Dockerfile
+++ b/agents/adapters/langgraph/Dockerfile
@@ -13,8 +13,11 @@
 # The module must be importable from the container's PYTHONPATH. Mount graph
 # modules via a volume or build a custom image extending this one.
 
+# BEGIN zynax-ci:images:python-slim
+ARG PYTHON_SLIM_DIGEST=sha256:090ba77e2958f6af52a5341f788b50b032dd4ca28377d2893dcf1ecbdfdfe203
+# END zynax-ci:images:python-slim
 # renovate: datasource=docker depName=python versioning=docker
-FROM python:3.12-slim@sha256:090ba77e2958f6af52a5341f788b50b032dd4ca28377d2893dcf1ecbdfdfe203 AS builder
+FROM python:3.12-slim@${PYTHON_SLIM_DIGEST} AS builder
 
 WORKDIR /app
 
@@ -27,7 +30,7 @@ COPY agents/adapters/langgraph/pyproject.toml agents/adapters/langgraph/uv.lock 
 RUN uv sync --no-dev --no-install-project --frozen
 
 # renovate: datasource=docker depName=python versioning=docker
-FROM python:3.12-slim@sha256:090ba77e2958f6af52a5341f788b50b032dd4ca28377d2893dcf1ecbdfdfe203
+FROM python:3.12-slim@${PYTHON_SLIM_DIGEST}
 
 WORKDIR /app
 

--- a/agents/adapters/llm/Dockerfile
+++ b/agents/adapters/llm/Dockerfile
@@ -9,8 +9,11 @@
 # Provider-specific: OPENAI_API_KEY | AWS_REGION | OLLAMA_BASE_URL
 # Optional: LLM_MODEL, LLM_MAX_TOKENS, ZYNAX_LLM_ADAPTER_GRPC_PORT (default 50057)
 
+# BEGIN zynax-ci:images:python-slim
+ARG PYTHON_SLIM_DIGEST=sha256:090ba77e2958f6af52a5341f788b50b032dd4ca28377d2893dcf1ecbdfdfe203
+# END zynax-ci:images:python-slim
 # renovate: datasource=docker depName=python versioning=docker
-FROM python:3.12-slim@sha256:090ba77e2958f6af52a5341f788b50b032dd4ca28377d2893dcf1ecbdfdfe203 AS builder
+FROM python:3.12-slim@${PYTHON_SLIM_DIGEST} AS builder
 
 WORKDIR /app
 
@@ -23,7 +26,7 @@ COPY agents/adapters/llm/pyproject.toml agents/adapters/llm/uv.lock ./
 RUN uv sync --no-dev --no-install-project --frozen
 
 # renovate: datasource=docker depName=python versioning=docker
-FROM python:3.12-slim@sha256:090ba77e2958f6af52a5341f788b50b032dd4ca28377d2893dcf1ecbdfdfe203
+FROM python:3.12-slim@${PYTHON_SLIM_DIGEST}
 
 WORKDIR /app
 

--- a/cmd/zynax-ci/internal/images/images_test.go
+++ b/cmd/zynax-ci/internal/images/images_test.go
@@ -217,6 +217,57 @@ func TestSync_Idempotent(t *testing.T) {
 	}
 }
 
+// TestSync_BannerRegion_UpdatesOnlyTargetRegion verifies that when a consumer file
+// contains multiple banner-marked digest regions, syncing one image name only
+// updates the sha256 within that image's own banner region and leaves all other
+// banner regions untouched.
+func TestSync_BannerRegion_UpdatesOnlyTargetRegion(t *testing.T) {
+	const bannerEntry = `
+  - name: ci-runner
+    ref: ghcr.io/example/ci-runner
+    digest: sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    consumers:
+      - Dockerfile
+`
+	// Simulate a Dockerfile with two banner-managed digests (the ci-runner one is stale).
+	const dockerfile = `# BEGIN zynax-ci:images:ci-runner
+ARG CI_RUNNER_DIGEST=sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+# END zynax-ci:images:ci-runner
+# BEGIN zynax-ci:images:other-image
+ARG OTHER_DIGEST=sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+# END zynax-ci:images:other-image
+FROM ghcr.io/example/ci-runner@${CI_RUNNER_DIGEST} AS builder
+FROM other/image@${OTHER_DIGEST}
+`
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "images"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, root, "images/images.yaml", makeImagesYAML(bannerEntry))
+	writeFile(t, root, "Dockerfile", dockerfile)
+
+	f, _ := images.Load(root)
+	_, err := images.Sync(f, root, false)
+	if err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+
+	data, _ := os.ReadFile(filepath.Join(root, "Dockerfile")) //nolint:gosec
+	content := string(data)
+
+	// ci-runner banner region must be updated to the target digest
+	// (reuse goodDigestTxt which holds the same canonical aaa digest).
+	if !strings.Contains(content, strings.TrimSpace(goodDigestTxt)) {
+		t.Errorf("ci-runner banner region was not updated:\n%s", content)
+	}
+
+	// other-image banner region must NOT be touched — its digest must remain unchanged.
+	otherDigest := "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+	if !strings.Contains(content, otherDigest) {
+		t.Errorf("other-image banner region was corrupted by ci-runner sync:\n%s", content)
+	}
+}
+
 func TestPrintCheckReport_Ok(t *testing.T) {
 	r := images.CheckReport{}
 	ok := images.PrintCheckReport(os.Stdout, r)

--- a/cmd/zynax-ci/internal/images/sync.go
+++ b/cmd/zynax-ci/internal/images/sync.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 )
 
 var sha256Re = regexp.MustCompile(`sha256:[a-f0-9]{64}`)
@@ -33,7 +34,7 @@ func Sync(f File, repoRoot string, dryRun bool) ([]SyncResult, error) {
 				return results, fmt.Errorf("images sync: read %s: %w", rel, err)
 			}
 			before := string(data)
-			after := replaceDigest(before, refPat, entry.Digest)
+			after := replaceDigest(entry.Name, before, refPat, entry.Digest)
 			r := SyncResult{File: rel, Image: entry.Name, Before: before, After: after, Changed: before != after}
 			results = append(results, r)
 			if r.Changed && !dryRun {
@@ -51,14 +52,52 @@ func buildRefPattern(ref string) *regexp.Regexp {
 	return regexp.MustCompile(regexp.QuoteMeta(ref) + `(?::[^\s@"]*)?@sha256:[a-f0-9]{64}`)
 }
 
-// replaceDigest replaces the sha256 portion matched by refPat with target.
-// Falls back to bare sha256 replacement when refPat finds no match
-// (e.g. config/ci-runner-digest.txt which contains only the raw digest).
-func replaceDigest(content string, refPat *regexp.Regexp, target string) string {
+// replaceDigest replaces the sha256 digest for imageName with target.
+// Priority order:
+//  1. Banner region — if the file contains "# BEGIN zynax-ci:images:<name>" markers,
+//     only the content between those markers is updated. This allows files with multiple
+//     pinned digests (e.g. both golang-alpine and distroless-static) to be synced
+//     independently without corrupting each other.
+//  2. Ref pattern — replaces <ref>[:<tag>]@sha256:<old> with <ref>[:<tag>]@sha256:<new>.
+//  3. Bare sha256 fallback — replaces all sha256:… occurrences (used for plain-text
+//     files like config/ci-runner-digest.txt that contain only a raw digest).
+func replaceDigest(imageName, content string, refPat *regexp.Regexp, target string) string {
+	if result, ok := replaceInBannerRegion(imageName, content, target); ok {
+		return result
+	}
 	if refPat.MatchString(content) {
 		return refPat.ReplaceAllStringFunc(content, func(m string) string {
 			return sha256Re.ReplaceAllString(m, target)
 		})
 	}
 	return sha256Re.ReplaceAllString(content, target)
+}
+
+// replaceInBannerRegion replaces sha256 digests within a banner-delimited region.
+// Returns (result, true) when a matching banner is found; (content, false) otherwise.
+// Only content between the BEGIN and END marker lines is modified.
+func replaceInBannerRegion(imageName, content, target string) (string, bool) {
+	begin := "# BEGIN zynax-ci:images:" + imageName
+	end := "# END zynax-ci:images:" + imageName
+
+	beginIdx := strings.Index(content, begin)
+	if beginIdx < 0 {
+		return content, false
+	}
+
+	// Advance past the BEGIN line (to the start of the region body).
+	beginLineEnd := strings.Index(content[beginIdx:], "\n")
+	if beginLineEnd < 0 {
+		return content, false
+	}
+	regionStart := beginIdx + beginLineEnd + 1
+
+	endIdx := strings.Index(content[regionStart:], end)
+	if endIdx < 0 {
+		return content, false
+	}
+
+	region := content[regionStart : regionStart+endIdx]
+	newRegion := sha256Re.ReplaceAllString(region, target)
+	return content[:regionStart] + newRegion + content[regionStart+endIdx:], true
 }

--- a/docs/milestones/M6-planning.md
+++ b/docs/milestones/M6-planning.md
@@ -49,7 +49,7 @@ All 2 O-steps merged. ✅ EPIC COMPLETE.
 | O1 chore(ci): images/images.yaml — schema + initial population | [#856](https://github.com/zynax-io/zynax/issues/856) | CI tooling | #913 | ✅ Merged |
 | O2 feat(zynax-ci): images sync + check subcommands | [#857](https://github.com/zynax-io/zynax/issues/857) | CI tooling | #915 | ✅ Merged |
 | O3 ci: wire drift-check into pr-checks.yml + ci.yml | [#858](https://github.com/zynax-io/zynax/issues/858) | CI | #916 | ✅ Merged |
-| O4 chore(infra): Dockerfile ARG migration | [#859](https://github.com/zynax-io/zynax/issues/859) | Infra | — | ⬜ Open |
+| O4 chore(infra): Dockerfile ARG migration | [#859](https://github.com/zynax-io/zynax/issues/859) | Infra | — | ✅ Merged |
 | O5 chore(ci): bump flow rewrite | [#860](https://github.com/zynax-io/zynax/issues/860) | CI tooling | — | ⬜ Open |
 | O6 docs: single source of truth propagation | [#861](https://github.com/zynax-io/zynax/issues/861) | Docs | — | ⬜ Open |
 | O7 docs: ADR-024 | [#862](https://github.com/zynax-io/zynax/issues/862) | Docs/ADR | — | ⬜ Open |

--- a/infra/docker/Dockerfile.ci-runner
+++ b/infra/docker/Dockerfile.ci-runner
@@ -31,7 +31,9 @@
 #
 # renovate: datasource=docker depName=golang versioning=docker
 ARG GO_VERSION=1.26.4
+# BEGIN zynax-ci:images:golang-alpine
 ARG GO_ALPINE_DIGEST=sha256:f23e8b227fb4493eabe03bede4d5a32d04092da71962f1fb79b5f7d1e6c2a17f
+# END zynax-ci:images:golang-alpine
 # renovate: datasource=docker depName=alpine versioning=docker
 ARG ALPINE_VERSION=3.21
 ARG ALPINE_DIGEST=sha256:f27cad9117495d32d067133afff942cb2dc745dfe9163e949f6bfe8a6a245339

--- a/infra/docker/Dockerfile.service
+++ b/infra/docker/Dockerfile.service
@@ -4,10 +4,16 @@
 #        Covers all five Go services: api-gateway, workflow-compiler, engine-adapter,
 #        task-broker, agent-registry.
 ARG GO_VERSION=1.26.4
+# BEGIN zynax-ci:images:golang-alpine
+ARG GO_ALPINE_DIGEST=sha256:f23e8b227fb4493eabe03bede4d5a32d04092da71962f1fb79b5f7d1e6c2a17f
+# END zynax-ci:images:golang-alpine
+# BEGIN zynax-ci:images:distroless-static
+ARG DISTROLESS_DIGEST=sha256:dfadf31470f770fcabd48903762dce126958e98d1ce320acf1216bbfaa42d79c
+# END zynax-ci:images:distroless-static
 ARG SVC
 
 # renovate: datasource=docker depName=golang
-FROM golang:${GO_VERSION}-alpine@sha256:f23e8b227fb4493eabe03bede4d5a32d04092da71962f1fb79b5f7d1e6c2a17f AS builder
+FROM golang:${GO_VERSION}-alpine@${GO_ALPINE_DIGEST} AS builder
 ARG SVC
 WORKDIR /workspace
 COPY protos/generated/go/go.mod protos/generated/go/go.sum ./protos/generated/go/
@@ -22,7 +28,7 @@ RUN cd tools/healthcheck && CGO_ENABLED=0 GOWORK=off \
     go build -trimpath -ldflags "-s -w" -o /healthcheck .
 
 # renovate: datasource=docker depName=gcr.io/distroless/static
-FROM gcr.io/distroless/static:nonroot@sha256:dfadf31470f770fcabd48903762dce126958e98d1ce320acf1216bbfaa42d79c
+FROM gcr.io/distroless/static:nonroot@${DISTROLESS_DIGEST}
 ARG SVC
 COPY --from=builder /svc /svc
 COPY --from=builder /healthcheck /healthcheck

--- a/infra/docker/Dockerfile.tools
+++ b/infra/docker/Dockerfile.tools
@@ -32,7 +32,9 @@
 #
 # renovate: datasource=docker depName=golang versioning=docker
 ARG GO_VERSION=1.26.4
+# BEGIN zynax-ci:images:golang-alpine
 ARG GO_ALPINE_DIGEST=sha256:f23e8b227fb4493eabe03bede4d5a32d04092da71962f1fb79b5f7d1e6c2a17f
+# END zynax-ci:images:golang-alpine
 # renovate: datasource=docker depName=python versioning=docker
 ARG PYTHON_VERSION=3.14
 ARG PYTHON_ALPINE_DIGEST=sha256:1aba322febb2d47185eb4db4934a1d7ce942cf3a469be8908dbce95aa513419b

--- a/state/current-milestone.md
+++ b/state/current-milestone.md
@@ -237,7 +237,7 @@ Canvas: `docs/spdd/855-images-sot/canvas.md` — Status: **Aligned** ✅
 | O1 chore(ci): images/images.yaml schema + initial population | [#856](https://github.com/zynax-io/zynax/issues/856) | ✅ Merged (PR #913) |
 | O2 feat(zynax-ci): images sync + check subcommands | [#857](https://github.com/zynax-io/zynax/issues/857) | ✅ Merged (PR #915) |
 | O3 ci: wire drift-check into CI | [#858](https://github.com/zynax-io/zynax/issues/858) | ✅ Merged (PR #916) |
-| O4 chore(infra): Dockerfile ARG migration | [#859](https://github.com/zynax-io/zynax/issues/859) | ⬜ Open |
+| O4 chore(infra): Dockerfile ARG migration | [#859](https://github.com/zynax-io/zynax/issues/859) | ✅ Merged |
 | O5 chore(ci): bump flow rewrite (closes #844) | [#860](https://github.com/zynax-io/zynax/issues/860) | ⬜ Open |
 | O6 docs: propagation | [#861](https://github.com/zynax-io/zynax/issues/861) | ⬜ Open |
 | O7 docs: ADR-024 | [#862](https://github.com/zynax-io/zynax/issues/862) | ⬜ Open |


### PR DESCRIPTION
## Summary

- Migrates all 8 service/adapter Dockerfiles from hardcoded `FROM ref@sha256:…` to the `ARG DIGEST=sha256:…` + `FROM ref@${DIGEST}` pattern, bounded by `# BEGIN/END zynax-ci:images:<name>` banner markers.
- Extends `zynax-ci images sync` with banner-region replacement (checked before ref-pattern and bare-sha256 fallback), so multi-digest Dockerfiles can be synced independently without corrupting adjacent pinned-digest regions.
- Adds a unit test (`TestSync_BannerRegion_UpdatesOnlyTargetRegion`) verifying multi-banner isolation.

## EPIC canvas
`docs/spdd/855-images-sot/canvas.md` — O-step 4

## Acceptance criteria
- [x] All 8 Dockerfiles use ARG + banner pattern for base image digests  [evidence: diff]
- [x] `zynax-ci images sync --dry-run` reports no changes needed  [evidence: `✅ All consumer files already match images/images.yaml.`]
- [x] `zynax-ci images check` exits 0  [evidence: `✅ All consumer files are aligned with images/images.yaml.`]
- [x] Banner-isolation test passes — multi-digest files keep independent regions  [evidence: TestSync_BannerRegion_UpdatesOnlyTargetRegion PASS]

## Test plan

### Build & unit
- [x] `GOWORK=off go build ./...` — exit 0
- [x] `GOWORK=off go test ./... -race -timeout 60s` — all pass (10 tests)
- [x] Domain coverage ≥90% — N/A (no domain/ touched)

### Lint & security
- [x] `make lint` — exit 0
- [x] `make security` — N/A (no Go/Python code affecting CVE surface)

### Contract
- [x] `.feature` file — N/A (no gRPC boundary touched)

### Engineering hygiene
- [x] `M6-planning.md` row ⬜→✅ in this diff
- [x] `current-milestone.md` updated in this diff
- [x] Canvas O-step 4 ✅ (no impl divergence from spec)
- [x] Branched off fresh `origin/main` · PR ≤200 lines · trailers on every commit