### PR TITLE
ci(infra): add OCI manifest annotations to all published images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -322,6 +322,15 @@ jobs:
       # provenance=true (default) attaches SLSA Build L1 attestation manifests.
       # These appear as "unknown/unknown" rows in GHCR — expected, not broken.
       # See docs/adr/ADR-025-slsa-provenance-attestation.md for the keep decision.
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
+        with:
+          images: ${{ env.IMAGE_PREFIX }}/${{ matrix.service }}
+          labels: |
+            org.opencontainers.image.title=zynax-${{ matrix.service }}
+            org.opencontainers.image.description=Zynax ${{ matrix.service }} service image
+
       - name: Build and push
         id: build
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
@@ -332,11 +341,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.img.outputs.tags }}
-          labels: |
-            org.opencontainers.image.source=https://github.com/${{ github.repository }}
-            org.opencontainers.image.revision=${{ github.sha }}
-            org.opencontainers.image.created=${{ steps.img.outputs.created }}
-            org.opencontainers.image.version=${{ steps.ver.outputs.version }}
+          labels: ${{ steps.meta.outputs.labels }}
+          annotations: ${{ steps.meta.outputs.annotations }}
 
       - name: Report image sizes
         env:

--- a/.github/workflows/tools-image.yml
+++ b/.github/workflows/tools-image.yml
@@ -60,6 +60,15 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          labels: |
+            org.opencontainers.image.title=Zynax Developer Tools
+            org.opencontainers.image.description=Developer tools image for Zynax local make commands. Pre-baked with protoc, buf, golangci-lint, govulncheck, mockery, gitleaks, and zynax-ci.
+
       - name: Compute image tags
         id: tags
         run: |
@@ -87,9 +96,8 @@ jobs:
           tags: ${{ steps.tags.outputs.tags }}
           cache-from: type=gha,scope=tools
           cache-to: type=gha,mode=max,scope=tools
-          labels: |
-            org.opencontainers.image.source=https://github.com/zynax-io/zynax
-            org.opencontainers.image.revision=${{ github.sha }}
+          labels: ${{ steps.meta.outputs.labels }}
+          annotations: ${{ steps.meta.outputs.annotations }}
 
       - name: Report tools image size
         env:
@@ -176,6 +184,9 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
             type=sha,prefix=main-,format=long
             type=semver,pattern={{version}}
+          labels: |
+            org.opencontainers.image.title=Zynax CI Runner
+            org.opencontainers.image.description=Purpose-built GitHub Actions container for Zynax CI. Pre-baked with golangci-lint, govulncheck, godog, mockery, actionlint, gitleaks, buf, zynax-ci, uv, ruff, mypy, bandit, pip-audit, and pytest — zero runtime downloads.
 
       # provenance=true (default) attaches SLSA Build L1 attestation manifests.
       # These appear as "unknown/unknown" rows in GHCR — expected, not broken.
@@ -191,9 +202,8 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           cache-from: type=gha,scope=ci-runner
           cache-to: type=gha,mode=max,scope=ci-runner
-          labels: |
-            org.opencontainers.image.source=https://github.com/zynax-io/zynax
-            org.opencontainers.image.revision=${{ github.sha }}
+          labels: ${{ steps.meta.outputs.labels }}
+          annotations: ${{ steps.meta.outputs.annotations }}
 
       - name: Report ci-runner digest and sizes
         env:

--- a/agents/adapters/ci/Dockerfile
+++ b/agents/adapters/ci/Dockerfile
@@ -27,4 +27,11 @@ FROM gcr.io/distroless/static:nonroot@${DISTROLESS_DIGEST}
 COPY --from=builder /ci-adapter /ci-adapter
 COPY --from=builder /healthcheck /healthcheck
 COPY --from=builder /workspace/agents/adapters/ci/agent-def.yaml.example /etc/ci-adapter/config.yaml
