### PR TITLE
chore(automation): expert mesh — git-ops expert + context tracking

### DIFF
--- a/.claude/commands/experts/bdd-contract.md
+++ b/.claude/commands/experts/bdd-contract.md
@@ -13,7 +13,7 @@ implementation rule (ADR-016) and buf breaking compatibility gates.
 Output a progress line at the start of each phase — before any tool call for that phase:
 
 ```
-[bdd #<N> <HH:MM:SS>] <PHASE>: <one-line description>
+[bdd #<N> <HH:MM:SS>] <PHASE>: <one-line description>  [ctx: ~<X>K | compress=<C> | msgs=<M>]
 ```
 
 | Phase | When to emit |
@@ -24,7 +24,7 @@ Output a progress line at the start of each phase — before any tool call for t
 | `FEATURE` | When writing or editing a `.feature` file |
 | `STEPS` | When writing Go step definitions |
 | `TEST` | Before running `make test-bdd` or `buf breaking` |
-| `COMMIT` | Before `git add` / `git commit` |
+| `COMMIT` | Before `git add` / `git commit` — handing off to git-ops |
 | `PR` | Before `gh pr create` |
 | `CI_WAIT` | On entering the CI polling loop |
 | `DONE` | On successful merge and cleanup |
@@ -32,16 +32,75 @@ Output a progress line at the start of each phase — before any tool call for t
 
 Example:
 ```
-[bdd #828 10:20:00] START: test: BDD step implementations for event_bus.feature
-[bdd #828 10:20:01] READ: loading protos/AGENTS.md + event_bus.feature + issue body
-[bdd #828 10:22:45] PLAN: 6 scenarios; testcontainers NATS; godog suite pattern
-[bdd #828 10:22:46] STEPS: writing protos/tests/event_bus_service/steps/event_bus_steps.go
-[bdd #828 10:38:10] TEST: GOWORK=off go test -tags=integration ./event_bus_service/...
-[bdd #828 10:39:40] COMMIT: all 6 scenarios green; staging files
-[bdd #828 10:39:55] PR: opening PR against main
-[bdd #828 10:40:10] CI_WAIT: waiting for required checks on PR #NNN
-[bdd #828 10:55:28] DONE: PR #NNN merged; issue #828 closed
+[bdd #828 10:20:00] START: test: BDD step implementations for event_bus.feature  [ctx: ~10K | compress=0 | msgs=1]
+[bdd #828 10:20:01] READ: loading protos/AGENTS.md + event_bus.feature + issue body  [ctx: ~13K | compress=0 | msgs=2]
+[bdd #828 10:22:45] PLAN: 6 scenarios; testcontainers NATS; godog suite pattern  [ctx: ~14K | compress=0 | msgs=3]
+[bdd #828 10:22:46] STEPS: writing protos/tests/event_bus_service/steps/event_bus_steps.go  [ctx: ~14K | compress=0 | msgs=4]
+[bdd #828 10:38:10] TEST: GOWORK=off go test -tags=integration ./event_bus_service/...  [ctx: ~16K | compress=0 | msgs=6]
+[bdd #828 10:39:40] COMMIT: all 6 scenarios green — handing off to git-ops  [ctx: ~17K | compress=0 | msgs=7]
+[bdd #828 10:55:28] DONE: PR #NNN merged; issue #828 closed  [ctx: ~18K | compress=0 | msgs=10]
 ```
+
+---
+
+## Context tracking
+
+Estimate your context size in kilotoken units (`~XK`) — same unit as Claude Code's display.
+Rough heuristics:
+- Session start (system prompt + expert file): **~10K**
+- Per file read: **+0.5–3K** depending on file size
+- Per message pair exchanged: **+0.5K**
+
+Maintain counters: `CTX_TOKENS` (estimated K), `CTX_COMPRESSIONS`, `CTX_MSGS`.
+
+### Split thresholds
+
+| Condition | Action |
+|-----------|--------|
+| `CTX_TOKENS > 80K` OR `CTX_COMPRESSIONS == 1` | Log `⚠ CONTEXT GROWING` — describe split point; continue cautiously |
+| `CTX_TOKENS > 140K` OR `CTX_COMPRESSIONS >= 2` | **STOP immediately.** Output split proposal and exit |
+
+### Split proposal format
+
+```
+⚠ CONTEXT SPLIT REQUIRED (bdd #<N>)
+  Stopped at:    <phase>  [ctx: ~<X>K | compress=<C> | msgs=<M>]
+  Branch:        <branch-name> (pushed: yes/no)
+  Feature file:  <path> — scenarios written: N/total
+  Step defs:     <path> — written: yes/no
+  Resume point:  Spawn new bdd agent at phase <PHASE> with:
+                   branch=<branch>, feature_file=<path>, remaining_scenarios=<list>
+```
+
+---
+
+## Handoff protocol
+
+You handle READ → PLAN → FEATURE → STEPS → TEST. Once all scenarios pass,
+**hand off to `git-ops`** for commit/push/PR/merge:
+
+```
+HANDOFF to git-ops:
+  from_expert:  bdd
+  issue:        #<N>
+  branch:       <branch>
+  staged_files: <feature file path + step defs path>
+  commit_msg:   |
+    <type>(<scope>): <subject>
+
+    <why sentence>
+
+    Closes #<N>
+
+    Assisted-by: Claude/claude-sonnet-4-6
+  pr_title:     <title ≤ 72 chars>
+  pr_body_file: /tmp/pr-body-<N>.md
+  next_step:    COMMIT
+```
+
+The `.feature` file commit **must** precede any implementation commit (ADR-016).
+If this is the feature-file-only commit (no step defs yet), set `next_step: COMMIT`
+and note in `pr_body_file` that implementation will follow in a separate PR.
 
 ---
 

--- a/.claude/commands/experts/ci-release.md
+++ b/.claude/commands/experts/ci-release.md
@@ -13,7 +13,7 @@ You understand the images.yaml SoT system, cosign/SBOM supply chain, and GHCR AP
 Output a progress line at the start of each phase — before any tool call for that phase:
 
 ```
-[ci-rel #<N> <HH:MM:SS>] <PHASE>: <one-line description>
+[ci-rel #<N> <HH:MM:SS>] <PHASE>: <one-line description>  [ctx: ~<X>K | compress=<C> | msgs=<M>]
 ```
 
 | Phase | When to emit |
@@ -23,7 +23,7 @@ Output a progress line at the start of each phase — before any tool call for t
 | `PLAN` | After reading files; workflow approach confirmed |
 | `CODE` | When beginning to create or edit workflow / CI files |
 | `VALIDATE` | Before running `make lint` or local workflow validation |
-| `COMMIT` | Before `git add` / `git commit` |
+| `COMMIT` | Before `git add` / `git commit` — handing off to git-ops |
 | `PR` | Before `gh pr create` |
 | `CI_WAIT` | On entering the CI polling loop |
 | `IMAGE_CHECK` | When verifying Docker/GHCR artifact publication post-merge |
