### PR TITLE
fix(ci): OCI annotations + workflow schema output field

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -444,6 +444,10 @@ jobs:
           done
 
           docker buildx imagetools create \
+            --annotation "index:org.opencontainers.image.description=Zynax ${{ matrix.service }} service" \
+            --annotation "index:org.opencontainers.image.title=${{ matrix.service }}" \
+            --annotation "index:org.opencontainers.image.source=https://github.com/${{ github.repository }}" \
+            --annotation "index:org.opencontainers.image.revision=${{ github.sha }}" \
             "${TAG_ARGS[@]}" \
             "${PREFIX}@${AMD64_DIGEST}" \
             "${PREFIX}@${ARM64_DIGEST}"

--- a/spec/schemas/workflow.schema.json
+++ b/spec/schemas/workflow.schema.json
@@ -155,6 +155,11 @@
           "type": "object",
           "description": "Key-value input template passed to the agent. Values may reference workflow context with expression syntax '{{ .ctx.key }}' or trigger data '{{ .trigger.field }}'.",
           "additionalProperties": true
+        },
+        "output": {
+          "type": "object",
+          "description": "Key-value mappings that write action result fields into the workflow context when the action completes. Keys are context paths (e.g. 'context.summary'), values are expression templates referencing the result (e.g. '{{ .result.summary }}').",
+          "additionalProperties": true
         }
       }
     },


### PR DESCRIPTION
## Summary

- **fix(ci)**: `docker buildx imagetools create` does not carry annotations from source manifests. The `report-image-meta` gate added in #866 fails when `org.opencontainers.image.description` is absent on the merged OCI index. Adds four `--annotation index:` flags to the merge step so all service images carry the required OCI metadata (description, title, source, revision).

- **fix(spec)**: `spec/schemas/workflow.schema.json` had `additionalProperties: false` on the `action` definition with no `output` property, causing `TestManifest_ValidWorkflow` and two related CLI tests to fail on main. Adds `output` as an allowed object property (the symmetrical counterpart to `input`) to match the usage in `spec/workflows/examples/code-review.yaml`.

## Root cause

PR #866 introduced the `report-image-meta` gate before `release.yml` was updated to add the annotation, leaving all service image builds in a broken state (images pushed but Report step fails → cosign signing + SBOM cancelled).

The schema gap was a pre-existing issue — the example workflow used `output` but the schema never declared it.

## Test plan

- [ ] CI `test-go` passes (schema fix resolves `TestManifest_ValidWorkflow`, `TestRunValidateManifest_ValidFile`, `TestRunValidateWorkflows_ValidManifest`)
- [ ] Post-merge: `Release` workflow `Report image sizes` step passes for any changed service
- [ ] Post-merge: cosign signing and SBOM generation no longer cancelled

Assisted-by: Claude/claude-sonnet-4-6