### PR TITLE
feat(event-bus): Publish path — JetStream stream create + event publish

### DIFF
--- a/services/event-bus/internal/api/handler.go
+++ b/services/event-bus/internal/api/handler.go
@@ -4,20 +4,74 @@
 package api
 
 import (
+	"context"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
 	zynaxv1 "github.com/zynax-io/zynax/protos/generated/go/zynax/v1"
 	"github.com/zynax-io/zynax/services/event-bus/internal/domain"
 )
 
 // Handler implements zynaxv1.EventBusServiceServer.
-// O1 scaffold: all RPCs return UNIMPLEMENTED via the embedded base.
-// O2–O4 will replace the stub with real domain dispatch.
+// O1–O2: Publish path wired; Subscribe/Unsubscribe remain UNIMPLEMENTED (O3–O4).
 type Handler struct {
 	zynaxv1.UnimplementedEventBusServiceServer
 	bus domain.EventBus
 }
 
-// NewHandler constructs a Handler. bus may be nil in the O1 scaffold;
-// it will be required once O2 wires the Publish path.
+// NewHandler constructs a Handler backed by the provided EventBus.
 func NewHandler(bus domain.EventBus) *Handler {
 	return &Handler{bus: bus}
+}
+
+// Publish validates the incoming CloudEvent and delegates to the domain bus.
+// Returns INVALID_ARGUMENT when the event envelope is missing or required
+// fields (id, source, type) are empty.
+func (h *Handler) Publish(ctx context.Context, req *zynaxv1.PublishRequest) (*zynaxv1.PublishResponse, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, status.FromContextError(err).Err()
+	}
+
+	if req.GetEvent() == nil {
+		return nil, status.Error(codes.InvalidArgument, "event must not be nil")
+	}
+	ev := req.GetEvent()
+	if ev.GetId() == "" {
+		return nil, status.Error(codes.InvalidArgument, "event.id must not be empty")
+	}
+	if ev.GetSource() == "" {
+		return nil, status.Error(codes.InvalidArgument, "event.source must not be empty")
+	}
+	if ev.GetType() == "" {
+		return nil, status.Error(codes.InvalidArgument, "event.type must not be empty")
+	}
+
+	domainEvent := domain.CloudEvent{
+		ID:              ev.GetId(),
+		Source:          ev.GetSource(),
+		SpecVersion:     ev.GetSpecversion(),
+		Type:            ev.GetType(),
+		DataContentType: ev.GetDatacontenttype(),
+		Data:            ev.GetData(),
+		WorkflowID:      ev.GetWorkflowId(),
+		RunID:           ev.GetRunId(),
+		Namespace:       ev.GetNamespace(),
+		CapabilityName:  ev.GetCapabilityName(),
+	}
+	if ev.GetTime() != nil {
+		domainEvent.Time = ev.GetTime().AsTime()
+	}
+
+	eventID, err := h.bus.Publish(ctx, domainEvent)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "publish failed: %v", err)
+	}
+
+	return &zynaxv1.PublishResponse{
+		EventId:    eventID,
+		AcceptedAt: timestamppb.New(time.Now().UTC()),
+	}, nil
 }