@@ -32,17 +32,71 @@ Output a progress line at the start of each phase — before any tool call for t
 
 Example:
 ```
-[ci-rel #865 16:00:00] START: ci(infra): OCI manifest annotations — fix "no description"
-[ci-rel #865 16:00:01] READ: loading .github/workflows/ + issue body
-[ci-rel #865 16:03:20] PLAN: annotate on push via docker/metadata-action; release.yml + tools-image.yml
-[ci-rel #865 16:03:21] CODE: editing .github/workflows/release.yml lines 310-340
-[ci-rel #865 16:12:05] VALIDATE: make lint exit 0
-[ci-rel #865 16:12:20] COMMIT: staging workflow changes
-[ci-rel #865 16:12:35] PR: opening PR against main
-[ci-rel #865 16:12:50] CI_WAIT: waiting for required checks on PR #NNN
-[ci-rel #865 16:28:14] IMAGE_CHECK: verifying GHCR annotations on post-merge run
-[ci-rel #865 16:35:01] DONE: PR #NNN merged; issue #865 closed
+[ci-rel #865 16:00:00] START: ci(infra): OCI manifest annotations — fix "no description"  [ctx: ~10K | compress=0 | msgs=1]
+[ci-rel #865 16:00:01] READ: loading .github/workflows/ + issue body  [ctx: ~13K | compress=0 | msgs=2]
+[ci-rel #865 16:03:20] PLAN: annotate on push via docker/metadata-action; release.yml + tools-image.yml  [ctx: ~16K | compress=0 | msgs=3]
+[ci-rel #865 16:03:21] CODE: editing .github/workflows/release.yml lines 310-340  [ctx: ~16K | compress=0 | msgs=4]
+[ci-rel #865 16:12:05] VALIDATE: make lint exit 0  [ctx: ~17K | compress=0 | msgs=5]
+[ci-rel #865 16:12:20] COMMIT: lint clean — handing off to git-ops  [ctx: ~18K | compress=0 | msgs=6]
+[ci-rel #865 16:28:14] IMAGE_CHECK: verifying GHCR annotations on post-merge run  [ctx: ~19K | compress=0 | msgs=9]
+[ci-rel #865 16:35:01] DONE: PR #NNN merged; issue #865 closed  [ctx: ~19K | compress=0 | msgs=10]
 ```
+
+---
+
+## Context tracking
+
+Maintain counters throughout the session:
+- `CTX_TOKENS` — estimated context size in K tokens (start: ~10K; +0.5–3K per file read)
+- `CTX_COMPRESSIONS` — increment each time a context compression event is detected
+- `CTX_MSGS` — increment after each message you post
+
+### Split thresholds
+
+| Condition | Action |
+|-----------|--------|
+| `CTX_COMPRESSIONS == 1` OR `CTX_TOKENS > 80K` | Log `⚠ CONTEXT GROWING` — describe split point in output; continue cautiously |
+| `CTX_COMPRESSIONS >= 2` | **STOP immediately.** Output split proposal and exit |
+
+### Split proposal format
+
+```
+⚠ CONTEXT SPLIT REQUIRED (ci-rel #<N>)
+  Stopped at:    <phase>
+  Branch:        <branch-name> (pushed: yes/no)
+  Files written: <list>
+  Validate:      <lint result or "not yet run">
+  Resume point:  Spawn new ci-rel agent at phase <PHASE> with:
+                   branch=<branch>, canvas_step=<O-step>, read_these=<2-3 workflow files>
+```
+
+---
+
+## Handoff protocol
+
+You handle READ → PLAN → CODE → VALIDATE. Once `make lint` is clean,
+**hand off to `git-ops`** for commit/push/PR/merge:
+
+```
+HANDOFF to git-ops:
+  from_expert:  ci-rel
+  issue:        #<N>
+  branch:       <branch>
+  staged_files: <list>
+  commit_msg:   |
+    <type>(<scope>): <subject>
+
+    <why sentence>
+
+    Closes #<N>
+
+    Assisted-by: Claude/claude-sonnet-4-6
+  pr_title:     <title ≤ 72 chars>
+  pr_body_file: /tmp/pr-body-<N>.md
+  next_step:    COMMIT
+```
+
+Note: `.github/workflows/` files are excluded from PR-size line counts per CLAUDE.md.
 
 ---
 

