### PR TITLE
docs(adr): ADR-025 — SLSA provenance attestation keep vs disable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -319,6 +319,9 @@ jobs:
           category: container-${{ matrix.service }}
 
       # ── Multi-arch push (only reached if trivy scan above exits 0) ────────────
+      # provenance=true (default) attaches SLSA Build L1 attestation manifests.
+      # These appear as "unknown/unknown" rows in GHCR — expected, not broken.
+      # See docs/adr/ADR-025-slsa-provenance-attestation.md for the keep decision.
       - name: Build and push
         id: build
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0

--- a/.github/workflows/tools-image.yml
+++ b/.github/workflows/tools-image.yml
@@ -73,6 +73,9 @@ jobs:
             echo "tags=${IMAGE}:latest,${SHA_TAG}" >> "$GITHUB_OUTPUT"
           fi
 
+      # provenance=true (default) attaches SLSA Build L1 attestation manifests.
+      # These appear as "unknown/unknown" rows in GHCR — expected, not broken.
+      # See docs/adr/ADR-025-slsa-provenance-attestation.md for the keep decision.
       - name: Build and push
         id: build-tools
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
@@ -174,6 +177,9 @@ jobs:
             type=sha,prefix=main-,format=long
             type=semver,pattern={{version}}
 
+      # provenance=true (default) attaches SLSA Build L1 attestation manifests.
+      # These appear as "unknown/unknown" rows in GHCR — expected, not broken.
+      # See docs/adr/ADR-025-slsa-provenance-attestation.md for the keep decision.
       - name: Build and push ci-runner
         id: build-ci-runner
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0

