### PR TITLE
feat(workflow-compiler): namespace-scoped capability routing (#799, O1)

### DIFF
--- a/services/api-gateway/internal/api/handler_test.go
+++ b/services/api-gateway/internal/api/handler_test.go
@@ -37,7 +37,7 @@ type stubEngine struct {
 	watchErr    error
 }
 
-func (s *stubEngine) SubmitWorkflow(_ context.Context, _ []byte, _, _ string) (string, error) {
+func (s *stubEngine) SubmitWorkflow(_ context.Context, _ []byte, _, _, _ string) (string, error) {
 	return s.submitID, s.submitErr
 }
 

--- a/services/api-gateway/internal/domain/apply.go
+++ b/services/api-gateway/internal/domain/apply.go
@@ -107,6 +107,9 @@ func (s *ApplyService) ApplyWorkflow(ctx context.Context, req ApplyRequest) (App
 //   - Running  → return existing run_id with Status "existing"
 //   - Completed → start new run with a timestamp-suffixed ID (re-run)
 //   - Not found / failed / other terminal → start new run with hash ID
+//
+// The compiled namespace is forwarded to EnginePort.SubmitWorkflow so that
+// the engine can enforce namespace-scoped capability routing.
 func (s *ApplyService) submit(ctx context.Context, manifestYAML []byte, compiled CompileResult, engineHint string) (ApplyResult, error) {
 	workflowID := ManifestWorkflowID(manifestYAML)
 
@@ -123,7 +126,7 @@ func (s *ApplyService) submit(ctx context.Context, manifestYAML []byte, compiled
 		}
 	}
 
-	runID, err := s.engine.SubmitWorkflow(ctx, compiled.IRBytes, engineHint, workflowID)
+	runID, err := s.engine.SubmitWorkflow(ctx, compiled.IRBytes, engineHint, workflowID, compiled.Namespace)
 	if err != nil {
 		return ApplyResult{}, fmt.Errorf("api-gateway: %w", err)
 	}

--- a/services/api-gateway/internal/domain/apply_test.go
+++ b/services/api-gateway/internal/domain/apply_test.go
@@ -26,6 +26,7 @@ type stubEngine struct {
 	submitID           string
 	submitErr          error
 	capturedWorkflowID string
+	capturedNamespace  string
 	statusRun          domain.WorkflowRunSummary
 	statusErr          error
 	cancelErr          error
@@ -33,8 +34,9 @@ type stubEngine struct {
 	watchErr           error
 }
 
-func (s *stubEngine) SubmitWorkflow(_ context.Context, _ []byte, _, workflowID string) (string, error) {
+func (s *stubEngine) SubmitWorkflow(_ context.Context, _ []byte, _, workflowID, namespace string) (string, error) {
 	s.capturedWorkflowID = workflowID
+	s.capturedNamespace = namespace
 	return s.submitID, s.submitErr
 }
 
@@ -373,5 +375,57 @@ func TestApplyService_ApplyWorkflow_New_UsesHashID(t *testing.T) {
 	}
 	if engine.capturedWorkflowID != wfID {
 		t.Errorf("new workflow must use hash ID %q, got %q", wfID, engine.capturedWorkflowID)
+	}
+}
+
+// ── Namespace propagation ────────────────────────────────────────────────────
+
+func TestApplyService_ApplyWorkflow_NamespacePropagatedToEngine(t *testing.T) {
+	manifest := []byte("kind: Workflow\nmetadata:\n  name: ns-test\n")
+	engine := &stubEngine{
+		statusErr: domain.ErrNotFound,
+		submitID:  "run-ns-001",
+	}
+	svc := domain.NewApplyService(
+		&stubCompiler{result: domain.CompileResult{
+			IRBytes:   []byte("ir"),
+			Namespace: "team-a",
+		}},
+		engine,
+		&stubRegistry{},
+	)
+	_, err := svc.ApplyWorkflow(context.Background(), domain.ApplyRequest{ManifestYAML: manifest})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if engine.capturedNamespace != "team-a" {
+		t.Errorf("engine received namespace %q, want team-a", engine.capturedNamespace)
+	}
+}
+
+func TestApplyService_ApplyWorkflow_CompiledNamespaceWins(t *testing.T) {
+	// The compiled IR namespace is authoritative; the engine uses it to enforce
+	// namespace-scoped capability routing.
+	engine := &stubEngine{
+		statusErr: domain.ErrNotFound,
+		submitID:  "run-ns-002",
+	}
+	svc := domain.NewApplyService(
+		&stubCompiler{result: domain.CompileResult{
+			IRBytes:   []byte("ir"),
+			Namespace: "ns-b",
+		}},
+		engine,
+		&stubRegistry{},
+	)
+	_, err := svc.ApplyWorkflow(context.Background(), domain.ApplyRequest{
+		ManifestYAML: []byte("kind: Workflow\nmetadata:\n  name: x\n"),
+		Namespace:    "ns-a",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if engine.capturedNamespace != "ns-b" {
+		t.Errorf("engine received namespace %q, want ns-b (compiled IR namespace)", engine.capturedNamespace)
 	}
 }

--- a/services/api-gateway/internal/domain/ports.go
+++ b/services/api-gateway/internal/domain/ports.go
@@ -16,11 +16,14 @@ type CompileError struct {
 
 // CompileResult carries the outcome of a WorkflowCompilerService call.
 // IRBytes is an opaque serialised WorkflowIR proto — the domain treats it
-// as an uninterpreted byte slice.
+// as an uninterpreted byte slice. Namespace mirrors the namespace embedded
+// in the compiled WorkflowIR so that the engine port can propagate it
+// without re-deserialising the IR bytes.
 type CompileResult struct {
-	IRBytes  []byte
-	Warnings []string
-	Errors   []CompileError
+	IRBytes   []byte
+	Namespace string
+	Warnings  []string
+	Errors    []CompileError
 }
 
 // WorkflowRunSummary is the domain view of a submitted workflow execution.
@@ -49,10 +52,12 @@ type CompilerPort interface {
 
 // EnginePort is the gateway's outbound dependency on EngineAdapterService.
 type EnginePort interface {
-	// SubmitWorkflow submits irBytes to the engine under the given workflowID.
-	// The engine uses workflowID as the Temporal workflow identifier so that
+	// SubmitWorkflow submits irBytes to the engine under the given workflowID
+	// within namespace. namespace is propagated to SubmitWorkflowRequest.namespace
+	// so the engine can enforce namespace-scoped capability routing at execution
+	// time. The engine uses workflowID as the Temporal workflow identifier so that
 	// subsequent DescribeWorkflowExecution lookups find the same execution.
-	SubmitWorkflow(ctx context.Context, irBytes []byte, engineHint, workflowID string) (string, error)
+	SubmitWorkflow(ctx context.Context, irBytes []byte, engineHint, workflowID, namespace string) (string, error)
 	GetWorkflowStatus(ctx context.Context, runID string) (WorkflowRunSummary, error)
 	CancelWorkflow(ctx context.Context, runID string) error
 	// WatchWorkflow streams lifecycle events for runID, calling send for each.

--- a/services/api-gateway/internal/infrastructure/clients.go
+++ b/services/api-gateway/internal/infrastructure/clients.go
@@ -105,7 +105,9 @@ func (c *GatewayClients) CompileWorkflow(ctx context.Context, manifestYAML []byt
 // SubmitWorkflow implements domain.EnginePort.
 // workflowID overrides the compiler-assigned WorkflowId in the IR so that
 // Temporal uses the hash-derived deterministic identifier for deduplication.
-func (c *GatewayClients) SubmitWorkflow(ctx context.Context, irBytes []byte, engineHint, workflowID string) (string, error) {
+// namespace is set explicitly on the request so the engine-adapter can enforce
+// namespace-scoped capability routing without re-parsing the IR bytes.
+func (c *GatewayClients) SubmitWorkflow(ctx context.Context, irBytes []byte, engineHint, workflowID, namespace string) (string, error) {
 	ir := &zynaxv1.WorkflowIR{}
 	if err := proto.Unmarshal(irBytes, ir); err != nil {
 		return "", fmt.Errorf("api-gateway: unmarshal IR: %w", err)
@@ -116,6 +118,7 @@ func (c *GatewayClients) SubmitWorkflow(ctx context.Context, irBytes []byte, eng
 	resp, err := c.engine.SubmitWorkflow(callCtx, &zynaxv1.SubmitWorkflowRequest{
 		WorkflowIr: ir,
 		EngineHint: engineHint,
+		Namespace:  namespace,
 	})
 	if err != nil {
 		return "", mapEngineGRPCError(err)
@@ -311,6 +314,7 @@ func compileResultFromProto(resp *zynaxv1.CompileWorkflowResponse) domain.Compil
 	}
 	if ir := resp.GetWorkflowIr(); ir != nil {
 		result.IRBytes, _ = proto.Marshal(ir)
+		result.Namespace = ir.GetNamespace()
 	}
 	return result
 }

--- a/services/api-gateway/tests/steps_test.go
+++ b/services/api-gateway/tests/steps_test.go
@@ -66,7 +66,7 @@ type fakeEngine struct {
 	runID string
 }
 
-func (f *fakeEngine) SubmitWorkflow(_ context.Context, _ []byte, _, _ string) (string, error) {
+func (f *fakeEngine) SubmitWorkflow(_ context.Context, _ []byte, _, _, _ string) (string, error) {
 	if f.mode == engineUnavail {
 		return "", domain.ErrEngineUnavailable
 	}

--- a/services/workflow-compiler/internal/domain/validators/semantic.go
+++ b/services/workflow-compiler/internal/domain/validators/semantic.go
@@ -4,13 +4,21 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/zynax-io/zynax/services/workflow-compiler/internal/domain"
 )
 
-// capabilityNameRe matches snake_case capability names: lowercase letters and
-// digits, words separated by single underscores, no leading/trailing underscore.
-var capabilityNameRe = regexp.MustCompile(`^[a-z][a-z0-9]*(_[a-z0-9]+)*$`)
+// capabilityNameRe matches snake_case capability names with an optional
+// namespace qualifier prefix. Two forms are accepted:
+//
+//   - Unqualified: snake_case only (e.g. "summarize", "send_email")
+//   - Qualified:   <namespace>/<capability> where the namespace is a DNS-label
+//     (e.g. "team-a/send_email", "ns-b/summarize")
+//
+// The cross-namespace validator checks whether the namespace prefix, if present,
+// matches the workflow's own namespace.
+var capabilityNameRe = regexp.MustCompile(`^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?/)?[a-z][a-z0-9]*(_[a-z0-9]+)*$`)
 
 // eventNameRe matches dot-separated event names, e.g. "review.approved", "push".
 // Each segment is a lowercase identifier.
@@ -35,14 +43,19 @@ func (CapabilityRefValidator) Validate(_ context.Context, g *domain.WorkflowGrap
 			if !capabilityNameRe.MatchString(capName) {
 				errs = append(errs, domain.ParseError{
 					Code:      domain.ErrorCodeInvalidFieldValue,
-					Message:   fmt.Sprintf("state %q action[%d]: capability %q must be snake_case (e.g. summarize, send_email)", stateID, i, capName),
+					Message:   fmt.Sprintf("state %q action[%d]: capability %q must be snake_case or <namespace>/snake_case (e.g. summarize, send_email, team-a/send_email)", stateID, i, capName),
 					Line:      state.Line,
 					StateName: stateID,
 				})
 				continue
 			}
+			// Extract the bare capability name (strip optional namespace prefix).
+			bareCap := capName
+			if slashIdx := strings.IndexByte(capName, '/'); slashIdx >= 0 {
+				bareCap = capName[slashIdx+1:]
+			}
 			for _, prefix := range reservedPrefixes {
-				if len(capName) >= len(prefix) && capName[:len(prefix)] == prefix {
+				if len(bareCap) >= len(prefix) && bareCap[:len(prefix)] == prefix {
 					errs = append(errs, domain.ParseError{
 						Code:      domain.ErrorCodeInvalidFieldValue,
 						Message:   fmt.Sprintf("state %q action[%d]: capability %q uses reserved prefix %q", stateID, i, capName, prefix),
@@ -124,6 +137,48 @@ func (TransitionSetValidator) Validate(_ context.Context, g *domain.WorkflowGrap
 						StateName: stateID,
 					})
 				}
+			}
+		}
+	}
+	return errs
+}
+
+// CrossNamespaceCapabilityValidator rejects capability references that explicitly
+// target a namespace different from the workflow's own namespace.
+//
+// Capability names may optionally carry a namespace qualifier in the form
+// "<namespace>/<capability_name>". When a qualifier is present, it must match
+// WorkflowGraph.Namespace so that workflows cannot dispatch across namespace
+// boundaries at compile time. Unqualified capability names (no "/") are always
+// allowed — they resolve to agents in the workflow's own namespace at runtime.
+//
+// Example — rejected: workflow namespace "ns-a", capability "ns-b/send_email"
+// Example — allowed:  workflow namespace "ns-a", capability "summarize"
+// Example — allowed:  workflow namespace "ns-a", capability "ns-a/summarize"
+type CrossNamespaceCapabilityValidator struct{}
+
+// Validate implements Validator.
+func (CrossNamespaceCapabilityValidator) Validate(_ context.Context, g *domain.WorkflowGraph) []domain.ParseError {
+	var errs []domain.ParseError
+	for stateID, state := range g.States {
+		for i, action := range state.Actions {
+			capRef := action.Capability
+			slashIdx := strings.IndexByte(capRef, '/')
+			if slashIdx < 0 {
+				// Unqualified capability — resolves within the workflow's namespace.
+				continue
+			}
+			capNS := capRef[:slashIdx]
+			if capNS != g.Namespace {
+				errs = append(errs, domain.ParseError{
+					Code: domain.ErrorCodeInvalidFieldValue,
+					Message: fmt.Sprintf(
+						"state %q action[%d]: capability %q targets namespace %q but workflow namespace is %q; cross-namespace capability dispatch is not allowed",
+						stateID, i, capRef, capNS, g.Namespace,
+					),
+					Line:      state.Line,
+					StateName: stateID,
+				})
 			}
 		}
 	}

--- a/services/workflow-compiler/internal/domain/validators/semantic_test.go
+++ b/services/workflow-compiler/internal/domain/validators/semantic_test.go
@@ -21,15 +21,19 @@ func TestCapabilityRefValidator(t *testing.T) {
 		{"multi_word", "fetch_and_parse", false},
 		{"with_digits", "run_step_2", false},
 		{"single_char", "a", false},
+		{"qualified_same_ns", "team-a/send_email", false},
+		{"qualified_numeric_ns", "ns1/summarize", false},
 		{"empty", "", true},
 		{"uppercase", "Summarize", true},
 		{"leading_underscore", "_summarize", true},
 		{"trailing_underscore", "summarize_", true},
 		{"double_underscore", "send__email", true},
 		{"hyphen", "send-email", true},
+		{"qualified_invalid_cap", "ns-a/send-email", true},
 		{"reserved_zynax", "zynax_exec", true},
 		{"reserved_system", "system_log", true},
 		{"reserved_internal", "internal_ping", true},
+		{"reserved_qualified", "ns-a/zynax_exec", true},
 	}
 
 	v := validators.CapabilityRefValidator{}
@@ -211,6 +215,101 @@ func TestTransitionSetValidator_NilSetPasses(t *testing.T) {
 	})
 	if errs := (validators.TransitionSetValidator{}).Validate(context.Background(), g); len(errs) != 0 {
 		t.Errorf("expected no errors for nil set, got %v", errs)
+	}
+}
+
+// CrossNamespaceCapabilityValidator ──────────────────────────────────────────
+
+// nsA is the test namespace used across CrossNamespaceCapabilityValidator tests.
+const nsA = "ns-a"
+
+func TestCrossNamespaceCapabilityValidator_UnqualifiedAllowed(t *testing.T) {
+	g := graphWith("a", map[string]*domain.State{
+		"a": {
+			ID:   "a",
+			Type: domain.StateTypeTerminal,
+			Actions: []domain.Action{
+				{Capability: "summarize"},
+				{Capability: "send_email"},
+			},
+		},
+	})
+	g.Namespace = nsA
+	errs := (validators.CrossNamespaceCapabilityValidator{}).Validate(context.Background(), g)
+	if len(errs) != 0 {
+		t.Errorf("unqualified capabilities must be allowed, got %v", errs)
+	}
+}
+
+func TestCrossNamespaceCapabilityValidator_SameNamespaceAllowed(t *testing.T) {
+	g := graphWith("a", map[string]*domain.State{
+		"a": {
+			ID:   "a",
+			Type: domain.StateTypeTerminal,
+			Actions: []domain.Action{
+				{Capability: nsA + "/summarize"},
+			},
+		},
+	})
+	g.Namespace = nsA
+	errs := (validators.CrossNamespaceCapabilityValidator{}).Validate(context.Background(), g)
+	if len(errs) != 0 {
+		t.Errorf("same-namespace qualified capability must be allowed, got %v", errs)
+	}
+}
+
+func TestCrossNamespaceCapabilityValidator_CrossNamespaceRejected(t *testing.T) {
+	// A workflow in ns-a must not dispatch a capability qualified with ns-b.
+	g := graphWith("a", map[string]*domain.State{
+		"a": {
+			ID:   "a",
+			Type: domain.StateTypeTerminal,
+			Actions: []domain.Action{
+				{Capability: "ns-b/send_email"},
+			},
+		},
+	})
+	g.Namespace = nsA
+	errs := (validators.CrossNamespaceCapabilityValidator{}).Validate(context.Background(), g)
+	if len(errs) == 0 {
+		t.Fatal("expected error for cross-namespace capability dispatch, got none")
+	}
+	if !hasCode(errs, domain.ErrorCodeInvalidFieldValue) {
+		t.Errorf("expected ErrorCodeInvalidFieldValue, got %v", errs)
+	}
+}
+
+func TestCrossNamespaceCapabilityValidator_MultipleActionsOneViolation(t *testing.T) {
+	g := graphWith("start", map[string]*domain.State{
+		"start": {
+			ID:   "start",
+			Type: domain.StateTypeNormal,
+			Actions: []domain.Action{
+				{Capability: "summarize"},        // ok: unqualified
+				{Capability: nsA + "/summarize"}, // ok: same namespace
+				{Capability: "ns-b/send_report"}, // violation
+			},
+			Transitions: []domain.Transition{
+				{EventType: "done", TargetState: "end"},
+			},
+		},
+		"end": terminalState(),
+	})
+	g.Namespace = nsA
+	errs := (validators.CrossNamespaceCapabilityValidator{}).Validate(context.Background(), g)
+	if len(errs) != 1 {
+		t.Errorf("expected exactly 1 error, got %d: %v", len(errs), errs)
+	}
+}
+
+func TestCrossNamespaceCapabilityValidator_NoActions(t *testing.T) {
+	g := graphWith("s", map[string]*domain.State{
+		"s": terminalState(),
+	})
+	g.Namespace = "default"
+	errs := (validators.CrossNamespaceCapabilityValidator{}).Validate(context.Background(), g)
+	if len(errs) != 0 {
+		t.Errorf("expected no errors for graph with no actions, got %v", errs)
 	}
 }
 

--- a/services/workflow-compiler/internal/domain/validators/validators.go
+++ b/services/workflow-compiler/internal/domain/validators/validators.go
@@ -40,5 +40,6 @@ func All() []Validator {
 		EventNameValidator{},
 		NamespaceValidator{},
 		TransitionSetValidator{},
+		CrossNamespaceCapabilityValidator{},
 	}
 }


### PR DESCRIPTION
## Summary

- Adds `namespace` parameter to `EnginePort.SubmitWorkflow` and propagates the compiled IR namespace to `SubmitWorkflowRequest.namespace`, enabling the engine to enforce namespace isolation at execution time.
- Adds `CrossNamespaceCapabilityValidator` in workflow-compiler: rejects qualified capability references (`<namespace>/<cap>`) that target a namespace other than the workflow's own namespace; unqualified capabilities are always allowed.
- Updates `CapabilityRefValidator` regex to accept the optional `<namespace>/<cap>` format in addition to plain snake_case.
- Extracts `Namespace` from `CompileWorkflowResponse` IR into `CompileResult` so no IR re-parsing is needed downstream.

## Acceptance criteria checklist

- [x] `EnginePort.SubmitWorkflow` signature includes `namespace` parameter
- [x] `SubmitWorkflowRequest.namespace` is populated from the compiled IR namespace
- [x] workflow-compiler rejects capability resolution across namespaces
- [x] Unit test: workflow in `ns-a` cannot dispatch capability from agent in `ns-b`
- [x] Domain coverage ≥ 90% after changes (api-gateway: 94.5%, workflow-compiler: 95.3%)

## Test plan

- [x] `GOWORK=off go test ./... -race` passes in `services/api-gateway/`
- [x] `GOWORK=off go test ./... -race` passes in `services/workflow-compiler/`
- [x] All pre-commit hooks pass (gofmt, golangci-lint)
- [x] Domain coverage gate ≥ 90% verified in Docker

Closes #799
Part of #767 (M6.NS multi-namespace, O1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)