### PR TITLE
feat(engine-adapter): ArgoEngine GetStatus + Cancel + Watch (#766, step 3)

### DIFF
--- a/services/engine-adapter/internal/infrastructure/argo_client.go
+++ b/services/engine-adapter/internal/infrastructure/argo_client.go
@@ -9,20 +9,49 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 )
 
 // ArgoWorkflow is a minimal representation of an Argo Workflows Workflow resource
-// submitted via the Argo Workflows REST API. Only the fields required for Submit
-// and Signal are included here; B.3 will add status-query fields.
+// submitted via the Argo Workflows REST API.
 type ArgoWorkflow struct {
-	APIVersion string           `json:"apiVersion"`
-	Kind       string           `json:"kind"`
-	Metadata   ArgoObjectMeta   `json:"metadata"`
-	Spec       ArgoWorkflowSpec `json:"spec"`
+	APIVersion string             `json:"apiVersion"`
+	Kind       string             `json:"kind"`
+	Metadata   ArgoObjectMeta     `json:"metadata"`
+	Spec       ArgoWorkflowSpec   `json:"spec"`
+	Status     ArgoWorkflowStatus `json:"status,omitempty"`
 }
+
+// ArgoWorkflowStatus holds the runtime status returned by the Argo Workflows API.
+// Only the fields needed for GetStatus and Watch are mapped here.
+type ArgoWorkflowStatus struct {
+	// Phase is the overall phase of the workflow: Pending, Running, Succeeded,
+	// Failed, Error, or Skipped.
+	Phase string `json:"phase,omitempty"`
+
+	// Message contains a human-readable error or completion message.
+	Message string `json:"message,omitempty"`
+
+	// StartedAt is the RFC3339 timestamp when the workflow entered Running.
+	StartedAt string `json:"startedAt,omitempty"`
+
+	// FinishedAt is the RFC3339 timestamp when the workflow reached a terminal phase.
+	FinishedAt string `json:"finishedAt,omitempty"`
+}
+
+// Argo phase constants mirror the Argo Workflows NodePhase string values.
+// These are the only values the Argo REST API returns for Workflow.Status.Phase.
+const (
+	ArgoPhaseRunning   = "Running"
+	ArgoPhasePending   = "Pending"
+	ArgoPhaseSucceeded = "Succeeded"
+	ArgoPhaseFailed    = "Failed"
+	ArgoPhaseError     = "Error"
+	ArgoPhaseSkipped   = "Skipped"
+)
 
 // ArgoObjectMeta holds the identifying metadata for an Argo resource.
 type ArgoObjectMeta struct {
@@ -63,6 +92,10 @@ type ArgoWorkflowEventBinding struct {
 	Payload json.RawMessage `json:"payload,omitempty"`
 }
 
+// errArgoNotFound is a sentinel error used by httpArgoClient to signal 404 responses.
+// ArgoEngine wraps this in domain.ErrExecutionNotFound.
+var errArgoNotFound = errors.New("workflow not found")
+
 // ArgoClient is the port that ArgoEngine uses to communicate with the Argo
 // Workflows REST API. It is defined as an interface so ArgoEngine can be
 // tested with a mock without a live Argo server.
@@ -76,6 +109,14 @@ type ArgoClient interface {
 	// discriminator must match the WorkflowEventBinding selector configured in
 	// the Argo Workflow resource.
 	SendEvent(ctx context.Context, namespace, discriminator string, payload []byte) error
+
+	// GetWorkflow retrieves an existing Argo Workflow resource by name.
+	// Returns (nil, errArgoNotFound) if the workflow does not exist.
+	GetWorkflow(ctx context.Context, namespace, name string) (*ArgoWorkflow, error)
+
+	// DeleteWorkflow deletes an Argo Workflow resource by name, which causes Argo
+	// to stop all running pods.
+	DeleteWorkflow(ctx context.Context, namespace, name string) error
 }
 
 // httpArgoClient is the production ArgoClient that talks to the Argo Workflows
@@ -127,6 +168,67 @@ func (c *httpArgoClient) SubmitWorkflow(ctx context.Context, namespace string, w
 	if resp.StatusCode >= 300 {
 		b, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("argo_client: submit workflow %q: HTTP %d: %s", wf.Metadata.Name, resp.StatusCode, string(b))
+	}
+	return nil
+}
+
+// GetWorkflow retrieves an Argo Workflow resource via the Argo REST API.
+// Returns a wrapped errArgoNotFound on HTTP 404.
+func (c *httpArgoClient) GetWorkflow(ctx context.Context, namespace, name string) (*ArgoWorkflow, error) {
+	url := fmt.Sprintf("%s/api/v1/workflows/%s/%s", c.serverURL, namespace, name)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
+	if err != nil {
+		return nil, fmt.Errorf("argo_client: create get-workflow request: %w", err)
+	}
+	if c.token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.token)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("argo_client: get workflow %q: %w", name, err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("argo_client: get workflow %q: %w", name, errArgoNotFound)
+	}
+	if resp.StatusCode >= 300 {
+		b, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("argo_client: get workflow %q: HTTP %d: %s", name, resp.StatusCode, string(b))
+	}
+
+	var wf ArgoWorkflow
+	if err := json.NewDecoder(resp.Body).Decode(&wf); err != nil {
+		return nil, fmt.Errorf("argo_client: decode workflow %q: %w", name, err)
+	}
+	return &wf, nil
+}
+
+// DeleteWorkflow sends a DELETE request to the Argo REST API to stop a workflow.
+// Returns a wrapped errArgoNotFound on HTTP 404.
+func (c *httpArgoClient) DeleteWorkflow(ctx context.Context, namespace, name string) error {
+	url := fmt.Sprintf("%s/api/v1/workflows/%s/%s", c.serverURL, namespace, name)
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, url, http.NoBody)
+	if err != nil {
+		return fmt.Errorf("argo_client: create delete-workflow request: %w", err)
+	}
+	if c.token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.token)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("argo_client: delete workflow %q: %w", name, err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if resp.StatusCode == http.StatusNotFound {
+		return fmt.Errorf("argo_client: delete workflow %q: %w", name, errArgoNotFound)
+	}
+	if resp.StatusCode >= 300 {
+		b, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("argo_client: delete workflow %q: HTTP %d: %s", name, resp.StatusCode, string(b))
 	}
 	return nil
 }

