### PR TITLE
fix(ci): coverage gates fail explicitly when coverage.out absent (#987)

### DIFF
--- a/.github/workflows/_test-go.yml
+++ b/.github/workflows/_test-go.yml
@@ -293,12 +293,16 @@ jobs:
             total=$(GOWORK=off go tool cover -func=coverage.out 2>/dev/null \
                     | grep "^total:" | awk '{print $3}' | tr -d '%')
             cd ../..
-            [ -z "$total" ] && echo "  ⚠ no coverage for cmd/zynax — skipping" && exit 0
+            if [ -z "$total" ]; then
+              echo "::error::no coverage total for cmd/zynax — test step likely failed"; exit 1
+            fi
             echo "── CLI coverage: cmd/zynax  ${total}%"
             if awk "BEGIN{exit !(${total} < ${COVERAGE_CLI_ZYNAX_GATE:-79})}"; then
               echo "  ❌ ${total}% < ${COVERAGE_CLI_ZYNAX_GATE:-79}% for cmd/zynax"; exit 1
             fi
             echo "  ✅ ${total}% ≥ ${COVERAGE_CLI_ZYNAX_GATE:-79}% for cmd/zynax"
+          else
+            echo "::error::coverage.out not found for cmd/zynax — test step likely failed"; exit 1
           fi
 
       - name: cmd/zynax-ci coverage gate (≥80%)
@@ -309,12 +313,16 @@ jobs:
             total=$(GOWORK=off go tool cover -func=coverage.out 2>/dev/null \
                     | grep "^total:" | awk '{print $3}' | tr -d '%')
             cd ../..
-            [ -z "$total" ] && echo "  ⚠ no coverage for cmd/zynax-ci — skipping" && exit 0
+            if [ -z "$total" ]; then
+              echo "::error::no coverage total for cmd/zynax-ci — test step likely failed"; exit 1
+            fi
             echo "── CLI coverage: cmd/zynax-ci  ${total}%"
             if awk "BEGIN{exit !(${total} < ${COVERAGE_CLI_ZYNAX_CI_GATE:-80})}"; then
               echo "  ❌ ${total}% < ${COVERAGE_CLI_ZYNAX_CI_GATE:-80}% for cmd/zynax-ci"; exit 1
             fi
             echo "  ✅ ${total}% ≥ ${COVERAGE_CLI_ZYNAX_CI_GATE:-80}% for cmd/zynax-ci"
+          else
+            echo "::error::coverage.out not found for cmd/zynax-ci — test step likely failed"; exit 1
           fi
 
       # ── Coverage comment ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Both `cmd/zynax` and `cmd/zynax-ci` coverage gate steps in `_test-go.yml` silently exited 0 when `coverage.out` was missing (no `else` clause) or when `go tool cover` returned no total (old `exit 0` guard)
- The gate was a no-op when the test step itself had failed and not produced a coverage file

## Change

**`.github/workflows/_test-go.yml`** — both coverage gate steps:

```diff
  if [ -f "cmd/zynax/coverage.out" ]; then
    ...
-   [ -z "$total" ] && echo "  ⚠ skipping" && exit 0
+   if [ -z "$total" ]; then
+     echo "::error::no coverage total — test step likely failed"; exit 1
+   fi
    ...
- fi
+ else
+   echo "::error::coverage.out not found — test step likely failed"; exit 1
+ fi
```

## Test plan
- [ ] CI passes on this PR (CLI tests skipped — no `cmd/*` changes)
- [ ] Coverage gate still passes normally above threshold
- [ ] Gate fails with `exit 1` when `coverage.out` is absent (verifiable by temporarily breaking test step)

Closes #987

Assisted-by: Claude/claude-sonnet-4-6