--- a/services/event-bus/internal/api/handler_test.go
+++ b/services/event-bus/internal/api/handler_test.go
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package api_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	zynaxv1 "github.com/zynax-io/zynax/protos/generated/go/zynax/v1"
+	"github.com/zynax-io/zynax/services/event-bus/internal/api"
+	"github.com/zynax-io/zynax/services/event-bus/internal/domain"
+)
+
+// fakeEventBus is an in-memory test double for domain.EventBus.
+// It records published events and allows callers to inject errors.
+type fakeEventBus struct {
+	publishErr error
+	published  []domain.CloudEvent
+	returnID   string
+}
+
+func (f *fakeEventBus) Publish(_ context.Context, event domain.CloudEvent) (string, error) {
+	if f.publishErr != nil {
+		return "", f.publishErr
+	}
+	f.published = append(f.published, event)
+	if f.returnID != "" {
+		return f.returnID, nil
+	}
+	return "STREAM:42", nil
+}
+
+func (f *fakeEventBus) Subscribe(_ context.Context, _ domain.SubscribeRequest) (<-chan domain.CloudEvent, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (f *fakeEventBus) Unsubscribe(_ context.Context, _ string) error {
+	return errors.New("not implemented")
+}
+
+func validEvent() *zynaxv1.CloudEvent {
+	return &zynaxv1.CloudEvent{
+		Id:          "evt-001",
+		Source:      "/zynax/wf-42/engine-adapter",
+		Specversion: "1.0",
+		Type:        "zynax.v1.engine-adapter.workflow.completed",
+		Time:        timestamppb.New(time.Now().UTC()),
+		Data:        []byte(`{"status":"ok"}`),
+	}
+}
+
+func TestPublish_NilEvent(t *testing.T) {
+	h := api.NewHandler(&fakeEventBus{})
+	_, err := h.Publish(context.Background(), &zynaxv1.PublishRequest{Event: nil})
+	requireCode(t, err, codes.InvalidArgument)
+}
+
+func TestPublish_EmptyID(t *testing.T) {
+	ev := validEvent()
+	ev.Id = ""
+	h := api.NewHandler(&fakeEventBus{})
+	_, err := h.Publish(context.Background(), &zynaxv1.PublishRequest{Event: ev})
+	requireCode(t, err, codes.InvalidArgument)
+}
+
+func TestPublish_EmptySource(t *testing.T) {
+	ev := validEvent()
+	ev.Source = ""
+	h := api.NewHandler(&fakeEventBus{})
+	_, err := h.Publish(context.Background(), &zynaxv1.PublishRequest{Event: ev})
+	requireCode(t, err, codes.InvalidArgument)
+}
+
+func TestPublish_EmptyType(t *testing.T) {
+	ev := validEvent()
+	ev.Type = ""
+	h := api.NewHandler(&fakeEventBus{})
+	_, err := h.Publish(context.Background(), &zynaxv1.PublishRequest{Event: ev})
+	requireCode(t, err, codes.InvalidArgument)
+}
+
+func TestPublish_HappyPath(t *testing.T) {
+	fake := &fakeEventBus{returnID: "MYSTREAM:7"}
+	h := api.NewHandler(fake)
+	ev := validEvent()
+
+	resp, err := h.Publish(context.Background(), &zynaxv1.PublishRequest{Event: ev})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.GetEventId() != "MYSTREAM:7" {
+		t.Errorf("EventId: got %q, want %q", resp.GetEventId(), "MYSTREAM:7")
+	}
+	if resp.GetAcceptedAt() == nil {
+		t.Error("AcceptedAt must not be nil")
+	}
+	if len(fake.published) != 1 {
+		t.Fatalf("expected 1 published event, got %d", len(fake.published))
+	}
+	got := fake.published[0]
+	if got.ID != ev.Id {
+		t.Errorf("domain event ID: got %q, want %q", got.ID, ev.Id)
+	}
+	if got.Source != ev.Source {
+		t.Errorf("domain event Source: got %q, want %q", got.Source, ev.Source)
+	}
+	if got.Type != ev.Type {
+		t.Errorf("domain event Type: got %q, want %q", got.Type, ev.Type)
+	}
+}
+
+func TestPublish_DomainError(t *testing.T) {
+	fake := &fakeEventBus{publishErr: errors.New("nats timeout")}
+	h := api.NewHandler(fake)
+
+	_, err := h.Publish(context.Background(), &zynaxv1.PublishRequest{Event: validEvent()})
+	requireCode(t, err, codes.Internal)
+}
+
+func TestPublish_CancelledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	h := api.NewHandler(&fakeEventBus{})
+	_, err := h.Publish(ctx, &zynaxv1.PublishRequest{Event: validEvent()})
+	if err == nil {
+		t.Fatal("expected error for cancelled context")
+	}
+}
+
+func TestPublish_ExtensionFieldsPropagated(t *testing.T) {
+	fake := &fakeEventBus{}
+	h := api.NewHandler(fake)
+	ev := validEvent()
+	ev.WorkflowId = "wf-99"
+	ev.RunId = "run-5"
+	ev.Namespace = "prod"
+	ev.CapabilityName = "echo"
+	ev.Datacontenttype = "application/json"
+
+	_, err := h.Publish(context.Background(), &zynaxv1.PublishRequest{Event: ev})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(fake.published) != 1 {
+		t.Fatalf("expected 1 published event, got %d", len(fake.published))
+	}
+	got := fake.published[0]
+	if got.WorkflowID != "wf-99" {
+		t.Errorf("WorkflowID: got %q, want wf-99", got.WorkflowID)
+	}
+	if got.RunID != "run-5" {
+		t.Errorf("RunID: got %q, want run-5", got.RunID)
+	}
+	if got.Namespace != "prod" {
+		t.Errorf("Namespace: got %q, want prod", got.Namespace)
+	}
+	if got.CapabilityName != "echo" {
+		t.Errorf("CapabilityName: got %q, want echo", got.CapabilityName)
+	}
+	if got.DataContentType != "application/json" {
+		t.Errorf("DataContentType: got %q, want application/json", got.DataContentType)
+	}
+}
+
+// requireCode asserts that err is a gRPC status error with the expected code.
+func requireCode(t *testing.T, err error, want codes.Code) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("expected error with code %s, got nil", want)
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("error %v is not a gRPC status error", err)
+	}
+	if st.Code() != want {
+		t.Errorf("code: got %s, want %s (message: %s)", st.Code(), want, st.Message())
+	}
+}

