### PR TITLE
chore(ci): update ci-runner digest pin — post-merge of PR #947

### DIFF
--- a/.github/workflows/_test-go.yml
+++ b/.github/workflows/_test-go.yml
@@ -38,7 +38,7 @@ jobs:
     name: test-go
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:35e84a949a1148a07e3e036afd8f94e5410b025beaf84e323286883ad39f5abc
+      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:9e95153e50c3ed57721a94ce3394a32baeeca55242686a6dcb0d07cf03292cec
       options: --user root
     env:
       UV_LINK_MODE: copy

--- a/.github/workflows/_test-python.yml
+++ b/.github/workflows/_test-python.yml
@@ -24,7 +24,7 @@ jobs:
     name: test-python
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:35e84a949a1148a07e3e036afd8f94e5410b025beaf84e323286883ad39f5abc
+      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:9e95153e50c3ed57721a94ce3394a32baeeca55242686a6dcb0d07cf03292cec
       options: --user root
     env:
       UV_LINK_MODE: copy

--- a/.github/workflows/ai-context-budget.yml
+++ b/.github/workflows/ai-context-budget.yml
@@ -26,7 +26,7 @@ jobs:
     name: Count AI context lines
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:35e84a949a1148a07e3e036afd8f94e5410b025beaf84e323286883ad39f5abc
+      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:9e95153e50c3ed57721a94ce3394a32baeeca55242686a6dcb0d07cf03292cec
       options: --user root
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
     name: dco
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:35e84a949a1148a07e3e036afd8f94e5410b025beaf84e323286883ad39f5abc
+      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:9e95153e50c3ed57721a94ce3394a32baeeca55242686a6dcb0d07cf03292cec
       options: --user root
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -106,7 +106,7 @@ jobs:
     name: changes
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:35e84a949a1148a07e3e036afd8f94e5410b025beaf84e323286883ad39f5abc
+      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:9e95153e50c3ed57721a94ce3394a32baeeca55242686a6dcb0d07cf03292cec
       options: --user root
     needs: [dco]
     outputs:
@@ -234,7 +234,7 @@ jobs:
     name: lint-proto
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:35e84a949a1148a07e3e036afd8f94e5410b025beaf84e323286883ad39f5abc
+      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:9e95153e50c3ed57721a94ce3394a32baeeca55242686a6dcb0d07cf03292cec
       options: --user root
     needs: [changes]
     if: needs.changes.outputs.proto == 'true'
@@ -376,7 +376,7 @@ jobs:
     name: lint-go
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:35e84a949a1148a07e3e036afd8f94e5410b025beaf84e323286883ad39f5abc
+      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:9e95153e50c3ed57721a94ce3394a32baeeca55242686a6dcb0d07cf03292cec
       options: --user root
     needs: [changes]
     if: needs.changes.outputs.go == 'true'
@@ -449,7 +449,7 @@ jobs:
     name: lint-python
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:35e84a949a1148a07e3e036afd8f94e5410b025beaf84e323286883ad39f5abc
+      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:9e95153e50c3ed57721a94ce3394a32baeeca55242686a6dcb0d07cf03292cec
       options: --user root
     needs: [changes]
     if: needs.changes.outputs.python == 'true'
@@ -537,7 +537,7 @@ jobs:
     name: test-unit
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:35e84a949a1148a07e3e036afd8f94e5410b025beaf84e323286883ad39f5abc
+      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:9e95153e50c3ed57721a94ce3394a32baeeca55242686a6dcb0d07cf03292cec
       options: --user root
     needs: [test-go, test-python]
     if: >-
@@ -554,7 +554,7 @@ jobs:
     name: test-integration
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:35e84a949a1148a07e3e036afd8f94e5410b025beaf84e323286883ad39f5abc
+      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:9e95153e50c3ed57721a94ce3394a32baeeca55242686a6dcb0d07cf03292cec
       options: --user root
     needs: [changes, lint-go, lint-proto, lint-python]
     if: >-
