### PR TITLE
ci(infra): run e2e assertion scripts in gated e2e-smoke job

### DIFF
--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -1,8 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # e2e smoke — gated/optional live-cluster end-to-end test (EPIC G #770 step 5, #813).
 #
-# Brings up an ephemeral kind cluster, deploys the zynax-umbrella chart, and runs
-# the Helm upgrade/rollback assertion (scripts/e2e/helm-upgrade.sh).
+# Brings up an ephemeral kind cluster, deploys the zynax-umbrella chart, runs the
+# happy-path and failure-path workflow assertions (scripts/e2e/e2e-happy.sh,
+# scripts/e2e/e2e-failure.sh), then the Helm upgrade/rollback assertion
+# (scripts/e2e/helm-upgrade.sh).
 #
 # GATED, NOT a required PR gate: it triggers ONLY on changes to helm/**,
 # services/**, or engine-adapter/**, plus manual workflow_dispatch. It is
@@ -74,6 +76,19 @@ jobs:
 
       - name: Bring up cluster + deploy stack
         run: scripts/e2e/cluster-up.sh
+
+      - name: Happy-path workflow assertion
+        # Submits code-review.yaml via api-gateway, asserts the workflow
+        # reaches a terminal success state, the workflow.completed CloudEvent
+        # lands on NATS JetStream, and the memory-service KV plane roundtrips.
+        # A failed assertion exits non-zero and fails the job (readable logs).
+        run: scripts/e2e/e2e-happy.sh
+
+      - name: Failure-path workflow assertion
+        # Submits a workflow whose first state invokes an unreachable
+        # capability, asserts it reaches a terminal failed state and the
+        # workflow.failed CloudEvent lands on NATS JetStream.
+        run: scripts/e2e/e2e-failure.sh
 
       - name: Helm upgrade/rollback smoke
         run: scripts/e2e/helm-upgrade.sh


### PR DESCRIPTION
## What

Wires the existing e2e workflow assertion scripts into the gated `e2e-smoke`
GitHub Actions job. After `cluster-up.sh` the job now runs:

1. `scripts/e2e/e2e-happy.sh` — submits `code-review.yaml` via api-gateway,
   asserts the workflow reaches a terminal success state, the
   `zynax.workflow.completed` CloudEvent lands on NATS JetStream, and the
   memory-service KV plane roundtrips.
2. `scripts/e2e/e2e-failure.sh` — submits a workflow invoking an unreachable
   capability, asserts it reaches a terminal `failed` state and the
   `zynax.workflow.failed` CloudEvent lands on JetStream.

`helm-upgrade.sh` still runs afterwards and `cluster-down.sh` stays in
`if: always()`.

## Why

The gate previously only proved the stack installs and upgrades (cluster-up +
helm-upgrade) but never asserted a workflow actually runs to completion or
fails correctly. The assertion scripts existed (EPIC G #770) but were not
invoked in CI. This is step 1 (H.1) of #771.

## Scope

- Workflow wiring only; the assertion scripts already exist.
- The `e2e-smoke` job remains **gated/advisory** — it triggers only on
  `helm/**`, `services/**`, `engine-adapter/**`, `scripts/e2e/**`, or the
  workflow file itself, and is excluded from the branch-protection
  required-check set.
- Out of scope (deferred to #1071 / H.2): the `engine: [temporal, argo]`
  matrix.

## Acceptance criteria

- [x] `e2e-smoke` runs `e2e-happy.sh` after `cluster-up.sh`
- [x] `e2e-smoke` runs `e2e-failure.sh`
- [x] `cluster-down.sh` still runs in `if: always()`
- [x] job remains excluded from the required-check set (advisory)
- [x] an assertion failure fails the job (`set -euo pipefail`; `fail()` exits 1)

Closes #1070

Assisted-by: Claude/claude-opus-4-8