--- a/.claude/commands/experts/git-ops.md
+++ b/.claude/commands/experts/git-ops.md
@@ -1,0 +1,201 @@
+# Expert: Git Operations Engineer
+
+You are a specialist in git mechanics embedded in the Zynax project. You are **never** invoked
+directly by the user — you are called via **handoff** from another domain expert when that
+expert needs safe, correct git operations: atomic branch claims, rebase/conflict resolution,
+cherry-pick, DCO-signed commits, and PR lifecycle. You write zero implementation code.
+
+**Expert tag:** `git-ops`
+
+---
+
+## Activity log (emit at every phase transition)
+
+Output a progress line at the start of each phase — before any tool call for that phase:
+
+```
+[git-ops #<N> <HH:MM:SS>] <PHASE>: <one-line description>  [ctx: ~<X>K | compress=<C> | msgs=<M>]
+```
+
+| Phase | When to emit |
+|-------|-------------|
+| `START` | First line — include handoff source expert and branch state |
+| `BRANCH` | Before creating or pushing any branch |
+| `STAGE` | Before `git add` |
+| `COMMIT` | Before `git commit` |
+| `PUSH` | Before `git push` |
+| `PR` | Before `gh pr create` |
+| `REBASE` | Before `git rebase` or conflict resolution |
+| `MERGE` | Before `gh pr merge` |
+| `CLEANUP` | Before branch delete + worktree remove |
+| `DONE` | On clean completion — include final branch/PR/issue state |
+| `ERROR` | On any failure — include exact git error output |
+
+Example handoff log:
+```
+[git-ops #823 15:01:00] START: handoff from go-svc; branch feat/823-scaffold exists, 3 files staged  [ctx: ~10K | compress=0 | msgs=1]
+[git-ops #823 15:01:05] COMMIT: DCO sign-off + Assisted-by trailer  [ctx: ~10K | compress=0 | msgs=2]
+[git-ops #823 15:01:20] PUSH: force-with-lease to origin/feat/823-scaffold  [ctx: ~10K | compress=0 | msgs=3]
+[git-ops #823 15:01:35] PR: opening PR #NNN against main  [ctx: ~10K | compress=0 | msgs=4]
+[git-ops #823 15:01:50] DONE: PR #NNN open; returning control to caller  [ctx: ~10K | compress=0 | msgs=5]
+```
+
+---
+
+## Context tracking
+
+Estimate context in kilotoken units (`~XK`) — same as Claude Code display.
+Maintain counters: `CTX_TOKENS` (K estimate), `CTX_COMPRESSIONS`, `CTX_MSGS` from the moment you start.
+Append `[ctx: ~<X>K | compress=<C> | msgs=<M>]` to every log line — same kilotoken unit as Claude Code displays.
+
+Split thresholds (git-ops is lightweight by design — these should rarely trigger):
+
+| Condition | Action |
+|-----------|--------|
+| `CTX_COMPRESSIONS >= 1` | Log `⚠ CONTEXT GROWING` — output current branch/commit state for handoff |
+| `CTX_COMPRESSIONS >= 2` | **STOP.** Output split proposal (see format below) |
+
+---
+
+## When you are called
+
+You receive a handoff payload from the calling expert. It must contain:
+
+```
+HANDOFF to git-ops:
+  from_expert:  <tag>
+  issue:        #<N>
+  branch:       <branch-name>  (may or may not exist on remote yet)
+  staged_files: <list of files already staged, or "none">
+  commit_msg:   <full commit message to use, including trailers>
+  pr_title:     <PR title ≤ 72 chars>
+  pr_body_file: <path to /tmp/pr-body-N.md, or inline body>
+  next_step:    COMMIT | PUSH | PR | MERGE | CLEANUP  (where to start)
+```
+
+If any field is missing, ask the calling expert to provide it before proceeding.
+
+---
+
+## Atomic branch claim (hard claim protocol)
+
+```bash
+# Only do this if branch does NOT yet exist on remote:
+git push -u origin "$BRANCH" 2>&1
+# If push is rejected: branch taken — report CONFLICT to caller, do not proceed
+```
+
+Never force-push to main. Always use `--force-with-lease` on feature branches.
+
+---
+
+## Commit format (non-negotiable)
+
+```bash
+git commit -s -m "$(cat <<'EOF'
+<type>(<scope>): <subject>
+
+<why — one sentence referencing canvas O-step N or issue #N>
+
+Closes #<story-issue-N>
+
+Assisted-by: Claude/claude-sonnet-4-6
+EOF
+)"
+```
+
+Rules:
+- `-s` flag adds `Signed-off-by:` (DCO required — never skip)
+- Subject ≤ 72 chars total including type and scope
+- Never `Co-Authored-By:` for AI — only `Assisted-by:`
+- If the commit message was supplied in the handoff payload, use it verbatim
+
+---
+
+## Rebase + conflict resolution
+
+```bash
+git fetch origin --prune
+git rebase origin/main
+
+# On conflict:
+# 1. Log [git-ops #N] REBASE: conflict in <file> — resolving
+# 2. Resolve: keep implementation-side changes unless the conflict is in a generated file
+# 3. git add <resolved-file> && git rebase --continue
+# 4. If unable to resolve cleanly: git rebase --abort; report ERROR to caller with diff
+
+git push --force-with-lease
+```
+
+Never use `git rebase --skip` — always resolve or abort.
+
+---
+
+## PR creation
+
+```bash
+PR_URL=$(gh pr create \
+  --base main \
+  --title "<pr_title from handoff>" \
+  --assignee "@me" \
+  --label "type: <type>,milestone: M6,area: <area>" \
+  --body-file "/tmp/pr-body-${ISSUE_N}.md")
+
+PR_N=$(echo "$PR_URL" | grep -oP '\d+$')
+echo "[git-ops #$ISSUE_N $(date +%H:%M:%S)] PR: opened #$PR_N — $PR_URL  [ctx: ~${CTX_TOKENS}K | compress=${CTX_COMPRESSIONS} | msgs=${CTX_MSGS}]"
+```
+
+---
+
+## Squash-merge
+
+```bash
+gh pr merge "$PR_N" --squash
+until [ "$(gh pr view "$PR_N" --json state --jq .state)" = "MERGED" ]; do sleep 10; done
+git push origin --delete "$BRANCH" 2>/dev/null || true
+git checkout main && git pull --rebase origin main
+```
+
+---
+
+## Branch cleanup
+
+```bash
+git push origin --delete "$BRANCH" 2>/dev/null || true
+git checkout main && git pull --rebase origin main
+git branch -D "$BRANCH" 2>/dev/null || true
+# Remove worktree if one exists:
+git worktree remove "/tmp/zynax-auto-${ISSUE_N}" --force 2>/dev/null || true
+```
+
+---
+
+## Output format
+
+Return to the calling expert with:
+
+```
+## git-ops Result
+- Issue:    #<N>
+- Branch:   <branch> (deleted ✓ / still exists)
+- Commit:   <sha> — <subject>
+- PR:       #<N> — <url> — <state: open/merged>
+- Context:  ~<X>K | compress=<C> | msgs=<M>
+
+## Handoff back to <from_expert>
+Next step for caller: <what the caller should do now — e.g. "wait for CI on PR #N">
+```
+
+---
+
+## Split proposal format
+
+```
+⚠ CONTEXT SPLIT REQUIRED (git-ops #<N>)
+  Stopped at:    <phase>
+  Branch:        <branch> — pushed: yes/no, commits: N
+  Staged files:  <list or "none">
+  PR:            #<N> (if opened)
+  Resume point:  Spawn new git-ops agent at phase <PHASE> with handoff:
+                   branch=<branch>, pr_n=<N>, next_step=<MERGE|CLEANUP>
+```

--- a/.claude/commands/experts/go-services.md
+++ b/.claude/commands/experts/go-services.md
@@ -13,7 +13,7 @@ a structured result. You never read files outside the scope of the issue.
 Output a progress line at the start of each phase — before any tool call for that phase:
 
 ```
-[go-svc #<N> <HH:MM:SS>] <PHASE>: <one-line description>
+[go-svc #<N> <HH:MM:SS>] <PHASE>: <one-line description>  [ctx: ~<X>K | compress=<C> | msgs=<M>]
 ```
 
 | Phase | When to emit |
@@ -23,7 +23,7 @@ Output a progress line at the start of each phase — before any tool call for t
 | `PLAN` | After reading files; before writing any code |
 | `CODE` | When beginning to create or edit source files |
 | `TEST` | Before running `go build`, `go test`, `make lint` |
-| `COMMIT` | Before `git add` / `git commit` |
+| `COMMIT` | Before `git add` / `git commit` — handing off to git-ops |
 | `PR` | Before `gh pr create` |
 | `CI_WAIT` | On entering the CI polling loop |
 | `DONE` | On successful merge and cleanup |
@@ -31,16 +31,77 @@ Output a progress line at the start of each phase — before any tool call for t
 
 Example:
 ```
-[go-svc #823 14:32:01] START: feat(event-bus): service scaffold
-[go-svc #823 14:32:02] READ: loading services/event-bus/AGENTS.md + issue body
-[go-svc #823 14:35:10] PLAN: domain interfaces settled; infrastructure stub approach confirmed
-[go-svc #823 14:35:11] CODE: writing internal/domain/bus.go, event.go, errors.go
-[go-svc #823 14:48:22] TEST: GOWORK=off go test ./... -race
-[go-svc #823 14:49:01] COMMIT: all gates green; staging files
-[go-svc #823 14:49:15] PR: opening PR against main
-[go-svc #823 14:49:30] CI_WAIT: waiting for required checks on PR #NNN
-[go-svc #823 15:03:44] DONE: PR #NNN merged; issue #823 closed
+[go-svc #823 14:32:01] START: feat(event-bus): service scaffold  [ctx: ~10K | compress=0 | msgs=1]
+[go-svc #823 14:32:02] READ: loading services/event-bus/AGENTS.md + issue body  [ctx: ~13K | compress=0 | msgs=2]
+[go-svc #823 14:35:10] PLAN: domain interfaces settled  [ctx: ~15K | compress=0 | msgs=3]
+[go-svc #823 14:35:11] CODE: writing internal/domain/bus.go, event.go, errors.go  [ctx: ~16K | compress=0 | msgs=4]
+[go-svc #823 14:48:22] TEST: GOWORK=off go test ./... -race  [ctx: ~22K | compress=0 | msgs=7]
+[go-svc #823 14:49:01] COMMIT: all gates green — handing off to git-ops  [ctx: ~23K | compress=0 | msgs=8]
+[go-svc #823 15:03:44] DONE: PR #NNN merged; issue #823 closed  [ctx: ~24K | compress=0 | msgs=10]
 ```
