### PR TITLE
docs(automation): apply expert learnings — 2026-06-09

### DIFF
--- a/.claude/commands/experts/ci-release.md
+++ b/.claude/commands/experts/ci-release.md
@@ -98,6 +98,12 @@ HANDOFF to git-ops:
 
 Note: `.github/workflows/` files are excluded from PR-size line counts per CLAUDE.md.
 
+- **PR title subject must be ≤72 chars (`amannn/action-semantic-pull-request`); fix via the
+  PATCH API, not `gh pr edit`.** Check with `echo -n '<subject>' | wc -m` after `gh pr create`.
+  `gh pr edit --title` can fail with a GraphQL Projects-Classic deprecation error — use
+  `gh api repos/zynax-io/zynax/pulls/<N> --method PATCH --field title='...'`, then
+  `gh run rerun <run_id> --failed` to recheck without a new commit. Seen in: #875, #806 (2 sessions).
+
 ---
 
 ## Mandatory reads before touching any workflow
@@ -139,6 +145,14 @@ images:
 The drift-check gate (`cmd/zynax-ci images check`) runs on every PR and fails if any
 image reference in a workflow file diverges from `images.yaml`.
 
+- **Every workflow that references a tracked image digest must be in that image's `consumers:`
+  list.** `make check-images` only diffs files in the consumers array, so a workflow referencing
+  the digest while absent from the list (e.g. `dev-advisory.yml` with 8 ci-runner digest
+  occurrences) drifts silently while the gate stays green. When adding a workflow that pins a
+  tracked digest, add it to `consumers:`. Also audit `paths:` filters: a workflow editing only
+  itself won't trigger if the workflow file isn't in its own `paths:`, leaving the change inert.
+  Seen in: #839 + post-merge (2 sessions).
+
 ---
 
 ## Docker build patterns
