### PR TITLE
test(automation): platform-readiness xfail test (#882)

### DIFF
--- a/automation/tests/conftest.py
+++ b/automation/tests/conftest.py
@@ -1,0 +1,20 @@
+"""
+conftest.py — stub fixtures for automation/tests/.
+
+The zynax_client fixture is intentionally unimplemented: it raises pytest.fail
+so that tests depending on a live platform xfail (not error) when the platform
+is not running. Because all tests that use this fixture are wrapped in
+pytest.mark.xfail(strict=True), the failure is treated as XFAIL.
+"""
+
+import pytest
+
+
+@pytest.fixture
+def zynax_client():
+    """Stub for a live Zynax platform client.
+
+    Raises pytest.fail so that xfail-wrapped tests are marked XFAIL rather
+    than ERROR. Replace with a real client once the platform is deployed.
+    """
+    pytest.fail("zynax platform not running — Wave 4 prerequisite not met")

--- a/automation/tests/test_platform_readiness.py
+++ b/automation/tests/test_platform_readiness.py
@@ -1,0 +1,56 @@
+# automation/tests/test_platform_readiness.py
+import json
+import yaml
+import pytest
+from pathlib import Path
+
+try:
+    import jsonschema
+
+    HAS_JSONSCHEMA = True
+except ImportError:
+    HAS_JSONSCHEMA = False
+
+SCHEMA_PATH = "spec/schemas/agent-def.json"
+ORCHESTRATOR_YAML = "automation/workflows/dev-advisory-orchestrator.yaml"
+EXPERT_YAMLS = list(Path("automation/workflows/experts/").glob("*.yaml"))
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "Wave 4 aspirational: requires M6.H (Postgres-backed repos, #626) + "
+        "M6.I (event-bus implementation, #772) + automation/workflows/ AgentDef "
+        "YAMLs to exist. Fails until all three prerequisites land."
+    ),
+)
+class TestPlatformReadiness:
+    def test_orchestrator_agentdef_schema_valid(self):
+        """AgentDef YAML validates against Zynax JSON schema."""
+        assert HAS_JSONSCHEMA, "jsonschema package required"
+        with open(SCHEMA_PATH) as f:
+            schema = json.load(f)
+        with open(ORCHESTRATOR_YAML) as f:
+            doc = yaml.safe_load(f)
+        jsonschema.validate(doc, schema)
+
+    def test_expert_agentdefs_schema_valid(self):
+        """All 9 expert AgentDef YAMLs validate against schema."""
+        assert HAS_JSONSCHEMA, "jsonschema package required"
+        assert len(EXPERT_YAMLS) == 9, f"Expected 9 experts, got {len(EXPERT_YAMLS)}"
+        with open(SCHEMA_PATH) as f:
+            schema = json.load(f)
+        for p in EXPERT_YAMLS:
+            with open(p) as f:
+                doc = yaml.safe_load(f)
+            jsonschema.validate(doc, schema)
+
+    def test_orchestrator_executes_on_platform(self, zynax_client):
+        """Orchestrator AgentDef loads and executes on a running Zynax platform."""
+        result = zynax_client.apply(ORCHESTRATOR_YAML)
+        assert result.workflow_id is not None
+        status = zynax_client.wait_for_completion(result.workflow_id, timeout=60)
+        assert status == "COMPLETED"
+        outputs = zynax_client.get_outputs(result.workflow_id)
+        assert "aggregated_verdict" in outputs
+        assert outputs["aggregated_verdict"]["confidence"] in ("low", "medium", "high")


### PR DESCRIPTION
## Summary

- Creates `automation/tests/test_platform_readiness.py` with `pytest.mark.xfail(strict=True)` to define the Wave 4 acceptance contract
- Adds `automation/tests/conftest.py` with a `zynax_client` fixture stub that raises `pytest.fail`, ensuring tests are XFAIL (not ERROR) when the platform is not running
- Adds `automation/tests/__init__.py` to make the directory a proper Python package

## Why it fails today (three independent reasons)

1. `automation/workflows/dev-advisory-orchestrator.yaml` does not exist yet
2. `spec/schemas/agent-def.json` does not exist (current schema is `agent-def.schema.json`)
3. `zynax_client` fixture raises `pytest.fail` — no running platform to execute against

## Test behavior

```
pytest automation/tests/test_platform_readiness.py -v
# → 3 xfailed in 0.05s
```

All three tests show as `XFAIL` (expected failure) — exactly the contract definition behavior.

## Closes

Closes #882

Assisted-by: Claude/claude-sonnet-4-6