### PR TITLE
ci: extend cosign + SBOM to SDK wheel/sdist artifacts

### DIFF
--- a/.github/workflows/sdk-publish.yml
+++ b/.github/workflows/sdk-publish.yml
@@ -31,8 +31,8 @@ jobs:
     environment: pypi   # OIDC trusted publisher environment — must match PyPI registration
 
     permissions:
-      contents: read
-      id-token: write   # required for OIDC token minting
+      contents: write   # required to upload SBOM + bundles to GitHub Release
+      id-token: write   # required for OIDC token minting (PyPI + cosign keyless)
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -47,8 +47,16 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install hatch (build + publish tool)
-        run: pip install --quiet "hatch>=1.13"
+      - name: Install hatch + supply-chain tools
+        run: |
+          pip install --quiet "hatch>=1.13"
+          # cosign — keyless signing via Sigstore OIDC
+          COSIGN_VERSION="v2.4.3"
+          curl -sSL "https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign-linux-amd64" \
+            -o /usr/local/bin/cosign
+          chmod +x /usr/local/bin/cosign
+          # syft — SBOM generation
+          curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin
 
       - name: Build wheel and sdist
         working-directory: agents/sdk
@@ -69,8 +77,51 @@ jobs:
           fi
           echo "OK — wheel: $WHL  sdist: $SDT"
 
+      - name: Generate SBOM for SDK package
+        working-directory: agents/sdk
+        run: |
+          syft packages dist/ -o spdx-json=dist/zynax_sdk.spdx.json
+          echo "SBOM generated:"
+          ls -lh dist/zynax_sdk.spdx.json
+
+      - name: Sign SDK wheel (keyless OIDC)
+        working-directory: agents/sdk
+        env:
+          COSIGN_EXPERIMENTAL: "1"
+        run: |
+          WHEEL=$(ls dist/*.whl | head -1)
+          echo "Signing wheel: $WHEEL"
+          cosign sign-blob --yes --bundle "${WHEEL}.bundle" "$WHEEL"
+          echo "Bundle created: ${WHEEL}.bundle"
+
+      - name: Sign SDK sdist (keyless OIDC)
+        working-directory: agents/sdk
+        env:
+          COSIGN_EXPERIMENTAL: "1"
+        run: |
+          SDIST=$(ls dist/*.tar.gz | head -1)
+          echo "Signing sdist: $SDIST"
+          cosign sign-blob --yes --bundle "${SDIST}.bundle" "$SDIST"
+          echo "Bundle created: ${SDIST}.bundle"
+
       - name: Publish to PyPI (OIDC — Trusted Publisher)
         uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc  # v1.12.4
         with:
           packages-dir: agents/sdk/dist/
           verbose: true
+
+      - name: Upload SBOM and signature bundles to GitHub Release
+        working-directory: agents/sdk
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="${{ github.ref_name }}"
+          echo "Uploading supply-chain artifacts to release $TAG"
+          # SBOM
+          gh release upload "$TAG" dist/zynax_sdk.spdx.json --clobber
+          # Cosign bundles
+          for bundle in dist/*.bundle; do
+            gh release upload "$TAG" "$bundle" --clobber
+          done
+          echo "Uploaded:"
+          ls -lh dist/*.bundle dist/*.spdx.json

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -42,6 +42,7 @@ See `AGENTS.md`, `docs/adr/ADR-001`, `ADR-008` and `docs/reviews/04-architecture
 - SPDX SBOM attached to every GitHub release for all service + tools images (✅ #489)
 - cosign keyless signing of all container image releases — SLSA L2 (✅ #489)
 - Multi-arch container images (linux/amd64 + linux/arm64) for all service + tools images (✅ #489)
+- cosign sign-blob + SPDX SBOM for zynax-sdk wheel/sdist PyPI artifacts (✅ #807)
 - Minimal image footprint — smaller images mean a smaller attack surface (✅ #841)
 
 ### Container image sizes (attack-surface budget)
@@ -71,6 +72,19 @@ cosign verify \
 ```
 
 Replace `api-gateway` with any service name (`engine-adapter`, `workflow-compiler`, `task-broker`, `agent-registry`, `http-adapter`, `tools`, `ci-runner`) and the tag with the release version.
+
+**Verify a SDK wheel signature:**
+```bash
+# Download the wheel, sdist, and their cosign bundles from the GitHub Release:
+# https://github.com/zynax-io/zynax/releases/tag/v0.1.0
+cosign verify-blob \
+  --bundle zynax_sdk-0.1.0-py3-none-any.whl.bundle \
+  --certificate-identity-regexp="https://github.com/zynax-io/zynax/.github/workflows/" \
+  --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \
+  zynax_sdk-0.1.0-py3-none-any.whl
+```
+
+Replace the version with the release you downloaded. To verify the sdist, use the `.tar.gz` and its corresponding `.tar.gz.bundle` instead.
 
 ### Planned (M6+)
 - mTLS between all platform services — ✅ shipped #488; cert-manager Helm chart in M6.Helm


### PR DESCRIPTION
Extends SDK release workflow with cosign + SBOM (M6.SDK canvas O3).

- cosign sign-blob on SDK wheel/sdist (keyless OIDC via Sigstore)
- syft generates SPDX SBOM for SDK package (`zynax_sdk.spdx.json`)
- SBOM and cosign bundles uploaded as GitHub Release assets
- SECURITY.md updated with `cosign verify-blob` instructions for SDK consumers
- `contents: write` permission added to `sdk-publish.yml` (required for release upload)

Closes #807. Also closes #489, #235, #239.

## Test plan
- [x] make lint passes (ruff, mypy, golangci-lint, proto — all green)
- [x] YAML syntax validated
- [ ] Workflow fires correctly on next `v*` tag push

🤖 Generated with [Claude Code](https://claude.com/claude-code)