### PR TITLE
chore(automation): orchestrator config — fan-out, aggregation and decision-log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ pr-body.md
 
 # Generated proto stubs ARE committed — do not add protos/generated/ here
 docs/spdd/**/canvas.private.md
+
+# DevAuto orchestrator decision logs — CI artifact, never committed
+.automation/decision-logs/

--- a/automation/orchestrator/aggregation-protocol.md
+++ b/automation/orchestrator/aggregation-protocol.md
@@ -1,0 +1,234 @@
+# Orchestrator Aggregation Protocol
+
+> **Issue:** #876 (M6.DevAuto — DevAuto.3)
+> **Plane:** near-term
+> **Depends-on:** `automation/experts/*.yaml` (DevAuto.2 — #875 CLOSED)
+
+This document describes how the DevAuto orchestrator weighs expert recommendations,
+decides when to act vs escalate, records reasons, and manages per-expert context budgets.
+
+---
+
+## 1. How the Orchestrator Weighs Expert Recommendations
+
+All 9 domain experts are invoked in **parallel** (fan-out mode, see `config.yaml`).
+Once all outputs are collected (or `timeout_seconds: 300` is reached), the orchestrator
+applies a **weighted consensus** strategy.
+
+### Vote-weight formula
+
+```
+vote_weight = aggregation_weight × confidence_score
+```
+
+Where:
+
+| Confidence | Score |
+|------------|-------|
+| `low`      | 1     |
+| `medium`   | 2     |
+| `high`     | 3     |
+
+`aggregation_weight` is declared per expert in `automation/experts/<name>.yaml`
+(field `aggregation_weight`). High-impact experts (security, arch, contract) carry `1.5`;
+all others carry `1.0`.
+
+### Effective weight table (snapshot)
+
+| Expert               | aggregation_weight | Max vote_weight (high conf) |
+|----------------------|--------------------|-----------------------------|
+| security-supply-chain | 1.5               | 4.5                         |
+| arch-adr             | 1.5                | 4.5                         |
+| api-contract         | 1.5                | 4.5                         |
+| qa-bdd               | 1.0                | 3.0                         |
+| ci-release           | 1.0                | 3.0                         |
+| persistence-state    | 1.0                | 3.0                         |
+| docs-agents          | 1.0                | 3.0                         |
+| planning-task-split  | 1.0                | 3.0                         |
+
+An action must reach `aggregate_weight_minimum: 3.0` (from `config.yaml`) in summed
+expert votes before it is included in the final verdict.
+
+### Conflict resolution baseline
+
+When two experts recommend contradictory actions, `conflict_resolution: highest_confidence_wins`
+applies: the expert with the higher `vote_weight` wins and its action is included in the verdict.
+This is the **default path**. Escalation overrides this when the thresholds below are reached.
+
+---
+
+## 2. When the Orchestrator Decides vs Escalates
+
+Escalation is triggered when **any** of the following conditions hold
+(from `config.yaml aggregation.escalation_threshold`):
+
+| Condition | Threshold | Effect |
+|-----------|-----------|--------|
+| `conflicting_high_confidence` | ≥2 high-confidence experts disagree | Escalate |
+| `any_critical_flag` | Any expert's `flags[]` is non-empty | Escalate |
+| `top_action_confidence` | Aggregate confidence for top action is `low` | Escalate |
+
+When none of these conditions hold, the orchestrator **decides autonomously** and,
+in Wave 2+, may execute actions from `human_in_the_loop.auto_allowed`.
+
+When escalation is triggered, `aggregated_verdict.escalated = true` and
+`human_action_required.required = true` are written to the decision log. No auto-action
+is taken. A PR comment is posted (this itself is in `auto_allowed`).
+
+### Never-auto actions
+
+Regardless of wave or confidence, the following actions are **never executed automatically**
+(from `config.yaml human_in_the_loop.never_auto`):
+
+- `merge`
+- `push`
+- `bump-dependency`
+- `close-issue`
+- `delete-branch`
+- `force-push`
+
+---
+
+## 3. How Reasons Are Recorded (ADR vs Decision-Log Entry)
+
+### Decision-log entry
+
+Every orchestrator run — whether it decides or escalates — writes a JSON decision-log
+document conforming to `decision-log-schema.yaml`. This records:
+
+- Per-expert outputs (`expert_outputs[].reasons_decisions`)
+- The aggregated verdict with full `expert_votes` map
+- The `human_action_required` block
+- `execution_result` once post-action is complete
+
+Decision-log files live in `.automation/decision-logs/` (gitignored) and are uploaded
+as GitHub Actions artifacts (`retention_days: 90`).
+
+### ADR
+
+An ADR is created only when the decision is a **one-way door**: a change that another
+engineer would reverse without knowing the rationale (per `AGENTS.md`). Orchestrator
+auto-actions do not by themselves require an ADR. A human reviewing an escalated run
+may choose to create an ADR if the resolution establishes a precedent.
+
+### Distinction
+
+| Record type      | When created              | Who creates it      | Location                              |
+|------------------|---------------------------|---------------------|---------------------------------------|
+| Decision-log     | Every orchestrator run    | Orchestrator (auto) | `.automation/decision-logs/` + CI artifact |
+| ADR              | One-way design decisions  | Human engineer      | `docs/adr/`                           |
+
+---
+
+## 4. Conflict Resolution Examples
+
+### Example 1 — Single-expert flag, immediate escalation
+
+**Scenario:** A PR modifies `.github/workflows/service-release.yml` to add a new
+`env:` block. The `security-supply-chain` expert raises a tier-2 flag
+`"secret_exposure_risk"` because the block references `${{ env.REGISTRY_PASSWORD }}`.
+
+**Expert outputs:**
+
+| Expert               | Confidence | Recommended action         | flags                    |
+|----------------------|------------|----------------------------|--------------------------|
+| security-supply-chain | high      | block-pr / request-changes | `["secret_exposure_risk"]` |
+| ci-release           | medium     | request-changes            | `[]`                     |
+| all others           | —          | no-action or not-applicable | `[]`                    |
+
+**Aggregation:**
+
+- `any_critical_flag: true` → `"secret_exposure_risk"` is non-empty → **escalate immediately**
+- `conflicting_high_confidence` threshold: not reached (only one high-confidence expert)
+- Decision: `escalated = true`, `human_action_required.required = true`
+- Reason: `"Tier-2 flag raised by security-supply-chain: secret_exposure_risk"`
+- No auto-action taken. A PR comment is posted with the flag details.
+
+---
+
+### Example 2 — Contradictory high-confidence experts, escalation
+
+**Scenario:** A PR adds a new gRPC field to an existing proto message.
+`api-contract` and `arch-adr` give contradictory high-confidence recommendations.
+
+**Expert outputs:**
+
+| Expert        | Confidence | vote_weight | Recommended action               |
+|---------------|------------|-------------|----------------------------------|
+| api-contract  | high       | 1.5 × 3 = 4.5 | block-pr: breaking-change detected |
+| arch-adr      | high       | 1.5 × 3 = 4.5 | pass: field is additive, non-breaking |
+| qa-bdd        | medium     | 1.0 × 2 = 2.0 | request-changes: missing BDD file |
+| others        | low/medium | < 3.0       | no-action                        |
+
+**Aggregation:**
+
+- `conflicting_high_confidence` = 2 experts disagree (api-contract says block, arch-adr says pass)
+- Threshold `conflicting_high_confidence: 2` is met → **escalate**
+- `highest_confidence_wins` would pick neither because both are equal — escalation takes over
+- Decision: `escalated = true`
+- Human reviews the contradiction and decides: the proto field is in a new message (additive)
+  → `arch-adr` reasoning was correct → `pass` applied manually
+
+---
+
+### Example 3 — Clear majority, no escalation (decision path)
+
+**Scenario:** A PR updates a Python adapter's unit test file only (no proto, no workflow,
+no security-sensitive path).
+
+**Expert outputs:**
+
+| Expert               | Confidence | vote_weight | Recommended action |
+|----------------------|------------|-------------|--------------------|
+| qa-bdd               | high       | 1.0 × 3 = 3.0 | pass              |
+| docs-agents          | high       | 1.0 × 3 = 3.0 | pass              |
+| planning-task-split  | medium     | 1.0 × 2 = 2.0 | pass              |
+| ci-release           | low        | 1.0 × 1 = 1.0 | pass              |
+| security-supply-chain | low       | 1.5 × 1 = 1.5 | pass              |
+| api-contract         | low        | 1.5 × 1 = 1.5 | pass              |
+| arch-adr             | low        | 1.5 × 1 = 1.5 | pass              |
+| persistence-state    | low        | 1.0 × 1 = 1.0 | pass              |
+
+**Aggregation:**
+
+- All experts recommend `pass`; no flags; no contradictions
+- `action = pass` total weight = 3.0 + 3.0 + 2.0 + 1.0 + 1.5 + 1.5 + 1.5 + 1.0 = 15.5
+  → exceeds `aggregate_weight_minimum: 3.0`
+- `conflicting_high_confidence` = 0 → no escalation
+- `any_critical_flag` = false → no escalation
+- Aggregate confidence = high (majority of weight from high-confidence votes)
+- Decision: `escalated = false`, verdict `pass`, `human_action_required.required = false`
+- Auto-actions executed (Wave 2+): `auto-label` → adds `approved` label
+
+---
+
+## 5. Context-Budget Management
+
+Each expert's context window is **strictly isolated**: no expert sees another expert's
+context files. Expert outputs (structured JSON) are collected by the orchestrator and
+fed only to the orchestrator expert's context slice.
+
+### Per-expert context slots
+
+| Expert               | max_tokens | Context files (from expert YAML context_slice) |
+|----------------------|------------|------------------------------------------------|
+| api-contract         | 4,000      | protos, buf config, AsyncAPI spec, capability schemas |
+| arch-adr             | 4,000      | ADRs, AGENTS.md, services/, docs/adr/         |
+| ci-release           | 3,000      | .github/workflows/, images.yaml, Makefile, Dockerfiles |
+| docs-agents          | 2,000      | docs/, AGENTS.md files, README patterns       |
+| persistence-state    | 3,000      | DB migrations, state/, service data models    |
+| planning-task-split  | 3,000      | state/current-milestone.md, issues, SPDD canvases |
+| qa-bdd               | 3,000      | protos/tests/, *.feature files, BDD contracts |
+| security-supply-chain | 3,000     | .github/workflows/, SECURITY.md, Dockerfiles, images.yaml |
+| orchestrator         | 8,000      | expert outputs (JSON), config.yaml, decision-log-schema.yaml |
+
+**Total maximum tokens per run:** 4000 + 4000 + 3000 + 2000 + 3000 + 3000 + 3000 + 3000 + 8000 = **33,000**
+
+Each expert slot is independent: if an expert's declared context files exceed its
+`max_tokens` budget, the `overflow_policy: truncate_oldest_files` in `config.yaml`
+drops the least recently modified files first until the budget is met. This ensures
+no expert exceeds its declared token cap.
+
+The orchestrator expert receives the JSON-serialized outputs of all 8 domain experts
+(not raw code) within its 8,000-token window, which is sufficient because each expert
+output is bounded by its `summary` (≤200 words) plus structured action lists.

