### PR TITLE
fix(workflow-compiler): remove Action.Output — silent data loss (#581)

### DIFF
--- a/services/workflow-compiler/internal/domain/manifest.go
+++ b/services/workflow-compiler/internal/domain/manifest.go
@@ -26,11 +26,13 @@ const (
 
 // Action is a single capability invocation within a state. It holds no proto
 // types — the api layer maps Action to ActionIR when building WorkflowIR.
+//
+// Note: output mapping is not yet implemented (tracked for M7+). The parser
+// rejects any action that sets output: with ErrorCodeInvalidFieldValue.
 type Action struct {
 	Capability string
 	Timeout    time.Duration // zero means no timeout
 	Input      map[string]interface{}
-	Output     map[string]interface{}
 	Async      bool
 }
 
@@ -250,11 +252,19 @@ func convertState( //nolint:funlen // validates type + actions + transitions in 
 				})
 			}
 		}
+		if len(ya.Output) > 0 {
+			errs = append(errs, ParseError{
+				Code:      ErrorCodeInvalidFieldValue,
+				Message:   fmt.Sprintf("state %q: action %q uses output: which is not yet implemented; remove it or upgrade to M7+", name, ya.Capability),
+				Line:      line,
+				StateName: name,
+			})
+			continue
+		}
 		st.Actions = append(st.Actions, Action{
 			Capability: ya.Capability,
 			Timeout:    d,
 			Input:      ya.Input,
-			Output:     ya.Output,
 			Async:      ya.Async,
 		})
 	}

--- a/services/workflow-compiler/internal/domain/manifest_test.go
+++ b/services/workflow-compiler/internal/domain/manifest_test.go
@@ -44,8 +44,6 @@ spec:
           timeout: 30s
           input:
             text: "{{ .ctx.doc }}"
-          output:
-            ctx.summary: "{{ .result.summary }}"
         - capability: notify
           async: true
       on:
@@ -318,6 +316,44 @@ spec:
 	}
 	if errs[0].Code != ErrorCodeInvalidFieldValue {
 		t.Errorf("code = %v, want ErrorCodeInvalidFieldValue", errs[0].Code)
+	}
+}
+
+func TestParseManifest_ActionOutputRejected(t *testing.T) {
+	data := []byte(`
+kind: Workflow
+apiVersion: zynax.io/v1
+metadata:
+  name: wf
+spec:
+  initial_state: s
+  states:
+    s:
+      type: terminal
+      actions:
+        - capability: summarize
+          output:
+            ctx.result: "{{ .result.text }}"
+`)
+	_, errs := ParseManifest(context.Background(), data)
+	if len(errs) == 0 {
+		t.Fatal("expected error when output: is used on an action")
+	}
+	found := false
+	for _, e := range errs {
+		if e.Code == ErrorCodeInvalidFieldValue {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected ErrorCodeInvalidFieldValue for output: usage, got %v", errs)
+	}
+	// Verify the error message is descriptive enough to guide the user.
+	if len(errs) > 0 {
+		msg := errs[0].Message
+		if msg == "" {
+			t.Error("expected non-empty error message for output: usage")
+		}
 	}
 }
 

--- a/spec/schemas/workflow.schema.json
+++ b/spec/schemas/workflow.schema.json
@@ -155,11 +155,6 @@
           "type": "object",
           "description": "Key-value input template passed to the agent. Values may reference workflow context with expression syntax '{{ .ctx.key }}' or trigger data '{{ .trigger.field }}'.",
           "additionalProperties": true
-        },
-        "output": {
-          "type": "object",
-          "description": "Mapping from capability result fields to workflow context keys. Allows the result of this action to be consumed by subsequent states.",
-          "additionalProperties": true
         }
       }
     },


### PR DESCRIPTION
## Summary

- Removes the `output:` property from `spec/schemas/workflow.schema.json` (the Action definition)
- Removes the `Output` field from the domain `Action` struct in `manifest.go`
- Adds a compile-time `ErrorCodeInvalidFieldValue` error in `convertState` when any action uses `output:`, with message directing users to M7+
- Updates `fullValid()` test fixture to drop the `output:` example
- Adds `TestParseManifest_ActionOutputRejected` to cover the new error path

## Why

`output:` was accepted by the YAML parser and domain struct but **never** included in the generated `ActionIR`. This caused silent data loss — users writing output mappings believed they worked but the engine never received them. Option A (remove + explicit error) is the safest M6 fix; proper implementation is deferred to M7+.

## Test plan

- [ ] `GOWORK=off go test ./... -race -timeout 60s` passes in `services/workflow-compiler/`
- [ ] New test `TestParseManifest_ActionOutputRejected` verifies that `output:` triggers `ErrorCodeInvalidFieldValue`
- [ ] `make validate-spec` passes with the updated schema

Closes #581

Assisted-by: Claude/claude-sonnet-4-6