### PR TITLE
feat(engine-adapter): multi-engine dispatch + ARGO flag

### DIFF
--- a/services/engine-adapter/cmd/engine-adapter/main.go
+++ b/services/engine-adapter/cmd/engine-adapter/main.go
@@ -42,6 +42,11 @@ type config struct {
 	TaskBrokerAddr      string
 	EventBusAddr        string
 	ActiveEngine        string
+	ArgoServerURL       string
+	ArgoToken           string
+	ArgoNamespace       string
+	ArgoWorkflowTmplRef string
+	ArgoServiceAccount  string
 	GRPCCallTimeoutS    int
 	MaxActivityAttempts int32
 	LivenessThresholdS  int
@@ -61,6 +66,11 @@ func loadConfig() config {
 		TaskBrokerAddr:      getEnv("ZYNAX_ENGINE_ADAPTER_TASK_BROKER_ADDR", "localhost:50053"),
 		EventBusAddr:        getEnv("ZYNAX_ENGINE_ADAPTER_EVENTBUS_ADDR", "localhost:50056"),
 		ActiveEngine:        getEnv("ZYNAX_ENGINE_ADAPTER_ACTIVE_ENGINE", "temporal"),
+		ArgoServerURL:       getEnv("ZYNAX_ENGINE_ADAPTER_ARGO_SERVER_URL", "http://localhost:2746"),
+		ArgoToken:           getEnv("ZYNAX_ENGINE_ADAPTER_ARGO_TOKEN", ""),
+		ArgoNamespace:       getEnv("ZYNAX_ENGINE_ADAPTER_ARGO_NAMESPACE", "argo"),
+		ArgoWorkflowTmplRef: getEnv("ZYNAX_ENGINE_ADAPTER_ARGO_WORKFLOW_TEMPLATE_REF", "zynax-ir-interpreter"),
+		ArgoServiceAccount:  getEnv("ZYNAX_ENGINE_ADAPTER_ARGO_SERVICE_ACCOUNT", ""),
 		GRPCCallTimeoutS:    getEnvInt("ZYNAX_ENGINE_ADAPTER_GRPC_CALL_TIMEOUT_S", 30),
 		MaxActivityAttempts: getEnvInt32("ZYNAX_ENGINE_MAX_ACTIVITY_ATTEMPTS", 3),
 		LivenessThresholdS:  getEnvInt("ZYNAX_ENGINE_ADAPTER_LIVENESS_THRESHOLD_S", 60),
@@ -84,13 +94,21 @@ func main() {
 
 // run contains the service lifecycle. Deferred cleanups execute before returning.
 func run(cfg config) error {
+	slog.Info("selecting workflow engine", "active_engine", cfg.ActiveEngine)
+
 	engine, cleanup, brokerConn, err := buildEngine(cfg)
 	if err != nil {
 		return fmt.Errorf("engine setup: %w", err)
 	}
 	defer cleanup()
 
+	// brokerConn is nil for engines that do not dispatch capabilities through the
+	// task-broker (e.g. the Argo engine submits to the cluster directly). In that
+	// case readiness depends only on the gRPC server, so report ready.
 	brokerReadyFn := func() bool {
+		if brokerConn == nil {
+			return true
+		}
 		s := brokerConn.GetState()
 		return s != connectivity.TransientFailure && s != connectivity.Shutdown
 	}
@@ -128,14 +146,48 @@ func run(cfg config) error {
 	return nil
 }
 
-// buildEngine creates the WorkflowEngine and its underlying Temporal worker.
+// Engine name constants. These are the ONLY place engine names appear outside of
+// the engine-selection switch (ADR-015 — no engine name hardcoded in dispatch logic).
+const (
+	engineTemporal = "temporal"
+	engineArgo     = "argo"
+)
+
+// buildEngine validates the configured active engine and constructs the matching
+// WorkflowEngine implementation (ADR-015 — pluggable engines selected by config flag).
+// The returned cleanup function releases all engine resources. brokerConn is returned
+// for the readiness probe; it is nil for engines that do not use the task-broker.
+func buildEngine(cfg config) (domain.WorkflowEngine, func(), *grpc.ClientConn, error) {
+	switch cfg.ActiveEngine {
+	case engineTemporal:
+		return buildTemporalEngine(cfg)
+	case engineArgo:
+		return buildArgoEngine(cfg)
+	default:
+		return nil, func() {}, nil, fmt.Errorf(
+			"unsupported engine %q: valid values are %q or %q (ZYNAX_ENGINE_ADAPTER_ACTIVE_ENGINE)",
+			cfg.ActiveEngine, engineTemporal, engineArgo,
+		)
+	}
+}
+
+// buildArgoEngine constructs an ArgoEngine backed by an HTTP Argo Workflows client.
+// It needs neither a Temporal worker nor a task-broker connection — Argo dispatches
+// workflows directly to the cluster — so brokerConn is returned as nil.
+func buildArgoEngine(cfg config) (domain.WorkflowEngine, func(), *grpc.ClientConn, error) {
+	client := infrastructure.NewHTTPArgoClient(cfg.ArgoServerURL, cfg.ArgoToken, nil)
+	engine := infrastructure.NewArgoEngine(client, infrastructure.ArgoConfig{
+		Namespace:           cfg.ArgoNamespace,
+		WorkflowTemplateRef: cfg.ArgoWorkflowTmplRef,
+		ServiceAccountName:  cfg.ArgoServiceAccount,
+	})
+	return engine, func() {}, nil, nil
+}
+
+// buildTemporalEngine creates the Temporal-backed WorkflowEngine and its worker.
 // The returned cleanup function stops the worker and closes connections.
 // brokerConn is returned separately so main can use it for the readiness probe.
-func buildEngine(cfg config) (domain.WorkflowEngine, func(), *grpc.ClientConn, error) {
-	if cfg.ActiveEngine != "temporal" {
-		return nil, func() {}, nil, fmt.Errorf("unsupported engine %q: only \"temporal\" is supported in M3", cfg.ActiveEngine)
-	}
-
+func buildTemporalEngine(cfg config) (domain.WorkflowEngine, func(), *grpc.ClientConn, error) {
 	infrastructure.DefaultActivityMaxAttempts = cfg.MaxActivityAttempts
 
 	tc, err := client.Dial(client.Options{

--- a/services/engine-adapter/cmd/engine-adapter/main_test.go
+++ b/services/engine-adapter/cmd/engine-adapter/main_test.go
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/zynax-io/zynax/services/engine-adapter/internal/domain"
+	"github.com/zynax-io/zynax/services/engine-adapter/internal/infrastructure"
+)
+
+// TestBuildEngine_ArgoSelected verifies that ZYNAX_ENGINE_ADAPTER_ACTIVE_ENGINE=argo
+// injects an *infrastructure.ArgoEngine (ADR-015 — engine chosen by config flag).
+func TestBuildEngine_ArgoSelected(t *testing.T) {
+	cfg := loadConfig()
+	cfg.ActiveEngine = engineArgo
+
+	engine, cleanup, brokerConn, err := buildEngine(cfg)
+	if err != nil {
+		t.Fatalf("buildEngine(argo) returned error: %v", err)
+	}
+	t.Cleanup(cleanup)
+
+	if _, ok := engine.(*infrastructure.ArgoEngine); !ok {
+		t.Fatalf("buildEngine(argo) = %T; want *infrastructure.ArgoEngine", engine)
+	}
+	// Argo does not dispatch through the task-broker, so no broker connection.
+	if brokerConn != nil {
+		t.Errorf("buildEngine(argo) brokerConn = %v; want nil", brokerConn)
+	}
+}
+
+// TestBuildEngine_UnrecognisedFatal verifies that an unknown engine name is a
+// startup error (run() turns this into os.Exit(1)).
+func TestBuildEngine_UnrecognisedFatal(t *testing.T) {
+	cfg := loadConfig()
+	cfg.ActiveEngine = "kubernetes-batch"
+
+	engine, _, _, err := buildEngine(cfg)
+	if err == nil {
+		t.Fatalf("buildEngine(unrecognised) returned nil error; want startup failure")
+	}
+	if engine != nil {
+		t.Errorf("buildEngine(unrecognised) engine = %v; want nil", engine)
+	}
+}
+
+// TestArgoEngine_UnknownRunID is the smoke test required by canvas O4: the argo
+// engine must surface domain.ErrExecutionNotFound for an unknown run ID. It uses a
+// stub ArgoClient so no live Argo server is required.
+func TestArgoEngine_UnknownRunID(t *testing.T) {
+	cfg := loadConfig()
+	cfg.ActiveEngine = engineArgo
+	engine := infrastructure.NewArgoEngine(
+		stubArgoClient{},
+		infrastructure.ArgoConfig{Namespace: cfg.ArgoNamespace},
+	)
+
+	_, err := engine.GetStatus(context.Background(), "no-such-run")
+	if !errors.Is(err, domain.ErrExecutionNotFound) {
+		t.Fatalf("GetStatus(unknown) error = %v; want domain.ErrExecutionNotFound", err)
+	}
+}
+
+// stubArgoClient is a not-found ArgoClient: every lookup reports the workflow is
+// absent, exercising the engine's ErrExecutionNotFound mapping.
+type stubArgoClient struct{}
+
+func (stubArgoClient) SubmitWorkflow(context.Context, string, *infrastructure.ArgoWorkflow) error {
+	return nil
+}
+
+func (stubArgoClient) SendEvent(context.Context, string, string, []byte) error {
+	return nil
+}
+
+func (stubArgoClient) GetWorkflow(context.Context, string, string) (*infrastructure.ArgoWorkflow, error) {
+	return nil, domain.ErrExecutionNotFound
+}
+
+func (stubArgoClient) DeleteWorkflow(context.Context, string, string) error {
+	return domain.ErrExecutionNotFound
+}


### PR DESCRIPTION
## What

Wires multi-engine dispatch into the engine-adapter startup (canvas O4 of #766, step B.4). Predecessor #797 (full ArgoEngine implementation) is merged; this PR makes the engine selectable at runtime.

- `cmd/engine-adapter/main.go`: refactor `buildEngine` into a config-flag switch — `engineTemporal` → `buildTemporalEngine`, `engineArgo` → `buildArgoEngine`, default → startup fatal error.
- Engine names (`temporal`, `argo`) are declared as constants used **only** in the selection switch (ADR-015 — no engine name hardcoded in dispatch logic).
- Add Argo config env vars (`ZYNAX_ENGINE_ADAPTER_ARGO_*`) and inject `ArgoEngine` via `NewHTTPArgoClient` + `NewArgoEngine`.
- Log the active engine at startup (`selecting workflow engine`).
- Readiness probe tolerates a nil broker connection (Argo dispatches to the cluster directly, no task-broker).

## Acceptance

- `=argo` injects `*infrastructure.ArgoEngine`; `=temporal` injects `TemporalEngine`.
- Unrecognised value → startup fatal error (`run()` → `os.Exit(1)`).
- Smoke test: argo engine returns `domain.ErrExecutionNotFound` for an unknown run ID (stubbed `ArgoClient`).
- TemporalEngine path unchanged — existing tests still pass.

## Evidence

```
GOWORK=off go build ./...    # exit 0
GOWORK=off go test ./... -race -timeout 120s
ok  .../cmd/engine-adapter
ok  .../internal/api
ok  .../internal/domain
ok  .../internal/infrastructure
ok  .../tests
GOWORK=off go vet ./...      # clean
golangci-lint + gofmt        # passed (pre-commit)
```

Out of scope: simultaneous multi-engine dispatch (one active engine per process — ADR-015).

Closes #798

🤖 Generated with [Claude Code](https://claude.com/claude-code)
