### PR TITLE
ci(infra): description-present gate and size-budget check in publish steps (#866)

### DIFF
--- a/.github/actions/report-image-meta/action.yml
+++ b/.github/actions/report-image-meta/action.yml
@@ -1,0 +1,155 @@
+# SPDX-License-Identifier: Apache-2.0
+# Composite action: report OCI image metadata after a docker/build-push-action push.
+#
+# Checks:
+#   - description annotation present (FAIL if absent)
+#   - title annotation present (WARN if absent)
+#   - per-platform compressed size vs budget (WARN if exceeded)
+#   - attestation manifest count (INFO, expected=2 for dual-arch)
+#   - index digest and applied tags (INFO)
+#
+# Size budgets:
+#   image-type=service  → WARN if any platform > 20 MB
+#   image-type=tooling  → WARN if any platform > 500 MB
+
+name: Report image metadata
+description: >
+  Query GHCR after a push, verify OCI annotations, report sizes vs budget,
+  and log attestation manifest count. Fails if the description annotation is absent.
+
+inputs:
+  image-name:
+    description: >
+      Image path under ghcr.io (without registry prefix), e.g.
+      zynax-io/zynax/tools  or  zynax-io/zynax/api-gateway
+    required: true
+  image-label:
+    description: Human-readable label shown in the step summary (e.g. tools, ci-runner, api-gateway)
+    required: true
+  digest:
+    description: The digest output from docker/build-push-action (sha256:...)
+    required: true
+  token:
+    description: GitHub token with packages:read scope (pass secrets.GITHUB_TOKEN)
+    required: true
+  image-type:
+    description: >
+      Budget class: "service" (warn >20 MB/platform) or "tooling" (warn >500 MB/platform)
+    required: false
+    default: service
+  extra-summary:
+    description: Optional extra Markdown lines appended after the digest line (no trailing newline needed)
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Check annotations and report sizes
+      shell: bash
+      env:
+        TOKEN: ${{ inputs.token }}
+        IMAGE_NAME: ${{ inputs.image-name }}
+        LABEL: ${{ inputs.image-label }}
+        DIGEST: ${{ inputs.digest }}
+        IMAGE_TYPE: ${{ inputs.image-type }}
+        EXTRA_SUMMARY: ${{ inputs.extra-summary }}
+      run: |
+        set -euo pipefail
+
+        BASE="https://ghcr.io/v2/${IMAGE_NAME}"
+        AUTH_HEADER="Authorization: Bearer ${TOKEN}"
+
+        # ── Fetch the index manifest ──────────────────────────────────────────
+        INDEX=$(curl -fsSL \
+          -H "${AUTH_HEADER}" \
+          -H "Accept: application/vnd.oci.image.index.v1+json" \
+          "${BASE}/manifests/${DIGEST}" 2>/dev/null) || true
+
+        # ── Check description annotation (FAIL if absent) ─────────────────────
+        DESCRIPTION=""
+        if [ -n "$INDEX" ]; then
+          DESCRIPTION=$(echo "$INDEX" | jq -r '.annotations["org.opencontainers.image.description"] // ""' 2>/dev/null || true)
+        fi
+
+        if [ -z "$DESCRIPTION" ]; then
+          echo "::error::Image ${IMAGE_NAME}@${DIGEST} is missing the org.opencontainers.image.description annotation. Add it via docker/metadata-action labels before pushing."
+          exit 1
+        fi
+
+        # ── Check title annotation (WARN if absent) ───────────────────────────
+        TITLE=""
+        if [ -n "$INDEX" ]; then
+          TITLE=$(echo "$INDEX" | jq -r '.annotations["org.opencontainers.image.title"] // ""' 2>/dev/null || true)
+        fi
+        if [ -z "$TITLE" ]; then
+          echo "::warning::Image ${IMAGE_NAME}@${DIGEST} is missing the org.opencontainers.image.title annotation."
+        fi
+
+        # ── Size budget thresholds ─────────────────────────────────────────────
+        if [ "$IMAGE_TYPE" = "tooling" ]; then
+          BUDGET_MB=500
+        else
+          BUDGET_MB=20
+        fi
+
+        # ── Attestation manifest count (INFO) ─────────────────────────────────
+        ATTEST_COUNT=0
+        if [ -n "$INDEX" ]; then
+          ATTEST_COUNT=$(echo "$INDEX" | jq '[.manifests[] | select(.platform.os == "unknown")] | length' 2>/dev/null || echo 0)
+        fi
+        if [ "$ATTEST_COUNT" -ne 2 ]; then
+          echo "::notice::Attestation manifests for ${IMAGE_NAME}: ${ATTEST_COUNT} (expected 2 for a dual-arch build). See ADR-025 — unknown/unknown entries are SLSA provenance, this is expected."
+        else
+          echo "INFO: Attestation manifest count for ${IMAGE_NAME}: ${ATTEST_COUNT} (expected 2) — OK"
+        fi
+
+        # ── Write step summary header ──────────────────────────────────────────
+        {
+          echo "## ${LABEL}"
+          echo "**Digest:** \`${DIGEST}\`"
+          if [ -n "$EXTRA_SUMMARY" ]; then
+            echo ""
+            echo "$EXTRA_SUMMARY"
+          fi
+          echo ""
+          echo "| Platform | Compressed size | Budget |"
+          echo "|----------|-----------------|--------|"
+        } >> "$GITHUB_STEP_SUMMARY"
+
+        # ── Per-platform sizes ─────────────────────────────────────────────────
+        SIZE_WARN=false
+        if [ -n "$INDEX" ]; then
+          while IFS='|' read -r osname arch pdigs; do
+            MF=$(curl -fsSL \
+              -H "${AUTH_HEADER}" \
+              -H "Accept: application/vnd.oci.image.manifest.v1+json" \
+              "${BASE}/manifests/${pdigs}" 2>/dev/null) || true
+            if [ -n "$MF" ]; then
+              BYTES=$(echo "$MF" | jq '[.layers[].size] | add // 0')
+              SIZE_MB=$(echo "scale=1; ${BYTES} / 1048576" | bc)
+              # Integer comparison: strip decimal for threshold check
+              SIZE_INT=$(echo "$SIZE_MB" | cut -d'.' -f1)
+              if [ "${SIZE_INT}" -gt "${BUDGET_MB}" ]; then
+                STATUS=":warning: > ${BUDGET_MB} MB"
+                SIZE_WARN=true
+              else
+                STATUS="OK"
+              fi
+              echo "| ${osname}/${arch} | ${SIZE_MB} MB | ${STATUS} |" >> "$GITHUB_STEP_SUMMARY"
+            else
+              echo "| ${osname}/${arch} | — | — |" >> "$GITHUB_STEP_SUMMARY"
+            fi
+          done < <(echo "$INDEX" | jq -r \
+            '.manifests[] | select(.platform.architecture == "amd64" or .platform.architecture == "arm64") | select(.platform.os != "unknown") | [.platform.os, .platform.architecture, .digest] | join("|")' \
+            2>/dev/null)
+        else
+          echo "| (manifest unavailable) | — | — |" >> "$GITHUB_STEP_SUMMARY"
+        fi
+
+        echo "" >> "$GITHUB_STEP_SUMMARY"
+
+        # ── Emit warning annotation if any platform exceeded budget ───────────
+        if [ "$SIZE_WARN" = "true" ]; then
+          echo "::warning::One or more platforms of ${IMAGE_NAME} exceed the ${BUDGET_MB} MB compressed size budget."
+        fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -346,39 +346,13 @@ jobs:
           annotations: ${{ steps.meta.outputs.annotations }}
 
       - name: Report image sizes
-        env:
-          TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          SVC="${{ matrix.service }}"
-          DIGEST="${{ steps.build.outputs.digest }}"
-          BASE="https://ghcr.io/v2/zynax-io/zynax/${SVC}"
-          { echo "## 📦 ${SVC}"; echo "**Digest:** \`${DIGEST}\`"; echo ""; \
-            echo "| Platform | Compressed size |"; echo "|----------|-----------------|"; \
-          } >> "$GITHUB_STEP_SUMMARY"
-          INDEX=$(curl -fsSL \
-            -H "Authorization: Bearer ${TOKEN}" \
-            -H "Accept: application/vnd.oci.image.index.v1+json" \
-            "${BASE}/manifests/${DIGEST}" 2>/dev/null) || true
-          if [ -n "$INDEX" ]; then
-            while IFS='|' read -r osname arch pdigs; do
-              MF=$(curl -fsSL \
-                -H "Authorization: Bearer ${TOKEN}" \
-                -H "Accept: application/vnd.oci.image.manifest.v1+json" \
-                "${BASE}/manifests/${pdigs}" 2>/dev/null) || true
-              if [ -n "$MF" ]; then
-                BYTES=$(echo "$MF" | jq '[.layers[].size] | add // 0')
-                SIZE_MB=$(echo "scale=1; ${BYTES} / 1048576" | bc)
-                echo "| ${osname}/${arch} | ${SIZE_MB} MB |" >> "$GITHUB_STEP_SUMMARY"
-              else
-                echo "| ${osname}/${arch} | — |" >> "$GITHUB_STEP_SUMMARY"
-              fi
-            done < <(echo "$INDEX" | jq -r \
-              '.manifests[] | select(.platform.architecture == "amd64" or .platform.architecture == "arm64") | select(.platform.os != "unknown") | [.platform.os, .platform.architecture, .digest] | join("|")' \
-              2>/dev/null)
-          else
-            echo "| (manifest unavailable) | — |" >> "$GITHUB_STEP_SUMMARY"
-          fi
-          echo "" >> "$GITHUB_STEP_SUMMARY"
+        uses: ./.github/actions/report-image-meta
+        with:
+          image-name: zynax-io/zynax/${{ matrix.service }}
+          image-label: ${{ matrix.service }}
+          digest: ${{ steps.build.outputs.digest }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          image-type: service
 
       - name: Install cosign
         if: github.ref_type == 'tag' || github.event_name == 'workflow_dispatch'

--- a/.github/workflows/tools-image.yml
+++ b/.github/workflows/tools-image.yml
@@ -101,27 +101,13 @@ jobs:
           annotations: ${{ steps.meta.outputs.annotations }}
 
       - name: Report tools image size
-        env:
-          TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          DIGEST="${{ steps.build-tools.outputs.digest }}"
-          BASE="https://ghcr.io/v2/${{ env.IMAGE_NAME }}"
-          { echo "## 📦 tools"; echo "**Digest:** \`${DIGEST}\`"; echo ""; \
-            echo "| Platform | Compressed size |"; echo "|----------|-----------------|"; \
-          } >> "$GITHUB_STEP_SUMMARY"
-          INDEX=$(curl -fsSL -H "Authorization: Bearer ${TOKEN}" \
-            -H "Accept: application/vnd.oci.image.index.v1+json" \
-            "${BASE}/manifests/${DIGEST}" 2>/dev/null) || true
-          if [ -n "$INDEX" ]; then
-            while IFS='|' read -r osname arch pdigs; do
-              MF=$(curl -fsSL -H "Authorization: Bearer ${TOKEN}" \
-                -H "Accept: application/vnd.oci.image.manifest.v1+json" \
-                "${BASE}/manifests/${pdigs}" 2>/dev/null) || true
-              [ -n "$MF" ] && echo "| ${osname}/${arch} | $(echo "$MF" | jq '[.layers[].size] | add // 0' | xargs -I{} sh -c 'echo "scale=1; {} / 1048576" | bc') MB |" >> "$GITHUB_STEP_SUMMARY" \
-                           || echo "| ${osname}/${arch} | — |" >> "$GITHUB_STEP_SUMMARY"
-            done < <(echo "$INDEX" | jq -r '.manifests[] | select(.platform.architecture == "amd64" or .platform.architecture == "arm64") | select(.platform.os != "unknown") | [.platform.os, .platform.architecture, .digest] | join("|")' 2>/dev/null)
-          fi
-          echo "" >> "$GITHUB_STEP_SUMMARY"
+        uses: ./.github/actions/report-image-meta
+        with:
+          image-name: ${{ env.IMAGE_NAME }}
+          image-label: tools
+          digest: ${{ steps.build-tools.outputs.digest }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          image-type: tooling
 
       - name: Install cosign
         if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
@@ -208,28 +194,16 @@ jobs:
           annotations: ${{ steps.meta.outputs.annotations }}
 
       - name: Report ci-runner digest and sizes
-        env:
-          TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          DIGEST="${{ steps.build-ci-runner.outputs.digest }}"
-          BASE="https://ghcr.io/v2/${{ env.CI_RUNNER_IMAGE }}"
-          { echo "## 📦 ci-runner"; echo "**Digest:** \`${DIGEST}\`"; \
-            echo ""; echo "> Update \`config/ci-runner-digest.txt\` and all \`ci.yml / pr-checks.yml / _test-*.yml\` references to \`${DIGEST}\`"; \
-            echo ""; echo "| Platform | Compressed size |"; echo "|----------|-----------------|"; \
-          } >> "$GITHUB_STEP_SUMMARY"
-          INDEX=$(curl -fsSL -H "Authorization: Bearer ${TOKEN}" \
-            -H "Accept: application/vnd.oci.image.index.v1+json" \
-            "${BASE}/manifests/${DIGEST}" 2>/dev/null) || true
-          if [ -n "$INDEX" ]; then
-            while IFS='|' read -r osname arch pdigs; do
-              MF=$(curl -fsSL -H "Authorization: Bearer ${TOKEN}" \
-                -H "Accept: application/vnd.oci.image.manifest.v1+json" \
-                "${BASE}/manifests/${pdigs}" 2>/dev/null) || true
-              [ -n "$MF" ] && echo "| ${osname}/${arch} | $(echo "$MF" | jq '[.layers[].size] | add // 0' | xargs -I{} sh -c 'echo "scale=1; {} / 1048576" | bc') MB |" >> "$GITHUB_STEP_SUMMARY" \
-                           || echo "| ${osname}/${arch} | — |" >> "$GITHUB_STEP_SUMMARY"
-            done < <(echo "$INDEX" | jq -r '.manifests[] | select(.platform.architecture == "amd64" or .platform.architecture == "arm64") | select(.platform.os != "unknown") | [.platform.os, .platform.architecture, .digest] | join("|")' 2>/dev/null)
-          fi
-          echo "" >> "$GITHUB_STEP_SUMMARY"
+        uses: ./.github/actions/report-image-meta
+        with:
+          image-name: ${{ env.CI_RUNNER_IMAGE }}
+          image-label: ci-runner
+          digest: ${{ steps.build-ci-runner.outputs.digest }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          image-type: tooling
+          extra-summary: >
+            Update `config/ci-runner-digest.txt` and all `ci.yml / pr-checks.yml / _test-*.yml`
+            references to `${{ steps.build-ci-runner.outputs.digest }}`
 
       - name: Open ci-runner bump issue
         if: github.event_name == 'push'


### PR DESCRIPTION
## Summary

- Extracts the duplicated \"Report image sizes\" shell blocks from `tools-image.yml` (tools job, ci-runner job) and `release.yml` (per-service job) into a reusable composite action at `.github/actions/report-image-meta/`.
- **Description-present gate:** Queries the OCI index manifest after push; exits 1 if `org.opencontainers.image.description` annotation is absent.
- **Title-present warning:** Emits `::warning::` if `org.opencontainers.image.title` is absent.
- **Size-budget threshold:** Warns (`::warning::`) when per-platform compressed size exceeds 20 MB (service images) or 500 MB (tooling images).
- **Attestation manifest count:** Emits `::notice::` if count ≠ 2 for a dual-arch build (INFO, never fails).

## Test plan

- [ ] CI green on this PR
- [ ] Verify composite action `action.yml` YAML is valid (actionlint would catch syntax errors)
- [ ] Manual: push a service image without description annotation → step exits 1
- [ ] Manual: push service image > 20 MB → warning in summary; tooling image > 500 MB → warning in summary

## Closes

Closes #866

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Assisted-by: Claude/claude-sonnet-4-6