### PR TITLE
docs(agents): SDK docstrings step 2 — document __init_subclass__ (#808)

### DIFF
--- a/agents/sdk/pyproject.toml
+++ b/agents/sdk/pyproject.toml
@@ -51,9 +51,6 @@ ignore_missing_imports = true
 
 [tool.ruff.lint]
 select = ["D"]
-# D105 (magic method docstring) is optional per Google style; __init_subclass__
-# and similar hooks are implementation details and need not be documented.
-extend-ignore = ["D105"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"

--- a/agents/sdk/src/zynax_sdk/agent.py
+++ b/agents/sdk/src/zynax_sdk/agent.py
@@ -73,6 +73,15 @@ class Agent(agent_pb2_grpc.AgentServiceServicer, ABC):  # type: ignore[misc]
     _capabilities: ClassVar[dict[str, Callable[..., Any]]] = {}
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
+        """Collect ``@capability``-decorated methods from each subclass.
+
+        Called automatically by Python when a class inherits from ``Agent``.
+        Populates ``cls._capabilities`` so that ``ExecuteCapability`` can
+        dispatch requests without per-request introspection.
+
+        Args:
+            **kwargs: Forwarded to ``super().__init_subclass__``.
+        """
         super().__init_subclass__(**kwargs)
         caps: dict[str, Callable[..., Any]] = {}
         for _attr_name, method in inspect.getmembers(cls, predicate=callable):


### PR DESCRIPTION
**Parent epic:** #769 M6.SDK
**Canvas step:** O4 — `docs/spdd/769-sdk-pypi/canvas.md`

## Summary

- Add Google-style docstring to `Agent.__init_subclass__` — the last undocumented public symbol in `agents/sdk/src/zynax_sdk/`
- Remove the now-redundant `extend-ignore = ["D105"]` from `pyproject.toml`
- `ruff check --select D src/zynax_sdk/` now passes with zero violations and zero `# noqa` suppressions
- `ruff check src/`, `mypy --strict`, and `bandit -ll` all pass

## Test plan

- [ ] `ruff check --select D agents/sdk/src/zynax_sdk/` → All checks passed
- [ ] `ruff check agents/sdk/src/` → All checks passed
- [ ] `bandit -r agents/sdk/src/ -ll` → No issues identified
- [ ] `mypy agents/sdk/src/` → Success (from pre-commit hook)
- [ ] CI lint job passes

Closes #808
Closes #376

Assisted-by: Claude/claude-sonnet-4-6