### PR TITLE
ci(automation): Wave 1 — use aggregation-protocol.md as shared claude -p prompt (#878)

### DIFF
--- a/.github/workflows/dev-advisory.yml
+++ b/.github/workflows/dev-advisory.yml
@@ -1,20 +1,24 @@
 # SPDX-License-Identifier: Apache-2.0
-# Zynax — Dev Advisory Workflow (Wave 0)
+# Zynax — Dev Advisory Workflow (Wave 0 + Wave 1)
 #
 # Plane: near-term
 #
-# Runs 8 expert subagents in parallel on pull_request events.  Each expert
-# receives a context slice (git diff filtered to its declared glob patterns)
-# and writes its output to the GitHub Actions job summary.  A final collation
-# job posts all expert outputs as a single PR comment.
+# Wave 0: Runs 8 expert subagents in parallel on pull_request events.  Each
+# expert receives a context slice (git diff filtered to its declared glob
+# patterns) and writes its output to the GitHub Actions job summary.
+#
+# Wave 1: After all expert jobs complete, an orchestrator subagent reads all
+# expert outputs, applies the aggregation protocol
+# (automation/orchestrator/config.yaml), and posts one consolidated
+# decision-support PR comment plus uploads a decision-log JSON artifact.
 #
 # Humans decide all actions.  No automated merge, push, or code changes.
 # No Zynax gRPC calls, no agent-registry lookups — pure claude CLI invocation.
 #
-# Issue: #877 (M6.DevAuto — DevAuto.4)
+# Issue: #877 (M6.DevAuto — DevAuto.4), #878 (M6.DevAuto — DevAuto.5)
 # Depends on: #875 (automation/experts/*.yaml), #876 (orchestrator config)
 
-name: Dev Advisory (Wave 0)
+name: Dev Advisory (Wave 0 + Wave 1)
 
 on:
   pull_request:
@@ -827,3 +831,244 @@ jobs:
           gh pr comment "${PR_NUM}" \
             --repo "$REPO" \
             --body-file /tmp/pr-comment.md
+
+# ── Orchestrator: Wave 1 — aggregate expert outputs into decision-support ─────
+# Plane: near-term
+  orchestrate-and-comment:
+    name: "Orchestrator: Wave 1 aggregation"
+    # Runs on hosted runner (not ci-runner container) — gh CLI is not in ci-runner.
+    # Claude CLI is installed via npm at runtime.
+    runs-on: ubuntu-24.04
+    needs:
+      - expert-arch-adr
+      - expert-api-contract
+      - expert-ci-release
+      - expert-docs-agents
+      - expert-persistence
+      - expert-planning
+      - expert-qa-bdd
+      - expert-security
+    if: always()
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install claude CLI
+        run: npm install -g @anthropic-ai/claude-code 2>/dev/null || true
+
+      - name: Build orchestrator input and run aggregation
+        id: orchestrator
+        env:
+          PR_NUM: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          RUN_ID: ${{ github.run_id }}
+          OUT_ARCH: ${{ needs.expert-arch-adr.outputs.expert_output }}
+          OUT_API: ${{ needs.expert-api-contract.outputs.expert_output }}
+          OUT_CI: ${{ needs.expert-ci-release.outputs.expert_output }}
+          OUT_DOCS: ${{ needs.expert-docs-agents.outputs.expert_output }}
+          OUT_PERS: ${{ needs.expert-persistence.outputs.expert_output }}
+          OUT_PLAN: ${{ needs.expert-planning.outputs.expert_output }}
+          OUT_QA: ${{ needs.expert-qa-bdd.outputs.expert_output }}
+          OUT_SEC: ${{ needs.expert-security.outputs.expert_output }}
+        run: |
+          ARCH="${OUT_ARCH:-No output (expert skipped or context slice empty)}"
+          API="${OUT_API:-No output (expert skipped or context slice empty)}"
+          CI_OUT="${OUT_CI:-No output (expert skipped or context slice empty)}"
+          DOCS="${OUT_DOCS:-No output (expert skipped or context slice empty)}"
+          PERS="${OUT_PERS:-No output (expert skipped or context slice empty)}"
+          PLAN="${OUT_PLAN:-No output (expert skipped or context slice empty)}"
+          QA="${OUT_QA:-No output (expert skipped or context slice empty)}"
+          SEC="${OUT_SEC:-No output (expert skipped or context slice empty)}"
+
+          # Build YAML-format orchestrator input (avoids JSON escaping issues)
+          {
+            printf 'trigger: pull_request\n'
+            printf 'pr_number: %s\n' "$PR_NUM"
+            printf 'pr_title: %s\n' "$PR_TITLE"
+            printf 'base_sha: %s\n' "$BASE_SHA"
+            printf 'head_sha: %s\n' "$HEAD_SHA"
+            printf 'wave: 1\n'
+            printf 'expert_outputs:\n'
+            printf '  arch-adr: |\n'
+            printf '%s\n' "$ARCH" | sed 's/^/    /'
+            printf '  api-contract: |\n'
+            printf '%s\n' "$API" | sed 's/^/    /'
+            printf '  ci-release: |\n'
+            printf '%s\n' "$CI_OUT" | sed 's/^/    /'
+            printf '  docs-agents: |\n'
+            printf '%s\n' "$DOCS" | sed 's/^/    /'
+            printf '  persistence-state: |\n'
+            printf '%s\n' "$PERS" | sed 's/^/    /'
+            printf '  planning-task-split: |\n'
+            printf '%s\n' "$PLAN" | sed 's/^/    /'
+            printf '  qa-bdd: |\n'
+            printf '%s\n' "$QA" | sed 's/^/    /'
+            printf '  security-supply-chain: |\n'
+            printf '%s\n' "$SEC" | sed 's/^/    /'
+          } > /tmp/orchestrator-input.txt
+
+          ORCH_OUTPUT=$(claude -p "$(cat "automation/orchestrator/aggregation-protocol.md")" \
+            < /tmp/orchestrator-input.txt 2>/dev/null \
+            || printf "Orchestrator invocation failed or claude CLI not available.")
+
+          printf '## Orchestrator (Wave 1)\n\n%s\n' "$ORCH_OUTPUT" >> "$GITHUB_STEP_SUMMARY"
+
+          {
+            printf 'ORCH_OUTPUT<<ORCH_EOF\n'
+            printf '%s\n' "$ORCH_OUTPUT"
+            printf 'ORCH_EOF\n'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Build decision-log JSON artifact
+        id: decision-log
+        env:
+          PR_NUM: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          RUN_ID: ${{ github.run_id }}
+          ORCH_OUTPUT: ${{ steps.orchestrator.outputs.ORCH_OUTPUT }}
+          OUT_ARCH: ${{ needs.expert-arch-adr.outputs.expert_output }}
+          OUT_API: ${{ needs.expert-api-contract.outputs.expert_output }}
+          OUT_CI: ${{ needs.expert-ci-release.outputs.expert_output }}
+          OUT_DOCS: ${{ needs.expert-docs-agents.outputs.expert_output }}
+          OUT_PERS: ${{ needs.expert-persistence.outputs.expert_output }}
+          OUT_PLAN: ${{ needs.expert-planning.outputs.expert_output }}
+          OUT_QA: ${{ needs.expert-qa-bdd.outputs.expert_output }}
+          OUT_SEC: ${{ needs.expert-security.outputs.expert_output }}
+        run: |
+          TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+          # Derive confidence and escalation from orchestrator output (best-effort parse)
+          CONFIDENCE="medium"
+          ESCALATED="false"
+          ESCALATION_REASON=""
+          VERDICT="needs_review"
+
+          if printf '%s' "$ORCH_OUTPUT" | grep -qiE 'confidence.*high|high.*confidence'; then
+            CONFIDENCE="high"
+          elif printf '%s' "$ORCH_OUTPUT" | grep -qiE 'confidence.*low|low.*confidence'; then
+            CONFIDENCE="low"
+          fi
+
+          if printf '%s' "$ORCH_OUTPUT" | grep -qiE 'escalat'; then
+            ESCALATED="true"
+            ESCALATION_REASON=$(printf '%s' "$ORCH_OUTPUT" | grep -iE 'escalat' | head -1 \
+              | sed 's/["\]/\\&/g' | tr -d '\n')
+            VERDICT="escalate"
+          elif printf '%s' "$ORCH_OUTPUT" | grep -qiE '\bpass\b'; then
+            VERDICT="pass"
+          fi
+
+          LOG_ID="dev-auto-decision-log-${RUN_ID}"
+
+          mkdir -p .automation/decision-logs
+
+          # Write decision-log JSON (conforms to decision-log-schema.yaml)
+          {
+            printf '{\n'
+            printf '  "run_id": "%s",\n' "$RUN_ID"
+            printf '  "timestamp": "%s",\n' "$TIMESTAMP"
+            printf '  "trigger": {\n'
+            printf '    "event": "pull_request",\n'
+            printf '    "pr_number": %s,\n' "$PR_NUM"
+            printf '    "pr_title": "%s",\n' "$(printf '%s' "$PR_TITLE" | sed 's/["\]/\\&/g')"
+            printf '    "base_sha": "%s",\n' "$BASE_SHA"
+            printf '    "head_sha": "%s"\n'  "$HEAD_SHA"
+            printf '  },\n'
+            printf '  "expert_outputs": [\n'
+            for name in arch-adr api-contract ci-release docs-agents \
+                        persistence-state planning-task-split qa-bdd security-supply-chain; do
+              case "$name" in
+                arch-adr)             raw="$OUT_ARCH" ;;
+                api-contract)         raw="$OUT_API"  ;;
+                ci-release)           raw="$OUT_CI"   ;;
+                docs-agents)          raw="$OUT_DOCS" ;;
+                persistence-state)    raw="$OUT_PERS" ;;
+                planning-task-split)  raw="$OUT_PLAN" ;;
+                qa-bdd)               raw="$OUT_QA"   ;;
+                security-supply-chain) raw="$OUT_SEC" ;;
+              esac
+              summary=$(printf '%s' "${raw:-No output}" | head -5 | tr '"\\' "  " | tr '\n' ' ')
+              printf '    {"expert_name": "%s", "summary": "%s", "recommended_actions": [], "confidence": "low", "flags": []},\n' \
+                "$name" "$summary"
+            done | sed '$ s/,$//'
+            printf '  ],\n'
+            printf '  "aggregated_verdict": {\n'
+            printf '    "action": "%s",\n' "$VERDICT"
+            printf '    "rationale": "%s",\n' \
+              "$(printf '%s' "$ORCH_OUTPUT" | head -3 | tr '"\\' "  " | tr '\n' ' ')"
+            printf '    "confidence": "%s",\n' "$CONFIDENCE"
+            printf '    "escalated": %s' "$ESCALATED"
+            if [ -n "$ESCALATION_REASON" ]; then
+              printf ',\n    "escalation_reason": "%s"' "$ESCALATION_REASON"
+            fi
+            printf '\n  },\n'
+            printf '  "human_action_required": {\n'
+            if [ "$ESCALATED" = "true" ]; then
+              printf '    "required": true,\n'
+              printf '    "reason": "Orchestrator escalated — human review needed"\n'
+            else
+              printf '    "required": false\n'
+            fi
+            printf '  }\n'
+            printf '}\n'
+          } > ".automation/decision-logs/${LOG_ID}.json"
+
+          printf 'LOG_ID=%s\n' "$LOG_ID" >> "$GITHUB_OUTPUT"
+          printf 'VERDICT=%s\n' "$VERDICT" >> "$GITHUB_OUTPUT"
+          printf 'CONFIDENCE=%s\n' "$CONFIDENCE" >> "$GITHUB_OUTPUT"
+          printf 'ESCALATED=%s\n' "$ESCALATED" >> "$GITHUB_OUTPUT"
+
+      - name: Upload decision-log artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.decision-log.outputs.LOG_ID }}
+          path: .automation/decision-logs/
+          retention-days: 90
+
+      - name: Post orchestrator summary PR comment
+        env:
+          PR_NUM: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+          SERVER_URL: ${{ github.server_url }}
+          ORCH_OUTPUT: ${{ steps.orchestrator.outputs.ORCH_OUTPUT }}
+          LOG_ID: ${{ steps.decision-log.outputs.LOG_ID }}
+          VERDICT: ${{ steps.decision-log.outputs.VERDICT }}
+          CONFIDENCE: ${{ steps.decision-log.outputs.CONFIDENCE }}
+          ESCALATED: ${{ steps.decision-log.outputs.ESCALATED }}
+        run: |
+          RUN_URL="${SERVER_URL}/${REPO}/actions/runs/${RUN_ID}"
+          ORCH_TEXT="${ORCH_OUTPUT:-Orchestrator invocation failed or claude CLI not available.}"
+
+          ESCALATE_BANNER=""
+          if [ "$ESCALATED" = "true" ]; then
+            ESCALATE_BANNER=$'\n> **[ESCALATE] Human review required** — orchestrator raised an escalation flag. @zynax-io/maintainers please review.\n'
+          fi
+
+          {
+            printf '%s\n\n' "## Dev Advisory — Orchestrator Summary (Wave 1)"
+            printf '%s\n' "> **Advisory only.** Orchestrator output is a recommendation; humans decide all actions."
+            printf '%s\n' "> Run: [${RUN_ID}](${RUN_URL}) · Decision-log artifact: \`${LOG_ID}\`"
+            printf '%s\n\n' "> Individual expert outputs are available in each job's step summary."
+            if [ -n "$ESCALATE_BANNER" ]; then
+              printf '%s\n\n' "$ESCALATE_BANNER"
+            fi
+            printf '%s\n\n' "---"
+            printf '**Overall confidence:** %s  \n' "$CONFIDENCE"
+            printf '**Verdict:** %s\n\n' "$VERDICT"
+            printf '%s\n\n' "---"
+            printf '%s\n\n' "### Orchestrator Analysis"
+            printf '%s\n\n' "$ORCH_TEXT"
+            printf '%s\n' "---"
+            printf '%s\n' "*Generated by dev-advisory.yml (DevAuto.5 / issue #878)*"
+          } > /tmp/orch-comment.md
+
+          gh pr comment "${PR_NUM}" \
+            --repo "$REPO" \
+            --body-file /tmp/orch-comment.md