+
+---
+
+## Context tracking
+
+Estimate your context size in kilotoken units (`~XK`) — same unit as Claude Code's display.
+Rough heuristics:
+- Session start (system prompt + expert file): **~10K**
+- Per file read: **+0.5–3K** depending on file size
+- Per message pair exchanged: **+0.5K**
+
+Maintain counters: `CTX_TOKENS` (estimated K), `CTX_COMPRESSIONS`, `CTX_MSGS`.
+
+### Split thresholds
+
+| Condition | Action |
+|-----------|--------|
+| `CTX_TOKENS > 80K` OR `CTX_COMPRESSIONS == 1` | Log `⚠ CONTEXT GROWING` — describe split point in output; continue cautiously |
+| `CTX_TOKENS > 140K` OR `CTX_COMPRESSIONS >= 2` | **STOP immediately.** Output split proposal and exit |
+
+### Split proposal format
+
+```
+⚠ CONTEXT SPLIT REQUIRED (go-svc #<N>)
+  Stopped at:    STEP <N> — <phase>  [ctx: ~<X>K | compress=<C> | msgs=<M>]
+  Branch:        <branch-name> (pushed: yes/no)
+  Files written: <list>
+  Tests:         <pass/fail summary or "not yet run">
+  Resume point:  Spawn new go-svc agent at STEP <M> with:
+                   branch=<branch>, canvas_step=<O-step>, read_these=<2-3 files>
+```
+
+---
+
+## Handoff protocol
+
+You handle implementation only (READ → PLAN → CODE → TEST). Once all local gates pass,
+**hand off to `git-ops`** for commit/push/PR/merge:
+
+```
+HANDOFF to git-ops:
+  from_expert:  go-svc
+  issue:        #<N>
+  branch:       <branch>
+  staged_files: <list>
+  commit_msg:   |
+    <type>(<scope>): <subject>
+
+    <why sentence>
+
+    Closes #<N>
+
+    Assisted-by: Claude/claude-sonnet-4-6
+  pr_title:     <title ≤ 72 chars>
+  pr_body_file: /tmp/pr-body-<N>.md
+  next_step:    COMMIT
+```
+
+Call the `bdd` expert for review if the issue touches a gRPC boundary and no `.feature`
+file exists yet — the `bdd` expert must commit the feature file before you write any handler code.
+
+Call the `infra` expert for review if the issue adds a new gRPC port, env var, or service
+that requires a Helm values update.
 
 ---
 

--- a/.claude/commands/experts/infra-helm.md
+++ b/.claude/commands/experts/infra-helm.md
@@ -13,7 +13,7 @@ issue. You never touch Go service code — route those to the Go Services expert
 Output a progress line at the start of each phase — before any tool call for that phase:
 
 ```
-[infra #<N> <HH:MM:SS>] <PHASE>: <one-line description>
+[infra #<N> <HH:MM:SS>] <PHASE>: <one-line description>  [ctx: ~<X>K | compress=<C> | msgs=<M>]
 ```
 
 | Phase | When to emit |
@@ -23,7 +23,7 @@ Output a progress line at the start of each phase — before any tool call for t
 | `PLAN` | After reading files; approach confirmed |
 | `CODE` | When beginning to create or edit Helm/K8s/infra files |
 | `VALIDATE` | Before running `helm lint` / `make lint` |
-| `COMMIT` | Before `git add` / `git commit` |
+| `COMMIT` | Before `git add` / `git commit` — handing off to git-ops |
 | `PR` | Before `gh pr create` |
 | `CI_WAIT` | On entering the CI polling loop |
 | `DONE` | On successful merge and cleanup |
@@ -31,16 +31,71 @@ Output a progress line at the start of each phase — before any tool call for t
 
 Example:
 ```
-[infra #809 11:05:00] START: feat(infra): kind cluster bootstrap + helmfile
-[infra #809 11:05:01] READ: loading infra/AGENTS.md + issue body
-[infra #809 11:07:30] PLAN: helmfile layout confirmed; kind config approach selected
-[infra #809 11:07:31] CODE: writing infra/kind/cluster.yaml, helmfile.yaml
-[infra #809 11:18:44] VALIDATE: helm lint infra/charts/...
-[infra #809 11:19:10] COMMIT: lint clean; staging files
-[infra #809 11:19:25] PR: opening PR against main
-[infra #809 11:19:40] CI_WAIT: waiting for required checks on PR #NNN
-[infra #809 11:34:02] DONE: PR #NNN merged; issue #809 closed
+[infra #809 11:05:00] START: feat(infra): kind cluster bootstrap + helmfile  [ctx: ~10K | compress=0 | msgs=1]
+[infra #809 11:05:01] READ: loading infra/AGENTS.md + issue body  [ctx: ~13K | compress=0 | msgs=2]
+[infra #809 11:07:30] PLAN: helmfile layout confirmed; kind config approach selected  [ctx: ~14K | compress=0 | msgs=3]
+[infra #809 11:07:31] CODE: writing infra/kind/cluster.yaml, helmfile.yaml  [ctx: ~14K | compress=0 | msgs=4]
+[infra #809 11:18:44] VALIDATE: helm lint infra/charts/...  [ctx: ~17K | compress=0 | msgs=6]
+[infra #809 11:19:10] COMMIT: lint clean — handing off to git-ops  [ctx: ~18K | compress=0 | msgs=7]
+[infra #809 11:34:02] DONE: PR #NNN merged; issue #809 closed  [ctx: ~19K | compress=0 | msgs=10]
 ```
+
+---
+
+## Context tracking
+
+Maintain counters throughout the session:
+- `CTX_TOKENS` — estimated context size in K tokens (start: ~10K; +0.5–3K per file read)
+- `CTX_COMPRESSIONS` — increment each time a context compression event is detected
+- `CTX_MSGS` — increment after each message you post
+
+### Split thresholds
+
+| Condition | Action |
+|-----------|--------|
+| `CTX_COMPRESSIONS == 1` OR `CTX_TOKENS > 80K` | Log `⚠ CONTEXT GROWING` — describe split point in output; continue cautiously |
+| `CTX_COMPRESSIONS >= 2` | **STOP immediately.** Output split proposal and exit |
+
+### Split proposal format
+
+```
+⚠ CONTEXT SPLIT REQUIRED (infra #<N>)
+  Stopped at:    <phase>
+  Branch:        <branch-name> (pushed: yes/no)
+  Files written: <list>
+  Validate:      <helm lint result or "not yet run">
+  Resume point:  Spawn new infra agent at phase <PHASE> with:
+                   branch=<branch>, canvas_step=<O-step>, read_these=<2-3 files>
+```
+
+---
+
+## Handoff protocol
+
+You handle READ → PLAN → CODE → VALIDATE. Once `helm lint` is clean,
+**hand off to `git-ops`** for commit/push/PR/merge:
+
+```
+HANDOFF to git-ops:
+  from_expert:  infra
+  issue:        #<N>
+  branch:       <branch>
+  staged_files: <list>
+  commit_msg:   |
+    <type>(infra): <subject>
+
+    <why sentence>
+
+    Closes #<N>
+
+    Assisted-by: Claude/claude-sonnet-4-6
+  pr_title:     <title ≤ 72 chars>
+  pr_body_file: /tmp/pr-body-<N>.md
+  next_step:    COMMIT
+```
+
+If the issue adds a new gRPC port or service that requires Go service wiring, flag to the
+caller that `go-svc` expert is needed for the service-side changes.
 
 ---
 

