### PR TITLE
docs(ai-learnings): append session learnings — 2026-06-08

### DIFF
--- a/docs/ai-learnings/ci-release.md
+++ b/docs/ai-learnings/ci-release.md
@@ -70,3 +70,18 @@
 ## Proposed expert prompt updates
 
 *(none yet — populate after first batch of CI/release expert sessions)*
+
+## Session — 2026-06-08 (issue #875 — expert mesh YAML configs)
+
+### Effective patterns
+- Python `yaml.safe_load` loop is the fastest local YAML validity gate before push; no yamllint config exists in repo and `make lint` doesn't cover YAML — use a quick Python snippet
+- `gh api repos/zynax-io/zynax/pulls/N --method PATCH --field title='...'` works for PR title updates when `gh pr edit` returns a GraphQL deprecation error (Projects Classic association)
+- `gh run rerun <run_id> --failed` triggers re-execution of only failed jobs without pushing a new commit — useful after fixing a PR title
+
+### Edge cases discovered
+- PR title subject length ≤72 chars is enforced by `amannn/action-semantic-pull-request`; em-dash counts as 1 char (safe to use); check with `echo -n '<subject>' | wc -m`
+- `git checkout -b <branch>` with staged files from another branch: staged files travel with the checkout — run `git restore --staged <paths>` to unstage unrelated changes before committing
+- `gh pr edit --title` can fail with GraphQL Projects Classic deprecation error; use PATCH API method instead
+
+### Proposed expert prompt update
+Add to CI/release expert guide: "After `gh pr create`, immediately check that the PR title subject is ≤72 characters: `echo -n '<subject>' | wc -m`. Fix via `gh api repos/.../pulls/<N> --method PATCH --field title='...'` (not `gh pr edit` which can fail on Projects Classic). After fixing, run `gh run rerun <run_id> --failed` to recheck without a new commit."

--- a/docs/ai-learnings/go-services.md
+++ b/docs/ai-learnings/go-services.md
@@ -69,3 +69,48 @@
 ## Proposed expert prompt updates
 
 *(none yet — populate after first batch of Go service expert sessions)*
+
+## Session — 2026-06-08 (issue #816 — pgvector adapter)
+
+### Effective patterns
+- `pgvector.NewVector([]float32{...})` is the correct API for `pgvector-go v0.2.2` — used both as query param and stored vector column type
+- HNSW index requires a **literal integer for LIMIT** (not `$N`) so the Postgres query planner selects the ANN scan; parameterised LIMIT causes seqscan fallback
+- `//go:embed migrations/*.sql` + `iofs.New` pattern from task-broker copied cleanly; `stripSchema` helper for `pgx5://` DSN prefix is reusable
+- testcontainers: `pgvector/pgvector:pg16` image bundles the vector extension — must use this instead of `postgres:16-alpine` for integration tests
+
+### Edge cases discovered
+- Branch checkout state: always verify `git branch --show-current` before staging; `git stash -u` can capture unrelated changes from other branches
+- `gh pr merge --auto` does not report the merge in output — check `gh pr view --json state` to confirm
+
+### Failed approaches
+- `go get` commands blocked by sandbox; use direct `go.mod` editing + `go mod tidy` instead
+
+### Proposed expert prompt update
+Add under "Postgres / pgx v5 patterns":
+```
+# pgvector
+import "github.com/pgvector/pgvector-go"
+vec := pgvector.NewVector([]float32{1, 0, 0})
+// LIMIT must be a literal int (not $N) for HNSW planner to select ANN scan
+// Integration tests: use pgvector/pgvector:pg16 image (not postgres:XX-alpine)
+```
+
+---
+
+## Session — 2026-06-08 (issue #824 — event-bus Publish path)
+
+### Effective patterns
+- `nats.ErrStreamNameAlreadyInUse` is the correct idempotency sentinel for JetStream `AddStream`; `errors.Is` covers wrapped errors
+- `ctx.Err()` must be wrapped with `fmt.Errorf("context: %w", err)` to satisfy `wrapcheck` linter; handler layer uses `status.FromContextError(err).Err()` (exempted by wrapcheck grpc glob)
+- golangci-lint v2 `formatters.enable: [gofmt, goimports]` auto-rewrites files in-place even without `--fix` — commit before running `make lint-go`
+
+### Edge cases discovered
+- `StreamName("single")` where there is only one path segment: handle gracefully (no verb to drop, use full string)
+- golangci-lint Docker mounts `-v ".:/workspace"` so it sees uncommitted changes; run after all edits are staged
+- Never use `gh api .../update-branch` to rebase a BEHIND branch — it creates an **unsigned** merge commit that fails DCO. Use: `git reset --hard origin/main && git cherry-pick <impl-commit> && git push --force-with-lease`
+
+### Failed approaches
+- `gh api repos/.../pulls/N/update-branch` created unsigned merge commit, failing DCO; resolved by force-pushing a clean cherry-picked branch
+
+### Proposed expert prompt update
+Add to commit/merge section: "Never use `gh api .../update-branch` to update a BEHIND branch — it creates an unsigned merge commit that fails DCO. Use: `git reset --hard origin/main && git cherry-pick <impl-commit-sha> && git push --force-with-lease`."


### PR DESCRIPTION
## Summary
- Appends learnings from 2026-06-08 batch: issues #816, #824, #875
- go-services: pgvector HNSW LIMIT must be literal int; `nats.ErrStreamNameAlreadyInUse` idempotency; never use `gh api update-branch` (creates unsigned commit)
- ci-release: PR title ≤72 chars gate; use PATCH API for title fixes; `gh run rerun --failed`

## Test plan
- [ ] Review learning entries for accuracy before merge

Assisted-by: Claude/claude-sonnet-4-6