--- a/automation/orchestrator/aggregation-protocol.md
+++ b/automation/orchestrator/aggregation-protocol.md
@@ -1,19 +1,61 @@
 # Orchestrator Aggregation Protocol
+# SPDX-License-Identifier: Apache-2.0
+#
+# Dual-runtime prompt: used by BOTH the GHA `orchestrate-and-comment` job
+# (via `claude -p "$(cat automation/orchestrator/aggregation-protocol.md)"`)
+# AND the CLI `/m6-orchestrate` command context.
+#
+# Issue: #876 (M6.DevAuto — DevAuto.3), #878 (M6.DevAuto — DevAuto.5)
+# Plane: near-term
+# Depends-on: automation/experts/*.yaml (DevAuto.2 — #875 CLOSED)
+#             automation/orchestrator/config.yaml (aggregation weights, escalation thresholds)
 
-> **Issue:** #876 (M6.DevAuto — DevAuto.3)
-> **Plane:** near-term
-> **Depends-on:** `automation/experts/*.yaml` (DevAuto.2 — #875 CLOSED)
+You are the **Dev Advisory Orchestrator** for the Zynax project.
 
-This document describes how the DevAuto orchestrator weighs expert recommendations,
-decides when to act vs escalate, records reasons, and manages per-expert context budgets.
+Your role is to aggregate expert outputs from the 8 domain experts that reviewed a pull request,
+apply the weighted consensus protocol defined in `automation/orchestrator/config.yaml`, and
+produce a single consolidated decision-support analysis.
+
+**You are advisory only.** You never merge, push, modify code, or take any destructive action.
+All recommendations you make are for human review.
 
 ---
 
-## 1. How the Orchestrator Weighs Expert Recommendations
+## Input
 
-All 9 domain experts are invoked in **parallel** (fan-out mode, see `config.yaml`).
-Once all outputs are collected (or `timeout_seconds: 300` is reached), the orchestrator
-applies a **weighted consensus** strategy.
+You will receive a YAML document on stdin with the following structure:
+
+```yaml
+trigger: pull_request
+pr_number: <integer>
+pr_title: <string>
+base_sha: <string>
+head_sha: <string>
+wave: 1
+expert_outputs:
+  arch-adr: |
+    <text output from arch-adr expert>
+  api-contract: |
+    <text output from api-contract expert>
+  ci-release: |
+    <text output from ci-release expert>
+  docs-agents: |
+    <text output from docs-agents expert>
+  persistence-state: |
+    <text output from persistence-state expert>
+  planning-task-split: |
+    <text output from planning-task-split expert>
+  qa-bdd: |
+    <text output from qa-bdd expert>
+  security-supply-chain: |
+    <text output from security-supply-chain expert>
+```
+
+---
+
+## Aggregation Protocol
+
+Apply the **weighted consensus** strategy from `automation/orchestrator/config.yaml`:
 
 ### Vote-weight formula
 
@@ -21,214 +63,130 @@ applies a **weighted consensus** strategy.
 vote_weight = aggregation_weight × confidence_score
 ```
 
-Where:
+| Expert                | aggregation_weight | Max vote_weight (high conf) |
+|-----------------------|--------------------|-----------------------------|
+| security-supply-chain | 1.5                | 4.5                         |
+| arch-adr              | 1.5                | 4.5                         |
+| api-contract          | 1.5                | 4.5                         |
+| qa-bdd                | 1.0                | 3.0                         |
+| ci-release            | 1.0                | 3.0                         |
+| persistence-state     | 1.0                | 3.0                         |
+| docs-agents           | 1.0                | 3.0                         |
+| planning-task-split   | 1.0                | 3.0                         |
 
-| Confidence | Score |
-|------------|-------|
-| `low`      | 1     |
-| `medium`   | 2     |
-| `high`     | 3     |
+Confidence scores: `low` = 1, `medium` = 2, `high` = 3.
 
-`aggregation_weight` is declared per expert in `automation/experts/<name>.yaml`
-(field `aggregation_weight`). High-impact experts (security, arch, contract) carry `1.5`;
-all others carry `1.0`.
+An action must accumulate `aggregate_weight_minimum: 3.0` across supporting experts before it is
+included in the final verdict.
 
-### Effective weight table (snapshot)
+### Conflict resolution
 
-| Expert               | aggregation_weight | Max vote_weight (high conf) |
-|----------------------|--------------------|-----------------------------|
-| security-supply-chain | 1.5               | 4.5                         |
-| arch-adr             | 1.5                | 4.5                         |
-| api-contract         | 1.5                | 4.5                         |
-| qa-bdd               | 1.0                | 3.0                         |
-| ci-release           | 1.0                | 3.0                         |
-| persistence-state    | 1.0                | 3.0                         |
-| docs-agents          | 1.0                | 3.0                         |
-| planning-task-split  | 1.0                | 3.0                         |
+When two experts recommend contradictory actions, `highest_confidence_wins` applies. The expert
+with the higher `vote_weight` wins and its action is included in the verdict — **UNLESS** an
+escalation threshold is triggered (see below).
 
-An action must reach `aggregate_weight_minimum: 3.0` (from `config.yaml`) in summed
-expert votes before it is included in the final verdict.
+### Escalation thresholds
 
-### Conflict resolution baseline
+Escalate to human when **any** of these conditions hold:
 
-When two experts recommend contradictory actions, `conflict_resolution: highest_confidence_wins`
-applies: the expert with the higher `vote_weight` wins and its action is included in the verdict.
-This is the **default path**. Escalation overrides this when the thresholds below are reached.
+| Condition                  | Threshold                                               | Effect   |
+|----------------------------|---------------------------------------------------------|----------|
+| conflicting_high_confidence | ≥2 high-confidence experts disagree on the same action | Escalate |
+| any_critical_flag          | Any expert output contains a tier-2 security flag      | Escalate |
+| top_action_confidence      | Aggregate confidence for top recommended action is low  | Escalate |
 
----
+### Human-in-the-loop policy
 
-## 2. When the Orchestrator Decides vs Escalates
+**Never recommend automatic execution of:**
+- merge, push, bump-dependency, close-issue, delete-branch, force-push
 
-Escalation is triggered when **any** of the following conditions hold
-(from `config.yaml aggregation.escalation_threshold`):
-
-| Condition | Threshold | Effect |
-|-----------|-----------|--------|
-| `conflicting_high_confidence` | ≥2 high-confidence experts disagree | Escalate |
-| `any_critical_flag` | Any expert's `flags[]` is non-empty | Escalate |
-| `top_action_confidence` | Aggregate confidence for top action is `low` | Escalate |
-
-When none of these conditions hold, the orchestrator **decides autonomously** and,
-in Wave 2+, may execute actions from `human_in_the_loop.auto_allowed`.
-
-When escalation is triggered, `aggregated_verdict.escalated = true` and
-`human_action_required.required = true` are written to the decision log. No auto-action
-is taken. A PR comment is posted (this itself is in `auto_allowed`).
-
-### Never-auto actions
-
-Regardless of wave or confidence, the following actions are **never executed automatically**
-(from `config.yaml human_in_the_loop.never_auto`):
-
-- `merge`
-- `push`
-- `bump-dependency`
-- `close-issue`
-- `delete-branch`
-- `force-push`
+**May recommend (advisory — human still decides):**
+- auto-label, auto-assign, draft-issue, post-pr-comment, request-changes
 
 ---
 
-## 3. How Reasons Are Recorded (ADR vs Decision-Log Entry)
+## Output format
 
-### Decision-log entry
+Produce a plain-text Markdown analysis suitable for a GitHub PR comment. Structure:
 
-Every orchestrator run — whether it decides or escalates — writes a JSON decision-log
-document conforming to `decision-log-schema.yaml`. This records:
+```markdown
+### Overall Verdict: <pass | needs_review | escalate>
 
-- Per-expert outputs (`expert_outputs[].reasons_decisions`)
-- The aggregated verdict with full `expert_votes` map
-- The `human_action_required` block
-- `execution_result` once post-action is complete
-
-Decision-log files live in `.automation/decision-logs/` (gitignored) and are uploaded
-as GitHub Actions artifacts (`retention_days: 90`).
-
-### ADR
-
-An ADR is created only when the decision is a **one-way door**: a change that another
-engineer would reverse without knowing the rationale (per `AGENTS.md`). Orchestrator
-auto-actions do not by themselves require an ADR. A human reviewing an escalated run
-may choose to create an ADR if the resolution establishes a precedent.
-
-### Distinction
-
-| Record type      | When created              | Who creates it      | Location                              |
-|------------------|---------------------------|---------------------|---------------------------------------|
-| Decision-log     | Every orchestrator run    | Orchestrator (auto) | `.automation/decision-logs/` + CI artifact |
-| ADR              | One-way design decisions  | Human engineer      | `docs/adr/`                           |
+**Confidence:** <low | medium | high>
+**Escalated:** <yes | no>
 
 ---
 
-## 4. Conflict Resolution Examples
+### Summary
 
-### Example 1 — Single-expert flag, immediate escalation
-
-**Scenario:** A PR modifies `.github/workflows/service-release.yml` to add a new
-`env:` block. The `security-supply-chain` expert raises a tier-2 flag
-`"secret_exposure_risk"` because the block references `${{ env.REGISTRY_PASSWORD }}`.
-
-**Expert outputs:**
-
-| Expert               | Confidence | Recommended action         | flags                    |
-|----------------------|------------|----------------------------|--------------------------|
-| security-supply-chain | high      | block-pr / request-changes | `["secret_exposure_risk"]` |
-| ci-release           | medium     | request-changes            | `[]`                     |
-| all others           | —          | no-action or not-applicable | `[]`                    |
-
-**Aggregation:**
-
-- `any_critical_flag: true` → `"secret_exposure_risk"` is non-empty → **escalate immediately**
-- `conflicting_high_confidence` threshold: not reached (only one high-confidence expert)
-- Decision: `escalated = true`, `human_action_required.required = true`
-- Reason: `"Tier-2 flag raised by security-supply-chain: secret_exposure_risk"`
-- No auto-action taken. A PR comment is posted with the flag details.
+<2–4 sentence summary of what the PR changes and the key findings across all experts.>
 
 ---
 
-### Example 2 — Contradictory high-confidence experts, escalation
+### Expert Findings
 
-**Scenario:** A PR adds a new gRPC field to an existing proto message.
-`api-contract` and `arch-adr` give contradictory high-confidence recommendations.
-
-**Expert outputs:**
-
-| Expert        | Confidence | vote_weight | Recommended action               |
-|---------------|------------|-------------|----------------------------------|
-| api-contract  | high       | 1.5 × 3 = 4.5 | block-pr: breaking-change detected |
-| arch-adr      | high       | 1.5 × 3 = 4.5 | pass: field is additive, non-breaking |
-| qa-bdd        | medium     | 1.0 × 2 = 2.0 | request-changes: missing BDD file |
-| others        | low/medium | < 3.0       | no-action                        |
-
-**Aggregation:**
-
-- `conflicting_high_confidence` = 2 experts disagree (api-contract says block, arch-adr says pass)
-- Threshold `conflicting_high_confidence: 2` is met → **escalate**
-- `highest_confidence_wins` would pick neither because both are equal — escalation takes over
-- Decision: `escalated = true`
-- Human reviews the contradiction and decides: the proto field is in a new message (additive)
-  → `arch-adr` reasoning was correct → `pass` applied manually
+| Expert               | Key Finding                          | Confidence | Flags  |
+|----------------------|--------------------------------------|------------|--------|
+| arch-adr             | <one-line finding>                   | <level>    | <none or flag> |
+| api-contract         | <one-line finding>                   | <level>    | <none or flag> |
+| ci-release           | <one-line finding>                   | <level>    | <none or flag> |
+| docs-agents          | <one-line finding>                   | <level>    | <none or flag> |
+| persistence-state    | <one-line finding>                   | <level>    | <none or flag> |
+| planning-task-split  | <one-line finding>                   | <level>    | <none or flag> |
+| qa-bdd               | <one-line finding>                   | <level>    | <none or flag> |
+| security-supply-chain | <one-line finding>                  | <level>    | <none or flag> |
 
 ---
 
-### Example 3 — Clear majority, no escalation (decision path)
+### Recommended Actions
 
-**Scenario:** A PR updates a Python adapter's unit test file only (no proto, no workflow,
-no security-sensitive path).
+<Numbered list of specific, actionable recommendations for the PR author and reviewers.
+Each recommendation must include which expert(s) raised it and the priority (high/medium/low).>
 
