### PR TITLE
fix(ci): test-unit always() — prevent SKIPPED bypass of required check (#986)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -533,6 +533,10 @@ jobs:
 # ── test-unit: required-check wrapper (branch protection gate) ────────────────
 # Branch protection requires "test-unit" to pass. This wrapper job fulfils
 # that requirement by waiting for test-go + test-python.
+# IMPORTANT: must use `if: always()` unconditionally. Using
+# `!contains(needs.*.result, 'failure')` causes the job to be SKIPPED (not
+# failed) when an upstream job fails — GitHub treats SKIPPED as neutral and
+# allows the merge, bypassing the required-check gate entirely (#986).
   test-unit:
     name: test-unit
     runs-on: ubuntu-24.04
@@ -540,13 +544,18 @@ jobs:
       image: ghcr.io/zynax-io/zynax/ci-runner@sha256:04074b10bb681e0cbeffd053b9d7cc6aaef4b7b92fd08b3a3c9ee3ede877b782
       options: --user root
     needs: [test-go, test-python]
-    if: >-
-      always() &&
-      !contains(needs.*.result, 'failure') &&
-      !contains(needs.*.result, 'cancelled')
+    if: always()
     steps:
       - name: All tests passed
-        run: echo "✅ test-go=${{ needs.test-go.result }}  test-python=${{ needs.test-python.result }}"
+        run: |
+          tg="${{ needs.test-go.result }}"
+          tp="${{ needs.test-python.result }}"
+          echo "test-go=${tg}  test-python=${tp}"
+          if [[ "${tg}" == "failure" || "${tp}" == "failure" ]]; then
+            echo "::error::test-go=${tg}  test-python=${tp}"
+            exit 1
+          fi
+          echo "✅ all tests passed or skipped"
 
 # ── Integration Tests ─────────────────────────────────────────────────────────
 # No-op skeleton until real integration tests exist (#227 / M7.C).


### PR DESCRIPTION
## Summary

- `test-unit` was SKIPPED (not failed) when `test-go` failed due to `!contains(needs.*.result, 'failure')` evaluating false
- GitHub treats SKIPPED required checks as neutral → merge allowed despite failing tests
- PR #974 merged with broken tests and 74.6% coverage (gate = 80%) via this bypass

## Change

**`.github/workflows/ci.yml`** — `test-unit` job:

```diff
-    if: >-
-      always() &&
-      !contains(needs.*.result, 'failure') &&
-      !contains(needs.*.result, 'cancelled')
+    if: always()
     steps:
       - name: All tests passed
-        run: echo "✅ ..."
+        run: |
+          if [[ "${{ needs.test-go.result }}" == "failure" || "${{ needs.test-python.result }}" == "failure" ]]; then
+            echo "::error::..."
+            exit 1
+          fi
```

## Test plan
- [ ] CI passes on this PR (test-go skipped — no code changes, path filter)
- [ ] `test-unit` shows success (not skipped) for a path-filtered PR
- [ ] `test-unit` shows **FAILED** when `test-go` fails (verifiable by forcing a test failure)

Closes #986

Assisted-by: Claude/claude-sonnet-4-6