### PR TITLE
docs(ai-learnings): record /m6-learn run 2026-06-09 — go-services proposals

### DIFF
--- a/docs/ai-learnings/APPLY_LOG.md
+++ b/docs/ai-learnings/APPLY_LOG.md
@@ -54,3 +54,14 @@
 | 10 | spdd-canvas | Reconcile all status surfaces from live issue/PR state | domain | #1001, #1011 | committed | spdd-canvas.md +17L |
 
 **Summary:** 10 proposed | 7 committed | 3 rejected (structural) | 0 pending
+
+## Run 2026-06-09 16:20 — domains: go-services
+
+| # | Domain | Pattern | Category | Source sessions | Status | Delta |
+|---|--------|---------|----------|-----------------|--------|-------|
+| 1 | go-services | Base testcontainers GenericContainer — avoid modules/<x> deps | domain | #818, #828 | pending | — |
+| 2 | go-services | Re-stage after lint/pre-commit hook rewrites files in place | structural-workaround | #819, #824 | rejected | — |
+| 3 | go-services | git rebase drops commits in target — verify diff after rebase | structural-workaround | #795, #838 | rejected | — |
+| 4 | go-services | Sandbox Bash forms: no env-prefix/multiline -m/compound cmds | env-constraint | #798, #877 | pending | — |
+
+**Summary:** 1 proposed (domain) | 0 applied | 2 rejected (structural) | 1 pending (env-constraint)


### PR DESCRIPTION
## What

Appends the pending **`/m6-learn`** synthesis run for the 2026-06-09 orchestrator batch (#798, #800, #801, #809, #841) to `docs/ai-learnings/APPLY_LOG.md`. This is the synthesize-mode output (proposals as `pending`/`rejected`) — **no expert files change here.**

## Synthesis result

The synthesizer read all 6 learning files (72 session blocks), deduped against the 13 already-committed patterns and the 7 expert guides, and applied the recurrence-≥2 rule. Most of the batch's findings were single-session and were correctly deferred (they re-surface in a future run once they recur).

| # | Pattern | Category | Sessions | Status |
|---|---------|----------|----------|--------|
| 1 | Base `testcontainers-go` `GenericContainer` — avoid `modules/<x>` sub-deps | domain | #818, #828 | **pending** |
| 2 | Re-stage after lint/pre-commit rewrites files in place | structural-workaround | #819, #824 | rejected |
| 3 | `git rebase` drops commits already in target — verify diff after | structural-workaround | #795, #838 | rejected |
| 4 | Sandbox Bash forms (no `env` prefix / multiline `-m` / compound cmds) | env-constraint | #798, #877 | pending |

- **#1** is the only actionable expert-file addition (keeps `go.mod` lean by using the base testcontainers module instead of `modules/redis`/`modules/nats`).
- **#2/#3** are shared-tree bandages made unnecessary by worktree isolation (EPIC #1001) → rejected, not promoted.
- **#4** is real but already delivered to the dispatch-prompt preamble in **#1023**; the row is kept only for traceability (it's outside `/m6-learn --apply`'s expert-file scope), so no action.

## Next step (separate, after this merges)

To adopt #1: edit `APPLY_LOG.md` row #1 (`Status: applied`, `Delta: pending-commit`) + add the pattern to `.claude/commands/experts/go-services.md`, then run `/m6-learn --apply`.

Companion to #1021 (raw learnings) and #1023 (dispatch-preamble fixes).

Assisted-by: Claude/claude-opus-4-8