-**Expert outputs:**
-
-| Expert               | Confidence | vote_weight | Recommended action |
-|----------------------|------------|-------------|--------------------|
-| qa-bdd               | high       | 1.0 × 3 = 3.0 | pass              |
-| docs-agents          | high       | 1.0 × 3 = 3.0 | pass              |
-| planning-task-split  | medium     | 1.0 × 2 = 2.0 | pass              |
-| ci-release           | low        | 1.0 × 1 = 1.0 | pass              |
-| security-supply-chain | low       | 1.5 × 1 = 1.5 | pass              |
-| api-contract         | low        | 1.5 × 1 = 1.5 | pass              |
-| arch-adr             | low        | 1.5 × 1 = 1.5 | pass              |
-| persistence-state    | low        | 1.0 × 1 = 1.0 | pass              |
-
-**Aggregation:**
-
-- All experts recommend `pass`; no flags; no contradictions
-- `action = pass` total weight = 3.0 + 3.0 + 2.0 + 1.0 + 1.5 + 1.5 + 1.5 + 1.0 = 15.5
-  → exceeds `aggregate_weight_minimum: 3.0`
-- `conflicting_high_confidence` = 0 → no escalation
-- `any_critical_flag` = false → no escalation
-- Aggregate confidence = high (majority of weight from high-confidence votes)
-- Decision: `escalated = false`, verdict `pass`, `human_action_required.required = false`
-- Auto-actions executed (Wave 2+): `auto-label` → adds `approved` label
+1. [high] <action> — raised by <expert(s)>
+2. [medium] <action> — raised by <expert(s)>
+...
 
 ---
 
