### PR TITLE
docs(ai-learnings): append session learnings — 2026-06-08

### DIFF
--- a/docs/ai-learnings/ci-release.md
+++ b/docs/ai-learnings/ci-release.md
@@ -85,3 +85,20 @@
 
 ### Proposed expert prompt update
 Add to CI/release expert guide: "After `gh pr create`, immediately check that the PR title subject is ≤72 characters: `echo -n '<subject>' | wc -m`. Fix via `gh api repos/.../pulls/<N> --method PATCH --field title='...'` (not `gh pr edit` which can fail on Projects Classic). After fixing, run `gh run rerun <run_id> --failed` to recheck without a new commit."
+
+## Session — 2026-06-08 (issue #860)
+
+### Avoid `make lint` before committing (Docker overwrites files)
+**Seen in:** #860. **Date:** 2026-06-08
+
+Docker-based `make lint` mounts the workspace and runs formatters (`gofmt`, `ruff-format`, etc.) which can overwrite uncommitted file changes. For pre-commit validation use targeted syntax checks (`bash -n <script>`, `python3 -c "import yaml; yaml.safe_load(...)"`, `yamllint`) instead of the full Docker lint. Run `make lint` only after the commit is in git history.
+
+### Staging only named files prevents unintended inclusions
+**Seen in:** #860. **Date:** 2026-06-08
+
+On a shared workspace where sibling agents have dirty tracked files, `git add .` picks up unrelated changes from other agents' work. Always stage specific files by path: `git add Makefile .github/workflows/tools-image.yml scripts/bump-ci-runner.sh`.
+
+### `gh run view --json jobs` for CI status
+**Seen in:** #860. **Date:** 2026-06-08
+
+`gh run view <run_id> --json status,conclusion,jobs --jq '.jobs[]'` gives a complete at-a-glance view of all job outcomes without repeated polling via `gh pr checks`.

--- a/docs/ai-learnings/go-services.md
+++ b/docs/ai-learnings/go-services.md
@@ -146,3 +146,35 @@ Always read the generated `.pb.go` file to get exact field names before writing 
 ### Proposed expert prompt update
 
 If a branch falls behind main during CI wait, never use GitHub's 'Update branch' button or API — it creates an unsigned merge commit that fails DCO. Always rebase: `git pull --rebase origin main && git push --force-with-lease`. After any force-push, verify `git log origin/main..origin/<branch>` shows only your commits; if sibling changes appear, reset and cherry-pick.
+
+## Session — 2026-06-08 (issues #818, #826)
+
+### Shell state reset pattern (critical — shared workspace)
+**Seen in:** #818, #826. **Date:** 2026-06-08
+
+The active git branch and shell cwd reset between every Bash tool call on a shared workspace.
+- Always include `git checkout <branch>` as the **first command** of any Bash call involving file edits or commits
+- Use `;` not `&&` for compound commands that must run sequentially (permission gating differs)
+- Prefer `git add <specific files>` over `git add .` — avoids staging stash-pop contamination from sibling agents
+- When `go.mod` needs updating across branch operations, use the Edit tool directly rather than `go mod tidy` (which reverts on branch switch)
+
+### Stash is dangerous across branches
+**Seen in:** #818. **Date:** 2026-06-08
+
+`git stash pop` on a different branch brings unrelated modifications into the working tree.
+Safer: `git restore -- <paths>` to discard unrelated tracked-file changes rather than stashing.
+
+### handler.go carried forward from prior step
+**Seen in:** #818. **Date:** 2026-06-08
+
+When a prior step (#817) left `handler.go` already fully wired, the current step scope was narrower than the issue implied (integration test + go.mod only). Always read `handler.go` first — don't assume UNIMPLEMENTED stubs remain.
+
+### testcontainers without modules/redis
+**Seen in:** #818. **Date:** 2026-06-08
+
+Use `testcontainers.GenericContainer{Image: "redis:7-alpine", ExposedPorts: []string{"6379/tcp"}, WaitingFor: wait.ForLog("Ready to accept connections")}` from the base `testcontainers-go` module (already an indirect dep). Avoids adding the `modules/redis` sub-dependency.
+
+### NATS DLQ pattern
+**Seen in:** #826. **Date:** 2026-06-08
+
+JetStream DLQ wiring: create `zynax.dlq.<topic>` stream with `retention=WorkQueue, MaxConsumers=1`; set `DeadLetterSubject` on the consumer; configure `BackOff: []time.Duration{1s, 5s, 30s, 120s, 300s}` matching `MaxDeliver=5`. `Unsubscribe` = delete the durable consumer by subscriber_id; handle not-found gracefully with `codes.NotFound`.


### PR DESCRIPTION
Appending learnings from batch: issues #818, #826, #860

**New entries:**
- go-services: shared-workspace branch-state reset pattern (critical), stash hazard, testcontainers without modules/redis, NATS DLQ wiring pattern
- ci-release: Docker `make lint` pre-commit hazard, named-file staging, `gh run view --json jobs` for CI status

🤖 Generated with [Claude Code](https://claude.com/claude-code)