### PR TITLE
ci(automation): fix drift-check regex cross-entry bleed with yaml.safe_load

### DIFF
--- a/.github/workflows/post-merge-completeness.yml
+++ b/.github/workflows/post-merge-completeness.yml
@@ -171,18 +171,18 @@ jobs:
         id: drift
         run: |
           python3 /dev/stdin << 'PYEOF'
-          import subprocess, re, sys
-          content = open("images/images.yaml").read()
-          entries = re.findall(
-              r'- name:\s+(\S+).*?ref:\s+(\S+)(?:.*?tag:\s+(\S+))?.*?digest:\s+(sha256:[a-f0-9]+)',
-              content, re.DOTALL
-          )
+          import subprocess, sys, yaml
+          data = yaml.safe_load(open("images/images.yaml"))
           drifted = []
           errors = []
-          for name, ref, tag, pinned in entries:
+          for entry in data.get("images", []):
+              name   = entry.get("name", "")
+              ref    = entry.get("ref", "")
+              tag    = entry.get("tag") or ""
+              pinned = entry.get("digest", "")
               if "ghcr.io" not in ref:
                   continue
-              img = f"{ref}:{tag}" if tag and tag not in ("", "null") else f"{ref}:latest"
+              img = f"{ref}:{tag}" if tag else f"{ref}:latest"
               r = subprocess.run(["crane", "digest", img], capture_output=True, text=True, timeout=30)
               if r.returncode != 0:
                   errors.append(f"{name}: {r.stderr.strip()}")


### PR DESCRIPTION
## Summary

- The `post-merge-drift-check` Python script used `re.findall` with `re.DOTALL`, which caused the `tag:` field from the `golang-alpine` entry to bleed into the `ci-runner` entry during regex matching.
- Result: `crane digest ghcr.io/zynax-io/zynax/ci-runner:"1.26.4-alpine"` — invalid reference, always errors, always opens a false-positive `[AUTO]` drift issue.
- Fix: replace regex parsing with `yaml.safe_load`, which parses each entry in isolation.

## Root cause

```
ERROR: ci-runner: could not parse reference: ghcr.io/zynax-io/zynax/ci-runner:"1.26.4-alpine"
```

The `ci-runner` entry has no `tag:` field. The DOTALL regex `(?:.*?tag:\s+(\S+))?` was non-greedy but still crossed into the next entry (`golang-alpine`, tag `"1.26.4-alpine"`) to satisfy the overall pattern.

## Fix

```diff
-import subprocess, re, sys
-content = open("images/images.yaml").read()
-entries = re.findall(
-    r'- name:\s+(\S+).*?ref:\s+(\S+)(?:.*?tag:\s+(\S+))?.*?digest:\s+(sha256:[a-f0-9]+)',
-    content, re.DOTALL
-)
+import subprocess, sys, yaml
+data = yaml.safe_load(open("images/images.yaml"))
```

`pyyaml` is pre-installed on `ubuntu-24.04` runners.

## Test plan

- [ ] After merge: `post-merge-drift-check` runs on next push and reports `OK ci-runner: sha256:04074b10...` instead of the `ERROR: could not parse reference` failure

Closes #1054

Assisted-by: Claude/claude-sonnet-4-6