--- a/services/event-bus/internal/infrastructure/nats.go
+++ b/services/event-bus/internal/infrastructure/nats.go
@@ -6,8 +6,10 @@ package infrastructure
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 
 	nats "github.com/nats-io/nats.go"
 
@@ -15,8 +17,6 @@ import (
 )
 
 // NATSEventBus implements domain.EventBus backed by NATS JetStream.
-// O1 scaffold: connect + ping only; Publish/Subscribe/Unsubscribe return
-// errors.New("not implemented") — these are wired in O2–O4 (#824–#826).
 type NATSEventBus struct {
 	conn *nats.Conn
 	js   nats.JetStreamContext
@@ -42,9 +42,126 @@ func (b *NATSEventBus) Close() {
 	_ = b.conn.Drain()
 }
 
-// Publish is a stub — full implementation in O2 (#824).
-func (b *NATSEventBus) Publish(_ context.Context, _ domain.CloudEvent) (string, error) {
-	return "", errors.New("not implemented")
+// cloudEventEnvelope is the JSON wire format for a CloudEvent published to JetStream.
+// Field names follow the CloudEvents v1.0 JSON format specification.
+type cloudEventEnvelope struct {
+	SpecVersion     string `json:"specversion"`
+	ID              string `json:"id"`
+	Source          string `json:"source"`
+	Type            string `json:"type"`
+	DataContentType string `json:"datacontenttype,omitempty"`
+	WorkflowID      string `json:"workflowid,omitempty"`
+	RunID           string `json:"runid,omitempty"`
+	Namespace       string `json:"namespace,omitempty"`
+	CapabilityName  string `json:"capabilityname,omitempty"`
+	Data            []byte `json:"data,omitempty"`
+}
+
+// StreamName derives a JetStream stream name from a dot-separated event type.
+// The stream covers the full event type as subject filter using ">" wildcard.
+// Examples:
+//
+//	"zynax.v1.engine-adapter.workflow.completed" → "ZYNAX_V1_ENGINE_ADAPTER_WORKFLOW"
+//	"zynax.v1.agent-registry.agent.registered"  → "ZYNAX_V1_AGENT_REGISTRY_AGENT"
+//
+// Dashes are replaced with underscores; dots become underscores; all uppercase.
+// The last segment (the verb) is dropped so all events of the same entity
+// share a single stream.
+func StreamName(eventType string) string {
+	parts := strings.Split(eventType, ".")
+	// Use all but the last segment (verb) for the stream name.
+	prefix := parts
+	if len(parts) > 1 {
+		prefix = parts[:len(parts)-1]
+	}
+	name := strings.Join(prefix, "_")
+	name = strings.ReplaceAll(name, "-", "_")
+	return strings.ToUpper(name)
+}
+
+// SubjectFilter returns the NATS subject filter for a stream created from eventType.
+// All events whose type starts with the entity prefix are captured.
+func SubjectFilter(eventType string) string {
+	parts := strings.Split(eventType, ".")
+	// Drop the last segment (verb) and replace with ">" wildcard.
+	if len(parts) > 1 {
+		prefix := strings.Join(parts[:len(parts)-1], ".")
+		return prefix + ".>"
+	}
+	return eventType + ".>"
+}
+
+// ensureStream creates the JetStream stream if it does not already exist.
+// If the stream already exists with the same config, this is a no-op (idempotent).
+func (b *NATSEventBus) ensureStream(eventType string) error {
+	name := StreamName(eventType)
+	filter := SubjectFilter(eventType)
+
+	cfg := &nats.StreamConfig{
+		Name:      name,
+		Subjects:  []string{filter},
+		Retention: nats.LimitsPolicy,
+		Storage:   nats.FileStorage,
+		Replicas:  1,
+	}
+
+	_, err := b.js.AddStream(cfg)
+	if err != nil {
+		// nats.ErrStreamNameAlreadyInUse is returned when the stream already exists.
+		if errors.Is(err, nats.ErrStreamNameAlreadyInUse) {
+			return nil
+		}
+		return fmt.Errorf("jetstream add stream %s: %w", name, err)
+	}
+	return nil
+}
+
+// Publish submits a CloudEvent to the JetStream stream for the event type.
+// It idempotently ensures the stream exists before publishing.
+// Returns a composite "STREAM:sequence" identifier as the event ID on success.
+func (b *NATSEventBus) Publish(ctx context.Context, event domain.CloudEvent) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", fmt.Errorf("context: %w", err)
+	}
+
+	if err := b.ensureStream(event.Type); err != nil {
+		return "", fmt.Errorf("nats publish: ensure stream: %w", err)
+	}
+
+	env := cloudEventEnvelope{
+		SpecVersion:     event.SpecVersion,
+		ID:              event.ID,
+		Source:          event.Source,
+		Type:            event.Type,
+		DataContentType: event.DataContentType,
+		WorkflowID:      event.WorkflowID,
+		RunID:           event.RunID,
+		Namespace:       event.Namespace,
+		CapabilityName:  event.CapabilityName,
+		Data:            event.Data,
+	}
+
+	payload, err := json.Marshal(env)
+	if err != nil {
+		return "", fmt.Errorf("nats publish: marshal event: %w", err)
+	}
+
+	msg := &nats.Msg{
+		Subject: event.Type,
+		Data:    payload,
+		Header:  nats.Header{},
+	}
+	msg.Header.Set("Content-Type", "application/cloudevents+json")
+	msg.Header.Set("ce-id", event.ID)
+	msg.Header.Set("ce-type", event.Type)
+	msg.Header.Set("ce-source", event.Source)
+
+	pubAck, err := b.js.PublishMsg(msg)
+	if err != nil {
+		return "", fmt.Errorf("nats publish: publish msg: %w", err)
+	}
+
+	return fmt.Sprintf("%s:%d", pubAck.Stream, pubAck.Sequence), nil
 }
 
 // Subscribe is a stub — full implementation in O3 (#825).

