### PR TITLE
docs(automation): AGENTS.md pointer + README + ARCHITECTURE section

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -245,6 +245,7 @@ Observed mistakes in AI-assisted contributions — check before writing code.
 | AI context line counts and budget thresholds (advisory, non-blocking) | `zynax-ci check ai-context` |
 | `zynax` CLI (standalone Go module, M4) — apply/get/delete/status/logs via api-gateway HTTP | `cmd/zynax/AGENTS.md` |
 | Per-layer rules | `services/AGENTS.md` · `agents/AGENTS.md` · `protos/AGENTS.md` · `spec/AGENTS.md` · `infra/AGENTS.md` |
+| `automation/` | Dev-automation orchestrator + expert mesh configs (consumed explicitly by GH Actions and the Zynax agent runtime — never auto-loaded here) |
 
 ---
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -479,3 +479,71 @@ Full ADR register: `docs/adr/INDEX.md`.
 | `docs/architecture/2026-04-30-execution-architecture.md` | 2026-04-30 | Execution architecture deep-dive (engine-adapter + Temporal) |
 | `docs/architecture/2026-05-18-external-architectural-review.md` | 2026-05-18 | External architectural review |
 | `docs/architecture/2026-05-20-principal-architect-review.md` | 2026-05-20 | **Authoritative** — 6.5/10 overall, G1-G24 gap list, 30-day plan |
