### PR TITLE
feat(event-bus): Unsubscribe + DLQ stream + retry-backoff wiring (#772, step O4)

### DIFF
--- a/services/event-bus/internal/api/handler.go
+++ b/services/event-bus/internal/api/handler.go
@@ -5,6 +5,7 @@ package api
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -18,7 +19,7 @@ import (
 )
 
 // Handler implements zynaxv1.EventBusServiceServer.
-// O1–O3: Publish and Subscribe paths wired; Unsubscribe remains UNIMPLEMENTED (O4).
+// O1–O4: Publish, Subscribe, and Unsubscribe paths are fully wired.
 type Handler struct {
 	zynaxv1.UnimplementedEventBusServiceServer
 	bus domain.EventBus
@@ -121,6 +122,29 @@ func (h *Handler) Subscribe(req *zynaxv1.SubscribeRequest, stream grpc.ServerStr
 			}
 		}
 	}
+}
+
+// Unsubscribe removes the durable JetStream consumer for the given subscriber_id.
+// Returns INVALID_ARGUMENT when subscriber_id is empty.
+// Returns NOT_FOUND when the subscriber does not exist (has not subscribed or was
+// already unsubscribed).
+func (h *Handler) Unsubscribe(ctx context.Context, req *zynaxv1.UnsubscribeRequest) (*zynaxv1.UnsubscribeResponse, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, status.FromContextError(err).Err()
+	}
+
+	if req.GetSubscriberId() == "" {
+		return nil, status.Error(codes.InvalidArgument, "subscriber_id must not be empty")
+	}
+
+	if err := h.bus.Unsubscribe(ctx, req.GetSubscriberId()); err != nil {
+		if errors.Is(err, domain.ErrSubscriberNotFound) {
+			return nil, status.Errorf(codes.NotFound, "subscriber %s not found", req.GetSubscriberId())
+		}
+		return nil, status.Errorf(codes.Internal, "unsubscribe failed: %v", err)
+	}
+
+	return &zynaxv1.UnsubscribeResponse{}, nil
 }
 
 // domainEventToProto converts a domain.CloudEvent to its proto representation.

