### PR TITLE
chore(automation): single-command Bash discipline in dispatch prompts

### DIFF
--- a/.claude/commands/m6-issue-generate.md
+++ b/.claude/commands/m6-issue-generate.md
@@ -115,6 +115,14 @@ echo "Worktree ready: $WORKTREE_PATH"
 > Every file read, edit, build, and commit from this point on happens inside
 > `$WORKTREE_PATH`. The caller's workspace is untouched.
 
+> **If this skill is driven by a sandboxed / background agent** (rather than run directly in
+> an interactive session): the Bash sandbox denies compound/chained commands and shell state
+> does not persist between calls. In that mode, run each line above as its OWN Bash call
+> (no `&&`/`;`/`|`/`rm -rf` chaining, no `env` prefix), do NOT `cd` — reference the worktree by
+> its **literal** path `/tmp/zynax-auto-<ISSUE_N>` with `git -C`, `GOWORK=off go -C`, and
+> `make -C` — and use `git commit -s -F <file>` for multiline messages, `gh pr checks <PR>
+> --watch` to wait on CI. Interactive runs in the main session can keep the `cd`-based flow.
+
 ---
 
 ## STEP 3 — Read the issue

--- a/.claude/commands/m6-learn.md
+++ b/.claude/commands/m6-learn.md
@@ -177,13 +177,22 @@ Agent({
     - Maximum 5 proposed additions per domain.
     - Write each proposed addition in the exact format used by the target section.
     - Cite the issues/sessions that support the proposal.
-    - Classify every proposal as `domain` or `structural-workaround`. A proposal is
-      `structural-workaround` if it only exists to survive a shared working tree: defensive
-      `git checkout`/branch-verify before Bash calls, "never `git add .`", stash-avoidance,
-      ref-lock recovery, cherry-pick rescue, "checkout target file to undo a sibling's edit".
-      A proposal is `domain` if it is genuine engineering knowledge (API shape, query planner
-      behaviour, proto field name, test pattern, gRPC code mapping). Prefer the `Category:`
-      line the session already emitted; if absent, infer it.
+    - Classify every proposal as `domain`, `structural-workaround`, or `env-constraint`:
+      - `structural-workaround` — only exists to survive a SHARED working tree: defensive
+        `git checkout`/branch-verify before Bash calls, "never `git add .`", stash-avoidance,
+        ref-lock recovery, cherry-pick rescue, "checkout target file to undo a sibling's edit".
+        These are made unnecessary by worktree isolation → default `rejected`.
+      - `env-constraint` — a RUNTIME/sandbox constraint that worktree isolation does NOT fix:
+        e.g. background-subagent Bash denies compound/chained commands, shell state not
+        persisting between calls (use literal paths, not vars), `env` prefix denied, multiline
+        `-m` denied (use `git commit -F`), CI-wait must be `gh pr checks --watch` not a loop.
+        These are REAL and must persist, but they belong in the **dispatch-prompt preamble of
+        m6-orchestrate.md / m6-issue-generate.md** (injected into every agent), NOT scattered
+        into the expert guides. Do NOT auto-reject: surface as `pending` with a note that the
+        fix is a manual command-file edit (outside `/m6-learn --apply`'s expert-file scope).
+      - `domain` — genuine engineering knowledge (API shape, query planner behaviour, proto
+        field name, test pattern, gRPC code mapping).
+      Prefer the `Category:` line the session already emitted; if absent, infer it.
     - Do NOT promote `structural-workaround` proposals to the expert guides while worktree
       isolation is in effect (m6-orchestrate STEP 6 / STEP 7.5; EPIC #1001). List them under a
       separate "Structural (suppressed — root cause fixed by worktree isolation)" heading so
@@ -334,6 +343,11 @@ Human reviews:
 > The `Category` column is required (added under EPIC #1001). `structural-workaround` rows are
 > defaulted to `rejected` while worktree isolation is in effect — they describe bandages the
 > shared-tree root-cause fix made unnecessary, so they must not re-enter the expert guides.
+> `env-constraint` rows (runtime/sandbox constraints worktree isolation does NOT fix — e.g.
+> background-subagent compound-Bash denial, non-persistent shell state) are NOT auto-rejected:
+> leave them `pending` and apply them by hand to the dispatch-prompt preamble in
+> `m6-orchestrate.md` / `m6-issue-generate.md` — they are outside `/m6-learn --apply`'s
+> expert-file scope, so `--apply` will not commit them.
 
 Status lifecycle: `pending` → `applied` (human sets) → `committed` (/m6-learn --apply sets)
 Or: `pending` → `rejected` (human sets, stays rejected)

--- a/.claude/commands/m6-orchestrate.md
+++ b/.claude/commands/m6-orchestrate.md
@@ -226,24 +226,39 @@ Agent({
 
     ---
 
-    ## Isolated worktree — this is your FIRST action, before reading or writing anything
-    Run this as your very first Bash call. Every read, edit, build, and commit after this
-    happens inside your private tree — branch switches, git add, and lint here are invisible
-    to sibling agents and theirs are invisible to you.
+    ## Sandbox Bash discipline — READ BEFORE YOUR FIRST COMMAND
+    You run under a Bash sandbox that allows SINGLE commands but DENIES compound/chained forms.
+    Two shell facts drive everything below: (a) chained commands are rejected, and (b) shell
+    state does NOT persist between Bash calls — a `WT=...`/`REPO=...` set in one call is GONE in
+    the next, so you must use LITERAL paths every time. Do NOT conclude "Bash is denied" when a
+    compound one-liner fails — decompose it and continue.
+    - NEVER chain: no `cd dir && ...`, no `a; b`, no `until/do/done` loops, no `printf | grep`
+      pipes, no `env VAR=x cmd` prefix, and no call mixing `rm -rf`/`worktree remove --force`
+      with another op. Each is reliably denied.
+    - NEVER `cd` and NEVER rely on shell vars across calls. Use LITERAL paths with
+      `git -C <REPO> ...`, `GOWORK=off go -C <WT>/<dir> ...`, and `make -C <WT> <target>`
+      (the bare `GOWORK=off` prefix is fine; an `env` prefix is not).
+    - Multiline commit messages: write the message to a file and `git commit -s -F <file>`
+      (a `-m` with embedded newlines is denied).
+    - Wait for CI with `gh pr checks <PR> --watch --interval 30` (foreground; never a poll loop
+      or the Monitor tool).
+    - On any denial: split into single commands and retry — abandoning the task is wrong.
+
+    ## Isolated worktree — your FIRST actions (run each line as its OWN separate Bash call)
+    The orchestrator substitutes <REPO> (the main checkout path) and the literal worktree path
+    when building this prompt. Every read, edit, build, and commit after this happens inside your
+    private tree — invisible to sibling agents and theirs to you.
 
     ```bash
-    REPO=$(git rev-parse --show-toplevel)   # remember the main checkout
-    WT=/tmp/zynax-orch-<RUN_ID>-<N>
-    git -C "$REPO" worktree remove "$WT" --force 2>/dev/null || true
-    rm -rf "$WT" 2>/dev/null || true
-    git -C "$REPO" fetch origin --prune
-    git -C "$REPO" worktree add "$WT" origin/main
-    cd "$WT"
+    # one Bash call each — do NOT combine; ignore an error from the first if the dir is absent:
+    git -C <REPO> worktree remove /tmp/zynax-orch-<RUN_ID>-<N> --force
+    git -C <REPO> fetch origin --prune
+    git -C <REPO> worktree add /tmp/zynax-orch-<RUN_ID>-<N> origin/main
     ```
 
-    Never cd out of "$WT" until cleanup. Do NOT run `git checkout <branch>` defensively, do
-    NOT verify the branch before each Bash call, do NOT avoid `git add .`, do NOT avoid
-    `git stash` — none of that is needed: this tree is yours alone.
+    Your tree is the literal path `/tmp/zynax-orch-<RUN_ID>-<N>`. It is yours alone — do NOT run
+    defensive `git checkout`, do NOT verify the branch before each call, do NOT avoid `git add`.
+    Reference it by literal path in every command (e.g. `git -C /tmp/zynax-orch-<RUN_ID>-<N> ...`).
 
     ---
 
@@ -266,12 +281,13 @@ Agent({
        wins (rename + push the slugged ref); never let a slug into the claim push.
     3. Implement, run all local gates, commit (DCO + Assisted-by), open PR.
     4. Wait for CI. Report result.
-    5. Cleanup — your LAST action, always, success or failure:
+    5. Cleanup — your LAST action, always, success or failure (a SINGLE Bash call, literal path):
        ```bash
-       cd "$REPO"
-       git worktree remove "$WT" --force 2>/dev/null || true
-       rm -rf "$WT" 2>/dev/null || true
+       git -C <REPO> worktree remove /tmp/zynax-orch-<RUN_ID>-<N> --force
        ```
+       Do NOT chain an `rm -rf` after it (that compound form is denied). If the directory
+       lingers because of root-owned Docker caches in a `.venv`, that is harmless — git's
+       worktree registry is what matters, and the orchestrator's STEP 7 sweep reclaims the path.
     6. End your response with the ## Session Learnings block (required, template below).
 
     ## Result format (required — orchestrator parses these for post-merge dispatch)
@@ -445,19 +461,25 @@ Agent({
 
     ---
 
-    ## Isolated worktree — this is your FIRST action
-    You are mostly read-only (GitHub + GHCR APIs) but may push a digest-pin commit. Work
-    entirely inside your own tree so any branch you create cannot stomp a sibling's checkout.
+    ## Sandbox Bash discipline — READ BEFORE YOUR FIRST COMMAND
+    You run under a Bash sandbox that allows SINGLE commands but DENIES compound/chained forms,
+    and shell state does NOT persist between calls. Use LITERAL paths, one command per Bash call:
+    no `cd … && …`, no `a; b`, no pipes/loops, no `env` prefix, no `rm -rf` chained to another op.
+    On a denial, decompose and retry — never conclude "Bash is denied". Wait for CI with
+    `gh pr checks <PR> --watch --interval 30`; multiline commits via `git commit -s -F <file>`.
+
+    ## Isolated worktree — your FIRST actions (run each line as its OWN separate Bash call)
+    You are mostly read-only (GitHub + GHCR APIs) but may push a digest-pin commit. Work entirely
+    inside your own tree. The orchestrator substitutes <REPO> and the literal worktree path.
 
     ```bash
-    REPO=$(git rev-parse --show-toplevel)
-    WT=/tmp/zynax-postmerge-<RUN_ID>-<PR_N>
-    git -C "$REPO" worktree remove "$WT" --force 2>/dev/null || true
-    rm -rf "$WT" 2>/dev/null || true
-    git -C "$REPO" fetch origin --prune
-    git -C "$REPO" worktree add "$WT" origin/main
-    cd "$WT"
+    # one Bash call each — do NOT combine:
+    git -C <REPO> worktree remove /tmp/zynax-postmerge-<RUN_ID>-<PR_N> --force
+    git -C <REPO> fetch origin --prune
+    git -C <REPO> worktree add /tmp/zynax-postmerge-<RUN_ID>-<PR_N> origin/main
     ```
+    Your tree is the literal path `/tmp/zynax-postmerge-<RUN_ID>-<PR_N>`; reference it literally
+    (`git -C /tmp/zynax-postmerge-<RUN_ID>-<PR_N> ...`) — never `cd`, never via a shell var.
 
     ---
 
@@ -477,12 +499,11 @@ Agent({
     6. Find all open "bump <image> digest" issues; close stale duplicates; implement newest.
     7. Commit all digest updates as a single chore(ci) PR; squash-merge.
     8. Output the full ## Post-Merge Evidence block.
-    9. Cleanup — your LAST action, always:
+    9. Cleanup — your LAST action, always (a SINGLE Bash call, literal path):
        ```bash
-       cd "$REPO"
-       git worktree remove "$WT" --force 2>/dev/null || true
-       rm -rf "$WT" 2>/dev/null || true
+       git -C <REPO> worktree remove /tmp/zynax-postmerge-<RUN_ID>-<PR_N> --force
        ```
+       Do NOT chain an `rm -rf` (denied); the STEP 7 sweep reclaims any lingering path.
     10. End with ## Session Learnings.
 
     ## Constraints


### PR DESCRIPTION
## Why
During the `/m6-orchestrate 5` run on 2026-06-09, 3 of 5 background-subagent agents abandoned their tasks after the **compound** worktree-bootstrap one-liner in their dispatch prompt was denied by the Bash sandbox — they wrongly concluded "Bash is fully denied". The 2 that decomposed into single commands succeeded. Root causes:
1. The sandbox allows **single** commands but denies compound/chained forms (`cd && …`, `a; b`, pipes, loops, `env` prefix, `rm -rf` chains).
2. **Shell state does not persist between Bash calls**, so the `WT=…`/`REPO=…` vars in the bootstrap evaporate — literal paths are required.

## Changes
- **m6-orchestrate.md** — rewrite the domain (STEP 6) and post-merge (STEP 7.5) dispatch worktree + cleanup blocks as **separate single commands using literal paths**; prepend a **"Sandbox Bash discipline"** preamble (no chaining/`env`-prefix; `git commit -s -F <file>` for multiline; `gh pr checks --watch` for CI; decompose-and-retry on any denial).
- **m6-issue-generate.md** — add a sandboxed/background-agent note to the STEP 2.5 bootstrap (interactive main-session runs keep the `cd` flow).
- **m6-learn.md** — add a third Category `env-constraint` so genuine runtime/sandbox constraints (NOT fixed by worktree isolation) are no longer mis-classified as shared-tree `structural-workaround` and auto-rejected; they're routed to the command-file dispatch preamble (outside `/m6-learn --apply`'s expert-file scope).

## Provenance
Findings captured in `docs/ai-learnings/` via #1021. Companion to issue #1022 (pre-existing Release failures, separate).

Assisted-by: Claude/claude-opus-4-8