### PR TITLE
docs(ai-learnings): append session learnings — 2026-06-08

### DIFF
--- a/docs/ai-learnings/ci-release.md
+++ b/docs/ai-learnings/ci-release.md
@@ -116,3 +116,18 @@ Use `gh api "/orgs/zynax-io/packages/container/${PKG}/versions" --paginate` to l
 **Seen in:** #867. **Date:** 2026-06-08
 
 Background agent branch switching causes commits to land on wrong branches. Rescue: `SHA=$(git rev-parse HEAD) && git checkout <correct-branch> && git reset --hard origin/main && git cherry-pick $SHA && git push --force-with-lease`.
+
+## Session — 2026-06-08 (orchestrator batch #824,#816,#860)
+
+### Claim-check: verify closed issues before any work
+**Seen in:** #860. **Date:** 2026-06-08
+
+`gh issue list --state open` can return issues already closed by a prior session in the same day
+(GitHub API eventual consistency lag). Before opening any branch:
+
+```bash
+gh issue view <N> --json state --jq .state           # must be OPEN
+gh pr list --state merged --search "<N>" --json number,mergedAt | jq .
+```
+
+If a merged PR references the issue: stop immediately, report the merge SHA and PR number.

--- a/docs/ai-learnings/go-services.md
+++ b/docs/ai-learnings/go-services.md
@@ -242,3 +242,21 @@ To simulate "consumer offline → event published → reconnect → catch-up": S
 **Seen in:** #819. **Date:** 2026-06-08
 
 After extracting go.mod/go.sum from a stash onto a new branch, run `GOWORK=off go mod tidy` to ensure consistency. Pre-commit hook (`golangci-lint`) auto-formats test files in-place — always re-stage after first commit attempt fails with "files were modified by hook".
+
+## Session — 2026-06-08 (orchestrator batch #824,#816,#860)
+
+### Cross-session idempotency: claim-check before any branch push
+**Seen in:** #824, #816 (and #860 ci-rel). **Date:** 2026-06-08
+
+In a multi-session environment, `gh issue list --state open` can return issues that were already
+merged by an earlier session in the same day. The claim-check step is not optional. Before the
+atomic branch push, always run both:
+
+```bash
+gh issue view <N> --json state --jq .state  # must be OPEN
+gh pr list --state merged --search "<N>" --json number,mergedAt --jq '.[] | "\(.number) \(.mergedAt)"'
+```
+
+If a merged PR referencing the issue exists: stop immediately and report the existing merge SHA
+without creating any branch or commits. Issues auto-closed by a merged PR will show CLOSED state
+but the `gh issue list --state open` query may lag due to GitHub API eventual consistency.


### PR DESCRIPTION
Appending cross-session idempotency learnings from batch: issues #824, #816, #860.

All 3 were already merged by prior sessions; agents correctly detected this and stopped.
Key learning: always verify issue+PR state before claiming, not just at batch-selection time.

Assisted-by: Claude/claude-sonnet-4-6