+LABEL org.opencontainers.image.title="Zynax CI Adapter" \
+      org.opencontainers.image.description="Zynax capability adapter for CI pipeline operations. Provides CI execution gRPC capabilities." \
+      org.opencontainers.image.url="https://github.com/zynax-io/zynax" \
+      org.opencontainers.image.source="https://github.com/zynax-io/zynax" \
+      org.opencontainers.image.documentation="https://github.com/zynax-io/zynax/blob/main/agents/adapters/ci/Dockerfile" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.vendor="Zynax"
 ENTRYPOINT ["/ci-adapter"]

--- a/agents/adapters/git/Dockerfile
+++ b/agents/adapters/git/Dockerfile
@@ -27,4 +27,11 @@ FROM gcr.io/distroless/static:nonroot@${DISTROLESS_DIGEST}
 COPY --from=builder /git-adapter /git-adapter
 COPY --from=builder /healthcheck /healthcheck
 COPY --from=builder /workspace/agents/adapters/git/agent-def.yaml.example /etc/git-adapter/config.yaml
+LABEL org.opencontainers.image.title="Zynax Git Adapter" \
+      org.opencontainers.image.description="Zynax capability adapter for Git repository operations. Provides GitClone and GitCommit gRPC capabilities." \
+      org.opencontainers.image.url="https://github.com/zynax-io/zynax" \
+      org.opencontainers.image.source="https://github.com/zynax-io/zynax" \
+      org.opencontainers.image.documentation="https://github.com/zynax-io/zynax/blob/main/agents/adapters/git/Dockerfile" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.vendor="Zynax"
 ENTRYPOINT ["/git-adapter"]

--- a/agents/adapters/langgraph/Dockerfile
+++ b/agents/adapters/langgraph/Dockerfile
@@ -52,6 +52,14 @@ COPY agents/adapters/langgraph/examples/ /app/examples/
 ENV PATH="/app/.venv/bin:$PATH"
 ENV PYTHONPATH="/app/src:/app:/protos"
 
+LABEL org.opencontainers.image.title="Zynax LangGraph Adapter" \
+      org.opencontainers.image.description="Zynax capability adapter for LangGraph workflows. Runs LangGraph state-machine graphs as Zynax capabilities." \
+      org.opencontainers.image.url="https://github.com/zynax-io/zynax" \
+      org.opencontainers.image.source="https://github.com/zynax-io/zynax" \
+      org.opencontainers.image.documentation="https://github.com/zynax-io/zynax/blob/main/agents/adapters/langgraph/Dockerfile" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.vendor="Zynax"
+
 USER zynax
 
 CMD ["python", "-m", "langgraph_adapter"]

--- a/agents/adapters/llm/Dockerfile
+++ b/agents/adapters/llm/Dockerfile
@@ -45,6 +45,14 @@ COPY agents/adapters/llm/src/ /app/src/
 ENV PATH="/app/.venv/bin:$PATH"
 ENV PYTHONPATH="/app/src:/protos"
 
+LABEL org.opencontainers.image.title="Zynax LLM Adapter" \
+      org.opencontainers.image.description="Zynax capability adapter for LLM inference. Supports multiple providers: OpenAI, Ollama, Amazon Bedrock." \
+      org.opencontainers.image.url="https://github.com/zynax-io/zynax" \
+      org.opencontainers.image.source="https://github.com/zynax-io/zynax" \
+      org.opencontainers.image.documentation="https://github.com/zynax-io/zynax/blob/main/agents/adapters/llm/Dockerfile" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.vendor="Zynax"
+
 USER zynax
 
 CMD ["python", "-m", "llm_adapter"]