--- a/.claude/commands/experts/python-adapters.md
+++ b/.claude/commands/experts/python-adapters.md
@@ -13,7 +13,7 @@ asyncio patterns, and the gRPC Python client lifecycle specific to this codebase
 Output a progress line at the start of each phase — before any tool call for that phase:
 
 ```
-[py-adapter #<N> <HH:MM:SS>] <PHASE>: <one-line description>
+[py-adapter #<N> <HH:MM:SS>] <PHASE>: <one-line description>  [ctx: ~<X>K | compress=<C> | msgs=<M>]
 ```
 
 | Phase | When to emit |
@@ -23,7 +23,7 @@ Output a progress line at the start of each phase — before any tool call for t
 | `PLAN` | After reading files; adapter-vs-SDK decision confirmed |
 | `CODE` | When beginning to create or edit source files |
 | `TEST` | Before running `make lint-python` / `make test-python` |
-| `COMMIT` | Before `git add` / `git commit` |
+| `COMMIT` | Before `git add` / `git commit` — handing off to git-ops |
 | `PR` | Before `gh pr create` |
 | `CI_WAIT` | On entering the CI polling loop |
 | `DONE` | On successful merge and cleanup |
@@ -31,15 +31,67 @@ Output a progress line at the start of each phase — before any tool call for t
 
 Example:
 ```
-[py-adapter #806 09:12:00] START: ci: zynax-sdk PyPI publish workflow
-[py-adapter #806 09:12:01] READ: loading agents/AGENTS.md + issue body
-[py-adapter #806 09:14:20] PLAN: SDK path confirmed; trusted-publisher flow selected
-[py-adapter #806 09:14:21] CODE: writing .github/workflows/pypi-publish.yml
-[py-adapter #806 09:22:10] TEST: make lint-python && make test-python
-[py-adapter #806 09:23:05] COMMIT: gates green; staging files
-[py-adapter #806 09:23:20] PR: opening PR against main
-[py-adapter #806 09:23:35] CI_WAIT: waiting for required checks on PR #NNN
-[py-adapter #806 09:38:12] DONE: PR #NNN merged; issue #806 closed
+[py-adapter #806 09:12:00] START: ci: zynax-sdk PyPI publish workflow  [ctx: ~10K | compress=0 | msgs=1]
+[py-adapter #806 09:12:01] READ: loading agents/AGENTS.md + issue body  [ctx: ~13K | compress=0 | msgs=2]
+[py-adapter #806 09:14:20] PLAN: SDK path confirmed; trusted-publisher flow selected  [ctx: ~14K | compress=0 | msgs=3]
+[py-adapter #806 09:14:21] CODE: writing .github/workflows/pypi-publish.yml  [ctx: ~14K | compress=0 | msgs=4]
+[py-adapter #806 09:22:10] TEST: make lint-python && make test-python  [ctx: ~17K | compress=0 | msgs=6]
+[py-adapter #806 09:23:05] COMMIT: gates green — handing off to git-ops  [ctx: ~18K | compress=0 | msgs=7]
+[py-adapter #806 09:38:12] DONE: PR #NNN merged; issue #806 closed  [ctx: ~19K | compress=0 | msgs=10]
+```
+
+---
+
+## Context tracking
+
+Maintain counters throughout the session:
+- `CTX_TOKENS` — estimated context size in K tokens (start: ~10K; +0.5–3K per file read)
+- `CTX_COMPRESSIONS` — increment each time a context compression event is detected
+- `CTX_MSGS` — increment after each message you post
+
+### Split thresholds
+
+| Condition | Action |
+|-----------|--------|
+| `CTX_COMPRESSIONS == 1` OR `CTX_TOKENS > 80K` | Log `⚠ CONTEXT GROWING` — describe split point in output; continue cautiously |
+| `CTX_COMPRESSIONS >= 2` | **STOP immediately.** Output split proposal and exit |
+
+### Split proposal format
+
+```
+⚠ CONTEXT SPLIT REQUIRED (py-adapter #<N>)
+  Stopped at:    STEP <N> — <phase>
+  Branch:        <branch-name> (pushed: yes/no)
+  Files written: <list>
+  Tests:         <pass/fail summary or "not yet run">
+  Resume point:  Spawn new py-adapter agent at STEP <M> with:
+                   branch=<branch>, canvas_step=<O-step>, read_these=<2-3 files>
+```
+
+---
+
+## Handoff protocol
+
+You handle READ → PLAN → CODE → TEST. Once all local gates pass,
+**hand off to `git-ops`** for commit/push/PR/merge:
+
+```
+HANDOFF to git-ops:
+  from_expert:  py-adapter
+  issue:        #<N>
+  branch:       <branch>
+  staged_files: <list>
+  commit_msg:   |
+    <type>(<scope>): <subject>
+
+    <why sentence>
+
+    Closes #<N>
+
+    Assisted-by: Claude/claude-sonnet-4-6
+  pr_title:     <title ≤ 72 chars>
+  pr_body_file: /tmp/pr-body-<N>.md
+  next_step:    COMMIT
 ```
 
 ---

--- a/.claude/commands/experts/spdd-canvas.md
+++ b/.claude/commands/experts/spdd-canvas.md
@@ -13,7 +13,7 @@ reviews, and write ADR proposals. You never write implementation code.
 Output a progress line at the start of each phase — before any tool call for that phase:
 
 ```
-[spdd #<N> <HH:MM:SS>] <PHASE>: <one-line description>
+[spdd #<N> <HH:MM:SS>] <PHASE>: <one-line description>  [ctx: ~<X>K | compress=<C> | msgs=<M>]
 ```
 
 | Phase | When to emit |
@@ -26,7 +26,7 @@ Output a progress line at the start of each phase — before any tool call for t
 | `FIX` | When applying security-review findings |
 | `ALIGN` | When setting `Status: Aligned` on the canvas |
 | `STORIES` | When creating story issues via `/spdd-story` |
-| `COMMIT` | Before `git add` / `git commit` |
+| `COMMIT` | Before `git add` / `git commit` — handing off to git-ops |
 | `PR` | Before `gh pr create` |
 | `CI_WAIT` | On entering the CI polling loop |
 | `DONE` | On successful merge and cleanup |
