### PR TITLE
chore(ci): update http-adapter digest pin — post-merge 2026-06-08

### DIFF
--- a/infra/docker-compose/docker-compose.services.yml
+++ b/infra/docker-compose/docker-compose.services.yml
@@ -43,7 +43,7 @@ services:
 
   http-adapter:
     profiles: [dev]
-    image: ghcr.io/zynax-io/zynax/http-adapter@sha256:b12750bf90c3617078ace8b90be54c137dc50a8d4b64916ed31dd11e9f2b27df
+    image: ghcr.io/zynax-io/zynax/http-adapter@sha256:d8f48af7f0f0700d78ecf0c5cbd5406f1650a3bb79eade26144c963e4453a966
     build:
       context: ../..
       dockerfile: agents/adapters/http/Dockerfile


### PR DESCRIPTION
## Summary

Post-merge digest sync for all PRs merged on 2026-06-08.

- Update `infra/docker-compose/docker-compose.services.yml` http-adapter pin to latest GHCR version
  - **Old:** `sha256:b12750bf90c3617078ace8b90be54c137dc50a8d4b64916ed31dd11e9f2b27df`
  - **New:** `sha256:d8f48af7f0f0700d78ecf0c5cbd5406f1650a3bb79eade26144c963e4453a966`
  - Latest tag: `main-370b2881` (built from PR #929 — Dockerfile ARG+banner migration)

## Verification

- ci-runner digest: ✓ already current (`sha256:9e95153e...` matches GHCR)
- All main workflow runs: ✓ green on HEAD `8c3915c`
- Release failure on `a89c649` (PR #957): only "Report image sizes" step, image pushed correctly (fixed by #956)
- Open digest-bump issues: none

Assisted-by: Claude/claude-sonnet-4-6