--- a/automation/orchestrator/config.yaml
+++ b/automation/orchestrator/config.yaml
@@ -1,0 +1,113 @@
+# SPDX-License-Identifier: Apache-2.0
+# automation/orchestrator/config.yaml
+#
+# Orchestrator runtime configuration — fan-out protocol, aggregation weights,
+# conflict-resolution rules, escalation thresholds, and human-in-the-loop policy.
+#
+# Plane: near-term
+# Issue: #876 (M6.DevAuto — DevAuto.3)
+# Depends-on: automation/experts/*.yaml (DevAuto.2 — #875 CLOSED)
+
+version: "1.0"
+plane: near-term
+experts_dir: ../experts/
+
+# ---------------------------------------------------------------------------
+# Fan-out protocol
+# All 9 domain experts are invoked in parallel. The orchestrator collects
+# structured outputs and then applies the aggregation strategy below.
+# Each expert runs in its own bounded context (see context_slice.max_tokens
+# in each expert YAML). Expert slots must not share context; they receive
+# only their declared context_slice files.
+# ---------------------------------------------------------------------------
+fan_out:
+  mode: parallel          # invoke all experts simultaneously
+  timeout_seconds: 300    # per-expert timeout; orchestrator continues with partial outputs
+  experts:
+    # Expert name maps directly to automation/experts/<name>.yaml
+    # max_tokens mirrors each expert's context_slice.max_tokens
+    - name: api-contract
+      max_tokens: 4000
+    - name: arch-adr
+      max_tokens: 4000
+    - name: ci-release
+      max_tokens: 3000
+    - name: docs-agents
+      max_tokens: 2000
+    - name: persistence-state
+      max_tokens: 3000
+    - name: planning-task-split
+      max_tokens: 3000
+    - name: qa-bdd
+      max_tokens: 3000
+    - name: security-supply-chain
+      max_tokens: 3000
+    - name: orchestrator         # self-referential read; computes final verdict
+      max_tokens: 8000
+
+  context_budget:
+    # Each expert's context window is hard-capped at its declared max_tokens.
+    # Expert contexts do NOT overlap — each expert sees only its context_slice files.
+    # The orchestrator expert receives all other expert outputs (not raw code files)
+    # as its context, up to its own max_tokens cap of 8000.
+    isolation: strict
+    overflow_policy: truncate_oldest_files  # if context_slice files exceed budget, drop older ones
+
+# ---------------------------------------------------------------------------
+# Aggregation strategy
+# After all expert outputs are collected the orchestrator computes a weighted
+# consensus verdict. Expert type multipliers are defined per expert's
+# aggregation_weight field in their YAML (range 0.1–5.0).
+# ---------------------------------------------------------------------------
+aggregation:
+  strategy: weighted_consensus
+
+  # Formula: vote_weight = aggregation_weight * confidence_score
+  # Where confidence_score: low=1, medium=2, high=3
+  # An action must accumulate aggregate_weight_minimum across supporting
+  # experts before it is included in the final verdict.
+  aggregate_weight_minimum: 3.0
+
+  conflict_resolution: highest_confidence_wins
+  # Rule: when two experts recommend contradictory actions, the expert with
+  # the higher weighted vote wins — UNLESS the escalation thresholds below
+  # are triggered, in which case the run escalates to human.
+
+  escalation_threshold:
+    # Escalate to human when ANY of these conditions are met:
+    conflicting_high_confidence: 2   # ≥2 high-conf experts disagree on the same action → escalate
+    any_critical_flag: true          # any tier-2 security flag in any expert's flags[] → escalate
+    top_action_confidence: low       # aggregate confidence for the top recommended action is low
+    # These mirror the escalation_threshold block in automation/experts/orchestrator.yaml
+
+# ---------------------------------------------------------------------------
+# Decision log
+# A JSON decision-log artifact is written for every orchestrator run.
+# Schema is defined in decision-log-schema.yaml (same directory).
+# The output_path is gitignored; CI uploads it as a GH Actions artifact.
+# ---------------------------------------------------------------------------
+decision_log:
+  schema: decision-log-schema.yaml
+  output_path: .automation/decision-logs/      # gitignored; CI artifact
+  artifact_name: "dev-auto-decision-log-{run_id}.json"
+  retention_days: 90
+
+# ---------------------------------------------------------------------------
+# Human-in-the-loop policy
+# auto_allowed actions may be executed automatically in Wave 2+.
+# never_auto actions MUST NOT be executed without explicit human approval.
+# ---------------------------------------------------------------------------
+human_in_the_loop:
+  auto_allowed:
+    - auto-label
+    - auto-assign
+    - draft-issue
+    - post-pr-comment
+
+  never_auto:
+    - merge
+    - push
+    - bump-dependency
+    - close-issue
+    - delete-branch
+    - force-push

