### PR TITLE
ci(infra): add Python adapter images to multi-arch release pipeline (#840)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,12 +164,16 @@ jobs:
     name: Detect changed services
     runs-on: ubuntu-24.04
     outputs:
-      api_gateway:       ${{ steps.detect.outputs.api_gateway }}
-      engine_adapter:    ${{ steps.detect.outputs.engine_adapter }}
-      workflow_compiler: ${{ steps.detect.outputs.workflow_compiler }}
-      task_broker:       ${{ steps.detect.outputs.task_broker }}
-      agent_registry:    ${{ steps.detect.outputs.agent_registry }}
-      http_adapter:      ${{ steps.detect.outputs.http_adapter }}
+      api_gateway:        ${{ steps.detect.outputs.api_gateway }}
+      engine_adapter:     ${{ steps.detect.outputs.engine_adapter }}
+      workflow_compiler:  ${{ steps.detect.outputs.workflow_compiler }}
+      task_broker:        ${{ steps.detect.outputs.task_broker }}
+      agent_registry:     ${{ steps.detect.outputs.agent_registry }}
+      http_adapter:       ${{ steps.detect.outputs.http_adapter }}
+      llm_adapter:        ${{ steps.detect.outputs.llm_adapter }}
+      langgraph_adapter:  ${{ steps.detect.outputs.langgraph_adapter }}
+      ci_adapter:         ${{ steps.detect.outputs.ci_adapter }}
+      git_adapter:        ${{ steps.detect.outputs.git_adapter }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -180,6 +184,7 @@ jobs:
         run: |
           api_gateway=false engine_adapter=false workflow_compiler=false
           task_broker=false agent_registry=false http_adapter=false
+          llm_adapter=false langgraph_adapter=false ci_adapter=false git_adapter=false
 
           if [ "${{ github.event_name }}" = "push" ] && [ "${{ github.ref_type }}" = "branch" ]; then
             if ! FILES=$(git diff --name-only HEAD^1...HEAD 2>/tmp/git-diff-err.txt); then
@@ -195,7 +200,11 @@ jobs:
                 echo "$f" | grep -qE '^(services/workflow-compiler/|protos/generated/go/|infra/docker/Dockerfile\.service)' && workflow_compiler=true
                 echo "$f" | grep -qE '^(services/task-broker/|protos/generated/go/|infra/docker/Dockerfile\.service)'      && task_broker=true
                 echo "$f" | grep -qE '^(services/agent-registry/|protos/generated/go/|infra/docker/Dockerfile\.service)'   && agent_registry=true
-                echo "$f" | grep -qE '^(agents/adapters/http/|protos/generated/go/)'      && http_adapter=true
+                echo "$f" | grep -qE '^(agents/adapters/http/|protos/generated/go/)'           && http_adapter=true
+                echo "$f" | grep -qE '^(agents/adapters/llm/|protos/generated/python/)'       && llm_adapter=true
+                echo "$f" | grep -qE '^(agents/adapters/langgraph/|protos/generated/python/)' && langgraph_adapter=true
+                echo "$f" | grep -qE '^(agents/adapters/ci/|protos/generated/go/)'            && ci_adapter=true
+                echo "$f" | grep -qE '^(agents/adapters/git/|protos/generated/go/)'           && git_adapter=true
               done <<< "$FILES"
             fi
           else
@@ -209,6 +218,10 @@ jobs:
             echo "task_broker=$task_broker"
             echo "agent_registry=$agent_registry"
             echo "http_adapter=$http_adapter"
+            echo "llm_adapter=$llm_adapter"
+            echo "langgraph_adapter=$langgraph_adapter"
+            echo "ci_adapter=$ci_adapter"
+            echo "git_adapter=$git_adapter"
           } >> "$GITHUB_OUTPUT"
 
   resolve-matrix:
@@ -237,7 +250,15 @@ jobs:
           [[ "$force" == "true" || "${{ needs.changes.outputs.task_broker }}"       == "true" ]] && entries+=(task-broker)
           [[ "$force" == "true" || "${{ needs.changes.outputs.agent_registry }}"    == "true" ]] && entries+=(agent-registry)
           [[ "$force" == "true" || "${{ needs.changes.outputs.http_adapter }}"      == "true" ]] && entries+=(http-adapter)
+          [[ "$force" == "true" || "${{ needs.changes.outputs.llm_adapter }}"       == "true" ]] && entries+=(llm-adapter)
+          [[ "$force" == "true" || "${{ needs.changes.outputs.langgraph_adapter }}" == "true" ]] && entries+=(langgraph-adapter)
+          [[ "$force" == "true" || "${{ needs.changes.outputs.ci_adapter }}"        == "true" ]] && entries+=(ci-adapter)
+          [[ "$force" == "true" || "${{ needs.changes.outputs.git_adapter }}"       == "true" ]] && entries+=(git-adapter)
           svc_dockerfile[http-adapter]="agents/adapters/http/Dockerfile"
+          svc_dockerfile[llm-adapter]="agents/adapters/llm/Dockerfile"
+          svc_dockerfile[langgraph-adapter]="agents/adapters/langgraph/Dockerfile"
+          svc_dockerfile[ci-adapter]="agents/adapters/ci/Dockerfile"
+          svc_dockerfile[git-adapter]="agents/adapters/git/Dockerfile"
 
           if [[ ${#entries[@]} -eq 0 ]]; then
             echo 'matrix={"include":[]}' >> "$GITHUB_OUTPUT"
@@ -630,6 +651,10 @@ jobs:
             docker pull ghcr.io/zynax-io/zynax/workflow-compiler:${{ steps.ver.outputs.version }}
             docker pull ghcr.io/zynax-io/zynax/task-broker:${{ steps.ver.outputs.version }}
             docker pull ghcr.io/zynax-io/zynax/http-adapter:${{ steps.ver.outputs.version }}
+            docker pull ghcr.io/zynax-io/zynax/llm-adapter:${{ steps.ver.outputs.version }}
+            docker pull ghcr.io/zynax-io/zynax/langgraph-adapter:${{ steps.ver.outputs.version }}
+            docker pull ghcr.io/zynax-io/zynax/ci-adapter:${{ steps.ver.outputs.version }}
+            docker pull ghcr.io/zynax-io/zynax/git-adapter:${{ steps.ver.outputs.version }}
             ```
 
             SPDX SBOMs for all service and adapter images are attached to this release. Verify image signatures with `cosign verify ghcr.io/zynax-io/zynax/<service>:<version>`.


### PR DESCRIPTION
## Summary

- Adds `llm-adapter`, `langgraph-adapter`, `ci-adapter`, and `git-adapter` to the `release.yml` service build matrix
- Each adapter specifies its own Dockerfile via `svc_dockerfile[<name>]` override (same pattern as `http-adapter`)
- Change detection in the `changes` job covers `agents/adapters/<name>/` and `protos/generated/{go,python}/` path prefixes
- All four Dockerfiles already had OCI `LABEL` annotations — no Dockerfile changes required
- Release notes `docker pull` section updated to list the 4 new adapter images

## Adapter details

| Adapter | Base image | Type |
|---|---|---|
| `llm-adapter` | `python:3.12-slim` | Python |
| `langgraph-adapter` | `python:3.12-slim` | Python |
| `ci-adapter` | `gcr.io/distroless/static:nonroot` | Go |
| `git-adapter` | `gcr.io/distroless/static:nonroot` | Go |

## Test plan

- [ ] On tag push: all 4 new adapters appear in the `Build <service> (amd64)` / `Build <service> (arm64)` matrix jobs
- [ ] `merge-and-sign` job creates multi-arch manifest index and signs with cosign for each adapter
- [ ] SPDX SBOM artifact generated for each adapter and attached to GitHub Release
- [ ] `docker pull ghcr.io/zynax-io/zynax/llm-adapter:<tag>` works on amd64 and arm64
- [ ] On branch push with changes to `agents/adapters/llm/`: only `llm_adapter=true` fires (not all services)

Closes #840

Assisted-by: Claude/claude-sonnet-4-6