--- a/services/event-bus/internal/infrastructure/nats_publish_test.go
+++ b/services/event-bus/internal/infrastructure/nats_publish_test.go
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package infrastructure_test
+
+import (
+	"testing"
+
+	"github.com/zynax-io/zynax/services/event-bus/internal/infrastructure"
+)
+
+func TestStreamName(t *testing.T) {
+	cases := []struct {
+		eventType string
+		want      string
+	}{
+		{
+			eventType: "zynax.v1.engine-adapter.workflow.completed",
+			want:      "ZYNAX_V1_ENGINE_ADAPTER_WORKFLOW",
+		},
+		{
+			eventType: "zynax.v1.agent-registry.agent.registered",
+			want:      "ZYNAX_V1_AGENT_REGISTRY_AGENT",
+		},
+		{
+			eventType: "zynax.v1.task-broker.task.submitted",
+			want:      "ZYNAX_V1_TASK_BROKER_TASK",
+		},
+		{
+			eventType: "single",
+			want:      "SINGLE",
+		},
+		{
+			eventType: "zynax.v1.workflow.completed",
+			want:      "ZYNAX_V1_WORKFLOW",
+		},
+	}
+
+	for _, tc := range cases {
+		got := infrastructure.StreamName(tc.eventType)
+		if got != tc.want {
+			t.Errorf("StreamName(%q): got %q, want %q", tc.eventType, got, tc.want)
+		}
+	}
+}
+
+func TestSubjectFilter(t *testing.T) {
+	cases := []struct {
+		eventType string
+		want      string
+	}{
+		{
+			eventType: "zynax.v1.engine-adapter.workflow.completed",
+			want:      "zynax.v1.engine-adapter.workflow.>",
+		},
+		{
+			eventType: "zynax.v1.agent-registry.agent.registered",
+			want:      "zynax.v1.agent-registry.agent.>",
+		},
+		{
+			eventType: "single",
+			want:      "single.>",
+		},
+	}
+
+	for _, tc := range cases {
+		got := infrastructure.SubjectFilter(tc.eventType)
+		if got != tc.want {
+			t.Errorf("SubjectFilter(%q): got %q, want %q", tc.eventType, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Implements **O2** of the REASONS Canvas (`docs/spdd/772-event-bus/canvas.md`) — the Publish path for `EventBusService`.
- `NATSEventBus.Publish`: idempotent JetStream stream creation (`AddStream` returns `ErrStreamNameAlreadyInUse` on duplicate — no-op), then `js.PublishMsg` with a CloudEvents v1.0 JSON envelope and `ce-*` headers. Returns composite `STREAM:sequence` event ID.
- `EventBusHandler.Publish`: validates nil event + empty `id`/`source`/`type` → `INVALID_ARGUMENT`; maps proto `CloudEvent` to domain type; delegates to `domain.EventBus`; returns `PublishResponse` with `event_id` and `accepted_at`.
- `StreamName` / `SubjectFilter` helpers exported for testing; stream naming derives from event type prefix (drops last verb segment), uppercases + replaces dashes/dots with underscores.
- Unit tests: 8 handler tests (nil event, empty id/source/type, happy path, domain error, cancelled ctx, extension field propagation) + 2 infrastructure helper tests (StreamName, SubjectFilter table-driven).
- Handler does **not** import `internal/infrastructure` — hexagonal layer rule preserved.

## Acceptance criteria met

- [x] Stream created idempotently (`ErrStreamNameAlreadyInUse` → no-op, no error)
- [x] Invalid topic (empty string) returns `codes.InvalidArgument`
- [x] `GOWORK=off go test ./... -race` passes
- [x] Domain coverage ≥ 90% (domain layer is pure value objects + errors, 100% covered by O1 tests)
- [x] Handler does not import `internal/infrastructure`

## Test plan

- [ ] `GOWORK=off go test ./... -race -timeout 60s` inside `services/event-bus/` passes
- [ ] CI `test-unit` job green
- [ ] `make lint-go` 0 issues for event-bus

## Canvas

- Epic: #772 M6.I — event-bus NATS JetStream
- O-step: O2 (#824) — Publish path
- Canvas status: Aligned (`docs/spdd/772-event-bus/canvas.md`)

Closes #824

🤖 Generated with [Claude Code](https://claude.com/claude-code)