--- a/docs/milestones/M6-planning.md
+++ b/docs/milestones/M6-planning.md
@@ -61,7 +61,7 @@ All 2 O-steps merged. ✅ EPIC COMPLETE.
 | Story | Issue | Area | PR | Status |
 |-------|-------|------|-----|--------|
 | docs(adr): ADR-025 — SLSA provenance attestation keep vs disable | [#868](https://github.com/zynax-io/zynax/issues/868) | Docs/ADR | — | ✅ Done |
-| ci: add OCI manifest annotations — fix "no description" on GHCR | [#865](https://github.com/zynax-io/zynax/issues/865) | CI/Infra | — | ⬜ Open |
+| ci: add OCI manifest annotations — fix "no description" on GHCR | [#865](https://github.com/zynax-io/zynax/issues/865) | CI/Infra | — | ✅ Done |
 | ci: description-present gate + size-budget check in publish steps | [#866](https://github.com/zynax-io/zynax/issues/866) | CI | — | ⬜ Open |
 | chore(ci): GHCR retention cap — keep last 5 builds per image | [#867](https://github.com/zynax-io/zynax/issues/867) | CI | — | ⬜ Open |
 | docs: document unknown/unknown — expected SLSA provenance | [#869](https://github.com/zynax-io/zynax/issues/869) | Docs/Infra | — | ⬜ Open |

--- a/state/current-milestone.md
+++ b/state/current-milestone.md
@@ -251,7 +251,7 @@ Delivery order (each is its own PR):
 | Story | Issue | Status |
 |-------|-------|--------|
 | docs(adr): ADR-025 — keep vs disable SLSA attestations | [#868](https://github.com/zynax-io/zynax/issues/868) | ✅ Done |
-| ci: OCI manifest annotations (fix "no description") | [#865](https://github.com/zynax-io/zynax/issues/865) | ⬜ Open — depends on #868 |
+| ci: OCI manifest annotations (fix "no description") | [#865](https://github.com/zynax-io/zynax/issues/865) | ✅ Done |
 | ci: description-present gate + size-budget check | [#866](https://github.com/zynax-io/zynax/issues/866) | ⬜ Open — depends on #865 |
 | chore(ci): GHCR retention cap (last 5 builds) | [#867](https://github.com/zynax-io/zynax/issues/867) | ⬜ Open |
 | docs: document unknown/unknown attestation manifests | [#869](https://github.com/zynax-io/zynax/issues/869) | ⬜ Open — depends on #868 |


### PR DESCRIPTION
## Summary

All 8 published GHCR images showed "No description provided" because OCI index manifests had `"annotations": null`. Per-platform image config labels are not read by GHCR for the package description — index-level annotations are required. This PR adds `docker/metadata-action` to the workflows that were missing it and passes both `labels` and `annotations` outputs to `docker/build-push-action`, while also adding a full OCI `LABEL` block to the 4 adapter Dockerfiles that had none.

## EPIC canvas

N/A — `ci:` issue, SPDD-exempt.

## Acceptance criteria

- [x] `tools-image.yml` build-push job: `docker/metadata-action` added with title+description labels; `labels: ${{ steps.meta.outputs.labels }}` + `annotations: ${{ steps.meta.outputs.annotations }}` passed to build step [tools-image.yml lines 67-77, 99-100]
- [x] `tools-image.yml` build-push-ci-runner job: labels override added to existing metadata-action; build step uses `meta.outputs.labels` + `meta.outputs.annotations` [tools-image.yml lines 186-191, 206-207]
- [x] `release.yml` build-push-images job: `docker/metadata-action` step added before multi-arch push; build step uses `meta.outputs.labels` + `meta.outputs.annotations` [release.yml lines 321-330, 335-336]
- [x] 4 adapter Dockerfiles each have a full OCI `LABEL` block in their final stage [agents/adapters/{git,ci,llm,langgraph}/Dockerfile]
- [x] `make lint` — exit 0 ✅

## Test plan

### Build & unit
- [x] `GOWORK=off go build ./...` — N/A (no Go code changed)
- [x] `GOWORK=off go test ./...` — N/A
- [x] Domain coverage ≥90% — N/A

### Lint & security
- [x] `make lint` — exit 0 ✅ (proto, Go, Python all pass)
- [x] `make security` — N/A (no code changes; workflow-only + Dockerfile labels)

### Contract
- [x] `.feature` file — N/A (no gRPC boundary touched)
- [x] `make test-bdd` — N/A

### Engineering hygiene
- [x] `M6-planning.md` row ⬜→✅ in this diff
- [x] `current-milestone.md` updated in this diff
- [x] Canvas — N/A (SPDD-exempt)
- [x] Branched off fresh `origin/main` · PR ≤900 lines (+61/-13) · trailers on every commit
