### PR TITLE
ci(infra): harden Release gate — drop adapter pip, pin Trivy DB, retry sizes

### DIFF
--- a/.github/actions/report-image-meta/action.yml
+++ b/.github/actions/report-image-meta/action.yml
@@ -60,11 +60,36 @@ runs:
         BASE="https://ghcr.io/v2/${IMAGE_NAME}"
         AUTH_HEADER="Authorization: Bearer ${TOKEN}"
 
-        # ── Fetch the index manifest ──────────────────────────────────────────
-        INDEX=$(curl -fsSL \
-          -H "${AUTH_HEADER}" \
-          -H "Accept: application/vnd.oci.image.index.v1+json" \
-          "${BASE}/manifests/${DIGEST}" 2>/dev/null) || true
+        # ── Fetch the index manifest (retry — GHCR can lag right after push) ──
+        # GHCR occasionally 404s/empties a just-pushed manifest for a few seconds
+        # (read-after-write / token propagation). A single curl then left INDEX
+        # empty and tripped the "missing description" hard-fail below on a healthy,
+        # already-signed image (#1022). Retry with backoff before deciding.
+        INDEX=""
+        for attempt in 1 2 3 4 5; do
+          INDEX=$(curl -fsSL \
+            -H "${AUTH_HEADER}" \
+            -H "Accept: application/vnd.oci.image.index.v1+json" \
+            "${BASE}/manifests/${DIGEST}" 2>/dev/null || true)
+          [ -n "$INDEX" ] && break
+          echo "::notice::index manifest for ${IMAGE_NAME}@${DIGEST} not ready (attempt ${attempt}/5); retrying in $((attempt * 3))s"
+          sleep $((attempt * 3))
+        done
+
+        # If GHCR never served the manifest, metadata/size reporting is NON-FATAL —
+        # a flaky read must never fail an image that was already pushed and signed.
+        # (A genuinely-absent description annotation is still caught below, but only
+        # once we have actually fetched the index.)
+        if [ -z "$INDEX" ]; then
+          echo "::warning::Could not fetch the index manifest for ${IMAGE_NAME}@${DIGEST} after 5 attempts — skipping annotation + size checks (non-fatal)."
+          {
+            echo "## ${LABEL}"
+            echo "**Digest:** \`${DIGEST}\`"
+            echo ""
+            echo "_Metadata/size report skipped: GHCR index manifest unavailable after retries (non-fatal)._"
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit 0
+        fi
 
         # ── Check description annotation (FAIL if absent) ─────────────────────
         DESCRIPTION=""

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -342,11 +342,23 @@ jobs:
       - name: Trivy container scan
         if: matrix.platform == 'amd64'
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        env:
+          # Pin the DB to a canonical GHCR digest (the default GCR mirror lagged and
+          # served a since-corrected CRITICAL, red-walling releases — #1022). The digest
+          # makes scans reproducible; renovate bumps it so vuln data stays current.
+          # renovate: datasource=docker depName=ghcr.io/aquasecurity/trivy-db
+          TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db:2@sha256:225c785a3ce630d8f8b75ab23f4d7b0b1402f94a54dfe6441e6711c7deb8dec8
+          # Gate on NVD CVSS when available, falling back to GHSA for the many
+          # Python advisories that have no NVD entry. Stops the gate firing on
+          # score-less, non-NVD vendor "CRITICAL"s that never surface in the
+          # Security tab, while still catching genuine GHSA-scored CRITICAL/HIGH.
+          TRIVY_VULN_SEVERITY_SOURCE: nvd,ghsa
         with:
           image-ref: scan-${{ matrix.service }}:${{ github.sha }}
+          version: v0.71.0
           format: sarif
           output: trivy-results-${{ matrix.service }}.sarif
-          severity: CRITICAL
+          severity: CRITICAL,HIGH
           exit-code: 1
           ignore-unfixed: true
           trivyignores: .trivyignore

--- a/agents/adapters/langgraph/Dockerfile
+++ b/agents/adapters/langgraph/Dockerfile
@@ -46,6 +46,15 @@ WORKDIR /app
 # Non-root user (ADR-002)
 RUN useradd -r -u 1001 -g nogroup zynax
 
+# Strip the base image's build-time-only packages (pip/setuptools/wheel). They are
+# never used at runtime — the app runs the uv venv via `python -m` — and are a
+# recurring source of Trivy CVE noise that red-walls the release gate (#1022).
+RUN rm -rf /usr/local/lib/python3.12/site-packages/pip* \
+           /usr/local/lib/python3.12/site-packages/setuptools* \
+           /usr/local/lib/python3.12/site-packages/pkg_resources \
+           /usr/local/lib/python3.12/site-packages/wheel* \
+           /usr/local/bin/pip /usr/local/bin/pip3 /usr/local/bin/pip3.12
+
 # Venv with all locked dependencies
 COPY --from=builder /app/.venv /app/.venv
 

--- a/agents/adapters/llm/Dockerfile
+++ b/agents/adapters/llm/Dockerfile
@@ -42,6 +42,15 @@ WORKDIR /app
 # Non-root user (ADR-002)
 RUN useradd -r -u 1001 -g nogroup zynax
 
+# Strip the base image's build-time-only packages (pip/setuptools/wheel). They are
+# never used at runtime — the app runs the uv venv via `python -m` — and are a
+# recurring source of Trivy CVE noise that red-walls the release gate (#1022).
+RUN rm -rf /usr/local/lib/python3.12/site-packages/pip* \
+           /usr/local/lib/python3.12/site-packages/setuptools* \
+           /usr/local/lib/python3.12/site-packages/pkg_resources \
+           /usr/local/lib/python3.12/site-packages/wheel* \
+           /usr/local/bin/pip /usr/local/bin/pip3 /usr/local/bin/pip3.12
+
 # Venv with all locked dependencies
 COPY --from=builder /app/.venv /app/.venv
 


### PR DESCRIPTION
Closes #1022 — fixes both pre-existing Release-on-`main` failures, with the full root-cause investigation in that issue.

## 1. Trivy gate (langgraph + llm adapters)
**Root cause:** Trivy gated `exit-code 1` on a `pip` CVE (base-image pip, unused at runtime) that it rated CRITICAL from a **non-NVD vendor source** with no CVSS — invisible in the Security tab and non-deterministic (depended on the GCR-mirror DB snapshot the runner pulled).

- **Drop unused pip/setuptools/wheel** from the llm + langgraph runtime stages — never used at runtime (the app runs the uv venv via `python -m`); eliminates the whole pip-CVE class and shrinks the image.
- **Pin `TRIVY_DB_REPOSITORY`** to a canonical GHCR **digest** (`trivy-db:2@sha256:225c785a…`) with a `renovate` annotation — the default GCR mirror was the laggy source. Reproducible scans, still auto-bumped.
- **Bump Trivy to v0.71.0** (was 0.70.0; pins the binary version).
- **Gate `CRITICAL,HIGH`** with `TRIVY_VULN_SEVERITY_SOURCE=nvd,ghsa` — uses NVD CVSS when present (matches the Security tab), falls back to GHSA so genuine Python advisories still gate, and no longer fires on score-less vendor-only CRITICALs.

## 2. Merge & sign "Report image sizes" (engine-adapter)
**Root cause:** the GHCR index-manifest `curl` (read-after-write lag right after push) left `INDEX` empty, which then tripped the *"missing description annotation"* **hard-fail** on a healthy, already-signed image.

- **Retry** the index fetch with backoff; if still unfetchable, metadata/size reporting is **non-fatal** (warn + skip). The genuine "annotation absent" gate still fires once the index is actually fetched.

## Verification (local)
Both adapters build, `import <module>` succeeds, ship **without pip**, and pass:
`trivy 0.71.0 image --severity CRITICAL,HIGH --ignore-unfixed --vuln-severity-source nvd,ghsa` → **exit 0**.

Decisions captured via the questions on #1022.

Assisted-by: Claude/claude-opus-4-8