### PR TITLE
docs(automation): move env-constraint learning out of expert guide

### DIFF
--- a/.claude/commands/experts/go-services.md
+++ b/.claude/commands/experts/go-services.md
@@ -150,21 +150,6 @@ GOWORK=off go mod tidy
 
 ---
 
-## Sandbox Bash forms
-
-Commands you emit run in a restricted, non-interactive shell. Three forms have failed across
-sessions — use the safe equivalent so a failure is attributable and parsing is reliable:
-
-- **Multiline `-m` strings** — literal newlines inside a single `-m "…"` (or `-m "$(printf …)"`)
-  can mis-parse. Use one `-m` flag per paragraph: `git commit -s -m "subject" -m "body"`.
-- **Compound commands** — `a && b`, `a; b`, `a || b` in one call are brittle and hide which step
-  failed. Prefer one command per Bash call. (Never rely on `||` fallbacks.)
-- **Inline env-var prefixes** — prefer `export VAR=val` on its own line over `VAR=val cmd`.
-  The required, documented exception that does work is `GOWORK=off go …` (ADR-017) — keep using it.
-- Seen in: #798, #877 (2 sessions).
-
----
-
 ## gRPC patterns
 
 ```go

--- a/docs/ai-learnings/APPLY_LOG.md
+++ b/docs/ai-learnings/APPLY_LOG.md
@@ -62,6 +62,6 @@
 | 1 | go-services | Base testcontainers GenericContainer — avoid modules/<x> deps | domain | #818, #828 | committed | go-services.md +39L |
 | 2 | go-services | Re-stage after lint/pre-commit hook rewrites files in place | structural-workaround | #819, #824 | rejected | — |
 | 3 | go-services | git rebase drops commits in target — verify diff after rebase | structural-workaround | #795, #838 | rejected | — |
-| 4 | go-services | Sandbox Bash forms: no env-prefix/multiline -m/compound cmds | env-constraint | #798, #877 | committed | go-services.md +13L |
+| 4 | go-services | Sandbox Bash forms: no env-prefix/multiline -m/compound cmds | env-constraint | #798, #877 | applied | covered by dispatch preamble (m6-orchestrate / m6-issue-generate); expert-guide copy reverted — env-constraint is outside /m6-learn --apply scope |
 
-**Summary:** 1 proposed (domain) | 2 committed | 2 rejected (structural) | 0 pending
+**Summary:** 1 proposed (domain) | 1 committed | 2 rejected (structural) | 1 env-constraint (covered by dispatch preamble)


### PR DESCRIPTION
## Summary

Corrects the placement of the learning applied in #1058. The `env-constraint` sandbox-Bash-forms learning (APPLY_LOG #4) was added to `experts/go-services.md`, but per the `/m6-learn` design ([m6-learn.md L185-192](.github)) `env-constraint` learnings **belong in the dispatch-prompt preamble** (injected into every agent), **not** the expert guides — and that guidance **already exists** in `m6-orchestrate.md` (L230, L465-469) and `m6-issue-generate.md` (L118-123).

## Changes
- **Remove** the redundant, misplaced `## Sandbox Bash forms` section from `experts/go-services.md` (−15L).
- **Annotate** APPLY_LOG row #4: `committed` → `applied`, Delta now records it is covered by the dispatch preamble and that the expert-guide copy was reverted.

## Not changed
- **The `/m6-learn --apply` regex** correctly excludes `env-constraint` by design (those rows are outside its expert-file scope) — no change.

## Test plan
- [x] `grep` confirms the section is gone; guidance still present in both dispatch preambles
- [x] Signed (`G`) + DCO + `Assisted-by`

Assisted-by: Claude/claude-opus-4-8