@@ -158,6 +172,15 @@ image reference in a workflow file diverges from `images.yaml`.
 
 **Multi-arch:** always build `linux/amd64,linux/arm64`. The M6.Build EPIC (#837) is moving
 to native arm64 runners — do not add QEMU emulation for new workflows.
+
+- **Native multi-arch = split-arch matrix + `merge-and-sign` fan-in (no QEMU).**
+  Use `resolve-matrix` → `platform_matrix` (services × platforms), then a `build-platform` job
+  with `runs-on: ${{ matrix.platform == 'amd64' && 'ubuntu-24.04' || 'ubuntu-24.04-arm' }}`, then
+  a `merge-and-sign` job that runs `docker buildx imagetools create` to assemble the index. Set
+  `provenance: false` on the per-platform images; apply provenance/attestation only on the merged
+  index. Capture the merged digest for cosign with
+  `docker buildx imagetools inspect --format '{{json .Manifest.Digest}}'`.
+  Seen in: #838, #840 (2 sessions).
 
 - **`docker buildx imagetools create` does NOT propagate OCI annotations from source manifests.**
   When assembling the multi-arch index in `merge-and-sign`, always add explicit `--annotation` flags:
@@ -263,6 +286,13 @@ Do not install tools directly in `run:` steps that are already in the container
   Jobs that need `gh` (PR comments, issue creation, API calls) must run on `ubuntu-24.04`
   (hosted runner), not inside `ci-runner`. For advisory-only steps, add `continue-on-error: true`.
   Seen in: #877 PR #969.
+
+- **No shell heredocs for multi-line CI output, and quote any string containing `--`.**
+  YAML treats `<<` as an anchor reference, breaking the parse — write intermediate results to
+  `/tmp` via `printf '%s\n' "$var"` chains instead. Likewise `printf 'text -- more\n'` fails in
+  the dash shell inside containers (`--` parsed as end-of-options); store the string in a variable
+  first. Cross-job result passing requires a job-level `outputs:` block writing to `$GITHUB_OUTPUT`.
+  Seen in: #877, #878 (2 sessions).
 
 ---
 

--- a/.claude/commands/experts/go-services.md
+++ b/.claude/commands/experts/go-services.md
@@ -167,6 +167,11 @@ func (h *Handler) Submit(ctx context.Context, req *pb.SubmitRequest) (*pb.Submit
 // Never log.Fatal or os.Exit in handlers or domain code — return error up the chain
 ```
 
+- **Wrap `ctx.Err()` before returning it — a bare `return ctx.Err()` fails `wrapcheck`.**
+  Outside gRPC use `return fmt.Errorf("context: %w", ctx.Err())`; inside a gRPC handler use
+  `status.FromContextError(ctx.Err()).Err()`, which the wrapcheck grpc glob exempts and which
+  maps cancellation/deadline to the correct gRPC code. Seen in: #824, #797 (2 sessions).
+
 ---
 
 ## Postgres / pgx v5 patterns (ADR-008 + M6.H canvas)
@@ -242,6 +247,12 @@ Never modify `*.pb.go` or `*_grpc.pb.go` files. If a new field is needed:
 1. Edit the `.proto` file in `protos/zynax/v1/`
 2. Run `make generate-protos` (runs in Docker — only prereq is Docker Desktop)
 3. Commit the generated stubs alongside the `.proto` change
+
+- **Read the generated `.pb.go` getters for exact field names before writing handler code —
+  proto source and generated structs diverge.** Use the nil-safe `req.GetField()` getters
+  rather than `req.Field`. Observed mismatches: requests that omit an `id` field (the service
+  must generate the UUID), `Embedding` vs `Vector`, `Prefix` vs `Pattern`. Seen in: #817, #488
+  (2 sessions).
 
 ---
 

--- a/.claude/commands/experts/spdd-canvas.md
+++ b/.claude/commands/experts/spdd-canvas.md
@@ -242,6 +242,23 @@ Body:
 
 ---
 
+## Status-surface reconciliation
+
+At every story delivery, reconcile **all** status surfaces from live issue/PR state — not just
+the local two. Live `gh issue list --state open` + `gh pr list --state merged` are the source of
+truth for "done", never the planning-doc column or the canvas `Status:` field. A per-story
+delivery updates only the local surfaces (the M6-planning row + the canvas O-step checkbox); the
+cross-cutting ones drift silently because no CI gate flags a stale milestone label. When an EPIC's
+last O-step merges:
+
+1. Flip the EPIC canvas `Status:` Aligned → Implemented.
+2. Update the milestone tables in README / ROADMAP / ARCHITECTURE / CLAUDE.md.
+3. Refresh `state/current-milestone.md` and its "as of" date.
+
+Then `grep` the markers across those files to confirm they agree. Seen in: #1001, #1011 (2 sessions).
+
+---
+
 ## Output format
 
 ```

--- a/docs/ai-learnings/APPLY_LOG.md
+++ b/docs/ai-learnings/APPLY_LOG.md
@@ -37,3 +37,20 @@
 | 6 | ci-release | gh CLI absent from ci-runner container — advisory jobs need hosted runner | #877 | applied | ci-release.md +5L |
 
 **Summary:** 6 proposed | 6 applied | 0 rejected | 0 pending
+
+## Run 2026-06-09 14:30 — domains: go-services, ci-release, spdd-canvas
+
+| # | Domain | Pattern | Category | Source sessions | Status | Delta |
+|---|--------|---------|----------|-----------------|--------|-------|
+| 1 | go-services | Wrap ctx.Err() before return — bare return fails wrapcheck | domain | #824, #797 | committed | go-services.md +5L |
+| 2 | go-services | Read generated .pb.go getters for exact field names | domain | #817, #488 | committed | go-services.md +6L |
+| 3 | go-services | File-reversion / write-related-files-in-one-turn | structural-workaround | #796, #797 | rejected | — |
+| 4 | go-services | Atomic empty-branch claim + cherry-pick/reset rescue | structural-workaround | #795, #799, #796 | rejected | — |
+| 5 | ci-release | Native multi-arch: split matrix + merge-and-sign fan-in | domain | #838, #840 | committed | ci-release.md +11L |
+| 6 | ci-release | No heredocs / quote `--` strings / job-level outputs in CI | domain | #877, #878 | committed | ci-release.md +6L |
+| 7 | ci-release | Tracked-digest workflows must be in image consumers list | domain | #839, #839-postmerge | committed | ci-release.md +8L |
+| 8 | ci-release | PR title ≤72 chars; fix via PATCH API not gh pr edit | domain | #875, #806 | committed | ci-release.md +5L |
+| 9 | ci-release | Avoid make lint pre-commit — Docker overwrites files | structural-workaround | #860, #879 | rejected | — |
+| 10 | spdd-canvas | Reconcile all status surfaces from live issue/PR state | domain | #1001, #1011 | committed | spdd-canvas.md +17L |
+
+**Summary:** 10 proposed | 7 committed | 3 rejected (structural) | 0 pending


### PR DESCRIPTION
## Summary

Applies approved `/m6-learn` proposals from the 2026-06-09 synthesis run. 7 recurring
domain patterns (seen in ≥2 sessions each) are promoted into the expert guides; 3
structural-workarounds are rejected per the worktree-isolation policy (EPIC #1001).

## Expert guide additions

| Expert | Pattern | Sessions |
|--------|---------|----------|
| go-services | Wrap `ctx.Err()` before return (wrapcheck) | #824, #797 |
| go-services | Read generated `.pb.go` getters for exact field names | #817, #488 |
| ci-release | Native multi-arch: split matrix + merge-and-sign fan-in | #838, #840 |
| ci-release | No heredocs / quote `--` strings / job-level outputs | #877, #878 |
| ci-release | Tracked-digest workflows must be in image consumers list | #839 + post-merge |
| ci-release | PR title ≤72 chars; fix via PATCH API not `gh pr edit` | #875, #806 |
| spdd-canvas | Reconcile all status surfaces from live issue/PR state | #1001, #1011 |

Rejected (structural-workaround): file-reversion/write-related-files-in-one-turn;
atomic empty-branch claim + cherry-pick/reset rescue; avoid `make lint` pre-commit.

See `docs/ai-learnings/APPLY_LOG.md` for the full run entry and per-row status.

Assisted-by: Claude/claude-opus-4-8
