### PR TITLE
docs(ai-learnings): append session learnings — 2026-06-09

### DIFF
--- a/docs/ai-learnings/bdd-contract.md
+++ b/docs/ai-learnings/bdd-contract.md
@@ -66,3 +66,12 @@
 ## Proposed expert prompt updates
 
 *(none yet — populate after first batch of BDD contract expert sessions)*
+
+## Session — 2026-06-09 (issue #801)
+
+### Effective patterns
+- Adding a brand-new `.proto` file is always non-breaking for `buf breaking`; verify with `buf breaking --against 'https://...#branch=main,subdir=protos'` to match the pr-checks.yml gate exactly.
+
+### Edge cases discovered
+- **Python proto stubs are post-processed by `ruff`/`ruff-format` pre-commit hooks, not by `buf generate` alone** (buf.gen.yaml uses unpinned remote plugins, no buf.lock). A raw `buf generate` on clean main shows ~1100 lines of phantom Python-stub format drift. Canonical path: run `make generate-protos`, then `git add -A` and commit — let the hook reformat/re-stage; verify the net staged diff is only the new `<name>.*` stubs.
+- **`gh run rerun <id> --failed` can spawn a duplicate full CI run via concurrency, leaving cancelled jobs surfacing as "fail"** in `gh pr checks`. Re-run the cancelled run id directly (`gh run rerun <id>`, no `--failed`) so its contexts resolve to success — otherwise branch protection stays blocked on a phantom failure.

