### PR TITLE
feat(infra): kind cluster bootstrap for full Zynax stack e2e

### DIFF
--- a/scripts/e2e/README.md
+++ b/scripts/e2e/README.md
@@ -1,0 +1,89 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Zynax e2e harness
+
+Reproducible end-to-end test harness for the full Zynax platform. These scripts
+spin up an ephemeral [kind](https://kind.sigs.k8s.io/) (Kubernetes IN Docker)
+cluster and deploy the complete stack via the `helm/zynax-umbrella` chart, so
+that e2e assertions run against a real Kubernetes cluster rather than mocks.
+
+Part of EPIC G (#770). This directory currently delivers **step 1 (#809)**:
+cluster bootstrap + teardown. The workflow/CloudEvents/upgrade assertion scripts
+(#810–#813) land in subsequent steps.
+
+## Minimum resource requirements
+
+The full stack — 7 Zynax services plus NATS JetStream, Postgres 16, and
+Temporal — needs real headroom. The cluster will evict pods under memory
+pressure below these limits:
+
+| Resource | Minimum |
+|----------|---------|
+| CPU      | **4 cores** |
+| RAM      | **8 GB** |
+| Disk     | 20 GB free |
+
+On CI this maps to the `ubuntu-latest` runner (4 vCPU / 16 GB), with Docker
+configured for Docker-in-Docker. Locally, ensure Docker Desktop is allocated at
+least 4 CPU and 8 GB RAM.
+
+## Prerequisites
+
+| Tool      | Notes |
+|-----------|-------|
+| `docker`  | running daemon (Docker Desktop or DinD) |
+| `kind`    | cluster bootstrap |
+| `kubectl` | cluster interaction |
+| `helm`    | chart deployment (v3.14+) |
+
+`cluster-up.sh` installs upstream **cert-manager** into the cluster itself —
+the `zynax-cert-manager` subchart only creates `Certificate` / `ClusterIssuer`
+resources and assumes cert-manager CRDs already exist (ADR-020).
+
+## Usage
+
+```bash
+# Bring up the cluster and deploy the full stack (idempotent).
+scripts/e2e/cluster-up.sh
+
+# … run e2e assertions (added in #810–#813) …
+
+# Tear the cluster down (idempotent).
+scripts/e2e/cluster-down.sh
+```
+
+Both scripts are idempotent: `cluster-up.sh` reuses an existing cluster and
+performs a `helm upgrade --install`; `cluster-down.sh` succeeds even if no
+cluster is present.
+
+### Configuration
+
+Override defaults via environment variables (see each script header for the
+full list):
+
+| Variable               | Default            | Purpose |
+|------------------------|--------------------|---------|
+| `CLUSTER_NAME`         | `zynax-e2e`        | kind cluster name |
+| `NAMESPACE`            | `zynax`            | release namespace |
+| `RELEASE_NAME`         | `zynax`            | Helm release name |
+| `CERT_MANAGER_VERSION` | `v1.14.5`          | cert-manager chart version |
+| `KIND_NODE_IMAGE`      | `kindest/node:v1.29.2` | kind node image (digest-pinnable in CI) |
+| `WAIT_TIMEOUT`         | `600s`             | per-resource rollout wait |
+
+## What `cluster-up.sh` does
+
+1. Creates a 3-node kind cluster (1 control-plane + 2 workers) from
+   [`kind-config.yaml`](kind-config.yaml), exposing the api-gateway REST port on
+   host `:8080`.
+2. Installs cert-manager (CRDs + controllers).
+3. Deploys `zynax-umbrella` with `event-bus` and `memory-service` enabled using
+   **placeholder images** (real implementations: EPIC I #772 / J #773).
+4. Waits for all **7 service Deployments** to reach a healthy rollout with their
+   startup / liveness / readiness probes passing.
+
+## CI
+
+Live cluster bring-up is exercised by the gated `e2e-smoke.yml` workflow added
+in #770 step 5 (#813). It triggers only on changes to `helm/**`, `services/**`,
+or `engine-adapter/**` and is **not** a required gate on every PR. The kind
+cluster is ephemeral per job run; kubeconfigs are never committed.

--- a/scripts/e2e/cluster-down.sh
+++ b/scripts/e2e/cluster-down.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# cluster-down.sh — tear down the kind cluster created by cluster-up.sh.
+#
+# EPIC G (#770) step 1 / #809. Deletes the ephemeral kind cluster and all of
+# its resources. Idempotent: succeeds even if the cluster does not exist.
+#
+# Usage:
+#   scripts/e2e/cluster-down.sh
+#
+# Environment overrides:
+#   CLUSTER_NAME   kind cluster name to delete   (default: zynax-e2e)
+
+set -euo pipefail
+
+CLUSTER_NAME="${CLUSTER_NAME:-zynax-e2e}"
+
+log() { printf '\033[1;34m[cluster-down]\033[0m %s\n' "$*"; }
+die() { printf '\033[1;31m[cluster-down]\033[0m %s\n' "$*" >&2; exit 1; }
+
+command -v kind >/dev/null 2>&1 || die "required tool not found on PATH: kind"
+
+if kind get clusters 2>/dev/null | grep -qx "${CLUSTER_NAME}"; then
+  log "deleting kind cluster '${CLUSTER_NAME}'…"
+  kind delete cluster --name "${CLUSTER_NAME}"
+  log "cluster '${CLUSTER_NAME}' deleted."
+else
+  log "kind cluster '${CLUSTER_NAME}' not found — nothing to tear down (idempotent)."
+fi

--- a/scripts/e2e/cluster-up.sh
+++ b/scripts/e2e/cluster-up.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# cluster-up.sh — bring up a kind cluster and deploy the full Zynax stack.
+#
+# EPIC G (#770) step 1 / #809. Creates a reproducible, ephemeral Kubernetes
+# cluster via kind and installs the `zynax-umbrella` Helm chart so that the
+# e2e assertion scripts (#810–#813) run against a real cluster.
+#
+# Idempotent: re-running against an existing cluster reuses it and performs a
+# `helm upgrade --install`, so the script is safe to invoke repeatedly.
+#
+# Usage:
+#   scripts/e2e/cluster-up.sh
+#
+# Environment overrides:
+#   CLUSTER_NAME          kind cluster name           (default: zynax-e2e)
+#   NAMESPACE             release namespace           (default: zynax)
+#   RELEASE_NAME          Helm release name           (default: zynax)
+#   CERT_MANAGER_VERSION  cert-manager release tag    (default: v1.14.5)
+#   KIND_NODE_IMAGE       kind node image (digest-pinnable)
+#   WAIT_TIMEOUT          per-resource rollout wait   (default: 600s)
+#
+# Minimum host resources: 4 CPU, 8 GB RAM (see scripts/e2e/README.md).
+
+set -euo pipefail
+
+# ── configuration ───────────────────────────────────────────────────────────────
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+CLUSTER_NAME="${CLUSTER_NAME:-zynax-e2e}"
+NAMESPACE="${NAMESPACE:-zynax}"
+RELEASE_NAME="${RELEASE_NAME:-zynax}"
+CERT_MANAGER_VERSION="${CERT_MANAGER_VERSION:-v1.14.5}"
+# kind node image — pin to a digest in CI for reproducibility. The default tag
+# tracks the kind release that the harness is validated against.
+KIND_NODE_IMAGE="${KIND_NODE_IMAGE:-kindest/node:v1.29.2}"
+WAIT_TIMEOUT="${WAIT_TIMEOUT:-600s}"
+
+KIND_CONFIG="${SCRIPT_DIR}/kind-config.yaml"
+UMBRELLA_CHART="${REPO_ROOT}/helm/zynax-umbrella"
+
+# The 7 Zynax service Deployments that must reach a healthy rollout. event-bus
+# and memory-service run as placeholder images until EPIC I (#772) / J (#773).
+SERVICE_DEPLOYMENTS=(
+  "${RELEASE_NAME}-zynax-api-gateway"
+  "${RELEASE_NAME}-zynax-workflow-compiler"
+  "${RELEASE_NAME}-zynax-engine-adapter"
+  "${RELEASE_NAME}-zynax-task-broker"
+  "${RELEASE_NAME}-zynax-agent-registry"
+  "${RELEASE_NAME}-zynax-event-bus"
+  "${RELEASE_NAME}-zynax-memory-service"
+)
+
+# ── helpers ──────────────────────────────────────────────────────────────────────
+
+log()  { printf '\033[1;34m[cluster-up]\033[0m %s\n' "$*"; }
+warn() { printf '\033[1;33m[cluster-up]\033[0m %s\n' "$*" >&2; }
+die()  { printf '\033[1;31m[cluster-up]\033[0m %s\n' "$*" >&2; exit 1; }
+
+require() {
+  command -v "$1" >/dev/null 2>&1 || die "required tool not found on PATH: $1"
+}
+
+# ── preflight ──────────────────────────────────────────────────────────────────
+
+require kind
+require kubectl
+require helm
+
+[[ -f "${KIND_CONFIG}" ]]   || die "kind config not found: ${KIND_CONFIG}"
+[[ -d "${UMBRELLA_CHART}" ]] || die "umbrella chart not found: ${UMBRELLA_CHART}"
+
+# ── 1. create (or reuse) the kind cluster ────────────────────────────────────────
+
+if kind get clusters 2>/dev/null | grep -qx "${CLUSTER_NAME}"; then
+  log "kind cluster '${CLUSTER_NAME}' already exists — reusing (idempotent)."
+else
+  log "creating kind cluster '${CLUSTER_NAME}' (node image: ${KIND_NODE_IMAGE})…"
+  kind create cluster \
+    --name "${CLUSTER_NAME}" \
+    --image "${KIND_NODE_IMAGE}" \
+    --config "${KIND_CONFIG}" \
+    --wait "${WAIT_TIMEOUT}"
+fi
+
+# Point kubectl/helm at the cluster regardless of how it was created.
+kubectl config use-context "kind-${CLUSTER_NAME}" >/dev/null
+
+# ── 2. install cert-manager (CRDs + controllers) ─────────────────────────────────
+
+# The umbrella chart's zynax-cert-manager subchart creates Certificate /
+# ClusterIssuer resources but does NOT install cert-manager itself (ADR-020).
+# Install upstream cert-manager so those CRDs exist; idempotent via upgrade.
+log "installing cert-manager ${CERT_MANAGER_VERSION}…"
+helm upgrade --install cert-manager cert-manager \
+  --repo https://charts.jetstack.io \
+  --namespace cert-manager \
+  --create-namespace \
+  --version "${CERT_MANAGER_VERSION}" \
+  --set installCRDs=true \
+  --wait \
+  --timeout "${WAIT_TIMEOUT}"
+
+# ── 3. deploy the full Zynax stack via the umbrella chart ────────────────────────
+
+# Build chart dependencies if the packaged subcharts are missing (e.g. a fresh
+# checkout where `helm dependency build` has not yet run). No-op if present.
+if [[ ! -d "${UMBRELLA_CHART}/charts" ]] || \
+   [[ -z "$(ls -A "${UMBRELLA_CHART}/charts" 2>/dev/null)" ]]; then
+  log "building umbrella chart dependencies…"
+  helm dependency build "${UMBRELLA_CHART}"
+fi
+
+log "deploying zynax-umbrella as release '${RELEASE_NAME}' in namespace '${NAMESPACE}'…"
+# event-bus + memory-service are enabled with placeholder images so all 7
+# service pods schedule; real implementations land via EPIC I (#772) / J (#773).
+helm upgrade --install "${RELEASE_NAME}" "${UMBRELLA_CHART}" \
+  --namespace "${NAMESPACE}" \
+  --create-namespace \
+  --set zynax-event-bus.enabled=true \
+  --set zynax-memory-service.enabled=true \
+  --set zynax-cert-manager.enabled=true \
+  --wait \
+  --timeout "${WAIT_TIMEOUT}"
+
+# ── 4. wait for all 7 service deployments to become healthy ──────────────────────
+
+log "waiting for all 7 service deployments to roll out…"
+for dep in "${SERVICE_DEPLOYMENTS[@]}"; do
+  if ! kubectl -n "${NAMESPACE}" get deployment "${dep}" >/dev/null 2>&1; then
+    die "expected deployment not found: ${dep} (umbrella values out of sync?)"
+  fi
+  log "  → ${dep}"
+  kubectl -n "${NAMESPACE}" rollout status "deployment/${dep}" \
+    --timeout "${WAIT_TIMEOUT}"
+done
+
+log "all 7 service deployments are healthy."
+kubectl -n "${NAMESPACE}" get pods -o wide
+
+log "cluster '${CLUSTER_NAME}' is up. api-gateway REST is reachable on host port 8080."
+log "tear down with: scripts/e2e/cluster-down.sh"

--- a/scripts/e2e/kind-config.yaml
+++ b/scripts/e2e/kind-config.yaml
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# kind cluster configuration for the Zynax e2e harness (EPIC G #770, step 1 / #809).
+#
+# One control-plane node + two workers. The full Zynax stack (7 services plus
+# NATS JetStream, Postgres 16, and Temporal) needs headroom; a single-node
+# cluster routinely evicts pods under memory pressure on CI Ubuntu-latest.
+#
+# Minimum host resources (see scripts/e2e/README.md): 4 CPU, 8 GB RAM.
+#
+# extraPortMappings expose the api-gateway REST port (8080) on the host so that
+# `zynax apply` and the e2e assertion scripts can reach the cluster without a
+# manual `kubectl port-forward`.
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+name: zynax-e2e
+nodes:
+  - role: control-plane
+    kubeadmConfigPatches:
+      - |
+        kind: InitConfiguration
+        nodeRegistration:
+          kubeletExtraArgs:
+            node-labels: "ingress-ready=true"
+    extraPortMappings:
+      # api-gateway REST — host 8080 -> nodePort 30080
+      - containerPort: 30080
+        hostPort: 8080
+        protocol: TCP
+  - role: worker
+  - role: worker


### PR DESCRIPTION
## What

Adds the e2e harness cluster bootstrap (EPIC G #770, step 1) under `scripts/e2e/`:

- `cluster-up.sh` — idempotent kind cluster bring-up: creates a 3-node cluster, installs cert-manager (CRDs + controllers), deploys the full stack via `helm/zynax-umbrella`, and waits for all 7 service Deployments to roll out healthy.
- `cluster-down.sh` — idempotent teardown (succeeds even if no cluster exists).
- `kind-config.yaml` — 1 control-plane + 2 workers, exposing api-gateway REST on host `:8080`.
- `README.md` — minimum resource requirements (4 CPU, 8 GB RAM), prerequisites, usage, configuration.

## Why

M6 claims K8s production-readiness but had no automated full-stack test on a real cluster. This story delivers the reproducible bootstrap that subsequent steps (#810–#813) build their workflow / CloudEvents / upgrade assertions on top of.

## Design notes

- `event-bus` and `memory-service` are enabled with **placeholder images** (real implementations land via EPIC I #772 / J #773), so all 7 service pods schedule today.
- cert-manager is installed by the script itself — the `zynax-cert-manager` subchart only creates `Certificate`/`ClusterIssuer` resources and assumes CRDs exist (ADR-020).
- The 7 waited-on Deployment names (`zynax-zynax-<service>`) were verified against `helm template` output of the umbrella chart with the placeholders enabled.
- kind node image and cert-manager version are env-overridable and can be digest-pinned in CI.

## Validation

- `bash -n` clean on both scripts.
- `helm lint helm/zynax-umbrella` passes (only the cosmetic `icon is recommended` INFO).
- `helm template` render confirms all 7 service Deployments resolve to the names the script waits on.
- Live cluster bring-up is **not** exercised here (no Docker-in-Docker in this environment); it runs in the gated `e2e-smoke.yml` CI workflow added in #770 step 5.

## Scope

Out of scope (per canvas O1): workflow assertions, Argo path, the CI workflow itself.

Closes #809

🤖 Generated with [Claude Code](https://claude.com/claude-code)
