### PR TITLE
chore(automation): prune obsolete tree-workarounds from expert guides

### DIFF
--- a/.claude/commands/experts/go-services.md
+++ b/.claude/commands/experts/go-services.md
@@ -218,31 +218,16 @@ for _, tt := range tests {
 
 ---
 
-## Shared workspace safety
+## Git safety
 
-Multiple subagents share a single working tree and continuously switch branches. These rules prevent cross-agent contamination:
+You run in your own isolated git worktree (EPIC #1001 — `m6-orchestrate` STEP 6 /
+`m6-issue-generate` STEP 2.5): a private checkout with its own `HEAD` and index. Branch
+switches, `git add`, and `git stash` here are invisible to sibling agents and theirs to you,
+so no defensive branch-verify before each Bash call, no explicit-path-only staging to dodge
+sibling contamination, and no stash-avoidance is needed.
 
-```bash
-# First command of any Bash call that touches files or commits:
-git branch --show-current   # verify; if wrong:
-git checkout <branch>       # set correct branch
-
-# Stage explicitly — never git add .
-git add services/foo/bar.go services/foo/bar_test.go
-```
-
-- **Branch state resets between every Bash tool call** — always verify and set the branch first.
-  CWD also resets; always use absolute file paths in file writes and edits.
-  Seen in: #818, #819, #826, #827, #828 (5 sessions).
-
-- **`git add .` picks up other agents' changes** — always stage by explicit path.
-  Seen in: #817, #818, #819, #826, #828 (5 sessions).
-
-- **`git stash` is unsafe across branches** — `git stash pop` on a different branch brings
-  unrelated modifications into the working tree and can fail with "untracked files would be
-  overwritten". Prefer `git restore -- <paths>` to discard unwanted tracked-file changes, or
-  `git checkout stash@{N} -- <specific-path>` to extract only the files needed without a full pop.
-  Seen in: #818, #819 (2 sessions).
+One hazard remains — it is server-side, not a working-tree problem, so worktree isolation
+does not address it:
 
 - **Never use `gh api .../pulls/N/update-branch`** — GitHub's "Update branch" API and button
   produce a merge commit with no `Signed-off-by`, failing both DCO and `required_signatures`.

--- a/.claude/commands/experts/post-merge.md
+++ b/.claude/commands/experts/post-merge.md
@@ -265,9 +265,9 @@ Only run if `$COMPOSE_PINS_UPDATED` or `$YAML_PINS_UPDATED` is non-empty:
 ```bash
 [post-mrg PR#${PR_NUMBER} $(date +%H:%M:%S)] COMMIT: opening digest-update PR  [ctx: ~16K | compress=0 | msgs=8]
 
-git checkout main && git pull --rebase origin main
+# Your worktree already starts at origin/main (EPIC #1001) — branch directly off it.
 DIGEST_BRANCH="chore/post-merge-digest-pr${PR_NUMBER}"
-git checkout -b "$DIGEST_BRANCH"
+git checkout -B "$DIGEST_BRANCH" origin/main
 
 STAGE_FILES=""
 [ -n "$COMPOSE_PINS_UPDATED" ] && STAGE_FILES="$STAGE_FILES infra/docker-compose/docker-compose.services.yml"

--- a/docs/milestones/M6-planning.md
+++ b/docs/milestones/M6-planning.md
@@ -118,8 +118,8 @@ DevAuto.8 is aspirational (Zynax AgentDef workflows) — gated by `automation/te
 |-------|-------|------|-----|--------|
 | step 1 feat(automation): isolate orchestrator subagents in per-run worktrees | [#1002](https://github.com/zynax-io/zynax/issues/1002) | CI | #1007 | ✅ Merged |
 | step 2 feat(automation): idempotent orchestrator dispatch | [#1003](https://github.com/zynax-io/zynax/issues/1003) | CI | — | ⬜ Open |
-| step 3 chore(automation): classify workaround learnings in m6-learn | [#1004](https://github.com/zynax-io/zynax/issues/1004) | CI | — | 🔄 In review |
-| step 4 chore(automation): prune obsolete tree-workarounds from experts *(after step 1)* | [#1005](https://github.com/zynax-io/zynax/issues/1005) | CI | — | ⬜ Open |
+| step 3 chore(automation): classify workaround learnings in m6-learn | [#1004](https://github.com/zynax-io/zynax/issues/1004) | CI | #1008 | ✅ Merged |
+| step 4 chore(automation): prune obsolete tree-workarounds from experts *(after step 1)* | [#1005](https://github.com/zynax-io/zynax/issues/1005) | CI | — | 🔄 In review |
 
 **M6.F — Platform Configuration Convergence** ✅ **COMPLETE** (EPIC [#670](https://github.com/zynax-io/zynax/issues/670); SPDD-exempt: refactor:/chore:/ci:)
 

--- a/docs/spdd/1001-orchestrator-concurrency-safety/canvas.md
+++ b/docs/spdd/1001-orchestrator-concurrency-safety/canvas.md
@@ -105,7 +105,7 @@ Each step = one PR.
 
 3. ✅ **Learning-loop classification (#1004, `chore`).** In `m6-learn` STEP 4, add the two synthesizer rules (classify `domain` / `structural-workaround`; suppress structural by default under a separate heading, defaulting Status to `rejected`). Add the `Category` column to the apply-log table. Leave the human-review gate unchanged.
 
-4. **Expert-guide cleanup (#1005, `chore`) — after #1002 is merged and validated.** Remove the obsolete shared-tree workarounds from `experts/go-services.md` ("Shared workspace safety" branch/stash/`git add` rules) and `experts/post-merge.md` (Phase 6 branch-prep dance). Verify every RC3 mitigation remains. Reference the validated step-1 batch as evidence in the PR.
+4. ✅ **Expert-guide cleanup (#1005, `chore`) — after #1002 is merged and validated.** Remove the obsolete shared-tree workarounds from `experts/go-services.md` ("Shared workspace safety" branch/stash/`git add` rules) and `experts/post-merge.md` (Phase 6 branch-prep dance). Verify every RC3 mitigation remains. Reference the validated step-1 batch as evidence in the PR.
 
 ---
 


### PR DESCRIPTION
## Summary

O-step 4 (final) of EPIC #1001. Now that every `/m6-orchestrate` subagent runs in its own isolated worktree (#1002, merged in PR #1007), the shared-working-tree workarounds in the expert guides are dead weight. This removes them while **retaining** the RC3 server-side mitigations that worktree isolation does not address.

## EPIC canvas

`docs/spdd/1001-orchestrator-concurrency-safety/canvas.md` — O-step 4 (marked ✅). This closes the EPIC's O-section.

## What changed

**`experts/go-services.md`** — replaced the "Shared workspace safety" section with a slim "Git safety" section:
- Removed (obsolete under worktree isolation): "verify/`git checkout <branch>` first command of every Bash call", "branch state resets between tool calls", "never `git add .` (sibling contamination)", "`git stash` is unsafe across branches".
- **Kept (RC3, server-side):** the `gh api .../update-branch` → unsigned-merge-commit rule.

**`experts/post-merge.md`** — Phase 6: removed the `git checkout main && git pull --rebase origin main` branch-prep dance; the post-merge worktree already starts at `origin/main`, so it branches directly with `git checkout -B "$DIGEST_BRANCH" origin/main`.

## Validation evidence (isolation is proven)

Per the story's gate ("after step 1 merged + validated"): #1002 merged via PR #1007; the orchestrator now creates per-run worktrees in STEP 6 / STEP 7.5 (verified on `main`: `ORCH_RUN_ID` present, `worktree add "$WT" origin/main` in both dispatch prompts). The workarounds removed here are exactly the ones that isolation makes unnecessary.

## Acceptance criteria

- [x] Neither expert guide contains shared-tree workarounds — grep for `shared work*|first command of any bash|branch state resets|git add .|stash is unsafe|continuously switch branches` → **NONE**
- [x] All RC3 mitigations remain — `update-branch` rule still present in `go-services.md` (grep count 1)
- [x] PR references the validated step-1 batch (#1002 / PR #1007) as evidence
- [x] No prompt-injection phrasing (ADR-018 T4); no secrets/PII in diff

## Test plan

- [x] RC1 phrasing scan → none; RC3 `update-branch` retained
- [x] Code-fence balance even in both files (28 / 24)
- [x] Secret/PII scan on diff — clean
- [x] Net −15 lines (10 insertions, 25 deletions) — cleanup only

> `make lint` / `make security` cover proto/Go/Python only — no-ops for this Markdown-only diff. Authoritative gates are the CI KB checks, which run on this PR.

Closes #1005

Assisted-by: Claude/claude-sonnet-4-6