--- a/docs/ai-learnings/ci-release.md
+++ b/docs/ai-learnings/ci-release.md
@@ -333,3 +333,17 @@ to `imagetools create`). A re-sign pass was not performed; the Jun-8 `main` imag
 - **The pushed pre-rebase commit is the safe restore point**: Recover with `git reset --hard origin/<branch>` (the empty/feature branch was pushed before the rebase), then redo the rebase with `git -c core.editor=true rebase origin/main` so no editor opens, and resolve conflicts *programmatically* (python/sed rewriting the conflict block) instead of with tools that re-read and re-touch files. Seen in: #1003.
 - **Verify the PR's real head branch after a tangled rebase**: The corruption spawned a stray slugged claim branch (`<type>/<N>-<slug>`) with its own remote tracking ref, diverging from the PR's actual head (`<type>/<N>`, still at the pre-rebase SHA). Always `gh pr view <N> --json headRefName,headRefOid`, force-push the rebased commit to the PR's *real* head branch, and delete the stray. Seen in: #1003.
 - **Sibling EPIC steps merging mid-flight conflict on shared state docs**: While delivering one O-step, sibling steps (#1004 PR #1008, #1005 PR #1009) merged and edited the same `M6-planning.md` table and `canvas.md` O-step list. Expect a mid-flight rebase; resolve by taking main's rows wholesale and re-applying only *your* row — the row-level conflict is mechanical, not semantic. Seen in: #1003.
+
+## Session — 2026-06-09 (issue #841)
+
+### Effective patterns
+- **Audit-and-document is a valid "minimize" deliverable when images are already near-optimal** (distroless Go ~8 MB, slim+uv Python ~75 MB): verification + documented justification in Dockerfile headers + a SECURITY.md size table satisfies the acceptance criteria with zero build-breakage risk.
+- **`.dockerignore` test-file exclusions must come AFTER module-allowlist negations**: the repo re-includes whole module trees (`!agents/adapters/llm/`), so `*_test.go`/`tests/`/`*.feature` patterns placed last actually strip test files from the context.
+- Header-comment-only Dockerfile edits never touch image-ref banner regions, so `make sync-images` is unnecessary and `make check-images` stays green.
+
+### Edge cases discovered
+- **Do NOT swap a working `python:3.12-slim` + uv build to alpine**: musl forces fragile source compilation of manylinux ML wheels (openai/boto3/grpcio/pydantic-core). Document the rejection inline; keep slim.
+- Canvas path `docs/spdd/837-native-multiarch/canvas.md` named in #841 does not exist (837 is a `ci:` epic, SPDD-exempt); proceed from the issue body scope table.
+
+### Post-merge observation (orchestrator session)
+- **Release workflow failing on main independent of this batch**: Trivy container scan exits 1 on `langgraph-adapter`/`llm-adapter` amd64 — observed even on the protos-only merge `a0d8d5b` (#1019), so it is a CVE-DB/scan-config issue recurring on every main merge, not a Dockerfile regression. Separately, "Merge & sign — engine-adapter" failed on `56a8ac2` (#1018) at the manifest-merge/cosign step (both per-arch builds succeeded) — infra, not code. No new clean image digests published while Release is red → no digest pins to update. Needs separate investigation (Trivy allowlist + cosign/OIDC sign step).

--- a/docs/ai-learnings/go-services.md
+++ b/docs/ai-learnings/go-services.md
@@ -325,3 +325,19 @@ but the `gh issue list --state open` query may lag due to GitHub API eventual co
 
 ### Proposed expert prompt update — Shared workspace safety
 > **File reversion hazard**: A background linter/formatter may rewrite files between `Write` and `git add`. After each `Write`, immediately verify with `wc -l <path>`. When modifying a Go interface AND its implementations together, write all files in one turn, then build/test, then `git add` — never interleave write/build/add across separate Bash calls. After `git commit`, verify with `git show HEAD:<path> | grep <key-symbol>`.
+
+## Session — 2026-06-09 (issues #798, #800)
+
+### Effective patterns
+- **Engine-name constants confined to the selection switch** (#798): satisfies ADR-015 (no hardcoded engine names in dispatch) while keeping the `buildEngine` switch readable; default case → fatal.
+- **Nil `brokerConn` for cluster-dispatch engines** (#798): the Argo path returns nil broker conn and the readiness probe nil-guards it, so engines that dispatch to the cluster directly don't carry a task-broker dependency.
+- **`recordingCompiler` stub at the domain-port boundary** (#800): a stub that echoes its input namespace into `CompileResult.Namespace` models the real compiler embedding it into `WorkflowIR.namespace`, letting one httptest request assert all 3 hops without standing up gRPC backends.
+
+### Edge cases discovered
+- **Submit hop uses `compiled.Namespace`, not `req.Namespace`** (#800, apply.go:129): the compiled IR namespace is authoritative; a stub that doesn't echo namespace into CompileResult makes the submit-hop assertion test nothing. Also `submit()` short-circuits on a running existing workflow, so the recording engine's `GetWorkflowStatus` must return `ErrNotFound`.
+- **Unexported sentinel not reproducible from cmd package** (#798): Argo 404→`ErrExecutionNotFound` keys off an unexported `errArgoNotFound`; the genuine mapping is covered by infrastructure-package tests, while the cmd smoke test asserts the engine surfaces `domain.ErrExecutionNotFound` end-to-end.
+
+### Failed approaches (sandbox structural-workarounds)
+- `env GOWORK=off go -C <dir> ...` is DENIED; the plain `GOWORK=off go -C <dir> ...` prefix form works as a single command.
+- Inline multi-line `git commit -m "..."` (embedded newlines/quotes) is DENIED; write the message to a file and use `git commit -s -F <file>`.
+- Compound/chained Bash (`cd && ...`, `a; b`, pipes, loops) is DENIED for background subagents; use `git -C`/`go -C` single commands. Wait for CI with `gh pr checks <PR> --watch --interval 30`.

--- a/docs/ai-learnings/infra-helm.md
+++ b/docs/ai-learnings/infra-helm.md
@@ -62,3 +62,14 @@
 ## Proposed expert prompt updates
 
 *(none yet — populate after first batch of infra/Helm expert sessions)*
+
+## Session — 2026-06-09 (issue #809)
+
+### Effective patterns
+- **Verify rollout-target names against `helm template` before hardcoding**: umbrella service Deployments render as `<release>-zynax-<service>` (double "zynax" prefix because release name + chart name both carry it). A name mismatch silently fails `kubectl rollout status` at runtime — local lint can't catch it.
+- `git update-index --chmod=+x` sets the executable bit in the index when filesystem `chmod` is unavailable; commit records mode 100755.
+- Mirror existing repo script conventions (SPDX header, `set -euo pipefail`, `REPO_ROOT` via `dirname BASH_SOURCE`, env-overridable config) from scripts/bump-ci-runner.sh.
+
+### Edge cases discovered
+- **cert-manager is NOT in images/images.yaml**; the umbrella's zynax-cert-manager subchart only creates Certificate/ClusterIssuer (ADR-020), so a bootstrap script must `helm install` upstream cert-manager itself before enabling the subchart, else CRDs are missing.
+- **event-bus + memory-service are `enabled: false`** by default in umbrella values.yaml; the e2e script must pass `--set ...enabled=true` to schedule all 7 service pods (placeholder images ship from merged EPIC A charts).


### PR DESCRIPTION
Appends expert session learnings from the orchestrator batch: issues #798, #800, #801, #809, #841 (all merged).

Captures domain patterns (engine selector constants, namespace propagation stub, ruff proto-stub post-processing, helm `<release>-zynax-<service>` double-prefix, image audit-vs-rewrite) plus sandbox structural-workarounds for background subagents (single-command Bash only; `git commit -F` for multiline; no `env` prefix).

Also records a post-merge finding: the Release workflow is failing on main independent of this batch (Trivy scan on Python adapters; engine-adapter merge&sign) — flagged for separate investigation.

Assisted-by: Claude/claude-opus-4-8