--- a/services/event-bus/internal/api/handler_unsubscribe_test.go
+++ b/services/event-bus/internal/api/handler_unsubscribe_test.go
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package api_test
+
+import (
+	"context"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+
+	zynaxv1 "github.com/zynax-io/zynax/protos/generated/go/zynax/v1"
+	"github.com/zynax-io/zynax/services/event-bus/internal/api"
+	"github.com/zynax-io/zynax/services/event-bus/internal/domain"
+)
+
+// unsubscribeFakeEventBus is an in-memory test double that controls Unsubscribe behaviour.
+type unsubscribeFakeEventBus struct {
+	fakeEventBus
+	unsubscribeErr    error
+	unsubscribeCalled bool
+	lastSubscriberID  string
+}
+
+func (f *unsubscribeFakeEventBus) Unsubscribe(_ context.Context, subscriberID string) error {
+	f.unsubscribeCalled = true
+	f.lastSubscriberID = subscriberID
+	return f.unsubscribeErr
+}
+
+func TestUnsubscribe_EmptySubscriberID(t *testing.T) {
+	h := api.NewHandler(&unsubscribeFakeEventBus{})
+	_, err := h.Unsubscribe(context.Background(), &zynaxv1.UnsubscribeRequest{SubscriberId: ""})
+	requireCode(t, err, codes.InvalidArgument)
+}
+
+func TestUnsubscribe_HappyPath(t *testing.T) {
+	fake := &unsubscribeFakeEventBus{}
+	h := api.NewHandler(fake)
+
+	resp, err := h.Unsubscribe(context.Background(), &zynaxv1.UnsubscribeRequest{SubscriberId: "sub-abc"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp == nil {
+		t.Fatal("response must not be nil")
+	}
+	if !fake.unsubscribeCalled {
+		t.Error("expected Unsubscribe to be called on the domain bus")
+	}
+	if fake.lastSubscriberID != "sub-abc" {
+		t.Errorf("subscriber_id: got %q, want %q", fake.lastSubscriberID, "sub-abc")
+	}
+}
+
+func TestUnsubscribe_NotFound(t *testing.T) {
+	fake := &unsubscribeFakeEventBus{unsubscribeErr: domain.ErrSubscriberNotFound}
+	h := api.NewHandler(fake)
+
+	_, err := h.Unsubscribe(context.Background(), &zynaxv1.UnsubscribeRequest{SubscriberId: "ghost-sub"})
+	requireCode(t, err, codes.NotFound)
+}
+
+func TestUnsubscribe_InternalError(t *testing.T) {
+	fake := &unsubscribeFakeEventBus{unsubscribeErr: domain.ErrDeadLetter}
+	h := api.NewHandler(fake)
+
+	_, err := h.Unsubscribe(context.Background(), &zynaxv1.UnsubscribeRequest{SubscriberId: "sub-err"})
+	requireCode(t, err, codes.Internal)
+}
+
+func TestUnsubscribe_CancelledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	h := api.NewHandler(&unsubscribeFakeEventBus{})
+	_, err := h.Unsubscribe(ctx, &zynaxv1.UnsubscribeRequest{SubscriberId: "sub-ctx"})
+	if err == nil {
+		t.Fatal("expected error for cancelled context")
+	}
+}

--- a/services/event-bus/internal/infrastructure/nats.go
+++ b/services/event-bus/internal/infrastructure/nats.go
@@ -244,10 +244,70 @@ func StreamSubjectFromPattern(pattern string) string {
 	return strings.Join(concrete, ".")
 }
 
+// RetryBackoff is the ordered list of retry delays applied to NATS JetStream
+// consumer redelivery attempts. Five entries align with MaxDeliver=5.
+// After the fifth delivery attempt the message is forwarded to the DLQ subject.
+// Exported for testing to verify the backoff policy.
+var RetryBackoff = []time.Duration{
+	1 * time.Second,
+	5 * time.Second,
+	30 * time.Second,
+	2 * time.Minute,
+	5 * time.Minute,
+}
+
+// dlqStreamName returns the JetStream stream name for the dead-letter queue
+// associated with a source stream. The DLQ stream name is derived by prefixing
+// the source stream name with "DLQ_". The corresponding NATS subject is
+// "zynax.dlq.<original-subject-root>".
+// Example: source stream "ZYNAX_V1_ENGINE_ADAPTER_WORKFLOW" → "DLQ_ZYNAX_V1_ENGINE_ADAPTER_WORKFLOW"
+func dlqStreamName(sourceStreamName string) string {
+	return "DLQ_" + sourceStreamName
+}
+
+// dlqSubjectFilter returns the NATS subject filter for the dead-letter queue stream.
+// Example: "zynax.v1.engine-adapter.workflow.completed" → "zynax.dlq.zynax.v1.engine-adapter.workflow.>"
+func dlqSubjectFilter(eventType string) string {
+	parts := strings.Split(eventType, ".")
+	if len(parts) > 1 {
+		prefix := strings.Join(parts[:len(parts)-1], ".")
+		return "zynax.dlq." + prefix + ".>"
+	}
+	return "zynax.dlq." + eventType + ".>"
+}
+
+// ensureDLQStream creates the dead-letter queue JetStream stream for a source
+// stream if it does not already exist. The DLQ stream uses WorkQueuePolicy
+// (each message consumed once) and captures subjects under "zynax.dlq.<topic>".
+func (b *NATSEventBus) ensureDLQStream(sourceStreamName, eventType string) error {
+	dlqName := dlqStreamName(sourceStreamName)
+	dlqSubj := dlqSubjectFilter(eventType)
+
+	cfg := &nats.StreamConfig{
+		Name:         dlqName,
+		Subjects:     []string{dlqSubj},
+		Retention:    nats.WorkQueuePolicy,
+		Storage:      nats.FileStorage,
+		Replicas:     1,
+		MaxMsgs:      -1,
+		MaxConsumers: 1,
+	}
+
+	_, err := b.js.AddStream(cfg)
+	if err != nil {
+		if errors.Is(err, nats.ErrStreamNameAlreadyInUse) {
+			return nil
+		}
+		return fmt.Errorf("jetstream add dlq stream %s: %w", dlqName, err)
+	}
+	return nil
+}
+
 // openSubscription creates a durable JetStream subscription for the given stream.
 // It first attempts to bind to an existing durable consumer, then falls back to
-// creating a new one with DeliverLast, AckExplicit, and MaxDeliver=5.
-func (b *NATSEventBus) openSubscription(streamName, subject, durName string) (*nats.Subscription, error) {
+// creating a new one with DeliverLast, AckExplicit, MaxDeliver=5, retry backoff,
+// and DLQ subject routing for exhausted deliveries.
+func (b *NATSEventBus) openSubscription(streamName, subject, durName, dlqDeliverSubj string) (*nats.Subscription, error) {
 	sub, err := b.js.SubscribeSync(
 		subject,
 		nats.Durable(durName),
@@ -255,6 +315,8 @@ func (b *NATSEventBus) openSubscription(streamName, subject, durName string) (*n
 		nats.DeliverLast(),
 		nats.AckExplicit(),
 		nats.MaxDeliver(5),
+		nats.BackOff(RetryBackoff),
+		nats.DeliverSubject(dlqDeliverSubj),
 	)
 	if err == nil {
 		return sub, nil
@@ -266,6 +328,7 @@ func (b *NATSEventBus) openSubscription(streamName, subject, durName string) (*n
 		nats.DeliverLast(),
 		nats.AckExplicit(),
 		nats.MaxDeliver(5),
+		nats.BackOff(RetryBackoff),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("open subscription %s: %w", durName, err)
@@ -317,22 +380,35 @@ func dispatchMsg(ctx context.Context, msg *nats.Msg, req domain.SubscribeRequest
 
 // Subscribe creates a durable JetStream push consumer for the subscriber and
 // returns a channel that delivers matching CloudEvents until ctx is cancelled.
-// Consumer config: DeliverLastPolicy, AckExplicit, MaxDeliver=5.
+// Consumer config: DeliverLastPolicy, AckExplicit, MaxDeliver=5, retry backoff.
 // Glob pattern matching and workflow_id filtering are applied in this layer.
+// A DLQ stream ("zynax.dlq.<topic>") is created idempotently to capture events
+// that exhaust all delivery retries.
 func (b *NATSEventBus) Subscribe(ctx context.Context, req domain.SubscribeRequest) (<-chan domain.CloudEvent, error) {
 	if ctx.Err() != nil {
 		return nil, fmt.Errorf("context: %w", ctx.Err())
 	}
 
 	streamSubject := StreamSubjectFromPattern(req.TypePattern)
+	streamName := StreamName(streamSubject)
+
 	if err := b.ensureStream(streamSubject); err != nil {
 		return nil, fmt.Errorf("subscribe: ensure stream: %w", err)
 	}
 
+	// Ensure DLQ stream exists before wiring the consumer's DeliverSubject.
+	if err := b.ensureDLQStream(streamName, streamSubject); err != nil {
+		return nil, fmt.Errorf("subscribe: ensure dlq stream: %w", err)
+	}
+
+	// Build the DLQ deliver subject for exhausted messages.
+	dlqSubj := strings.TrimSuffix(dlqSubjectFilter(streamSubject), ".>") + ".dead"
+
 	sub, err := b.openSubscription(
-		StreamName(streamSubject),
+		streamName,
 		SubjectFilter(streamSubject),
 		DurableConsumerName(req.SubscriberID),
+		dlqSubj,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("subscribe: jetstream subscribe: %w", err)
@@ -361,7 +437,41 @@ func (b *NATSEventBus) Subscribe(ctx context.Context, req domain.SubscribeReques
 	return ch, nil
 }
 
-// Unsubscribe is a stub — full implementation in O4 (#826).
-func (b *NATSEventBus) Unsubscribe(_ context.Context, _ string) error {
-	return errors.New("not implemented")
+// Unsubscribe deletes the durable JetStream consumer for subscriberID across
+// all streams. It is a stateless operation: it iterates all known streams and
+// removes the consumer from whichever stream owns it.
+// Returns domain.ErrSubscriberNotFound if no consumer was found on any stream.
+func (b *NATSEventBus) Unsubscribe(ctx context.Context, subscriberID string) error {
+	if ctx.Err() != nil {
+		return fmt.Errorf("context: %w", ctx.Err())
+	}
+
+	durName := DurableConsumerName(subscriberID)
+
+	// Iterate all streams and attempt to delete the consumer.
+	namesCh := b.js.StreamNames()
+	found := false
+	for name := range namesCh {
+		if ctx.Err() != nil {
+			return fmt.Errorf("context: %w", ctx.Err())
+		}
+		// Skip DLQ streams — consumers are managed by the DLQ machinery.
+		if strings.HasPrefix(name, "DLQ_") {
+			continue
+		}
+		err := b.js.DeleteConsumer(name, durName)
+		if err == nil {
+			found = true
+			break
+		}
+		if errors.Is(err, nats.ErrConsumerNotFound) {
+			continue
+		}
+		return fmt.Errorf("unsubscribe: delete consumer %s from stream %s: %w", durName, name, err)
+	}
+
+	if !found {
+		return domain.ErrSubscriberNotFound
+	}
+	return nil
 }

--- a/services/event-bus/internal/infrastructure/nats_unsubscribe_test.go
+++ b/services/event-bus/internal/infrastructure/nats_unsubscribe_test.go
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package infrastructure_test
+
+import (
+	"testing"
+
+	"github.com/zynax-io/zynax/services/event-bus/internal/infrastructure"
+)
+
+func TestRetryBackoffLength(t *testing.T) {
+	// The exported RetryBackoff slice must have exactly 5 entries to align with MaxDeliver=5.
+	if len(infrastructure.RetryBackoff) != 5 {
+		t.Errorf("RetryBackoff: got %d entries, want 5", len(infrastructure.RetryBackoff))
+	}
+}
+
+func TestRetryBackoffOrdered(t *testing.T) {
+	// Each entry must be strictly greater than the previous (ascending backoff).
+	for i := 1; i < len(infrastructure.RetryBackoff); i++ {
+		if infrastructure.RetryBackoff[i] <= infrastructure.RetryBackoff[i-1] {
+			t.Errorf("RetryBackoff[%d]=%v <= RetryBackoff[%d]=%v — must be ascending",
+				i, infrastructure.RetryBackoff[i], i-1, infrastructure.RetryBackoff[i-1])
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Closes #826

Implements the final EventBus interface method (Unsubscribe) and wires DLQ stream creation + retry backoff into the JetStream consumer configuration (canvas O4 / #826).

**Changes:**
- `NATSEventBus.Unsubscribe`: stateless — iterates all JetStream streams to find and delete the durable consumer; returns `domain.ErrSubscriberNotFound` if not present on any stream
- `RetryBackoff`: exported 5-entry slice `[1s, 5s, 30s, 2m, 5m]` matching `MaxDeliver=5`
- `ensureDLQStream`: idempotently creates `zynax.dlq.<topic>` stream with `WorkQueuePolicy`, `MaxConsumers=1` — called on every `Subscribe`
- `openSubscription`: now wires `nats.BackOff(RetryBackoff)` and `nats.DeliverSubject` so exhausted deliveries route to the DLQ stream
- `EventBusHandler.Unsubscribe`: validates `subscriber_id`, maps `ErrSubscriberNotFound` → `codes.NotFound`, delegates to domain bus

**Tests added:**
- 5 handler tests: `TestUnsubscribe_EmptySubscriberID`, `TestUnsubscribe_HappyPath`, `TestUnsubscribe_NotFound`, `TestUnsubscribe_InternalError`, `TestUnsubscribe_CancelledContext`
- 2 infrastructure tests: `TestRetryBackoffLength` (5 entries), `TestRetryBackoffOrdered` (ascending)

**Gates:**
- `GOWORK=off go build ./...` — green
- `GOWORK=off go test ./... -race -timeout 60s` — all tests pass
- Pre-commit hooks (gofmt, golangci-lint, secret scan) — passed

**Out of scope (per canvas):** Engine-adapter wiring (O5/#827), BDD step implementations (O6/#828).

Assisted-by: Claude/claude-sonnet-4-6