--- a/automation/orchestrator/decision-log-schema.yaml
+++ b/automation/orchestrator/decision-log-schema.yaml
@@ -1,0 +1,252 @@
+# SPDX-License-Identifier: Apache-2.0
+# automation/orchestrator/decision-log-schema.yaml
+#
+# JSON Schema (draft-07) for the decision log produced after each orchestrator run.
+# Every orchestrator invocation writes one conforming JSON document to:
+#   .automation/decision-logs/dev-auto-decision-log-{run_id}.json
+# That directory is gitignored; CI uploads it as a GitHub Actions artifact.
+#
+# Plane: near-term
+# Issue: #876 (M6.DevAuto — DevAuto.3)
+
+$schema: "http://json-schema.org/draft-07/schema#"
+$id: "https://github.com/zynax-io/zynax/automation/orchestrator/decision-log-schema.yaml"
+title: DecisionLog
+description: >
+  Structured record of one orchestrator run: trigger, per-expert outputs,
+  aggregated verdict, and post-action execution result.
+type: object
+required:
+  - run_id
+  - timestamp
+  - trigger
+  - expert_outputs
+  - aggregated_verdict
+  - human_action_required
+additionalProperties: false
+
+properties:
+
+  run_id:
+    type: string
+    description: Unique identifier for this orchestrator run (GH Actions run_id or UUID).
+    pattern: "^[a-zA-Z0-9_-]+$"
+
+  timestamp:
+    type: string
+    description: ISO 8601 UTC timestamp when the orchestrator run started.
+    format: date-time
+
+  trigger:
+    type: object
+    description: What caused this orchestrator run.
+    required:
+      - event
+    additionalProperties: false
+    properties:
+      event:
+        type: string
+        description: GitHub event type that triggered the run.
+        enum:
+          - pull_request
+          - push
+          - post_merge
+      pr_number:
+        type: integer
+        description: PR number (required when event == pull_request).
+        minimum: 1
+      pr_title:
+        type: string
+        description: PR title (pull_request event only).
+      base_sha:
+        type: string
+        description: Base commit SHA for diff range.
+        pattern: "^[0-9a-f]{40}$"
+      head_sha:
+        type: string
+        description: Head commit SHA for diff range.
+        pattern: "^[0-9a-f]{40}$"
+      diff_summary:
+        type: string
+        description: Output of `git diff --stat` for the trigger range.
+      changed_files:
+        type: array
+        description: List of changed file paths.
+        items:
+          type: string
+        minItems: 0
+
+  expert_outputs:
+    type: array
+    description: Structured output from each expert in the fan-out.
+    items:
+      $ref: "#/definitions/ExpertOutput"
+    minItems: 0
+
+  aggregated_verdict:
+    type: object
+    description: Final decision computed by the orchestrator after aggregation.
+    required:
+      - action
+      - rationale
+      - confidence
+      - escalated
+    additionalProperties: false
+    properties:
+      action:
+        type: string
+        description: Top-level recommended action (pass | needs_review | escalate).
+        enum:
+          - pass
+          - needs_review
+          - escalate
+      rationale:
+        type: string
+        description: Plain-text explanation of why this verdict was reached.
+      confidence:
+        type: string
+        description: Orchestrator's aggregate confidence in the verdict.
+        enum:
+          - low
+          - medium
+          - high
+      escalated:
+        type: boolean
+        description: True if the orchestrator escalated to human rather than auto-acting.
+      escalation_reason:
+        type: string
+        description: Reason for escalation (required when escalated == true).
+      expert_votes:
+        type: object
+        description: Map of action → vote weight and supporting experts.
+        additionalProperties:
+          type: object
+          required:
+            - weight
+            - supporting_experts
+          properties:
+            weight:
+              type: number
+              description: Aggregated weighted vote for this action.
+            supporting_experts:
+              type: array
+              items:
+                type: string
+      auto_actions_taken:
+        type: array
+        description: Actions the orchestrator executed automatically (Wave 2+ only).
+        items:
+          type: string
+
+  human_action_required:
+    type: object
+    description: Whether a human must act before the orchestrator proceeds.
+    required:
+      - required
+    additionalProperties: false
+    properties:
+      required:
+        type: boolean
+        description: True when the orchestrator cannot proceed without human approval.
+      reason:
+        type: string
+        description: Human-readable explanation (required when required == true).
+      blocking_flags:
+        type: array
+        description: Tier-2 security flags or threshold breaches that triggered escalation.
+        items:
+          type: string
+
+  execution_result:
+    type: object
+    description: >
+      Filled post-action: records what actually ran and its outcome.
+      Absent if the run escalated and no action was taken.
+    additionalProperties: false
+    properties:
+      actions_executed:
+        type: array
+        description: Actions that were executed (may be empty if escalated).
+        items:
+          type: string
+      outcome:
+        type: string
+        description: Final outcome of execution.
+        enum:
+          - success
+          - partial
+          - skipped
+          - failure
+      details:
+        type: string
+        description: Additional detail, error messages, or links to GH Actions logs.
+      completed_at:
+        type: string
+        description: ISO 8601 UTC timestamp when execution completed.
+        format: date-time
+
+definitions:
+
+  ExpertOutput:
+    type: object
+    description: Structured output from a single expert in the fan-out.
+    required:
+      - expert_name
+      - summary
+      - recommended_actions
+      - confidence
+      - flags
+    additionalProperties: true
+    properties:
+      expert_name:
+        type: string
+        description: Expert identifier matching automation/experts/<name>.yaml.
+        pattern: "^[a-z][a-z0-9-]*$"
+      summary:
+        type: string
+        description: Plain-text expert summary (≤200 words).
+      recommended_actions:
+        type: array
+        description: Ordered list of specific actions with rationale.
+        items:
+          type: object
+          required:
+            - action
+            - rationale
+            - priority
+          properties:
+            action:
+              type: string
+            rationale:
+              type: string
+            priority:
+              type: string
+              enum:
+                - low
+                - medium
+                - high
+      reasons_decisions:
+        type: array
+        description: Reasoning chain for each recommendation.
+        items:
+          type: string
+      confidence:
+        type: string
+        description: Expert's confidence in its output.
+        enum:
+          - low
+          - medium
+          - high
+      flags:
+        type: array
+        description: Tier-2 security or blocker flags (empty list if none).
+        items:
+          type: string
+      timed_out:
+        type: boolean
+        description: True if the expert did not return within timeout_seconds.
+      aggregation_weight:
+        type: number
+        description: Effective weight used for this expert in aggregation (from expert YAML).
+        minimum: 0.1
+        maximum: 5.0


