### PR TITLE
docs(automation): apply expert learning — testcontainers GenericContainer

### DIFF
--- a/.claude/commands/experts/go-services.md
+++ b/.claude/commands/experts/go-services.md
@@ -223,6 +223,45 @@ for _, tt := range tests {
 
 ---
 
+## Integration tests — testcontainers
+
+Use the **base `testcontainers-go` `GenericContainer`** — do NOT add the `modules/<x>`
+sub-dependencies (`modules/redis`, `modules/nats`, …). The base module is already an indirect
+dep; a `modules/*` package adds a new *direct* dep and bloats `go.mod`. Pin the image and gate
+on the ready log line.
+
+```go
+import (
+    "github.com/testcontainers/testcontainers-go"
+    "github.com/testcontainers/testcontainers-go/wait"
+)
+
+// Redis
+redis, _ := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+    ContainerRequest: testcontainers.ContainerRequest{
+        Image:        "redis:7-alpine",
+        ExposedPorts: []string{"6379/tcp"},
+        WaitingFor:   wait.ForLog("Ready to accept connections"),
+    },
+    Started: true,
+})
+
+// NATS with JetStream
+nats, _ := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+    ContainerRequest: testcontainers.ContainerRequest{
+        Image:        "nats:2.10-alpine",
+        Cmd:          []string{"-js"},
+        ExposedPorts: []string{"4222/tcp"},
+        WaitingFor:   wait.ForLog("Server is ready"),
+    },
+    Started: true,
+})
+```
+
+*(Applied via /m6-learn from #818 (Redis) + #828 (NATS).)*
+
+---
+
 ## Git safety
 
 You run in your own isolated git worktree (EPIC #1001 — `m6-orchestrate` STEP 6 /

--- a/docs/ai-learnings/APPLY_LOG.md
+++ b/docs/ai-learnings/APPLY_LOG.md
@@ -59,9 +59,9 @@
 
 | # | Domain | Pattern | Category | Source sessions | Status | Delta |
 |---|--------|---------|----------|-----------------|--------|-------|
-| 1 | go-services | Base testcontainers GenericContainer — avoid modules/<x> deps | domain | #818, #828 | pending | — |
+| 1 | go-services | Base testcontainers GenericContainer — avoid modules/<x> deps | domain | #818, #828 | committed | go-services.md +39L |
 | 2 | go-services | Re-stage after lint/pre-commit hook rewrites files in place | structural-workaround | #819, #824 | rejected | — |
 | 3 | go-services | git rebase drops commits in target — verify diff after rebase | structural-workaround | #795, #838 | rejected | — |
 | 4 | go-services | Sandbox Bash forms: no env-prefix/multiline -m/compound cmds | env-constraint | #798, #877 | pending | — |
 
-**Summary:** 1 proposed (domain) | 0 applied | 2 rejected (structural) | 1 pending (env-constraint)
+**Summary:** 1 proposed (domain) | 1 committed | 2 rejected (structural) | 1 pending (env-constraint)


### PR DESCRIPTION
## What

Applies approved `/m6-learn` **proposal #1** (run 2026-06-09 16:20) — the only `domain`/`pending` row from that synthesis.

## Change
- **`.claude/commands/experts/go-services.md`** — new *"Integration tests — testcontainers"* section: use the base `testcontainers-go` `GenericContainer` (already an indirect dep) rather than the `modules/<x>` sub-packages (`modules/redis`, `modules/nats`, …), which add a new *direct* dep and bloat `go.mod`. Includes pinned-image + ready-log examples for Redis and NATS/JetStream.
- **`docs/ai-learnings/APPLY_LOG.md`** — row #1 → `committed` (Delta `go-services.md +39L`); summary updated.

## Provenance
Synthesized from #818 (Redis integration suite) + #828 (NATS integration suite) — recurrence 2. Rows #2/#3 stay `rejected` (shared-tree workarounds, moot under worktree isolation #1001); row #4 stays `pending` (env-constraint already delivered in #1023). Follows the `/m6-learn --apply` lifecycle. Companion to #1024 (the run entry).

Assisted-by: Claude/claude-opus-4-8