--- a/services/engine-adapter/internal/infrastructure/argo_engine.go
+++ b/services/engine-adapter/internal/infrastructure/argo_engine.go
@@ -7,6 +7,7 @@ package infrastructure
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -25,6 +26,9 @@ const (
 	// the serialised WorkflowIR JSON. The WorkflowTemplate in the cluster is
 	// expected to expose a parameter with this name.
 	argoIRPayloadParam = "workflow-ir"
+
+	// argoWatchPollInterval is the polling interval used by Watch.
+	argoWatchPollInterval = 2 * time.Second
 )
 
 // ArgoConfig holds the runtime configuration for ArgoEngine. All values are
@@ -43,9 +47,6 @@ type ArgoConfig struct {
 
 // ArgoEngine implements domain.WorkflowEngine backed by the Argo Workflows REST API.
 // Selected when ZYNAX_ENGINE_ADAPTER_ACTIVE_ENGINE=argo (ADR-015).
-//
-// ArgoEngine only implements Submit and Signal in this step (O2 / issue #796).
-// GetStatus, Cancel, and Watch are implemented in O3 / issue #797.
 type ArgoEngine struct {
 	client ArgoClient
 	cfg    ArgoConfig
@@ -118,25 +119,150 @@ func (e *ArgoEngine) Signal(ctx context.Context, runID, eventType string, payloa
 	return nil
 }
 
-// Cancel, GetStatus, and Watch are unimplemented in this step (O2).
-// They are implemented in O3 / issue #797 to keep PRs atomic.
+// GetStatus retrieves the current run metadata for the given runID by querying
+// the Argo Workflows REST API. Argo WorkflowStatus.Phase values are mapped to
+// domain.WorkflowStatus constants.
+//
+// Returns domain.ErrExecutionNotFound if the workflow does not exist.
+func (e *ArgoEngine) GetStatus(ctx context.Context, runID string) (*domain.WorkflowRun, error) {
+	if runID == "" {
+		return nil, fmt.Errorf("engine-adapter(argo): GetStatus: runID must not be empty")
+	}
 
-// Cancel is not yet implemented — returns an error indicating the method
-// will be available after issue #797 is merged.
-func (e *ArgoEngine) Cancel(_ context.Context, runID, _ string) error {
-	return fmt.Errorf("engine-adapter(argo): Cancel not yet implemented (issue #797): run %q", runID)
+	wf, err := e.client.GetWorkflow(ctx, e.cfg.Namespace, runID)
+	if err != nil {
+		if errors.Is(err, errArgoNotFound) {
+			return nil, fmt.Errorf("engine-adapter(argo): GetStatus %q: %w", runID, domain.ErrExecutionNotFound)
+		}
+		return nil, fmt.Errorf("engine-adapter(argo): GetStatus %q: %w", runID, err)
+	}
+
+	run := &domain.WorkflowRun{
+		RunID:        runID,
+		WorkflowID:   wf.Metadata.Name,
+		Namespace:    wf.Metadata.Namespace,
+		Engine:       argoEngineName,
+		Labels:       wf.Metadata.Labels,
+		CurrentState: wf.Status.Phase,
+		Status:       mapArgoPhase(wf.Status.Phase),
+	}
+
+	if wf.Status.StartedAt != "" {
+		if t, err := time.Parse(time.RFC3339, wf.Status.StartedAt); err == nil {
+			run.StartedAt = t
+		}
+	}
+	if wf.Status.FinishedAt != "" {
+		if t, err := time.Parse(time.RFC3339, wf.Status.FinishedAt); err == nil {
+			run.FinishedAt = t
+		}
+	}
+
+	return run, nil
 }
 
-// GetStatus is not yet implemented — returns ErrExecutionNotFound so callers
-// receive a sensible gRPC NOT_FOUND rather than a panic.
-func (e *ArgoEngine) GetStatus(_ context.Context, runID string) (*domain.WorkflowRun, error) {
-	return nil, fmt.Errorf("engine-adapter(argo): GetStatus not yet implemented (issue #797): %w — run %q",
-		domain.ErrExecutionNotFound, runID)
+// Cancel requests cancellation of a running workflow by deleting the Argo Workflow
+// resource, which causes Argo to terminate all running pods.
+//
+// Returns domain.ErrExecutionNotFound if the workflow does not exist.
+// Returns domain.ErrTerminalState if the workflow has already reached a terminal phase.
+func (e *ArgoEngine) Cancel(ctx context.Context, runID, _ string) error {
+	if runID == "" {
+		return fmt.Errorf("engine-adapter(argo): Cancel: runID must not be empty")
+	}
+
+	// Fetch current status first so we can guard against terminal-state cancels.
+	wf, err := e.client.GetWorkflow(ctx, e.cfg.Namespace, runID)
+	if err != nil {
+		if errors.Is(err, errArgoNotFound) {
+			return fmt.Errorf("engine-adapter(argo): Cancel %q: %w", runID, domain.ErrExecutionNotFound)
+		}
+		return fmt.Errorf("engine-adapter(argo): Cancel %q: %w", runID, err)
+	}
+
+	if mapArgoPhase(wf.Status.Phase).IsTerminal() {
+		return fmt.Errorf("engine-adapter(argo): Cancel %q: %w (phase=%s)",
+			runID, domain.ErrTerminalState, wf.Status.Phase)
+	}
+
+	if err := e.client.DeleteWorkflow(ctx, e.cfg.Namespace, runID); err != nil {
+		if errors.Is(err, errArgoNotFound) {
+			// Race: workflow was deleted between GetWorkflow and DeleteWorkflow.
+			return fmt.Errorf("engine-adapter(argo): Cancel %q: %w", runID, domain.ErrExecutionNotFound)
+		}
+		return fmt.Errorf("engine-adapter(argo): Cancel %q: %w", runID, err)
+	}
+	return nil
 }
 
-// Watch is not yet implemented.
-func (e *ArgoEngine) Watch(_ context.Context, runID string, _ func(*domain.WorkflowEvent) error) error {
-	return fmt.Errorf("engine-adapter(argo): Watch not yet implemented (issue #797): run %q", runID)
+// Watch polls the Argo Workflows API until the workflow reaches a terminal state
+// or ctx is cancelled, calling send for each observed status transition.
+// send is called at least once with a terminal-status event before Watch returns nil.
+//
+// Returns domain.ErrExecutionNotFound if the workflow does not exist on the first poll.
+func (e *ArgoEngine) Watch(ctx context.Context, runID string, send func(*domain.WorkflowEvent) error) error {
+	if runID == "" {
+		return fmt.Errorf("engine-adapter(argo): Watch: runID must not be empty")
+	}
+
+	var lastPhase string
+
+	for {
+		wf, err := e.client.GetWorkflow(ctx, e.cfg.Namespace, runID)
+		if err != nil {
+			if errors.Is(err, errArgoNotFound) {
+				return fmt.Errorf("engine-adapter(argo): Watch %q: %w", runID, domain.ErrExecutionNotFound)
+			}
+			return fmt.Errorf("engine-adapter(argo): Watch %q: %w", runID, err)
+		}
+
+		currentPhase := wf.Status.Phase
+		status := mapArgoPhase(currentPhase)
+
+		if currentPhase != lastPhase {
+			event := &domain.WorkflowEvent{
+				RunID:     runID,
+				EventType: "status.changed",
+				FromState: lastPhase,
+				ToState:   currentPhase,
+				Status:    status,
+				Timestamp: time.Now(),
+			}
+			if err := send(event); err != nil {
+				return fmt.Errorf("engine-adapter(argo): Watch %q: send: %w", runID, err)
+			}
+			lastPhase = currentPhase
+		}
+
+		if status.IsTerminal() {
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("engine-adapter(argo): Watch %q: %w", runID, ctx.Err())
+		case <-time.After(argoWatchPollInterval):
+		}
+	}
+}
+
+// mapArgoPhase converts an Argo WorkflowStatus.Phase string to a domain.WorkflowStatus.
+// Unknown or empty phases map to WorkflowStatusPending.
+func mapArgoPhase(phase string) domain.WorkflowStatus {
+	switch phase {
+	case ArgoPhasePending, "":
+		return domain.WorkflowStatusPending
+	case ArgoPhaseRunning:
+		return domain.WorkflowStatusRunning
+	case ArgoPhaseSucceeded:
+		return domain.WorkflowStatusCompleted
+	case ArgoPhaseFailed, ArgoPhaseError:
+		return domain.WorkflowStatusFailed
+	case ArgoPhaseSkipped:
+		return domain.WorkflowStatusCancelled
+	default:
+		return domain.WorkflowStatusPending
+	}
 }
 
 // buildArgoWorkflow constructs the Argo Workflow resource from a WorkflowIR

--- a/services/engine-adapter/internal/infrastructure/argo_engine_query_test.go
+++ b/services/engine-adapter/internal/infrastructure/argo_engine_query_test.go
@@ -1,0 +1,467 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package infrastructure provides concrete implementations of domain ports backed by
+// external services and SDKs. Only this package may import engine-specific dependencies
+// such as the Temporal Go SDK (ADR-015).
+package infrastructure
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/zynax-io/zynax/services/engine-adapter/internal/domain"
+)
+
+// ─── mapArgoPhase tests ──────────────────────────────────────────────────────
+
+func TestMapArgoPhase(t *testing.T) {
+	cases := []struct {
+		phase string
+		want  domain.WorkflowStatus
+	}{
+		{"", domain.WorkflowStatusPending},
+		{ArgoPhasePending, domain.WorkflowStatusPending},
+		{ArgoPhaseRunning, domain.WorkflowStatusRunning},
+		{ArgoPhaseSucceeded, domain.WorkflowStatusCompleted},
+		{ArgoPhaseFailed, domain.WorkflowStatusFailed},
+		{ArgoPhaseError, domain.WorkflowStatusFailed},
+		{ArgoPhaseSkipped, domain.WorkflowStatusCancelled},
+		{"unknown-future-phase", domain.WorkflowStatusPending},
+	}
+
+	for _, tc := range cases {
+		got := mapArgoPhase(tc.phase)
+		if got != tc.want {
+			t.Errorf("mapArgoPhase(%q) = %v; want %v", tc.phase, got, tc.want)
+		}
+	}
+}
+
+// ─── GetStatus tests ─────────────────────────────────────────────────────────
+
+func TestArgoEngine_GetStatus_Success(t *testing.T) {
+	stub := &stubArgoClient{
+		getWFResult: &ArgoWorkflow{
+			Metadata: ArgoObjectMeta{
+				Name:      "wf-001",
+				Namespace: testArgoNamespace,
+				Labels:    map[string]string{"env": "prod"},
+			},
+			Status: ArgoWorkflowStatus{
+				Phase:      ArgoPhaseRunning,
+				StartedAt:  "2026-06-09T10:00:00Z",
+				FinishedAt: "",
+			},
+		},
+	}
+	engine := newTestArgoEngine(stub)
+
+	run, err := engine.GetStatus(context.Background(), "wf-001")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if run == nil {
+		t.Fatal("expected non-nil WorkflowRun")
+	}
+	if run.RunID != "wf-001" {
+		t.Errorf("RunID = %q; want %q", run.RunID, "wf-001")
+	}
+	if run.Status != domain.WorkflowStatusRunning {
+		t.Errorf("Status = %v; want Running", run.Status)
+	}
+	if run.Engine != argoEngineName {
+		t.Errorf("Engine = %q; want %q", run.Engine, argoEngineName)
+	}
+	if run.StartedAt.IsZero() {
+		t.Error("StartedAt must be parsed from status")
+	}
+	if run.Labels["env"] != "prod" {
+		t.Errorf("Labels not forwarded: %v", run.Labels)
+	}
+	if stub.lastGetNamespace != testArgoNamespace {
+		t.Errorf("GetWorkflow namespace = %q; want %q", stub.lastGetNamespace, testArgoNamespace)
+	}
+	if stub.lastGetName != "wf-001" {
+		t.Errorf("GetWorkflow name = %q; want %q", stub.lastGetName, "wf-001")
+	}
+}
+
+func TestArgoEngine_GetStatus_Succeeded(t *testing.T) {
+	stub := &stubArgoClient{
+		getWFResult: &ArgoWorkflow{
+			Metadata: ArgoObjectMeta{Name: "wf-done", Namespace: testArgoNamespace},
+			Status: ArgoWorkflowStatus{
+				Phase:      ArgoPhaseSucceeded,
+				StartedAt:  "2026-06-09T10:00:00Z",
+				FinishedAt: "2026-06-09T10:05:00Z",
+			},
+		},
+	}
+	engine := newTestArgoEngine(stub)
+
+	run, err := engine.GetStatus(context.Background(), "wf-done")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if run.Status != domain.WorkflowStatusCompleted {
+		t.Errorf("Status = %v; want Completed", run.Status)
+	}
+	if run.FinishedAt.IsZero() {
+		t.Error("FinishedAt must be parsed from status")
+	}
+	if !run.Status.IsTerminal() {
+		t.Error("Completed must be terminal")
+	}
+}
+
+func TestArgoEngine_GetStatus_NotFound(t *testing.T) {
+	stub := &stubArgoClient{
+		getWFErr: fmt.Errorf("argo_client: get workflow %q: %w", "missing", errArgoNotFound),
+	}
+	engine := newTestArgoEngine(stub)
+
+	_, err := engine.GetStatus(context.Background(), "missing")
+	if err == nil {
+		t.Fatal("expected error for missing workflow")
+	}
+	if !errors.Is(err, domain.ErrExecutionNotFound) {
+		t.Errorf("expected ErrExecutionNotFound, got: %v", err)
+	}
+}
+
+func TestArgoEngine_GetStatus_EmptyRunID(t *testing.T) {
+	stub := &stubArgoClient{}
+	engine := newTestArgoEngine(stub)
+
+	_, err := engine.GetStatus(context.Background(), "")
+	if err == nil {
+		t.Fatal("expected error for empty runID")
+	}
+}
+
+func TestArgoEngine_GetStatus_ClientError(t *testing.T) {
+	stub := &stubArgoClient{getWFErr: errors.New("argo server unreachable")}
+	engine := newTestArgoEngine(stub)
+
+	_, err := engine.GetStatus(context.Background(), "wf-err")
+	if err == nil {
+		t.Fatal("expected error from client")
+	}
+	if !containsStr(err.Error(), "argo server unreachable") {
+		t.Errorf("expected wrapped client error, got: %v", err)
+	}
+}
+
+func TestArgoEngine_GetStatus_InvalidTimestamp(t *testing.T) {
+	// Invalid timestamps must not cause a panic; StartedAt/FinishedAt stay zero.
+	stub := &stubArgoClient{
+		getWFResult: &ArgoWorkflow{
+			Metadata: ArgoObjectMeta{Name: "wf-ts", Namespace: testArgoNamespace},
+			Status: ArgoWorkflowStatus{
+				Phase:      ArgoPhaseRunning,
+				StartedAt:  "not-a-timestamp",
+				FinishedAt: "also-bad",
+			},
+		},
+	}
+	engine := newTestArgoEngine(stub)
+
+	run, err := engine.GetStatus(context.Background(), "wf-ts")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !run.StartedAt.IsZero() {
+		t.Error("invalid StartedAt should remain zero")
+	}
+	if !run.FinishedAt.IsZero() {
+		t.Error("invalid FinishedAt should remain zero")
+	}
+}
+
+// ─── Cancel tests ─────────────────────────────────────────────────────────────
+
+func TestArgoEngine_Cancel_Success(t *testing.T) {
+	stub := &stubArgoClient{
+		getWFResult: &ArgoWorkflow{
+			Metadata: ArgoObjectMeta{Name: "wf-cancel", Namespace: testArgoNamespace},
+			Status:   ArgoWorkflowStatus{Phase: ArgoPhaseRunning},
+		},
+	}
+	engine := newTestArgoEngine(stub)
+
+	err := engine.Cancel(context.Background(), "wf-cancel", "user requested")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if stub.lastDelName != "wf-cancel" {
+		t.Errorf("DeleteWorkflow name = %q; want %q", stub.lastDelName, "wf-cancel")
+	}
+	if stub.lastDelNamespace != testArgoNamespace {
+		t.Errorf("DeleteWorkflow namespace = %q; want %q", stub.lastDelNamespace, testArgoNamespace)
+	}
+}
+
+func TestArgoEngine_Cancel_NotFound(t *testing.T) {
+	stub := &stubArgoClient{
+		getWFErr: fmt.Errorf("argo_client: get workflow %q: %w", "missing", errArgoNotFound),
+	}
+	engine := newTestArgoEngine(stub)
+
+	err := engine.Cancel(context.Background(), "missing", "")
+	if err == nil {
+		t.Fatal("expected error for missing workflow")
+	}
+	if !errors.Is(err, domain.ErrExecutionNotFound) {
+		t.Errorf("expected ErrExecutionNotFound, got: %v", err)
+	}
+}
+
+func TestArgoEngine_Cancel_TerminalState(t *testing.T) {
+	for _, phase := range []string{ArgoPhaseSucceeded, ArgoPhaseFailed, ArgoPhaseError, ArgoPhaseSkipped} {
+		phase := phase
+		t.Run(phase, func(t *testing.T) {
+			stub := &stubArgoClient{
+				getWFResult: &ArgoWorkflow{
+					Metadata: ArgoObjectMeta{Name: "wf-done", Namespace: testArgoNamespace},
+					Status:   ArgoWorkflowStatus{Phase: phase},
+				},
+			}
+			engine := newTestArgoEngine(stub)
+
+			err := engine.Cancel(context.Background(), "wf-done", "")
+			if err == nil {
+				t.Fatalf("expected ErrTerminalState for phase %q", phase)
+			}
+			if !errors.Is(err, domain.ErrTerminalState) {
+				t.Errorf("expected ErrTerminalState, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestArgoEngine_Cancel_EmptyRunID(t *testing.T) {
+	stub := &stubArgoClient{}
+	engine := newTestArgoEngine(stub)
+
+	err := engine.Cancel(context.Background(), "", "")
+	if err == nil {
+		t.Fatal("expected error for empty runID")
+	}
+}
+
+func TestArgoEngine_Cancel_DeleteClientError(t *testing.T) {
+	stub := &stubArgoClient{
+		getWFResult: &ArgoWorkflow{
+			Metadata: ArgoObjectMeta{Name: "wf-del-err", Namespace: testArgoNamespace},
+			Status:   ArgoWorkflowStatus{Phase: ArgoPhaseRunning},
+		},
+		delWFErr: errors.New("k8s unavailable"),
+	}
+	engine := newTestArgoEngine(stub)
+
+	err := engine.Cancel(context.Background(), "wf-del-err", "")
+	if err == nil {
+		t.Fatal("expected error from delete client")
+	}
+	if !containsStr(err.Error(), "k8s unavailable") {
+		t.Errorf("expected wrapped delete error, got: %v", err)
+	}
+}
+
+func TestArgoEngine_Cancel_RaceDeleteNotFound(t *testing.T) {
+	// Simulate race: GetWorkflow returns running but DeleteWorkflow returns 404.
+	stub := &stubArgoClient{
+		getWFResult: &ArgoWorkflow{
+			Metadata: ArgoObjectMeta{Name: "wf-race", Namespace: testArgoNamespace},
+			Status:   ArgoWorkflowStatus{Phase: ArgoPhaseRunning},
+		},
+		delWFErr: fmt.Errorf("argo_client: delete workflow %q: %w", "wf-race", errArgoNotFound),
+	}
+	engine := newTestArgoEngine(stub)
+
+	err := engine.Cancel(context.Background(), "wf-race", "")
+	if err == nil {
+		t.Fatal("expected error for race delete not found")
+	}
+	if !errors.Is(err, domain.ErrExecutionNotFound) {
+		t.Errorf("expected ErrExecutionNotFound for race, got: %v", err)
+	}
+}
+
+// ─── Watch tests ──────────────────────────────────────────────────────────────
+
+// sequentialStub is a specialised stub that returns a different ArgoWorkflow on
+// each successive call to GetWorkflow, cycling through the provided states.
+// This lets Watch tests exercise multi-poll transitions.
+type sequentialStub struct {
+	states  []ArgoWorkflowStatus
+	call    int
+	delErr  error
+	sendErr error
+}
+
+func (s *sequentialStub) GetWorkflow(_ context.Context, _, _ string) (*ArgoWorkflow, error) {
+	if s.call >= len(s.states) {
+		// Return last state when exhausted.
+		last := s.states[len(s.states)-1]
+		return &ArgoWorkflow{
+			Metadata: ArgoObjectMeta{Name: "wf-watch", Namespace: testArgoNamespace},
+			Status:   last,
+		}, nil
+	}
+	st := s.states[s.call]
+	s.call++
+	return &ArgoWorkflow{
+		Metadata: ArgoObjectMeta{Name: "wf-watch", Namespace: testArgoNamespace},
+		Status:   st,
+	}, nil
+}
+
+func (s *sequentialStub) SubmitWorkflow(_ context.Context, _ string, _ *ArgoWorkflow) error {
+	return nil
+}
+func (s *sequentialStub) SendEvent(_ context.Context, _, _ string, _ []byte) error {
+	return s.sendErr
+}
+func (s *sequentialStub) DeleteWorkflow(_ context.Context, _, _ string) error {
+	return s.delErr
+}
+
+func TestArgoEngine_Watch_TerminalImmediate(t *testing.T) {
+	// Workflow is already Succeeded on first poll — send must be called once.
+	stub := &stubArgoClient{
+		getWFResult: &ArgoWorkflow{
+			Metadata: ArgoObjectMeta{Name: "wf-done", Namespace: testArgoNamespace},
+			Status:   ArgoWorkflowStatus{Phase: ArgoPhaseSucceeded},
+		},
+	}
+	engine := newTestArgoEngine(stub)
+
+	var events []*domain.WorkflowEvent
+	err := engine.Watch(context.Background(), "wf-done", func(e *domain.WorkflowEvent) error {
+		events = append(events, e)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(events) == 0 {
+		t.Fatal("Watch must call send at least once")
+	}
+	last := events[len(events)-1]
+	if !last.Status.IsTerminal() {
+		t.Errorf("last event must be terminal; got status=%v", last.Status)
+	}
+}
+
+func TestArgoEngine_Watch_Transitions(t *testing.T) {
+	// Workflow transitions: Pending → Running → Succeeded.
+	cfg := defaultConfig()
+	seq := &sequentialStub{
+		states: []ArgoWorkflowStatus{
+			{Phase: ArgoPhasePending},
+			{Phase: ArgoPhaseRunning},
+			{Phase: ArgoPhaseSucceeded},
+		},
+	}
+	engine := NewArgoEngine(seq, cfg)
+
+	var events []*domain.WorkflowEvent
+	err := engine.Watch(context.Background(), "wf-watch", func(e *domain.WorkflowEvent) error {
+		events = append(events, e)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Expect 3 events: Pending, Running, Succeeded.
+	if len(events) != 3 {
+		t.Fatalf("expected 3 transition events, got %d", len(events))
+	}
+	if events[0].ToState != ArgoPhasePending {
+		t.Errorf("event[0].ToState = %q; want %q", events[0].ToState, ArgoPhasePending)
+	}
+	if events[1].ToState != ArgoPhaseRunning {
+		t.Errorf("event[1].ToState = %q; want %q", events[1].ToState, ArgoPhaseRunning)
+	}
+	if events[2].ToState != ArgoPhaseSucceeded {
+		t.Errorf("event[2].ToState = %q; want %q", events[2].ToState, ArgoPhaseSucceeded)
+	}
+	if !events[2].Status.IsTerminal() {
+		t.Error("last event must be terminal")
+	}
+}
+
+func TestArgoEngine_Watch_NotFound(t *testing.T) {
+	stub := &stubArgoClient{
+		getWFErr: fmt.Errorf("argo_client: get workflow %q: %w", "missing", errArgoNotFound),
+	}
+	engine := newTestArgoEngine(stub)
+
+	err := engine.Watch(context.Background(), "missing", func(_ *domain.WorkflowEvent) error { return nil })
+	if err == nil {
+		t.Fatal("expected error for missing workflow")
+	}
+	if !errors.Is(err, domain.ErrExecutionNotFound) {
+		t.Errorf("expected ErrExecutionNotFound, got: %v", err)
+	}
+}
+
+func TestArgoEngine_Watch_ContextCancelled(t *testing.T) {
+	// Watch on a running workflow should return ctx.Err() when context is cancelled.
+	// Use a sequentialStub that always returns Running so Watch loops forever until cancelled.
+	seq := &sequentialStub{
+		states: []ArgoWorkflowStatus{
+			{Phase: ArgoPhaseRunning},
+			{Phase: ArgoPhaseRunning},
+			{Phase: ArgoPhaseRunning},
+		},
+	}
+	engine := NewArgoEngine(seq, defaultConfig())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	err := engine.Watch(ctx, "wf-running", func(_ *domain.WorkflowEvent) error { return nil })
+	if err == nil {
+		t.Fatal("expected context cancellation error")
+	}
+	// The error wraps context.DeadlineExceeded or context.Canceled.
+	if !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, context.Canceled) {
+		t.Errorf("expected DeadlineExceeded or Canceled, got: %v", err)
+	}
+}
+
+func TestArgoEngine_Watch_EmptyRunID(t *testing.T) {
+	stub := &stubArgoClient{}
+	engine := newTestArgoEngine(stub)
+
+	err := engine.Watch(context.Background(), "", func(_ *domain.WorkflowEvent) error { return nil })
+	if err == nil {
+		t.Fatal("expected error for empty runID")
+	}
+}
+
+func TestArgoEngine_Watch_SendError(t *testing.T) {
+	stub := &stubArgoClient{
+		getWFResult: &ArgoWorkflow{
+			Metadata: ArgoObjectMeta{Name: "wf-send-err", Namespace: testArgoNamespace},
+			Status:   ArgoWorkflowStatus{Phase: ArgoPhaseSucceeded},
+		},
+	}
+	engine := newTestArgoEngine(stub)
+
+	sendErr := errors.New("downstream closed")
+	err := engine.Watch(context.Background(), "wf-send-err", func(_ *domain.WorkflowEvent) error {
+		return sendErr
+	})
+	if err == nil {
+		t.Fatal("expected error when send returns error")
+	}
+	if !containsStr(err.Error(), "downstream closed") {
+		t.Errorf("expected wrapped send error, got: %v", err)
+	}
+}

--- a/services/engine-adapter/internal/infrastructure/argo_engine_submit_test.go
+++ b/services/engine-adapter/internal/infrastructure/argo_engine_submit_test.go
@@ -19,6 +19,11 @@ import (
 type stubArgoClient struct {
 	submitErr error
 	sendErr   error
+	getWFErr  error
+	delWFErr  error
+
+	// getWFResult controls the ArgoWorkflow returned by GetWorkflow.
+	getWFResult *ArgoWorkflow
 
 	// Captured arguments for assertion.
 	lastSubmitNamespace string
@@ -26,6 +31,10 @@ type stubArgoClient struct {
 	lastSendNamespace   string
 	lastSendDiscrim     string
 	lastSendPayload     []byte
+	lastGetNamespace    string
+	lastGetName         string
+	lastDelNamespace    string
+	lastDelName         string
 }
 
 func (s *stubArgoClient) SubmitWorkflow(_ context.Context, namespace string, wf *ArgoWorkflow) error {
@@ -39,6 +48,18 @@ func (s *stubArgoClient) SendEvent(_ context.Context, namespace, discriminator s
 	s.lastSendDiscrim = discriminator
 	s.lastSendPayload = payload
 	return s.sendErr
+}
+
+func (s *stubArgoClient) GetWorkflow(_ context.Context, namespace, name string) (*ArgoWorkflow, error) {
+	s.lastGetNamespace = namespace
+	s.lastGetName = name
+	return s.getWFResult, s.getWFErr
+}
+
+func (s *stubArgoClient) DeleteWorkflow(_ context.Context, namespace, name string) error {
+	s.lastDelNamespace = namespace
+	s.lastDelName = name
+	return s.delWFErr
 }
 
 const (


### PR DESCRIPTION
## Summary

- Implements `ArgoEngine.GetStatus`, `ArgoEngine.Cancel`, and `ArgoEngine.Watch` (Canvas O3, #766 step 3)
- Extends `ArgoClient` interface with `GetWorkflow` and `DeleteWorkflow` methods + HTTP implementations
- Adds `ArgoWorkflowStatus` struct and Argo phase constants for phase→domain status mapping
- `GetStatus` returns `ErrExecutionNotFound` for unknown run IDs
- `Cancel` guards against terminal-state cancels (`ErrTerminalState`) and handles delete-not-found races
- `Watch` polls until terminal, calling `send` on each phase transition; respects context cancellation
- Unit tests in `argo_engine_query_test.go` cover all three methods including edge cases

## Test plan

- [x] `GOWORK=off go build ./...` passes
- [x] `GOWORK=off go test ./... -race -timeout 60s` passes (all 4 packages green)
- [x] `golangci-lint` passes (pre-commit hook)
- [x] `GetStatus` returns `ErrExecutionNotFound` for unknown run IDs ✓
- [x] `Cancel` returns `ErrTerminalState` for completed workflows (all terminal phases) ✓
- [x] `Watch` calls `send` at least once with a terminal-status event ✓
- [x] Unit tests cover GetStatus, Cancel, Watch — including NotFound, TerminalState, transitions, context cancel ✓

## Canvas reference

`docs/spdd/766-argo-engine/canvas.md` — O3 step

🤖 Generated with [Claude Code](https://claude.com/claude-code)