### PR DESCRIPTION
## Summary

- Adds `automation/orchestrator/config.yaml` with complete fan-out + aggregation spec, escalation thresholds, and human-in-the-loop policy (`never_auto` explicitly includes `merge`, `push`, `bump-dependency`)
- Adds `automation/orchestrator/decision-log-schema.yaml` — valid JSON Schema draft-07 covering run_id, timestamp, trigger, expert_outputs, aggregated_verdict, human_action_required, and execution_result
- Adds `automation/orchestrator/aggregation-protocol.md` — human-readable description covering all 5 required items (weighting, escalation, ADR vs decision-log, 3 conflict-resolution examples, context-budget management)
- Updates `.gitignore` to exclude `.automation/decision-logs/` (CI artifact, never committed)

Closes step DevAuto.3 of EPIC #873. Depends on DevAuto.2 (#875 — CLOSED ✅).

## Acceptance criteria

- [x] `automation/orchestrator/config.yaml` committed with complete fan-out + aggregation spec
- [x] `automation/orchestrator/decision-log-schema.yaml` committed — valid JSON Schema draft-07
- [x] `automation/orchestrator/aggregation-protocol.md` committed — covers all 5 items
- [x] `human_in_the_loop.never_auto` explicitly includes `merge`, `push`, `bump-dependency`
- [x] Escalation thresholds documented and traceable to specific criteria in `config.yaml`
- [x] Context-budget: each expert slot has explicit `max_tokens` and proven non-overlap

## Test plan

- [ ] Verify YAML syntax: `python3 -c "import yaml; yaml.safe_load(open('automation/orchestrator/config.yaml'))"`
- [ ] Verify YAML syntax: `python3 -c "import yaml; yaml.safe_load(open('automation/orchestrator/decision-log-schema.yaml'))"`
- [ ] Confirm `$schema: http://json-schema.org/draft-07/schema#` is present in `decision-log-schema.yaml`
- [ ] Confirm `never_auto` list includes `merge`, `push`, `bump-dependency`, `close-issue`, `delete-branch`
- [ ] Confirm `aggregation-protocol.md` contains 3+ conflict-resolution examples
- [ ] Confirm `.gitignore` includes `.automation/decision-logs/`

Closes #876

🤖 Generated with [Claude Code](https://claude.com/claude-code)