### PR TITLE
docs(ai-learnings): append session learnings — 2026-06-10

### DIFF
--- a/docs/ai-learnings/bdd-contract.md
+++ b/docs/ai-learnings/bdd-contract.md
@@ -93,3 +93,14 @@
   Category: structural-workaround
 - Rule: "Before writing a test file, check `spec/schemas/` for the actual filename of schemas referenced in the issue. Use the exact path from the issue body — mismatches are intentional and are part of the xfail contract."
   Category: domain
+
+## Session — 2026-06-10 (issue #811)
+
+### Effective patterns
+- Mirror-then-diverge: cloning `e2e-happy.sh` wholesale and replacing only the engine-specific steps (`?engine=argo`, assert Argo `Workflow` CR phase) kept config/helpers/polling identical — the diff reads as "same harness, engine swapped".
+- Source-anchored assertion: confirmed via `argo_engine.go` that the Argo `Workflow` resource name == runID == api-gateway run_id, so `kubectl get workflow.argoproj.io <run_id> -o jsonpath='{.status.phase}'` locates the CR with no label guessing; cited the file path in a comment.
+- Verified the `?engine=` query param at its source (api-gateway `handler.go: r.URL.Query().Get("engine")`) rather than trusting issue text.
+- Matched PR typing to the predecessor: #810's merged PR was `test(infra):` / label `type: test`, not the canvas's `feat:` — look up the sibling PR's actual type.
+
+### Edge cases discovered
+- shellcheck absent on host; run it via `docker run --rm -v <wt>:/mnt koalaman/shellcheck:stable <relpath>` for real lint coverage.

--- a/docs/ai-learnings/ci-release.md
+++ b/docs/ai-learnings/ci-release.md
@@ -459,3 +459,25 @@ Post-merge verification of an engine-adapter change. Outcome: SKIP — image pub
 
 ### Edge cases discovered
 - A single merge SHA can show multiple "Post-Merge Completeness (Wave 3)" runs (re-runs). Treat any one `success` as sufficient; don't block waiting for a specific run instance.
