### PR TITLE
fix(ci): copy libs/zynaxconfig into Dockerfile.service builder stage

### DIFF
--- a/infra/docker/Dockerfile.service
+++ b/infra/docker/Dockerfile.service
@@ -17,9 +17,11 @@ FROM golang:${GO_VERSION}-alpine@${GO_ALPINE_DIGEST} AS builder
 ARG SVC
 WORKDIR /workspace
 COPY protos/generated/go/go.mod protos/generated/go/go.sum ./protos/generated/go/
+COPY libs/zynaxconfig/go.mod libs/zynaxconfig/go.sum ./libs/zynaxconfig/
 COPY services/${SVC}/go.mod services/${SVC}/go.sum ./services/${SVC}/
 RUN cd services/${SVC} && GOWORK=off go mod download
 COPY protos/generated/go/ ./protos/generated/go/
+COPY libs/zynaxconfig/ ./libs/zynaxconfig/
 COPY services/${SVC}/ ./services/${SVC}/
 COPY tools/healthcheck/ ./tools/healthcheck/
 RUN cd services/${SVC} && CGO_ENABLED=0 GOWORK=off \


### PR DESCRIPTION
## Problem

\`infra/docker/Dockerfile.service\` copies go.mod files before \`GOWORK=off go mod download\`, but \`services/task-broker/go.mod\` has a replace directive for \`../../libs/zynaxconfig\` that was not copied into the builder stage, causing \`go mod download\` to fail for task-broker.

## Consequence

\`Merge & sign\` uses \`needs: [build-platform]\` — any failing service blocks multi-arch manifest merge for ALL services. task-broker build failure silently blocked image signing and SBOM generation for every service on every main push since the service was added to the matrix.

## Fix

Two new COPY lines mirror the existing pattern for protos/generated/go/:
1. \`COPY libs/zynaxconfig/go.mod libs/zynaxconfig/go.sum\` — before go mod download
2. \`COPY libs/zynaxconfig/\` — after go mod download (source for build)

Safe for all services without the replace directive.

Closes #982

Assisted-by: Claude/claude-sonnet-4-6