@@ -598,7 +598,7 @@ jobs:
     name: security
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:35e84a949a1148a07e3e036afd8f94e5410b025beaf84e323286883ad39f5abc
+      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:9e95153e50c3ed57721a94ce3394a32baeeca55242686a6dcb0d07cf03292cec
       options: --user root
     needs: [dco, changes]
     if: github.event_name != 'push' || needs.changes.outputs.code == 'true'

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -44,7 +44,7 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:35e84a949a1148a07e3e036afd8f94e5410b025beaf84e323286883ad39f5abc
+      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:9e95153e50c3ed57721a94ce3394a32baeeca55242686a6dcb0d07cf03292cec
       options: --user root
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -58,7 +58,7 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:35e84a949a1148a07e3e036afd8f94e5410b025beaf84e323286883ad39f5abc
+      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:9e95153e50c3ed57721a94ce3394a32baeeca55242686a6dcb0d07cf03292cec
       options: --user root
     steps:
       - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6
@@ -87,7 +87,7 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:35e84a949a1148a07e3e036afd8f94e5410b025beaf84e323286883ad39f5abc
+      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:9e95153e50c3ed57721a94ce3394a32baeeca55242686a6dcb0d07cf03292cec
       options: --user root
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -141,7 +141,7 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:35e84a949a1148a07e3e036afd8f94e5410b025beaf84e323286883ad39f5abc
+      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:9e95153e50c3ed57721a94ce3394a32baeeca55242686a6dcb0d07cf03292cec
       options: --user root
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -185,7 +185,7 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:35e84a949a1148a07e3e036afd8f94e5410b025beaf84e323286883ad39f5abc
+      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:9e95153e50c3ed57721a94ce3394a32baeeca55242686a6dcb0d07cf03292cec
       options: --user root
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -264,7 +264,7 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:35e84a949a1148a07e3e036afd8f94e5410b025beaf84e323286883ad39f5abc
+      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:9e95153e50c3ed57721a94ce3394a32baeeca55242686a6dcb0d07cf03292cec
       options: --user root
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -301,7 +301,7 @@ jobs:
     name: Image digest alignment (images.yaml SoT)
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:35e84a949a1148a07e3e036afd8f94e5410b025beaf84e323286883ad39f5abc
+      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:9e95153e50c3ed57721a94ce3394a32baeeca55242686a6dcb0d07cf03292cec
       options: --user root
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -320,7 +320,7 @@ jobs:
     name: Secret scan (gitleaks)
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:35e84a949a1148a07e3e036afd8f94e5410b025beaf84e323286883ad39f5abc
+      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:9e95153e50c3ed57721a94ce3394a32baeeca55242686a6dcb0d07cf03292cec
       options: --user root
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/config/ci-runner-digest.txt
+++ b/config/ci-runner-digest.txt
@@ -8,4 +8,4 @@
 #     image: ghcr.io/zynax-io/zynax/ci-runner@<digest>
 #
 # Digest from last build (update after each tools-image.yml run):
-sha256:35e84a949a1148a07e3e036afd8f94e5410b025beaf84e323286883ad39f5abc
+sha256:9e95153e50c3ed57721a94ce3394a32baeeca55242686a6dcb0d07cf03292cec

--- a/images/images.yaml
+++ b/images/images.yaml
@@ -16,7 +16,7 @@ images:
 
   - name: ci-runner
     ref: ghcr.io/zynax-io/zynax/ci-runner
-    digest: sha256:35e84a949a1148a07e3e036afd8f94e5410b025beaf84e323286883ad39f5abc
+    digest: sha256:9e95153e50c3ed57721a94ce3394a32baeeca55242686a6dcb0d07cf03292cec
     consumers:
       - .github/workflows/ai-context-budget.yml
       - .github/workflows/ci.yml


### PR DESCRIPTION
## Summary

- Bump ci-runner digest from `sha256:35e84a94` → `sha256:9e95153e` in `images/images.yaml` and all 5 consumer workflow files
- Digest built at commit `370b2881c305` on 2026-06-08T08:18Z by the `tools-image.yml` workflow after PR #947 merged
- Close stale digest-bump issues #912 and #917 (superseded); implements #931

## Files changed

- `images/images.yaml` — source-of-truth digest updated
- `.github/workflows/ci.yml` — 8 pins updated
- `.github/workflows/pr-checks.yml` — 8 pins updated
- `.github/workflows/_test-go.yml` — 1 pin updated
- `.github/workflows/_test-python.yml` — 1 pin updated
- `.github/workflows/ai-context-budget.yml` — 1 pin updated
- `config/ci-runner-digest.txt` — legacy file updated for backward compat

## Test plan

- [ ] CI passes on this PR (all jobs use the new digest)
- [ ] `make check-images` passes (no divergence between images.yaml and consumers)

Closes #931

🤖 Generated with [Claude Code](https://claude.com/claude-code)