+
+## Session — 2026-06-10 (post-merge: PRs #1062, #1065; issues #804, #491)
+
+### Effective patterns
+- Filtering `actions/runs?branch=main` by `head_sha` returns all runs for a merge immediately; check run state BEFORE entering a wait loop to avoid burning the 20-min budget on already-complete runs (#1062).
+- Verify the GHCR image tag against the short merge SHA (`main-<sha7>`) as positive proof release.yml rebuilt the right commit, not a stale cache (#1062).
+
+### Edge cases discovered
+- Most services are consumed via the floating `main` tag and are NOT digest-pinned (only http-adapter + base nats/redis are). Before flagging a compose pin stale, `grep -rn '<svc>@sha256' <wt> --include=*.yml --include=*.yaml`; a matrix service that was built but has zero digest references is a valid DONE no-op, not SKIP and not an empty PR (#1062).
+- release.yml change-detection + build matrix cover only 5 Go services (api-gateway, engine-adapter, workflow-compiler, task-broker, agent-registry). `event-bus` and `memory-service` have NO matrix entry — touching them builds no image. Do not assume "touched 7 services" == "7 images built" (#1065).
+- **A shared `libs/*` module added with `replace =>` in service go.mods breaks release.yml image builds** unless `infra/docker/Dockerfile.service` COPYs the new lib into the build context. This passes all PR checks (release builds run only post-merge) and lands red on main. Fix: add the COPY line in the same feature PR; if missed, ship a fast `fix(ci): copy libs/<name> into service build context` PR (#1065 → #1067).
+
+### Failed approaches
+- Passing a nonexistent path (`deploy/`) to `grep -rn` aborts the whole call (exit 2). Use `grep -r --include=*.yaml <worktree-root>` instead of guessing subdirs (#1062).
+
+### Orchestrator process note
+- The pre-spawn reconcile (layer 2) `gh pr list --state merged --search "<N> in:body"` FALSE-POSITIVES on canvas/review PRs that merely reference an issue number in a list (#804→#820 canvas PR, #491→#631 review doc). The issue being still OPEN is the reliable signal; treat `in:body` matches as advisory only and confirm against issue state before dropping a claim.
+
+### gh / DCO gotchas (both post-merge + domain agents hit these)
+- `gh pr create --milestone "M6"` fails — pass either the full title `K8s Production-Ready (M6)` OR (simpler, repo-wide) the LABEL `--label "milestone: M6"`. Resolve titles with `gh api repos/zynax-io/zynax/milestones --jq '.[].title'`.
+- `gh pr checks --json` is unsupported; use `gh pr view <n> --json statusCheckRollup`.
+- DCO: do NOT pass `-s` to `git commit` (nor `--signoff` to `git rebase`) when the message file already has a `Signed-off-by` line — it duplicates the trailer. Put one signoff in the file + plain `git commit -F`, or use `-s` with no trailer in the file.

--- a/docs/ai-learnings/go-services.md
+++ b/docs/ai-learnings/go-services.md
@@ -383,3 +383,20 @@ but the `gh issue list --state open` query may lag due to GitHub API eventual co
   Category: domain
 - Rule: "When `gh pr merge --squash` fails with 'base branch policy prohibits the merge' after CI passes, the branch is behind main. Run `git fetch origin main && git rebase --signoff origin/main && git push --force-with-lease`, then retry with `--auto` flag."
   Category: structural-workaround
+
+## Session — 2026-06-10 (issues #804, #491)
+
+### Effective patterns
+- Mirroring the #803 compiler `PolicyGate.checkCapabilityQuota` shape (per-namespace config map + injected counter port + fail-open semantics) into the engine-adapter second gate kept both quota gates consistent and self-reviewing (#804).
+- Keeping the new quota checker self-contained in `infrastructure/` (no change to `domain.ActivityInput` or existing dispatch code) meant existing `DispatchCapabilityActivity` tests passed untouched (#804).
+- One shared `libs/zynaxobs` lib for cross-cutting observability (interceptor + promhttp handler + tracer) reused by all 7 services kept the functional diff ~250 LOC despite touching every service — the canvas's "shared helper in libs/" guidance (#491).
+- For services with no existing HTTP server (event-bus, agent-registry, task-broker, memory-service), a `StartMetricsServer(port)` helper returning `*http.Server` avoided hand-rolling a server in each main.go (#491).
+
+### Edge cases discovered
+- New `libs/*` modules MUST pin shared deps (`google.golang.org/grpc`, `google.golang.org/protobuf`, `go.opentelemetry.io/otel*`) to the SAME versions every other go.mod uses — CI runs both `zynax-ci check deps` (version-alignment) and a Trivy `security` gate that fail on drift or known-CVE versions. `go mod tidy` alone resolves lower-but-valid versions that still trip both gates; pin direct requires explicitly (#491).
+- `make lint-go` only iterates `services/` — it does NOT lint `libs/`. Lint a new lib via the tools Docker image with `--config ../../tools/golangci-lint.yml` (#491).
+- `funlen` (40-stmt limit) + `contextcheck` fire easily: extract a `newGRPCServer(...)` helper rather than inlining setup; a returned-closure cleanup trips `contextcheck` (wants ctx threaded) — use inline `defer func(){ _ = shutdown(context.Background()) }()` (#491).
+- **Adding a new `libs/*` shared module that services `replace =>` requires updating the Docker build context.** `infra/docker/Dockerfile.service` only COPYs the libs it knows about (e.g. `libs/zynaxconfig`); a new `libs/zynaxobs` replace directive makes `go mod download` fail in the image build (`reading ../../libs/zynaxobs/go.mod: no such file`). The PR's own CI does NOT catch this — release.yml builds images only post-merge — so it lands red on main. Update Dockerfile.service COPY lines in the SAME PR (regression in #491, fixed by #1067).
+
+### Failed approaches
+- Pinning the new lib to the versions `go mod tidy` first resolved (grpc v1.67.1 / otel 1.31.0) passed local build/tests but failed CI deps-alignment + Trivy gates — had to bump to repo-prevailing versions and re-tidy every consumer (#491).


### PR DESCRIPTION
Appends learnings from the 2026-06-10 orchestrator batch (issues #804, #491, #811).

Key entries:
- go-services/ci-release: adding a libs/* shared module with a replace directive requires updating infra/docker/Dockerfile.service COPY lines or release.yml image builds fail post-merge (regression in #1065, fixed by #1067).
- go-services: new libs/* go.mod must pin shared deps to repo-prevailing versions (zynax-ci check deps + Trivy gates).
- ci-release: release.yml matrix covers only 5 Go services; most services use floating main tag (no digest pin).
- bdd-contract: e2e mirror-then-diverge + source-anchored CR assertions.
- process: pre-spawn reconcile in:body search false-positives on canvas/review PRs.

Assisted-by: Claude/claude-opus-4-8