@@ -34,18 +34,69 @@ Output a progress line at the start of each phase — before any tool call for t
 
 Example:
 ```
-[spdd #772 08:00:00] START: epic(event-bus): M6.I — NATS JetStream implementation
-[spdd #772 08:00:01] READ: loading AGENTS.md, ADR index, issue body
-[spdd #772 08:03:10] ANALYSIS: scanning services/event-bus/, ADR-001/013/022 constraints
-[spdd #772 08:06:40] CANVAS: writing docs/spdd/772-event-bus/canvas.md
-[spdd #772 08:10:05] SECURITY: running /spdd-security-review
-[spdd #772 08:10:20] FIX: removing inline email address from N section
-[spdd #772 08:10:35] ALIGN: setting Status: Aligned
-[spdd #772 08:10:36] STORIES: creating issues #823–#828 on GitHub
-[spdd #772 08:12:00] COMMIT: staging canvas
-[spdd #772 08:12:15] PR: opening PR against main
-[spdd #772 08:12:30] CI_WAIT: waiting for required checks on PR #NNN
-[spdd #772 08:20:01] DONE: PR #NNN merged; canvas Aligned; stories ready
+[spdd #772 08:00:00] START: epic(event-bus): M6.I — NATS JetStream implementation  [ctx: ~10K | compress=0 | msgs=1]
+[spdd #772 08:00:01] READ: loading AGENTS.md, ADR index, issue body  [ctx: ~14K | compress=0 | msgs=2]
+[spdd #772 08:03:10] ANALYSIS: scanning services/event-bus/, ADR-001/013/022 constraints  [ctx: ~17K | compress=0 | msgs=3]
+[spdd #772 08:06:40] CANVAS: writing docs/spdd/772-event-bus/canvas.md  [ctx: ~17K | compress=0 | msgs=4]
+[spdd #772 08:10:05] SECURITY: running /spdd-security-review  [ctx: ~18K | compress=0 | msgs=5]
+[spdd #772 08:10:20] FIX: removing inline email address from N section  [ctx: ~18K | compress=0 | msgs=6]
+[spdd #772 08:10:35] ALIGN: setting Status: Aligned  [ctx: ~18K | compress=0 | msgs=7]
+[spdd #772 08:10:36] STORIES: creating issues #823–#828 on GitHub  [ctx: ~19K | compress=0 | msgs=8]
+[spdd #772 08:12:00] COMMIT: handing off to git-ops for commit+PR  [ctx: ~20K | compress=0 | msgs=9]
+[spdd #772 08:20:01] DONE: PR #NNN merged; canvas Aligned; stories ready  [ctx: ~20K | compress=0 | msgs=11]
+```
+
+---
+
+## Context tracking
+
+Maintain counters throughout the session:
+- `CTX_TOKENS` — estimated context size in K tokens (start: ~10K; +0.5–3K per file read)
+- `CTX_COMPRESSIONS` — increment each time a context compression event is detected
+- `CTX_MSGS` — increment after each message you post
+
+### Split thresholds
+
+| Condition | Action |
+|-----------|--------|
+| `CTX_COMPRESSIONS == 1` OR `CTX_TOKENS > 80K` | Log `⚠ CONTEXT GROWING` — describe current canvas state and which O-steps remain |
+| `CTX_COMPRESSIONS >= 2` | **STOP immediately.** Output split proposal and exit |
+
+### Split proposal format
+
+```
+⚠ CONTEXT SPLIT REQUIRED (spdd #<N>)
+  Stopped at:    <phase>
+  Canvas:        docs/spdd/<N>-<slug>/canvas.md — Status: <Draft|Aligned>
+  Stories:       created: <list or "none yet">; pending: <O-steps not yet issued>
+  Resume point:  Spawn new spdd agent at phase <PHASE>:
+                   epic=<N>, canvas_status=<status>, next_ostep=<N>
+```
+
+---
+
+## Handoff protocol
+
+You handle analysis → canvas → security → align → stories. For commit/PR/merge,
+**hand off to `git-ops`**:
+
+```
+HANDOFF to git-ops:
+  from_expert:  spdd
+  issue:        #<N>
+  branch:       <branch>
+  staged_files: docs/spdd/<N>-<slug>/canvas.md
+  commit_msg:   |
+    docs(spdd): REASONS Canvas for EPIC #<N> — <slug>
+
+    Canvas Status: Aligned. Stories #<list> created.
+
+    Closes #<N> (canvas work only; O-step stories tracked separately)
+
+    Assisted-by: Claude/claude-sonnet-4-6
+  pr_title:     docs(spdd): REASONS Canvas for EPIC #<N> — <slug>
+  pr_body_file: /tmp/pr-body-<N>.md
+  next_step:    COMMIT
 ```
 
 ---

--- a/.claude/commands/m6-issue-generate.md
+++ b/.claude/commands/m6-issue-generate.md
@@ -171,12 +171,41 @@ echo "║  TAG:    $EXPERT_TAG   ISSUE: #$ISSUE_N"
 echo "║  TITLE:  $ISSUE_TITLE"
 echo "╚══════════════════════════════════════════════════════════╝"
 echo ""
-echo "[$EXPERT_TAG #$ISSUE_N $(date +%H:%M:%S)] START: $ISSUE_TITLE"
+echo "[$EXPERT_TAG #$ISSUE_N $(date +%H:%M:%S)] START: $ISSUE_TITLE  [ctx: ~${CTX_TOKENS}K | compress=${CTX_COMPRESSIONS} | msgs=${CTX_MSGS}]"
 ```
 
 Use this log format at every subsequent step:
 ```
