### PR TITLE
fix(ci): copy libs/zynaxobs into service build context

### DIFF
--- a/infra/docker/Dockerfile.service
+++ b/infra/docker/Dockerfile.service
@@ -26,10 +26,12 @@ ARG SVC
 WORKDIR /workspace
 COPY protos/generated/go/go.mod protos/generated/go/go.sum ./protos/generated/go/
 COPY libs/zynaxconfig/go.mod libs/zynaxconfig/go.sum ./libs/zynaxconfig/
+COPY libs/zynaxobs/go.mod libs/zynaxobs/go.sum ./libs/zynaxobs/
 COPY services/${SVC}/go.mod services/${SVC}/go.sum ./services/${SVC}/
 RUN cd services/${SVC} && GOWORK=off go mod download
 COPY protos/generated/go/ ./protos/generated/go/
 COPY libs/zynaxconfig/ ./libs/zynaxconfig/
+COPY libs/zynaxobs/ ./libs/zynaxobs/
 COPY services/${SVC}/ ./services/${SVC}/
 COPY tools/healthcheck/ ./tools/healthcheck/
 RUN cd services/${SVC} && CGO_ENABLED=0 GOWORK=off \


### PR DESCRIPTION
## Summary

Post-merge of #1065 the Release workflow failed for every service image
(api-gateway, engine-adapter, workflow-compiler, task-broker, agent-registry —
both amd64 and arm64). #1065 introduced the shared `libs/zynaxobs` lib and added
a `replace github.com/zynax-io/zynax/libs/zynaxobs => ../../libs/zynaxobs`
directive to each service go.mod, but `infra/docker/Dockerfile.service` was never
updated to COPY that module into the build context.

Builder stage failure:

```
go: github.com/zynax-io/zynax/libs/zynaxobs@v0.0.0 (replaced by ../../libs/zynaxobs):
  reading ../../libs/zynaxobs/go.mod: open /workspace/libs/zynaxobs/go.mod: no such file or directory
```

## Fix

Mirror the existing `zynaxconfig` COPY lines for `zynaxobs` (go.mod/go.sum before
`go mod download`, full source before build). No service images currently use
digest pins (consumed via floating `main`), so no compose/images.yaml updates are
needed — this PR only unblocks the build.

Refs #491

Assisted-by: Claude/claude-opus-4-8
