### PR TITLE
docs(infra): document SLSA attestation manifests (unknown/unknown) (#869)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -319,9 +319,6 @@ jobs:
           category: container-${{ matrix.service }}
 
       # ── Multi-arch push (only reached if trivy scan above exits 0) ────────────
-      # provenance=true (default) attaches SLSA Build L1 attestation manifests.
-      # These appear as "unknown/unknown" rows in GHCR — expected, not broken.
-      # See docs/adr/ADR-025-slsa-provenance-attestation.md for the keep decision.
       - name: Docker metadata
         id: meta
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
@@ -331,6 +328,10 @@ jobs:
             org.opencontainers.image.title=zynax-${{ matrix.service }}
             org.opencontainers.image.description=Zynax ${{ matrix.service }} service image
 
+      # provenance=true (default) attaches SLSA Build L1 attestation manifests.
+      # These appear as "unknown/unknown" rows in GHCR — expected, not broken.
+      # Each image gets two attestation entries: one for linux/amd64, one for linux/arm64.
+      # Manifest size ~565 bytes. See ADR-025: docs/adr/ADR-025-slsa-provenance-attestation.md
       - name: Build and push
         id: build
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0

--- a/.github/workflows/tools-image.yml
+++ b/.github/workflows/tools-image.yml
@@ -84,7 +84,8 @@ jobs:
 
       # provenance=true (default) attaches SLSA Build L1 attestation manifests.
       # These appear as "unknown/unknown" rows in GHCR — expected, not broken.
-      # See docs/adr/ADR-025-slsa-provenance-attestation.md for the keep decision.
+      # Each image gets two attestation entries: one for linux/amd64, one for linux/arm64.
+      # Manifest size ~565 bytes. See ADR-025: docs/adr/ADR-025-slsa-provenance-attestation.md
       - name: Build and push
         id: build-tools
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
@@ -190,7 +191,8 @@ jobs:
 
       # provenance=true (default) attaches SLSA Build L1 attestation manifests.
       # These appear as "unknown/unknown" rows in GHCR — expected, not broken.
-      # See docs/adr/ADR-025-slsa-provenance-attestation.md for the keep decision.
+      # Each image gets two attestation entries: one for linux/amd64, one for linux/arm64.
+      # Manifest size ~565 bytes. See ADR-025: docs/adr/ADR-025-slsa-provenance-attestation.md
       - name: Build and push ci-runner
         id: build-ci-runner
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -227,7 +227,7 @@ Observed mistakes in AI-assisted contributions — check before writing code.
 | Go best practices — service layout, context, `crypto/subtle`, `ReadHeaderTimeout`, gRPC deadlines | `docs/engineering/best-practices/go.md` |
 | Python best practices — mypy strict, Agent base class, Pydantic Settings, async gRPC, bandit | `docs/engineering/best-practices/python.md` |
 | Dockerfile best practices — multi-stage, distroless, HEALTHCHECK, version pinning | `docs/engineering/best-practices/dockerfiles.md` |
-| GitHub CI best practices — SHA-pinned actions, least-privilege, concurrency, ci-runner usage | `docs/engineering/best-practices/github-ci.md` |
+| GitHub CI best practices — SHA-pinned actions, least-privilege, concurrency, ci-runner usage, GHCR hygiene (unknown/unknown = SLSA attestations per ADR-025) | `docs/engineering/best-practices/github-ci.md` |
 | Architecture patterns — hexagonal, WorkflowEngine strategy, Fowler event taxonomy, outbox | `docs/engineering/best-practices/architecture-patterns.md` |
 | Dependency version policy, security scanning, upgrade cadence | `docs/engineering/dependency-strategy.md` |
 | Renovate bot CI failure fix procedure (go.sum, go directive) | `docs/engineering/renovate-fix-sop.md` |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -417,7 +417,58 @@ extra scrutiny and versioning discipline.
 
 ---
 
-## 14. First Contribution
+## 14. GHCR Package Hygiene
+
+### OCI labels vs manifest annotations
+
+Docker image metadata published to GHCR requires **both** Docker labels (for runtime
+tools like `docker inspect`) and OCI manifest annotations (for the registry UI).
+Labels are set via `org.opencontainers.image.*` in the `docker/metadata-action` labels
+block; annotations are the corresponding entries forwarded via the `annotations:` key
+in `docker/build-push-action`.  If annotations are omitted, the package description
+appears blank in the GHCR web UI even though `docker inspect` shows the correct label.
+
+### unknown/unknown rows are expected — do not delete them
+
+Every multi-arch push produces two extra entries in the GHCR Packages UI listed with
+no platform tag (`unknown/unknown`).  These are **SLSA Build L1 provenance attestation
+manifests** generated automatically by `docker buildx` (`--provenance=mode=min`).
+
+- One entry per platform variant (linux/amd64, linux/arm64).
+- Manifest size ~565 bytes; contains build invocation, GitHub Actions run ID, source
+  commit, and SLSA Build L1 statement.
+- Media type: `application/vnd.oci.image.manifest.v1+json` with
+  `vnd.docker.reference.type: attestation-manifest`.
+
+**Decision:** keep attestations enabled (see
+[ADR-025](docs/adr/ADR-025-slsa-provenance-attestation.md)).  Disabling them drops
+SLSA provenance, weakens the OpenSSF Scorecard posture, and breaks
+`cosign verify-attestation`.  The `unknown/unknown` appearance is a GHCR UI cosmetic
+issue — do not set `provenance: false` to work around it.
+
+### Verifying a published image
+
+```bash
+# Inspect the full manifest index (shows platform entries + attestation refs):
+docker buildx imagetools inspect ghcr.io/zynax-io/zynax/<image>:<tag> --raw
+
+# Verify SLSA attestation:
+cosign verify-attestation --type slsaprovenance \
+  ghcr.io/zynax-io/zynax/<image>@sha256:<digest>
+
+# Verify cosign signature (tag builds only):
+cosign verify ghcr.io/zynax-io/zynax/<image>:<version>
+```
+
+### Retention policy
+
+GHCR is capped at the last **5** `main-sha` builds per image.  `:latest` and
+`v*.*.*` tags are never pruned.  The cleanup job runs automatically after every
+successful multi-arch push (see `tools-image.yml` and `release.yml`).
+
+---
+
+## 15. First Contribution
 
 If this is your first contribution to Zynax, welcome. Here is the fastest path to
 your first merged PR:

--- a/docs/engineering/best-practices/github-ci.md
+++ b/docs/engineering/best-practices/github-ci.md
@@ -115,16 +115,63 @@ See #549 for the full per-module granularity enhancement.
 ## Release Artifacts (supply chain)
 
 The unified release workflow (`release.yml`) produces:
-- CLI binary `zynax` for darwin/linux × amd64/arm64 (4 platforms)
-- `zynax-ci` binary for the same platforms
+- CLI binary `zynax` for darwin/linux/windows × amd64/arm64 (5 platforms)
+- `zynax-ci` binary for darwin/linux × amd64/arm64 (4 platforms)
 - Service Docker images pushed to GHCR (`ghcr.io/zynax-io/zynax/<service>:v<version>`)
+- SPDX SBOM per service image (syft — attached to GitHub Release)
+- cosign keyless signature per image (tag builds and `workflow_dispatch` only)
+- SLSA Build L1 provenance attestation — generated automatically by `docker/build-push-action`
+  (see [ADR-025](../../adr/ADR-025-slsa-provenance-attestation.md) and the GHCR Package Hygiene
+  section below)
 
-**Planned (M6, #489):**
-- SBOM per artifact (syft SPDX format via `anchore/sbom-action`)
-- cosign keyless signing (`cosign sign --keyless`)
-- SLSA L2 provenance (via `slsa-framework/slsa-github-generator`)
+---
 
-Until these are implemented, do NOT claim supply-chain security in documentation.
+## GHCR Package Hygiene
+
+### OCI labels vs manifest annotations
+
+Docker image metadata requires **both** Docker labels (for `docker inspect`) and OCI
+manifest annotations (for the GHCR web UI).  Labels are set via
+`org.opencontainers.image.*` in the `docker/metadata-action` labels block; annotations
+are forwarded via the `annotations:` key in `docker/build-push-action`.  Omitting
+annotations leaves the package description blank in the GHCR UI.
+
+### unknown/unknown rows are expected — do not delete them
+
+Every multi-arch push produces two extra entries in the GHCR Packages UI labelled
+`unknown/unknown`.  These are **SLSA Build L1 provenance attestation manifests**
+generated automatically by `docker buildx` (`--provenance=mode=min`).
+
+- One entry per platform variant (linux/amd64, linux/arm64).
+- Manifest size ~565 bytes; encodes build invocation, GitHub Actions run ID, source
+  commit, and SLSA Build L1 statement.
+- Media type: `application/vnd.oci.image.manifest.v1+json` with
+  `vnd.docker.reference.type: attestation-manifest`.
+
+**Decision:** keep attestations enabled. See
+[ADR-025](../../adr/ADR-025-slsa-provenance-attestation.md).  Do **not** set
+`provenance: false` — it drops SLSA provenance, weakens the OpenSSF Scorecard posture,
+and breaks `cosign verify-attestation`.
+
+### Verifying a published image
+
+```bash
+# Inspect the full manifest index (shows platform entries + attestation refs):
+docker buildx imagetools inspect ghcr.io/zynax-io/zynax/<image>:<tag> --raw
+
+# Verify SLSA attestation:
+cosign verify-attestation --type slsaprovenance \
+  ghcr.io/zynax-io/zynax/<image>@sha256:<digest>
+
+# Verify cosign signature (tag builds only):
+cosign verify ghcr.io/zynax-io/zynax/<image>:<version>
+```
+
+### Retention policy
+
+GHCR is capped at the last **5** `main-sha` builds per image.  `:latest` and `v*.*.*`
+tags are never pruned.  The cleanup job runs automatically in `tools-image.yml` and
+`release.yml` after every successful multi-arch push.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds inline comments above every `Build and push` step in `tools-image.yml` and `release.yml` explaining that `unknown/unknown` rows in GHCR are expected SLSA Build L1 provenance attestation manifests (2 per image, ~565 bytes each), not broken entries, per ADR-025.
- Adds a "GHCR Package Hygiene" section to `CONTRIBUTING.md` (§14) covering OCI label vs annotation distinction, the unknown/unknown explanation, verify commands, and retention policy.
- Updates `docs/engineering/best-practices/github-ci.md` to remove stale "Planned M6" supply-chain items (SBOM/cosign/SLSA are now shipped) and adds the same GHCR Package Hygiene section.
- Extends the `AGENTS.md` KB index entry for `github-ci.md` to mention GHCR hygiene and ADR-025.

## Test plan

- [ ] `make lint` passes (docs-only change — no code to test)
- [ ] Verify inline comments appear directly above `Build and push` steps in both workflow files
- [ ] Verify CONTRIBUTING.md section 14 and docs/engineering/best-practices/github-ci.md GHCR Package Hygiene section render correctly
- [ ] Confirm ADR-025 cross-references resolve

Closes #869
Depends on #868 (ADR-025, already merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)