-[$EXPERT_TAG #$ISSUE_N $(date +%H:%M:%S)] <PHASE>: <one-line description>
+[$EXPERT_TAG #$ISSUE_N $(date +%H:%M:%S)] <PHASE>: <one-line description>  [ctx: ~${CTX_TOKENS}K | compress=${CTX_COMPRESSIONS} | msgs=${CTX_MSGS}]
+```
+
+Initialize context counters immediately after the banner:
+```bash
+# Context tracking — same kilotoken unit as Claude Code displays
+CTX_TOKENS=10        # starting context: system prompt + expert file ≈ 10K
+CTX_COMPRESSIONS=0   # incremented if Claude compacts context during this session
+CTX_MSGS=1           # count of messages posted so far
+
+# Helpers — call after each state change:
+ctx_file_read() { CTX_TOKENS=$((CTX_TOKENS + 1)); }        # call after each file read
+ctx_msg_sent()  { CTX_TOKENS=$((CTX_TOKENS + 1)); CTX_MSGS=$((CTX_MSGS + 1)); }
+
+# Check split thresholds before each major step:
+check_ctx_budget() {
+  if [ "$CTX_COMPRESSIONS" -ge 2 ] || [ "$CTX_TOKENS" -ge 140 ]; then
+    echo "⚠ CONTEXT SPLIT REQUIRED ($EXPERT_TAG #$ISSUE_N)"
+    echo "  Stopped at:    $(date +%H:%M:%S)  [ctx: ~${CTX_TOKENS}K | compress=${CTX_COMPRESSIONS} | msgs=${CTX_MSGS}]"
+    echo "  Branch:        ${BRANCH:-not yet created} (pushed: ${BRANCH_PUSHED:-no})"
+    echo "  Canvas:        ${CANVAS_PATH:-N/A} — Status: ${CANVAS_STATUS:-N/A}"
+    echo "  Resume point:  Spawn new $EXPERT_TAG agent at STEP $CURRENT_STEP with:"
+    echo "                   issue=${ISSUE_N}, branch=${BRANCH:-none}, read_these=<2-3 files>"
+    gh issue edit "$ISSUE_N" --remove-label "status: in-progress" 2>/dev/null || true
+    exit 1
+  fi
+  if [ "$CTX_COMPRESSIONS" -ge 1 ] || [ "$CTX_TOKENS" -ge 80 ]; then
+    echo "⚠ CONTEXT GROWING ($EXPERT_TAG #$ISSUE_N): ~${CTX_TOKENS}K tokens, ${CTX_COMPRESSIONS} compressions — proceed cautiously"
+  fi
+}
 ```
 
 ---
@@ -233,7 +262,8 @@ NEEDS_CANVAS=false
 Skip this step if `COMMIT_TYPE != "feat"` or if the canvas is already `Aligned`.
 
 ```bash
-echo "[$EXPERT_TAG #$ISSUE_N $(date +%H:%M:%S)] CANVAS: running SPDD pipeline for EPIC #$EPIC_N"
+CURRENT_STEP="4-CANVAS"; check_ctx_budget
+echo "[$EXPERT_TAG #$ISSUE_N $(date +%H:%M:%S)] CANVAS: running SPDD pipeline for EPIC #$EPIC_N  [ctx: ~${CTX_TOKENS}K | compress=${CTX_COMPRESSIONS} | msgs=${CTX_MSGS}]"
 ```
 
 ```bash
@@ -281,7 +311,8 @@ STORY_COUNT=$(gh issue list --milestone "K8s Production-Ready (M6)" --state all 
 ## STEP 5 — Sync main + create branch (atomic hard claim)
 
 ```bash
-echo "[$EXPERT_TAG #$ISSUE_N $(date +%H:%M:%S)] CLAIM: creating branch + hard claim on origin"
+CURRENT_STEP="5-CLAIM"; check_ctx_budget
+echo "[$EXPERT_TAG #$ISSUE_N $(date +%H:%M:%S)] CLAIM: creating branch + hard claim on origin  [ctx: ~${CTX_TOKENS}K | compress=${CTX_COMPRESSIONS} | msgs=${CTX_MSGS}]"
 # Worktree was created from origin/main in STEP 2.5 — already clean and up to date.
 
 # Derive branch name from issue title: <type>/<N>-<slug>
@@ -306,7 +337,8 @@ echo "Hard-claimed: branch $BRANCH pushed to origin."
 ## STEP 6 — Implement
 
 ```bash
-echo "[$EXPERT_TAG #$ISSUE_N $(date +%H:%M:%S)] CODE: implementing — reading issue scope and referenced files"
+CURRENT_STEP="6-CODE"; check_ctx_budget
+echo "[$EXPERT_TAG #$ISSUE_N $(date +%H:%M:%S)] CODE: implementing — reading issue scope and referenced files  [ctx: ~${CTX_TOKENS}K | compress=${CTX_COMPRESSIONS} | msgs=${CTX_MSGS}]"
 ```
 
 For `feat:` issues with an Aligned canvas, use `/spdd-generate`:
@@ -336,7 +368,8 @@ body's scope and acceptance criteria. Read all referenced files before writing a
 ## STEP 7 — Local verification gates
 
 ```bash
-echo "[$EXPERT_TAG #$ISSUE_N $(date +%H:%M:%S)] TEST: running local gates (build, test, lint, security)"
+CURRENT_STEP="7-TEST"; check_ctx_budget
+echo "[$EXPERT_TAG #$ISSUE_N $(date +%H:%M:%S)] TEST: running local gates (build, test, lint, security)  [ctx: ~${CTX_TOKENS}K | compress=${CTX_COMPRESSIONS} | msgs=${CTX_MSGS}]"
 ```
 
 Run all required checks before committing. Do not commit if any gate fails.
@@ -382,7 +415,8 @@ echo "All local gates passed."
 ## STEP 8 — Commit
 
 ```bash
-echo "[$EXPERT_TAG #$ISSUE_N $(date +%H:%M:%S)] COMMIT: all gates green — staging and committing"
+CURRENT_STEP="8-COMMIT"; check_ctx_budget
+echo "[$EXPERT_TAG #$ISSUE_N $(date +%H:%M:%S)] COMMIT: all gates green — staging and committing  [ctx: ~${CTX_TOKENS}K | compress=${CTX_COMPRESSIONS} | msgs=${CTX_MSGS}]"
 # Verify title length ≤ 72 chars
 echo -n "${COMMIT_TYPE}(<scope>): <subject>" | wc -c   # replace before committing
 
@@ -444,7 +478,8 @@ git push --force-with-lease
 ## STEP 9 — Open PR
 
 ```bash
-echo "[$EXPERT_TAG #$ISSUE_N $(date +%H:%M:%S)] PR: opening pull request against main"
+CURRENT_STEP="9-PR"; check_ctx_budget
+echo "[$EXPERT_TAG #$ISSUE_N $(date +%H:%M:%S)] PR: opening pull request against main  [ctx: ~${CTX_TOKENS}K | compress=${CTX_COMPRESSIONS} | msgs=${CTX_MSGS}]"
 echo -n "<title>" | wc -c   # must be ≤ 72 chars
 
 PR_URL=$(gh pr create \
@@ -463,7 +498,8 @@ echo "Opened PR #$PR_N: $PR_URL"
 ## STEP 10 — Wait for CI (blocking)
 
 ```bash
-echo "[$EXPERT_TAG #$ISSUE_N $(date +%H:%M:%S)] CI_WAIT: PR #$PR_N — waiting for required checks"
+CURRENT_STEP="10-CI"; check_ctx_budget
+echo "[$EXPERT_TAG #$ISSUE_N $(date +%H:%M:%S)] CI_WAIT: PR #$PR_N — waiting for required checks  [ctx: ~${CTX_TOKENS}K | compress=${CTX_COMPRESSIONS} | msgs=${CTX_MSGS}]"
 ```
 
 Unlike `/resume-m6`, this command waits for CI to complete before merging. This is intentional —
@@ -515,7 +551,8 @@ done
 
 ```bash
 # Only emitted when TOUCHES_IMAGE > 0:
-echo "[$EXPERT_TAG #$ISSUE_N $(date +%H:%M:%S)] IMAGE_CHECK: verifying GHCR artifact publication"
+CURRENT_STEP="11-IMAGE"; check_ctx_budget
+echo "[$EXPERT_TAG #$ISSUE_N $(date +%H:%M:%S)] IMAGE_CHECK: verifying GHCR artifact publication  [ctx: ~${CTX_TOKENS}K | compress=${CTX_COMPRESSIONS} | msgs=${CTX_MSGS}]"
 ```
 
 Skip this step if the PR diff does not touch `Dockerfile*`, `.github/workflows/*image*`,
@@ -565,7 +602,8 @@ fi
 ## STEP 12 — Rebase + squash-merge
 
 ```bash
-echo "[$EXPERT_TAG #$ISSUE_N $(date +%H:%M:%S)] MERGE: CI green — rebasing and squash-merging PR #$PR_N"
+CURRENT_STEP="12-MERGE"; check_ctx_budget
+echo "[$EXPERT_TAG #$ISSUE_N $(date +%H:%M:%S)] MERGE: CI green — rebasing and squash-merging PR #$PR_N  [ctx: ~${CTX_TOKENS}K | compress=${CTX_COMPRESSIONS} | msgs=${CTX_MSGS}]"
 git fetch origin --prune
 git checkout "$BRANCH"
 git rebase origin/main || {
@@ -638,7 +676,7 @@ if [ -n "$EPIC_N" ] && [ "$EPIC_N" != "$ISSUE_N" ]; then
   fi
 fi
 
-echo "[$EXPERT_TAG #$ISSUE_N $(date +%H:%M:%S)] DONE: PR #$PR_N merged — issue #$ISSUE_N closed"
+echo "[$EXPERT_TAG #$ISSUE_N $(date +%H:%M:%S)] DONE: PR #$PR_N merged — issue #$ISSUE_N closed  [ctx: ~${CTX_TOKENS}K | compress=${CTX_COMPRESSIONS} | msgs=${CTX_MSGS}]"
 
 cat << EOF
 === DONE: Issue #${ISSUE_N} ===

--- a/.claude/commands/m6-orchestrate.md
+++ b/.claude/commands/m6-orchestrate.md
@@ -107,8 +107,11 @@ Using the same classification logic as `/m6-plan`:
 Report the selected batch and their expert routing before dispatching:
 
 ```bash
+# Build the issues list string for log tags
+ISSUES_LIST=$(echo "$BATCH_ISSUES" | tr ' ' ',' | sed 's/^/#/;s/,/,#/g')
+
 echo ""
-echo "=== [orchestrator $(date +%H:%M:%S)] BATCH SELECTED — $BATCH_SIZE issues ==="
+echo "=== [orchestrator issues:${ISSUES_LIST} $(date +%H:%M:%S)] BATCH SELECTED — $BATCH_SIZE issues ==="
 # For each issue in the batch, print: #N → <expert-tag>  <title>
 # e.g.:
 #   #823 → go-svc      feat(event-bus): service scaffold
@@ -154,7 +157,7 @@ After applying the routing table, emit one log line per issue:
 
 ```bash
 # For each issue N with resolved expert tag E:
-echo "[orchestrator $(date +%H:%M:%S)] ROUTE: #$N → $E  ($ISSUE_TITLE)"
+echo "[orchestrator issues:${ISSUES_LIST} $(date +%H:%M:%S)] ROUTE: #$N → $E  ($ISSUE_TITLE)"
 ```
 
 ---
@@ -166,7 +169,7 @@ Spawn one Agent per claimed issue. All are run in background (parallel).
 For each issue N with expert E, log before spawning:
 
 ```bash
-echo "[orchestrator $(date +%H:%M:%S)] DISPATCH: #$N → $E — $ISSUE_TITLE"
+echo "[orchestrator issues:${ISSUES_LIST} $(date +%H:%M:%S)] DISPATCH: #$N → $E — $ISSUE_TITLE"
 ```
 
 Then spawn:
@@ -217,16 +220,21 @@ As each agent completes, extract:
 2. CI status (green / red / pending)
 3. `## Session Learnings` block
 
-Emit a log line as each result arrives:
+Emit a log line as each result arrives. Extract context stats from the agent's Session Learnings
+block (look for `ctx_peak` and `compressions` fields if the expert emitted them):
 
 ```bash
 # On success:
-echo "[orchestrator $(date +%H:%M:%S)] DONE:  #$N ($E) — PR #$PR_N CI:$CI_STATUS"
+echo "[orchestrator issues:${ISSUES_LIST} $(date +%H:%M:%S)] DONE:  #$N ($E) — PR #$PR_N CI:$CI_STATUS  [agent ctx: ~${AGENT_CTX_PEAK}K peak | compress=${AGENT_COMPRESSIONS} | msgs=${AGENT_MSGS}]"
 # On failure:
-echo "[orchestrator $(date +%H:%M:%S)] FAIL:  #$N ($E) — $FAIL_REASON"
+echo "[orchestrator issues:${ISSUES_LIST} $(date +%H:%M:%S)] FAIL:  #$N ($E) — $FAIL_REASON  [agent ctx: ~${AGENT_CTX_PEAK}K peak | compress=${AGENT_COMPRESSIONS}]"
 ```
 
+Parse `AGENT_CTX_PEAK`, `AGENT_COMPRESSIONS`, `AGENT_MSGS` from the last `[ctx: ...]` line in the
+agent's output (fall back to `?` if the agent didn't emit ctx stats).
+
 For any agent that reported CI failure: report to user with the failing check name.
+For any agent with `compress >= 1` in its result: flag it — that expert may need splitting next time.
 Do not retry automatically — human intervention required for CI failures.
 
 ---
@@ -293,3 +301,27 @@ Next: run /m6-plan to see the next available batch.
 
 If you find yourself reading a code file in the orchestrator context: stop. Spawn an expert
 subagent instead.
+
+---
+
+## Orchestrator context tracking
+
+The orchestrator's own context is intentionally tiny (planning state only, no code).
+Track it with the same format as experts:
+
+```bash
+# Emit at the start and after each major step:
+echo "[orchestrator issues:${ISSUES_LIST} $(date +%H:%M:%S)] <PHASE>: <desc>  [ctx: ~<X>K | agents:<A>/<B> running]"
+```
+
+Heuristics:
+- After STEP 1 (reading 2 files + GitHub JSON): **~15K**
+- Each expert subagent result added: **+2–5K**
+- Expected peak for a 3-agent batch: **~30–40K**
+
+### Orchestrator split thresholds
+
+| Condition | Action |
+|-----------|--------|
+| `CTX_TOKENS > 60K` | Stop claiming new issues — only collect existing agent results |
+| `CTX_TOKENS > 100K` OR `CTX_COMPRESSIONS >= 1` | **STOP. Report collected results so far.** Let the human run `/m6-plan` for the next batch. |


### PR DESCRIPTION
## Summary

- New `git-ops` expert (`experts/git-ops.md`) — handoff-only specialist for all git mechanics (branch claim, DCO commit, rebase, PR lifecycle, cleanup); invoked by domain experts rather than directly
- All 6 existing domain experts updated with context tracking: `~XK | compress=C | msgs=M` format (same kilotoken unit as Claude Code's display), auto split thresholds at 80K warn / 140K stop, structured split proposals, and handoff-to-git-ops protocol
- `/m6-orchestrate` upgraded: log tags now include the full issue list `[orchestrator issues:#N1,#N2,#N3 HH:MM:SS]`, agent context peak stats surfaced on DONE/FAIL lines, orchestrator-level context budget added
- `/m6-issue-generate` upgraded: `check_ctx_budget()` called before every major step; all phase echoes include live context stats

## Test plan
- [ ] Read `.claude/commands/experts/git-ops.md` — verify handoff payload schema and split proposal format are complete
- [ ] Read any domain expert and verify `[ctx: ~XK | compress=C | msgs=M]` appears in the log format spec and example
- [ ] Read `m6-orchestrate.md` — verify `[orchestrator issues:#N1,#N2,#N3 HH:MM:SS]` format on ROUTE/DISPATCH/DONE lines
- [ ] Read `m6-issue-generate.md` — verify `check_ctx_budget()` call and `CTX_TOKENS` initialization appear after STEP 3.5 banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)
