### PR TITLE
docs(automation): apply expert learnings — 2026-06-09

### DIFF
--- a/.claude/commands/experts/go-services.md
+++ b/.claude/commands/experts/go-services.md
@@ -150,6 +150,21 @@ GOWORK=off go mod tidy
 
 ---
 
+## Sandbox Bash forms
+
+Commands you emit run in a restricted, non-interactive shell. Three forms have failed across
+sessions — use the safe equivalent so a failure is attributable and parsing is reliable:
+
+- **Multiline `-m` strings** — literal newlines inside a single `-m "…"` (or `-m "$(printf …)"`)
+  can mis-parse. Use one `-m` flag per paragraph: `git commit -s -m "subject" -m "body"`.
+- **Compound commands** — `a && b`, `a; b`, `a || b` in one call are brittle and hide which step
+  failed. Prefer one command per Bash call. (Never rely on `||` fallbacks.)
+- **Inline env-var prefixes** — prefer `export VAR=val` on its own line over `VAR=val cmd`.
+  The required, documented exception that does work is `GOWORK=off go …` (ADR-017) — keep using it.
+- Seen in: #798, #877 (2 sessions).
+
+---
+
 ## gRPC patterns
 
 ```go

--- a/docs/ai-learnings/APPLY_LOG.md
+++ b/docs/ai-learnings/APPLY_LOG.md
@@ -62,6 +62,6 @@
 | 1 | go-services | Base testcontainers GenericContainer — avoid modules/<x> deps | domain | #818, #828 | committed | go-services.md +39L |
 | 2 | go-services | Re-stage after lint/pre-commit hook rewrites files in place | structural-workaround | #819, #824 | rejected | — |
 | 3 | go-services | git rebase drops commits in target — verify diff after rebase | structural-workaround | #795, #838 | rejected | — |
-| 4 | go-services | Sandbox Bash forms: no env-prefix/multiline -m/compound cmds | env-constraint | #798, #877 | pending | — |
+| 4 | go-services | Sandbox Bash forms: no env-prefix/multiline -m/compound cmds | env-constraint | #798, #877 | committed | go-services.md +13L |
 
-**Summary:** 1 proposed (domain) | 1 committed | 2 rejected (structural) | 1 pending (env-constraint)
+**Summary:** 1 proposed (domain) | 2 committed | 2 rejected (structural) | 0 pending


### PR DESCRIPTION
## Summary

Applies the approved `/m6-learn` proposal — APPLY_LOG.md **Run 2026-06-09 16:20, entry #4** (`env-constraint`, sessions #798/#877). Adds a **Sandbox Bash forms** section to the go-services expert guide and flips the log row `pending` → `committed`.

## What was added (go-services.md, +13L)
Three shell forms that have failed in the restricted subagent shell, with safe equivalents:
- **Multiline `-m`** → one `-m` per paragraph
- **Compound commands** (`&&`/`;`/`||`) → one command per Bash call
- **Inline env-prefix** → `export` first; `GOWORK=off go …` (ADR-017) kept as the working exception

## Notes
- **Applied by hand, not via `/m6-learn --apply`:** that command's regex matches only `domain|structural-workaround` categories, so an approved `env-constraint` row is silently skipped. Worth a follow-up fix to the regex in `.claude/commands/m6-learn.md`.
- The captured pattern's terse "no env-prefix" partly conflicts with the guide's working `GOWORK=off` usage — scoped the note to defensible forms and kept `GOWORK=off` as the documented exception.

## Test plan
- [x] APPLY_LOG entry #4 → `committed`; run summary updated (0 pending)
- [x] Commit signed (`G`) + DCO + `Assisted-by`

Assisted-by: Claude/claude-opus-4-8