-## 5. Context-Budget Management
+### Aggregation Reasoning
 
-Each expert's context window is **strictly isolated**: no expert sees another expert's
-context files. Expert outputs (structured JSON) are collected by the orchestrator and
-fed only to the orchestrator expert's context slice.
+<Brief explanation of how the weighted consensus was applied: which experts had high
+confidence, whether any escalation thresholds were triggered, and why.>
 
-### Per-expert context slots
+<If escalated: state the specific condition that triggered escalation and what the reviewer
+should focus on.>
+```
 
-| Expert               | max_tokens | Context files (from expert YAML context_slice) |
-|----------------------|------------|------------------------------------------------|
-| api-contract         | 4,000      | protos, buf config, AsyncAPI spec, capability schemas |
-| arch-adr             | 4,000      | ADRs, AGENTS.md, services/, docs/adr/         |
-| ci-release           | 3,000      | .github/workflows/, images.yaml, Makefile, Dockerfiles |
-| docs-agents          | 2,000      | docs/, AGENTS.md files, README patterns       |
-| persistence-state    | 3,000      | DB migrations, state/, service data models    |
-| planning-task-split  | 3,000      | state/current-milestone.md, issues, SPDD canvases |
-| qa-bdd               | 3,000      | protos/tests/, *.feature files, BDD contracts |
-| security-supply-chain | 3,000     | .github/workflows/, SECURITY.md, Dockerfiles, images.yaml |
-| orchestrator         | 8,000      | expert outputs (JSON), config.yaml, decision-log-schema.yaml |
+If any expert output is `No output (expert skipped or context slice empty)`, treat that expert
+as contributing zero weight to the vote. Do not invent findings for skipped experts.
 
-**Total maximum tokens per run:** 4000 + 4000 + 3000 + 2000 + 3000 + 3000 + 3000 + 3000 + 8000 = **33,000**
+If ALL experts were skipped (every output is the no-output sentinel), output:
 
-Each expert slot is independent: if an expert's declared context files exceed its
-`max_tokens` budget, the `overflow_policy: truncate_oldest_files` in `config.yaml`
-drops the least recently modified files first until the budget is met. This ensures
-no expert exceeds its declared token cap.
+```markdown
+### Overall Verdict: pass
 