--- a/docs/adr/ADR-025-slsa-provenance-attestation.md
+++ b/docs/adr/ADR-025-slsa-provenance-attestation.md
@@ -1,0 +1,120 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# ADR-025 — SLSA Provenance Attestation: Keep vs Disable
+
+| Field | Value |
+|-------|-------|
+| **Status** | Accepted |
+| **Date** | 2026-06-08 |
+| **Deciders** | Oscar Gómez Manresa |
+| **Scope** | Container image builds — `tools-image.yml`, `release.yml`, all `docker/build-push-action` steps |
+
+---
+
+## Context
+
+`docker buildx` (via `docker/build-push-action`) attaches a SLSA provenance
+attestation to every multi-arch build by default. In GHCR this appears as two
+`unknown/unknown` rows in the Packages UI — one per platform variant of the
+provenance manifest.
+
+These rows are **not** broken or stray images. They are the expected SLSA Build
+L1 provenance attestations produced by `buildkit` when `--provenance=mode=min`
+(the default) is in effect. Contributors occasionally see them and assume something
+is wrong.
+
+### What provenance attestations are
+
+A SLSA provenance attestation is an OCI image manifest of media type
+`application/vnd.oci.image.manifest.v1+json` whose subject references the main
+image digest. It encodes:
+
+- The build invocation (GitHub Actions run ID, workflow ref, actor)
+- The source repository and commit SHA
+- The build platform (SLSA Build L1)
+
+Because it is a separate OCI manifest rather than an image layer, GHCR displays
+it as a row with no platform tag — hence `unknown/unknown` in the UI.
+
+### Why this is a decision worth recording
+
+Disabling provenance (`provenance: false` in the `docker/build-push-action` step)
+is a one-way door: once the attestations stop appearing in GHCR, OpenSSF Scorecard
+and other tools that verify them will begin penalising the project's score. Re-
+enabling requires waiting for the next Scorecard evaluation cycle. This is exactly
+the kind of irreversible architectural choice that warrants an ADR.
+
+### Relationship to existing decisions
+
+- **M6.C (#465, ADR-020)** — supply-chain hardening: cosign signing and SBOM
+  generation were added to `release.yml` and `tools-image.yml`. Provenance
+  attestations are a complementary (automatically generated) supply-chain artefact
+  produced by the same build steps.
+- **ADR-019 (SPDD)** — this issue (#868) is `docs:` type and SPDD-exempt.
+- **#865** — depends on this decision: OCI manifest annotations (`org.opencontainers.image.*`)
+  will be added to fix the missing-description issue in GHCR. That change is
+  orthogonal to provenance attestations.
+- **#869** — documentation of `unknown/unknown` rows for contributors; gated on
+  this ADR.
+
+---
+
+## Decision
+
+**Keep SLSA provenance attestations.** Do not set `provenance: false` anywhere
+in the repository.
+
+The `unknown/unknown` rows in the GHCR UI are a cosmetic issue. The fix is to
+document them (via #869) and add OCI manifest annotations that give each real
+image a description (via #865). Neither fix requires removing provenance.
+
+---
+
+## Rationale
+
+| Option | Assessment |
+|--------|------------|
+| **Keep attestations** (chosen) | ✅ SLSA Build L1 provenance retained; `cosign verify-attestation` works; OpenSSF Scorecard benefits; `unknown/unknown` rows explained by documentation |
+| Disable via `provenance: false` | ✗ Rejected — drops SLSA provenance; weakens Scorecard posture; `cosign verify-attestation` fails; one-way door with multi-cycle recovery |
+
+Specific reasons for rejecting `provenance: false`:
+
+1. This repo explicitly advertises OpenSSF Scorecard compliance and uses `cosign`
+   for keyless signing. SLSA provenance attestations are exactly what those
+   programmes reward.
+2. Disabling provenance is a one-way door: once dropped and Scorecard score
+   settles, recovering it requires re-opting in and waiting for the next score
+   cycle.
+3. The `unknown/unknown` confusion is a documentation problem, not a packaging
+   defect. Fix it with docs and OCI annotations, not by removing the attestation.
+4. SLSA provenance is generated for free by `docker/build-push-action`; there is
+   no build-time or storage cost that would justify removing it.
+
+---
+
+## Consequences
+
+### Positive
+
+- SLSA Build L1 provenance remains on all images produced by `release.yml` and
+  `tools-image.yml`.
+- `cosign verify-attestation --type slsaprovenance <image>` continues to work for
+  any image built after the M6.C supply-chain hardening PR (#489).
+- OpenSSF Scorecard "Signed-Releases" and "SLSA" checks continue to benefit from
+  the attestations.
+- No workflow changes are required — the default `build-push-action` behaviour is
+  already correct.
+
+### Negative / trade-offs
+
+- GHCR continues to display `unknown/unknown` rows until OCI annotations are
+  added (#865) and/or GitHub improves their UI treatment of provenance manifests.
+- Contributors may still be confused by the rows until #869 is merged (docs).
+
+### Follow-up required
+
+| Action | Issue |
+|--------|-------|
+| Add OCI manifest annotations to fix "no description" in GHCR | #865 |
+| Document `unknown/unknown` rows as expected SLSA provenance | #869 |
+| Add inline comments in workflow files pointing to this ADR | Done in this PR |

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -34,6 +34,7 @@ a PR against `docs/adr/`.
 | [ADR-021](ADR-021-horizontal-scale.md) | Postgres-backed repositories for horizontal scaling | Accepted | 2026-05-21 | task-broker + agent-registry repos — #578 #626 |
 | [ADR-022](ADR-022-event-bus-architecture.md) | EventBusService gRPC wrapper over NATS JetStream | Accepted | 2026-06-02 | `services/event-bus/`, `protos/zynax/v1/event_bus.proto`, EPIC I (#772) |
 | [ADR-023](ADR-023-restrict-direct-pushes-to-main.md) | Restrict direct pushes to `main`; rebase-merge only | Accepted | 2026-06-03 | All branches, PRs, and merge operations |
+| [ADR-025](ADR-025-slsa-provenance-attestation.md) | SLSA provenance attestation: keep vs disable | Accepted | 2026-06-08 | `tools-image.yml`, `release.yml` — all `docker/build-push-action` steps |
 
 ---
 

--- a/docs/milestones/M6-planning.md
+++ b/docs/milestones/M6-planning.md
@@ -58,7 +58,7 @@ All 2 O-steps merged. ✅ EPIC COMPLETE.
 
 | Story | Issue | Area | PR | Status |
 |-------|-------|------|-----|--------|
-| docs(adr): ADR-025 — SLSA provenance attestation keep vs disable | [#868](https://github.com/zynax-io/zynax/issues/868) | Docs/ADR | — | ⬜ Open |
+| docs(adr): ADR-025 — SLSA provenance attestation keep vs disable | [#868](https://github.com/zynax-io/zynax/issues/868) | Docs/ADR | — | ✅ Done |
 | ci: add OCI manifest annotations — fix "no description" on GHCR | [#865](https://github.com/zynax-io/zynax/issues/865) | CI/Infra | — | ⬜ Open |
 | ci: description-present gate + size-budget check in publish steps | [#866](https://github.com/zynax-io/zynax/issues/866) | CI | — | ⬜ Open |
 | chore(ci): GHCR retention cap — keep last 5 builds per image | [#867](https://github.com/zynax-io/zynax/issues/867) | CI | — | ⬜ Open |

--- a/state/current-milestone.md
+++ b/state/current-milestone.md
@@ -250,7 +250,7 @@ Delivery order (each is its own PR):
 
 | Story | Issue | Status |
 |-------|-------|--------|
-| docs(adr): ADR-025 — keep vs disable SLSA attestations | [#868](https://github.com/zynax-io/zynax/issues/868) | ⬜ Open |
+| docs(adr): ADR-025 — keep vs disable SLSA attestations | [#868](https://github.com/zynax-io/zynax/issues/868) | ✅ Done |
 | ci: OCI manifest annotations (fix "no description") | [#865](https://github.com/zynax-io/zynax/issues/865) | ⬜ Open — depends on #868 |
 | ci: description-present gate + size-budget check | [#866](https://github.com/zynax-io/zynax/issues/866) | ⬜ Open — depends on #865 |
 | chore(ci): GHCR retention cap (last 5 builds) | [#867](https://github.com/zynax-io/zynax/issues/867) | ⬜ Open |


### PR DESCRIPTION
## Summary

- Record the architectural decision to keep SLSA Build L1 provenance attestations on all container image builds (ADR-025)
- The `unknown/unknown` GHCR rows are expected provenance manifests, not broken images — fix is documentation + OCI annotations (#865), not disabling provenance
- Add inline comments at all `docker/build-push-action` steps in `tools-image.yml` and `release.yml` explaining the attestation manifests and linking to ADR-025

## EPIC canvas

SPDD-exempt (`docs:` issue)

## Acceptance criteria

- [x] `docs/adr/ADR-025-slsa-provenance-attestation.md` merged [evidence: new file in diff]
- [x] `docs/adr/INDEX.md` entry added [evidence: ADR-025 row added]
- [x] Inline comments at `build-push-action` steps in both workflow files [evidence: 9 comment lines added to `tools-image.yml` and `release.yml`]
- [x] No change to `provenance:` or `sbom:` flags in any workflow (attestations stay on) [evidence: diff shows no `provenance:` key changes]
- [x] `make lint` passes [evidence: exit 0, `✅ Python lint passed`]

## Test plan

### Lint
- [x] `make lint` — exit 0 ✅

### Engineering hygiene
- [x] `M6-planning.md` row ⬜→✅ in this diff
- [x] `current-milestone.md` updated in this diff
- [x] Branched off fresh `origin/main` · PR ≤900 lines · trailers on every commit
- [x] Rebased onto `origin/main` (370b288) before push

### Unblocks
- [x] Gates #865 (OCI manifest annotations) — establishes the keep decision
- [x] Gates #869 (attestation docs) — establishes the authoritative explanation

🤖 Generated with [Claude Code](https://claude.ai/claude-code)