### PR TITLE
ci(agents): add sdk-publish.yml for PyPI Trusted Publisher (#806)

### DIFF
--- a/.github/workflows/sdk-publish.yml
+++ b/.github/workflows/sdk-publish.yml
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: Apache-2.0
+# Zynax — SDK PyPI Publish
+#
+# Fires on version-tag pushes (v*.*.*) and publishes zynax-sdk to the
+# real PyPI via GitHub Actions OIDC Trusted Publisher — no API keys
+# stored in secrets.
+#
+# Prerequisites (one-time manual setup — see agents/sdk/AGENTS.md):
+#   1. Register a Trusted Publisher on pypi.org for this repo.
+#   2. Workflow file name:  sdk-publish.yml
+#   3. Environment name:    pypi
+#
+# Related:
+#   tools-publish.yml — TestPyPI dry-run on PRs touching agents/sdk/ (#805, F.1)
+#   This file is F.2 (#806).
+
+name: SDK PyPI Publish
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Build & publish zynax-sdk to PyPI
+    runs-on: ubuntu-24.04
+    environment: pypi   # OIDC trusted publisher environment — must match PyPI registration
+
+    permissions:
+      contents: read
+      id-token: write   # required for OIDC token minting
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb  # v6.1.0
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        with:
+          python-version: "3.12"
+
+      - name: Install hatch (build + publish tool)
+        run: pip install --quiet "hatch>=1.13"
+
+      - name: Build wheel and sdist
+        working-directory: agents/sdk
+        run: |
+          hatch build
+          echo "Build artifacts:"
+          ls -lh dist/
+
+      - name: Verify dist contents
+        working-directory: agents/sdk
+        run: |
+          # Confirm both wheel and sdist were produced.
+          WHL=$(ls dist/*.whl 2>/dev/null | wc -l)
+          SDT=$(ls dist/*.tar.gz 2>/dev/null | wc -l)
+          if [ "$WHL" -eq 0 ] || [ "$SDT" -eq 0 ]; then
+            echo "ERROR: expected both .whl and .tar.gz in dist/" >&2
+            exit 1
+          fi
+          echo "OK — wheel: $WHL  sdist: $SDT"
+
+      - name: Publish to PyPI (OIDC — Trusted Publisher)
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc  # v1.12.4
+        with:
+          packages-dir: agents/sdk/dist/
+          verbose: true


### PR DESCRIPTION
## Summary

Adds `.github/workflows/sdk-publish.yml` — a release-triggered workflow that publishes
`zynax-sdk` to PyPI automatically whenever a `v*.*.*` tag is pushed.

Uses OIDC Trusted Publisher (no API key stored) and `hatch build` for wheel + sdist packaging.
All Actions are SHA-pinned. Part of M6.SDK epic (#769), O2 step.

## Changes

- `.github/workflows/sdk-publish.yml` — new publish workflow

## Test plan

- [ ] Verify workflow syntax: `make lint` passes
- [ ] On next `v*.*.*` tag push: confirm wheel + sdist published to PyPI

Closes #806

---
🤖 Assisted-by: Claude/claude-sonnet-4-6