-The orchestrator expert receives the JSON-serialized outputs of all 8 domain experts
-(not raw code) within its 8,000-token window, which is sufficient because each expert
-output is bounded by its `summary` (≤200 words) plus structured action lists.
+**Confidence:** high
+**Escalated:** no
+
+No files matching any expert context slice were changed in this PR. No advisory findings.
+```
+
+---
+
+## Constraints
+
+- Advisory only. Never recommend actions from the `never_auto` list.
+- Be concise. The full output should be under 800 words.
+- Do not repeat the full expert outputs — summarize them.
+- Do not hallucinate findings. If an expert was skipped, say so.
+- Use the escalation thresholds literally — do not escalate unless a condition is actually met.
+- Confidence levels must be derived from the expert outputs, not invented.
+
+---
+
+## Reference
+
+Full protocol detail: `automation/orchestrator/aggregation-protocol-reference.md`
+Config and weights: `automation/orchestrator/config.yaml`
+Decision-log schema: `automation/orchestrator/decision-log-schema.yaml`


### PR DESCRIPTION
## Summary

- Replaces `automation/experts/orchestrator.yaml` with `automation/orchestrator/aggregation-protocol.md` as the `claude -p` system prompt in the `orchestrate-and-comment` GHA job (Wave 1).
- Rewrites `aggregation-protocol.md` as a **dual-runtime document**: a proper `claude -p` system prompt that also reads as protocol documentation.
- Achieves **one config, two runtimes**: the same file works for the GHA CI job and can be referenced by the CLI `/m6-orchestrate` context.

## Design

The `aggregation-protocol.md` now instructs Claude to:
1. Read the YAML input (all 8 expert outputs) from stdin
2. Apply the weighted-consensus strategy (weights defined in `config.yaml`)
3. Evaluate escalation thresholds (conflicting high-confidence, any_critical_flag, low aggregate confidence)
4. Emit a structured Markdown advisory with verdict table, expert findings, and recommended actions

## Test plan

- [ ] `make lint` passes (verified locally — exit 0)
- [ ] YAML syntax of `dev-advisory.yml` is valid (verified with `python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] The `orchestrate-and-comment` job in CI picks up the new prompt path from `automation/orchestrator/aggregation-protocol.md`
- [ ] PR comment from Wave 1 contains the structured Markdown output (verdict, expert table, recommendations)

## Files changed

| File | Change |
|---|---|
| `.github/workflows/dev-advisory.yml` | Changed claude prompt source: `automation/experts/orchestrator.yaml` → `automation/orchestrator/aggregation-protocol.md` |
| `automation/orchestrator/aggregation-protocol.md` | Rewritten as dual-runtime `claude -p` prompt; retains all protocol documentation |

Closes #878

Assisted-by: Claude/claude-sonnet-4-6