### PR TITLE
chore(ci): GHCR retention cap — keep last 5 main-sha builds (#867)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,7 @@ env:
   REGISTRY: ghcr.io
   IMAGE_PREFIX: ghcr.io/zynax-io/zynax
   SYFT_VERSION: "1.44.0"
+  GHCR_KEEP_VERSIONS: "5"
 
 # ── CLI binary — 5 platforms ──────────────────────────────────────────────────
 
@@ -353,6 +354,24 @@ jobs:
           digest: ${{ steps.build.outputs.digest }}
           token: ${{ secrets.GITHUB_TOKEN }}
           image-type: service
+
+      - name: Prune old service builds
+        if: github.ref_type == 'branch'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          SVC="${{ matrix.service }}"
+          PKG="zynax%2F${SVC}"
+          KEEP="${{ env.GHCR_KEEP_VERSIONS }}"
+          IDS=$(gh api "/orgs/zynax-io/packages/container/${PKG}/versions" --paginate \
+            --jq "[.[] | select(
+                (.metadata.container.tags | any(test(\"^main-[a-f0-9]\"))) and
+                (.metadata.container.tags | all(. != \"latest\" and . != \"main\" and (test(\"^v[0-9]\") | not)))
+            ) | {id:.id,ts:.updated_at}] | sort_by(.ts) | reverse | .[${KEEP}:] | .[].id")
+          [ -z "$IDS" ] && { echo "Nothing to prune (≤${KEEP} main-sha versions)."; exit 0; }
+          echo "$IDS" | while read -r ID; do
+            gh api -X DELETE "/orgs/zynax-io/packages/container/${PKG}/versions/${ID}" && echo "Deleted version ${ID}"
+          done
 
       - name: Install cosign
         if: github.ref_type == 'tag' || github.event_name == 'workflow_dispatch'

--- a/.github/workflows/tools-image.yml
+++ b/.github/workflows/tools-image.yml
@@ -39,6 +39,7 @@ env:
   IMAGE_NAME: zynax-io/zynax/tools
   CI_RUNNER_IMAGE: zynax-io/zynax/ci-runner
   SYFT_VERSION: "1.44.0"
+  GHCR_KEEP_VERSIONS: "5"
 
 jobs:
   build-push:
@@ -143,6 +144,23 @@ jobs:
           path: tools-sbom.spdx.json
           retention-days: 7
 
+      - name: Prune old tools builds
+        if: github.event_name == 'push'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PKG="zynax%2Ftools"
+          KEEP="${{ env.GHCR_KEEP_VERSIONS }}"
+          IDS=$(gh api "/orgs/zynax-io/packages/container/${PKG}/versions" --paginate \
+            --jq "[.[] | select(
+                (.metadata.container.tags | any(test(\"^main-[a-f0-9]\"))) and
+                (.metadata.container.tags | all(. != \"latest\" and . != \"main\" and (test(\"^v[0-9]\") | not)))
+            ) | {id:.id,ts:.updated_at}] | sort_by(.ts) | reverse | .[${KEEP}:] | .[].id")
+          [ -z "$IDS" ] && { echo "Nothing to prune (≤${KEEP} main-sha versions)."; exit 0; }
+          echo "$IDS" | while read -r ID; do
+            gh api -X DELETE "/orgs/zynax-io/packages/container/${PKG}/versions/${ID}" && echo "Deleted version ${ID}"
+          done
+
   build-push-ci-runner:
     name: Build and push ci-runner image
     runs-on: ubuntu-24.04
@@ -228,3 +246,20 @@ jobs:
         run: |
           cosign sign --yes \
             "${{ env.REGISTRY }}/${{ env.CI_RUNNER_IMAGE }}@${{ steps.build-ci-runner.outputs.digest }}"
+
+      - name: Prune old ci-runner builds
+        if: github.event_name == 'push'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PKG="zynax%2Fci-runner"
+          KEEP="${{ env.GHCR_KEEP_VERSIONS }}"
+          IDS=$(gh api "/orgs/zynax-io/packages/container/${PKG}/versions" --paginate \
+            --jq "[.[] | select(
+                (.metadata.container.tags | any(test(\"^main-[a-f0-9]\"))) and
+                (.metadata.container.tags | all(. != \"latest\" and . != \"main\" and (test(\"^v[0-9]\") | not)))
+            ) | {id:.id,ts:.updated_at}] | sort_by(.ts) | reverse | .[${KEEP}:] | .[].id")
+          [ -z "$IDS" ] && { echo "Nothing to prune (≤${KEEP} main-sha versions)."; exit 0; }
+          echo "$IDS" | while read -r ID; do
+            gh api -X DELETE "/orgs/zynax-io/packages/container/${PKG}/versions/${ID}" && echo "Deleted version ${ID}"
+          done


### PR DESCRIPTION
## Summary

- Adds `GHCR_KEEP_VERSIONS: "5"` top-level env var to both `tools-image.yml` and `release.yml`
- Adds \`Prune old tools builds\` step at end of \`build-push\` job in tools-image.yml
- Adds \`Prune old ci-runner builds\` step at end of \`build-push-ci-runner\` job in tools-image.yml
- Adds \`Prune old service builds\` step at end of \`build-push-images\` job in release.yml
- Uses GHCR REST API (\`gh api\`) to delete main-sha tagged versions beyond the cap
- `:latest`, `v*.*.*` release tags, and the floating `main` tag are always retained
- Attestation manifests are deleted implicitly when their parent index version is deleted
- Only runs on branch pushes (not tag releases) via `if: github.event_name == 'push'` / `if: github.ref_type == 'branch'`

## Test plan

- [ ] After next push to main, tools/ci-runner/service packages show ≤5 main-sha versions
- [ ] `:latest` tag is always retained
- [ ] Release version tags (`v*.*.*`) are not deleted
- [ ] `make lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)