+
+---
+
+## 16. Dev-Automation Plane
+
+> Full design and wave specs: [`automation/STATUS-AND-DIRECTION.md`](automation/STATUS-AND-DIRECTION.md)
+> EPIC: [#873 M6.DevAuto](https://github.com/zynax-io/zynax/issues/873)
+
+The dev-automation plane adds an **orchestrator + expert mesh** to the CI/CD loop. Nine
+context-scoped AI expert agents review pull requests in parallel; an orchestrator aggregates
+their outputs into a single verdict. This is a separate concern from the three-layer
+platform architecture — it does not live in `services/`, `agents/`, or `protos/`.
+
+### Two-Plane Model
+
+The automation system is explicitly split into two planes:
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  NEAR-TERM PLANE (Waves 0–3)                                │
+│  GitHub Actions + Claude Code subagents                     │
+│  Runnable today. Zero Zynax runtime dependency.             │
+│                                                             │
+│  Wave 0: Advisory — expert subagents on PR events           │
+│  Wave 1: Orchestrated advisory — single aggregated comment  │
+│  Wave 2: Gated automation — non-destructive actions only    │
+│  Wave 3: Post-merge completeness mesh                       │
+└────────────────────────────┬────────────────────────────────┘
+                             │
+         automation/tests/test_platform_readiness.py
+         @pytest.mark.xfail(strict=True)
+         ← THE HONEST LINE BETWEEN PLANES →
+         Fails today. Passes only when M6.H + M6.I complete.
+                             │
+┌────────────────────────────▼────────────────────────────────┐
+│  ASPIRATIONAL PLANE (Wave 4)                                │
+│  Zynax AgentDef workflows running on Zynax itself           │
+│  BLOCKED: needs M6.H (Postgres) + M6.I (event-bus)         │
+│  GATED: failing test must flip to pass first                │
+└─────────────────────────────────────────────────────────────┘
+```
+
+The **near-term plane** (Waves 0–3) runs entirely on GitHub Actions with Claude Code
+subagents — no Zynax runtime required. The **aspirational plane** (Wave 4) runs the same
+orchestrator + experts as Zynax `kind: AgentDef` workflows on the Zynax platform itself,
+which requires durable state persistence (M6.H #626) and durable async fan-out (M6.I #772).
+
+### The Failing Test as an Honest Gate
+
+`automation/tests/test_platform_readiness.py` is marked `@pytest.mark.xfail(strict=True)`.
+It fails today for three independent reasons:
+
+1. `automation/workflows/` does not exist — AgentDef YAMLs are blocked on M6.H + M6.I
+2. task-broker and agent-registry use in-memory repositories — state lost on restart
+3. EventBusService is a log-only stub — cannot deliver messages between orchestrator and experts
+
+The test uses `strict=True` so that an unexpected pass (XPASS) turns the build red —
+alerting the team that something changed and Wave 4 might be viable. Silence is not
+acceptable; neither is skipping the test.
+
+Wave 4 automation must not be wired into main CI until this test flips to a clean pass.
+
+### Not Ambient Context
+
+The `automation/` folder is **not** referenced by any `AGENTS.md` glob or auto-load
+mechanism. Expert definitions, orchestrator config, and AgentDef workflows all live there
+and are consumed explicitly. See the Knowledge Base Index row in root `AGENTS.md` and
+`automation/README.md` for the complete folder map.

--- a/automation/README.md
+++ b/automation/README.md
@@ -1,0 +1,137 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# automation/ — Dev-Automation Orchestrator + Expert Mesh
+
+> **This folder is NOT ambient context.** It is not auto-loaded by any `AGENTS.md` glob.
+> It is consumed **explicitly** by GitHub Actions workflows (which read `experts/*.yaml`)
+> and (aspirationally) by the Zynax agent runtime (which will read `workflows/*.yaml`).
+>
+> Full architecture direction: [`STATUS-AND-DIRECTION.md`](STATUS-AND-DIRECTION.md)
+> EPIC: [#873](https://github.com/zynax-io/zynax/issues/873) M6.DevAuto
+
+---
+
+## What this folder IS
+
+A **two-plane automation system** that brings expert AI review into the CI/CD loop:
+
+- **Near-term plane (Waves 0–3):** GitHub Actions + Claude Code subagents. Runnable
+  today. Zero Zynax runtime dependency.
+- **Aspirational plane (Wave 4):** Orchestrator + experts running as Zynax `kind: AgentDef`
+  workflows on the Zynax platform itself. Blocked until M6.H (#626) and M6.I (#772) are
+  both complete.
+
+The **honest dividing line** between the two planes is a failing test:
+`automation/tests/test_platform_readiness.py` — it is marked `@pytest.mark.xfail(strict=True)`
+and fails today for three independent reasons (no `workflows/` AgentDefs, in-memory repos,
+stub EventBusService). When M6.H + M6.I land and `workflows/` is authored (#881), that test
+flips to pass and Wave 4 becomes viable.
+
+## What this folder is NOT
+
+- Not a Zynax service — no `go.mod`, no `pyproject.toml`, no gRPC handler
+- Not a CI workflow — the `.github/workflows/` directory contains the actual workflow YAML
+- Not ambient context — no `AGENTS.md` in any layer auto-includes this path
+- Not safe to hand-edit banner-marked regions — use `make sync-images` for image refs
+
+---
+
+## Folder Structure
+
+```
+automation/
+├── STATUS-AND-DIRECTION.md    ← Living architecture doc (full two-plane model, wave specs)
+├── README.md                  ← This file — entry point for contributors
+│
+├── experts/                   ← Expert YAML configs (DevAuto.2, #875)
+│   ├── schema.yaml            ← JSON Schema for all expert config files
+│   ├── orchestrator.yaml      ← Orchestrator expert (aggregation, escalation)
+│   ├── arch-adr.yaml          ← Architecture / ADR expert
+│   ├── persistence-state.yaml ← Persistence / state expert
+│   ├── api-contract.yaml      ← API / contract expert
+│   ├── security-supply-chain.yaml ← Security + supply-chain expert
+│   ├── qa-bdd.yaml            ← QA / BDD expert
+│   ├── docs-agents.yaml       ← Docs / AGENTS expert
+│   ├── ci-release.yaml        ← CI / release expert
+│   └── planning-task-split.yaml   ← Planning / task-split expert
+│
+├── orchestrator/              ← Orchestrator config (DevAuto.3, #876)
+│   ├── config.yaml            ← Aggregation thresholds, escalation rules, auto_allowed list
+│   ├── decision-log-schema.yaml   ← JSON Schema for per-run decision-log artifact
+│   └── aggregation-protocol.md   ← Human-readable description of the weighting algorithm
+│
+├── workflows/                 ← AgentDef YAMLs — ASPIRATIONAL (DevAuto.8, #881)
+│   └── (not yet authored — blocked on M6.H #626 + M6.I #772)
+│
+└── tests/                     ← Platform-readiness gate (DevAuto.9, #882)
+    ├── test_platform_readiness.py ← xfail test — the honest Wave 4 gate
+    ├── conftest.py
+    └── requirements.txt
+```
+
+---
+
+## How to Read / Consume
+
+### GitHub Actions (near-term plane)
+
+GH Actions reads `automation/experts/*.yaml` to configure expert subagent invocations.
+Each expert file declares:
+- `context_slice` — which files/paths to feed as context
+- `max_tokens` — hard budget for this expert's context window
+- `system_prompt` — expert role and output contract
+
+The `.github/workflows/dev-advisory.yml` workflow (DevAuto.4, #877) fans out to all 9
+experts in parallel, then the orchestrator aggregates their outputs into a single PR comment.
+
+### Zynax Runtime (aspirational plane — Wave 4 only)
+
+When M6.H (#626) and M6.I (#772) are complete, the Zynax agent runtime will read
+`automation/workflows/*.yaml` as `kind: AgentDef` manifests and execute the
+orchestrator + expert mesh as native Zynax workflows.
+
+**Do not wire `workflows/*.yaml` into main CI** until
+`automation/tests/test_platform_readiness.py` flips from `xfail` to a clean pass.
+
+---
+
+## Two-Plane Summary
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  NEAR-TERM PLANE (Waves 0–3)                                │
+│  GitHub Actions + Claude Code subagents                     │
+│  Runnable today. No Zynax runtime dependency.               │
+│                                                             │
+│  Wave 0: Advisory — expert subagents on PR events           │
+│  Wave 1: Orchestrated advisory — aggregated PR comment      │
+│  Wave 2: Gated automation — non-destructive actions only    │
+│  Wave 3: Post-merge completeness mesh                       │
+└────────────────────────────┬────────────────────────────────┘
+                             │
+         automation/tests/test_platform_readiness.py
+         @pytest.mark.xfail(strict=True)
+         ← THE HONEST LINE BETWEEN PLANES →
+         Fails today. Passes only when M6.H + M6.I complete.
+                             │
+┌────────────────────────────▼────────────────────────────────┐
+│  ASPIRATIONAL PLANE (Wave 4)                                │
+│  Zynax AgentDef workflows running on Zynax itself           │
+│  BLOCKED: needs M6.H (Postgres) + M6.I (event-bus)         │
+│  GATED: failing test must flip to pass first                │
+└─────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Links
+
+- Full architecture direction and wave specs: [`STATUS-AND-DIRECTION.md`](STATUS-AND-DIRECTION.md)
+- EPIC: [#873 M6.DevAuto](https://github.com/zynax-io/zynax/issues/873)
+- Platform-readiness gate: `automation/tests/test_platform_readiness.py` ([#882](https://github.com/zynax-io/zynax/issues/882))
+- Root `AGENTS.md` pointer: see Knowledge Base Index table (`automation/` row)
+
+---
+
+*Zynax — automation/README.md · Apache 2.0*
+*Assisted-by: Claude/claude-sonnet-4-6*


### PR DESCRIPTION
## Summary

- Root `AGENTS.md`: adds one pointer row (≤2 lines) in the Knowledge Base Index table for `automation/` — no expert YAML, wave specs, or orchestrator config in AGENTS.md
- `automation/README.md` (new): contributor entry point — two-plane model, folder structure map, consumption guide (GH Actions reads `experts/*.yaml`; Zynax runtime reads `workflows/*.yaml`), links to STATUS-AND-DIRECTION.md and EPIC #873
- `ARCHITECTURE.md §16` (new section): Dev-Automation Plane — two-plane model diagram, failing-test gate rationale, not-ambient-context note

## Acceptance criteria verified

- [x] Root `AGENTS.md` updated — pointer row added to Knowledge Base Index table (≤2 lines)
- [x] Root `AGENTS.md` does NOT contain any expert YAML, wave spec, or orchestrator config
- [x] `automation/README.md` committed with two-plane model, folder map, links
- [x] `ARCHITECTURE.md` updated with Dev-Automation Plane section
- [x] No ambient-context glob in any AGENTS.md picks up `automation/` paths
- [x] `make lint` passes

## Test plan

- [ ] Verify `AGENTS.md` Knowledge Base Index has exactly one new row for `automation/`
- [ ] Verify `automation/README.md` renders correctly on GitHub
- [ ] Verify `ARCHITECTURE.md §16` appears as expected

Closes #883

🤖 Assisted-by: Claude/claude-sonnet-4-6