### PR TITLE
feat(services): graceful gRPC health drain + named serving status

### DIFF
--- a/protos/tests/features/health.feature
+++ b/protos/tests/features/health.feature
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+# Zynax — gRPC Health Checking Protocol BDD Contract Specification
+#
+# This file is the SPECIFICATION. It is written BEFORE the implementation.
+# It describes the contract every Zynax gRPC service must honour by exposing
+# the standard grpc.health.v1.Health service.
+# See protos/AGENTS.md §7 for contract test rules.
+#
+# Business context: Kubernetes 1.24+ native gRPC probes (livenessProbe.grpc /
+# readinessProbe.grpc) and grpc-health-probe rely on the server implementing
+# grpc.health.v1.Health. Services must report SERVING for both the overall ""
+# key and a per-service named key on startup, and must flip to NOT_SERVING
+# before GracefulStop() so load balancers drain in-flight requests during
+# rolling restarts. (issue #656, ADR-016)
+
+Feature: gRPC Health Checking Protocol contract — Kubernetes-native probes
+  As a platform engineer deploying Zynax to Kubernetes
+  I want every gRPC service to implement grpc.health.v1.Health
+  So that native gRPC probes and grpc-health-probe work without a sidecar
+
+  Background:
+    Given a gRPC service with the standard Health server is running
+
+  Scenario: Service reports SERVING on the overall key at startup
+    When a HealthCheckRequest is sent with service ""
+    Then the health status is SERVING
+
+  Scenario: Service reports SERVING on its per-service named key at startup
+    When a HealthCheckRequest is sent with the service's named key
+    Then the health status is SERVING
+
+  Scenario: Unknown service name is reported NOT_FOUND
+    When a HealthCheckRequest is sent with service "does.not.Exist"
+    Then the gRPC health status is NOT_FOUND
+
+  Scenario: Service reports NOT_SERVING after a graceful shutdown signal
+    When the service receives a graceful shutdown signal
+    And a HealthCheckRequest is sent with service ""
+    Then the health status is NOT_SERVING

--- a/protos/tests/health_service/steps_test.go
+++ b/protos/tests/health_service/steps_test.go
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: Apache-2.0
+// BDD contract tests for the gRPC Health Checking Protocol (grpc.health.v1.Health).
+package health_service_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/cucumber/godog"
+	zynaxv1 "github.com/zynax-io/zynax/protos/generated/go/zynax/v1"
+	"github.com/zynax-io/zynax/protos/tests/testserver"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/health"
+	grpc_health_v1 "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/status"
+)
+
+// namedKey is the per-service named serving key under test. Any of the Zynax
+// service descriptors works; agent-registry is representative.
+var namedKey = zynaxv1.AgentRegistryService_ServiceDesc.ServiceName
+
+type healthCtx struct {
+	client     grpc_health_v1.HealthClient
+	healthSrv  *health.Server
+	lastStatus grpc_health_v1.HealthCheckResponse_ServingStatus
+	grpcErr    error
+}
+
+func (hc *healthCtx) setupServer(t *testing.T) error {
+	t.Helper()
+	srv, dialer := testserver.NewBufconnServer(t)
+	hc.healthSrv = health.NewServer()
+	grpc_health_v1.RegisterHealthServer(srv, hc.healthSrv)
+	hc.healthSrv.SetServingStatus("", grpc_health_v1.HealthCheckResponse_SERVING)
+	hc.healthSrv.SetServingStatus(namedKey, grpc_health_v1.HealthCheckResponse_SERVING)
+
+	conn, err := grpc.NewClient("passthrough://bufnet",
+		grpc.WithContextDialer(dialer),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		return err //nolint:wrapcheck
+	}
+	t.Cleanup(func() { _ = conn.Close() }) //nolint:errcheck
+	hc.client = grpc_health_v1.NewHealthClient(conn)
+	return nil
+}
+
+func (hc *healthCtx) check(service string) {
+	callCtx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	resp, err := hc.client.Check(callCtx, &grpc_health_v1.HealthCheckRequest{Service: service})
+	hc.grpcErr = err
+	if resp != nil {
+		hc.lastStatus = resp.GetStatus()
+	}
+}
+
+func (hc *healthCtx) assertStatus(want grpc_health_v1.HealthCheckResponse_ServingStatus) error {
+	if hc.grpcErr != nil {
+		return fmt.Errorf("expected status %v but got error: %w", want, hc.grpcErr)
+	}
+	if hc.lastStatus != want {
+		return fmt.Errorf("expected status %v, got %v", want, hc.lastStatus)
+	}
+	return nil
+}
+
+//nolint:funlen
+func TestFeatures(t *testing.T) {
+	suite := godog.TestSuite{
+		ScenarioInitializer: func(sc *godog.ScenarioContext) {
+			var hc *healthCtx
+
+			sc.Before(func(ctx context.Context, _ *godog.Scenario) (context.Context, error) {
+				hc = &healthCtx{}
+				return ctx, nil
+			})
+
+			sc.Step(`^a gRPC service with the standard Health server is running$`, func(ctx context.Context) (context.Context, error) {
+				return ctx, hc.setupServer(t)
+			})
+
+			sc.Step(`^a HealthCheckRequest is sent with service ""$`, func(ctx context.Context) (context.Context, error) {
+				hc.check("")
+				return ctx, nil
+			})
+
+			sc.Step(`^a HealthCheckRequest is sent with the service's named key$`, func(ctx context.Context) (context.Context, error) {
+				hc.check(namedKey)
+				return ctx, nil
+			})
+
+			sc.Step(`^a HealthCheckRequest is sent with service "([^"]*)"$`, func(ctx context.Context, service string) (context.Context, error) {
+				hc.check(service)
+				return ctx, nil
+			})
+
+			sc.Step(`^the service receives a graceful shutdown signal$`, func(ctx context.Context) (context.Context, error) {
+				// Mirror the cmd/<svc>/main.go drain ordering: NOT_SERVING before stop.
+				hc.healthSrv.SetServingStatus("", grpc_health_v1.HealthCheckResponse_NOT_SERVING)
+				hc.healthSrv.SetServingStatus(namedKey, grpc_health_v1.HealthCheckResponse_NOT_SERVING)
+				return ctx, nil
+			})
+
+			sc.Step(`^the health status is SERVING$`, func(ctx context.Context) (context.Context, error) {
+				return ctx, hc.assertStatus(grpc_health_v1.HealthCheckResponse_SERVING)
+			})
+
+			sc.Step(`^the health status is NOT_SERVING$`, func(ctx context.Context) (context.Context, error) {
+				return ctx, hc.assertStatus(grpc_health_v1.HealthCheckResponse_NOT_SERVING)
+			})
+
+			sc.Step(`^the gRPC health status is NOT_FOUND$`, func(ctx context.Context) (context.Context, error) {
+				if hc.grpcErr == nil {
+					return ctx, fmt.Errorf("expected NOT_FOUND error, got nil")
+				}
+				st, _ := status.FromError(hc.grpcErr)
+				if st.Code() != codes.NotFound {
+					return ctx, fmt.Errorf("expected NOT_FOUND, got %v", st.Code())
+				}
+				return ctx, nil
+			})
+		},
+		Options: &godog.Options{
+			Format:   "pretty",
+			Paths:    []string{"../features/health.feature"},
+			TestingT: t,
+		},
+	}
+	if suite.Run() != 0 {
+		t.Fatal("non-zero status returned, failed to run feature tests")
+	}
+}

--- a/services/agent-registry/cmd/agent-registry/main.go
+++ b/services/agent-registry/cmd/agent-registry/main.go
@@ -97,7 +97,7 @@ func run(cfg config) error {
 
 	healthSvc := health.NewServer()
 	grpc_health_v1.RegisterHealthServer(srv, healthSvc)
-	healthSvc.SetServingStatus("", grpc_health_v1.HealthCheckResponse_SERVING)
+	setHealth(healthSvc, grpc_health_v1.HealthCheckResponse_SERVING)
 
 	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", cfg.GRPCPort))
 	if err != nil {
@@ -113,8 +113,18 @@ func run(cfg config) error {
 
 	<-ctx.Done()
 	slog.Info("shutting down")
+	// Drain: report NOT_SERVING so load balancers stop routing before the
+	// graceful stop completes (canvas O-step 2, #656).
+	setHealth(healthSvc, grpc_health_v1.HealthCheckResponse_NOT_SERVING)
 	srv.GracefulStop()
 	return nil
+}
+
+// setHealth sets both the overall "" key and the per-service named key to the
+// given serving status (canvas O-step 2, #656).
+func setHealth(h *health.Server, st grpc_health_v1.HealthCheckResponse_ServingStatus) {
+	h.SetServingStatus("", st)
+	h.SetServingStatus(zynaxv1.AgentRegistryService_ServiceDesc.ServiceName, st)
 }
 
 func parseLogLevel(level string) slog.Level {

--- a/services/engine-adapter/cmd/engine-adapter/main.go
+++ b/services/engine-adapter/cmd/engine-adapter/main.go
@@ -130,7 +130,7 @@ func run(cfg config) error {
 	}
 	probes := api.NewProbes(int64(cfg.LivenessThresholdS), brokerReadyFn)
 
-	grpcSrv, err := startGRPC(cfg, engine, probes)
+	grpcSrv, healthSvc, err := startGRPC(cfg, engine, probes)
 	if err != nil {
 		return fmt.Errorf("gRPC start: %w", err)
 	}
@@ -152,6 +152,9 @@ func run(cfg config) error {
 	<-ctx.Done()
 
 	slog.Info("shutting down")
+	// Drain: report NOT_SERVING so load balancers stop routing before the
+	// graceful stop completes (canvas O-step 2, #656).
+	setHealth(healthSvc, grpc_health_v1.HealthCheckResponse_NOT_SERVING)
 	grpcSrv.GracefulStop()
 
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -278,10 +281,10 @@ func dialGRPCClients(cfg config) (*grpc.ClientConn, *grpc.ClientConn, error) {
 	return brokerConn, eventBusConn, nil
 }
 
-func startGRPC(cfg config, engine domain.WorkflowEngine, probes *api.Probes) (*grpc.Server, error) {
+func startGRPC(cfg config, engine domain.WorkflowEngine, probes *api.Probes) (*grpc.Server, *health.Server, error) {
 	serverCreds, err := infrastructure.TLSCreds(cfg.TLSCert, cfg.TLSKey, cfg.TLSCA)
 	if err != nil {
-		return nil, fmt.Errorf("tls credentials: %w", err)
+		return nil, nil, fmt.Errorf("tls credentials: %w", err)
 	}
 	srv := grpc.NewServer(
 		grpc.Creds(serverCreds),
@@ -295,12 +298,12 @@ func startGRPC(cfg config, engine domain.WorkflowEngine, probes *api.Probes) (*g
 
 	healthSvc := health.NewServer()
 	grpc_health_v1.RegisterHealthServer(srv, healthSvc)
-	healthSvc.SetServingStatus("", grpc_health_v1.HealthCheckResponse_SERVING)
+	setHealth(healthSvc, grpc_health_v1.HealthCheckResponse_SERVING)
 	zynaxv1.RegisterEngineAdapterServiceServer(srv, api.NewHandler(engine))
 
 	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", cfg.GRPCPort))
 	if err != nil {
-		return nil, fmt.Errorf("listen :%d: %w", cfg.GRPCPort, err)
+		return nil, nil, fmt.Errorf("listen :%d: %w", cfg.GRPCPort, err)
 	}
 
 	go func() {
@@ -309,7 +312,14 @@ func startGRPC(cfg config, engine domain.WorkflowEngine, probes *api.Probes) (*g
 		}
 	}()
 
-	return srv, nil
+	return srv, healthSvc, nil
+}
+
+// setHealth sets both the overall "" key and the per-service named key to the
+// given serving status (canvas O-step 2, #656).
+func setHealth(h *health.Server, st grpc_health_v1.HealthCheckResponse_ServingStatus) {
+	h.SetServingStatus("", st)
+	h.SetServingStatus(zynaxv1.EngineAdapterService_ServiceDesc.ServiceName, st)
 }
 
 func startHTTP(cfg config, probes *api.Probes) *http.Server {

--- a/services/event-bus/cmd/event-bus/main.go
+++ b/services/event-bus/cmd/event-bus/main.go
@@ -92,7 +92,7 @@ func run(cfg config) error {
 
 	healthSvc := health.NewServer()
 	grpc_health_v1.RegisterHealthServer(srv, healthSvc)
-	healthSvc.SetServingStatus("", grpc_health_v1.HealthCheckResponse_SERVING)
+	setHealth(healthSvc, grpc_health_v1.HealthCheckResponse_SERVING)
 
 	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", cfg.GRPCPort))
 	if err != nil {
@@ -108,6 +108,16 @@ func run(cfg config) error {
 
 	<-ctx.Done()
 	slog.Info("shutting down")
+	// Drain: report NOT_SERVING so load balancers stop routing before the
+	// graceful stop completes (canvas O-step 2, #656).
+	setHealth(healthSvc, grpc_health_v1.HealthCheckResponse_NOT_SERVING)
 	srv.GracefulStop()
 	return nil
+}
+
+// setHealth sets both the overall "" key and the per-service named key to the
+// given serving status (canvas O-step 2, #656).
+func setHealth(h *health.Server, st grpc_health_v1.HealthCheckResponse_ServingStatus) {
+	h.SetServingStatus("", st)
+	h.SetServingStatus(zynaxv1.EventBusService_ServiceDesc.ServiceName, st)
 }

--- a/services/memory-service/cmd/memory-service/main.go
+++ b/services/memory-service/cmd/memory-service/main.go
@@ -93,7 +93,7 @@ func run(cfg config) error {
 
 	healthSvc := health.NewServer()
 	grpc_health_v1.RegisterHealthServer(srv, healthSvc)
-	healthSvc.SetServingStatus("", grpc_health_v1.HealthCheckResponse_SERVING)
+	setHealth(healthSvc, grpc_health_v1.HealthCheckResponse_SERVING)
 
 	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", cfg.GRPCPort))
 	if err != nil {
@@ -109,6 +109,16 @@ func run(cfg config) error {
 
 	<-ctx.Done()
 	slog.Info("shutting down")
+	// Drain: report NOT_SERVING so load balancers stop routing before the
+	// graceful stop completes (canvas O-step 2, #656).
+	setHealth(healthSvc, grpc_health_v1.HealthCheckResponse_NOT_SERVING)
 	srv.GracefulStop()
 	return nil
+}
+
+// setHealth sets both the overall "" key and the per-service named key to the
+// given serving status (canvas O-step 2, #656).
+func setHealth(h *health.Server, st grpc_health_v1.HealthCheckResponse_ServingStatus) {
+	h.SetServingStatus("", st)
+	h.SetServingStatus(zynaxv1.MemoryService_ServiceDesc.ServiceName, st)
 }

--- a/services/task-broker/cmd/task-broker/main.go
+++ b/services/task-broker/cmd/task-broker/main.go
@@ -96,7 +96,7 @@ func run(cfg config) error {
 	executor := infrastructure.NewAgentExecutor(creds)
 	svc := domain.NewTaskService(repo, finder, executor)
 
-	srv := newGRPCServer(creds, svc)
+	srv, healthSvc := newGRPCServer(creds, svc)
 
 	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", cfg.GRPCPort))
 	if err != nil {
@@ -111,14 +111,22 @@ func run(cfg config) error {
 	}()
 
 	<-ctx.Done()
-	slog.Info("shutting down")
-	srv.GracefulStop()
+	gracefulShutdown(srv, healthSvc)
 	return nil
+}
+
+// gracefulShutdown drains health (NOT_SERVING) before GracefulStop() so load
+// balancers stop routing during rolling restarts (canvas O-step 2, #656).
+func gracefulShutdown(srv *grpc.Server, healthSvc *health.Server) {
+	slog.Info("shutting down")
+	setHealth(healthSvc, grpc_health_v1.HealthCheckResponse_NOT_SERVING)
+	srv.GracefulStop()
 }
 
 // newGRPCServer builds the gRPC server with metrics + tracing interceptors,
 // reflection, the TaskBroker handler, and the gRPC health service registered.
-func newGRPCServer(creds credentials.TransportCredentials, svc *domain.TaskService) *grpc.Server {
+// It returns the health server so the caller can mark NOT_SERVING on shutdown.
+func newGRPCServer(creds credentials.TransportCredentials, svc *domain.TaskService) (*grpc.Server, *health.Server) {
 	srv := grpc.NewServer(
 		grpc.Creds(creds),
 		grpc.StatsHandler(zynaxobs.TracingStatsHandler()),
@@ -129,6 +137,13 @@ func newGRPCServer(creds credentials.TransportCredentials, svc *domain.TaskServi
 
 	healthSvc := health.NewServer()
 	grpc_health_v1.RegisterHealthServer(srv, healthSvc)
-	healthSvc.SetServingStatus("", grpc_health_v1.HealthCheckResponse_SERVING)
-	return srv
+	setHealth(healthSvc, grpc_health_v1.HealthCheckResponse_SERVING)
+	return srv, healthSvc
+}
+
+// setHealth sets both the overall "" key and the per-service named key to the
+// given serving status (canvas O-step 2, #656).
+func setHealth(h *health.Server, st grpc_health_v1.HealthCheckResponse_ServingStatus) {
+	h.SetServingStatus("", st)
+	h.SetServingStatus(zynaxv1.TaskBrokerService_ServiceDesc.ServiceName, st)
 }

--- a/services/workflow-compiler/cmd/workflow-compiler/main.go
+++ b/services/workflow-compiler/cmd/workflow-compiler/main.go
@@ -69,7 +69,7 @@ func main() {
 
 	healthSvc := health.NewServer()
 	grpc_health_v1.RegisterHealthServer(grpcServer, healthSvc)
-	healthSvc.SetServingStatus("", grpc_health_v1.HealthCheckResponse_SERVING)
+	setHealth(healthSvc, grpc_health_v1.HealthCheckResponse_SERVING)
 
 	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", cfg.GRPCPort))
 	if err != nil {
@@ -90,8 +90,7 @@ func main() {
 	}()
 
 	<-ctx.Done()
-	slog.Info("shutting down")
-	grpcServer.GracefulStop()
+	drainAndStop(grpcServer, healthSvc)
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	if err := metricsSrv.Shutdown(shutdownCtx); err != nil {
@@ -123,6 +122,21 @@ func startMetricsServer(port int) *http.Server {
 		}
 	}()
 	return srv
+}
+
+// setHealth sets both the overall "" key and the per-service named key to the
+// given serving status (canvas O-step 2, #656).
+func setHealth(h *health.Server, st grpc_health_v1.HealthCheckResponse_ServingStatus) {
+	h.SetServingStatus("", st)
+	h.SetServingStatus(zynaxv1.WorkflowCompilerService_ServiceDesc.ServiceName, st)
+}
+
+// drainAndStop drains health (NOT_SERVING) before GracefulStop() so load
+// balancers stop routing during rolling restarts (canvas O-step 2, #656).
+func drainAndStop(srv *grpc.Server, h *health.Server) {
+	slog.Info("shutting down")
+	setHealth(h, grpc_health_v1.HealthCheckResponse_NOT_SERVING)
+	srv.GracefulStop()
 }
 
 // buildPolicyGate constructs a domain.PolicyGate from the environment-backed


### PR DESCRIPTION
## Summary

Completes the gRPC Health Checking Protocol story for #656. The 6 gRPC services
already registered `grpc_health_v1.RegisterHealthServer` and set the overall `""`
key to `SERVING` on startup. This PR closes the remaining graceful-lifecycle gaps
(canvas O1–O3):

- **O2 — graceful `NOT_SERVING` drain + named status** across all 6 gRPC services
  (agent-registry, task-broker, workflow-compiler, engine-adapter, event-bus,
  memory-service): each now also sets a per-service **named** serving key
  (`zynax.v1.<Svc>Service`, sourced from the generated `ServiceDesc.ServiceName`)
  to `SERVING` on startup, and flips both the overall and named keys to
  `NOT_SERVING` **before** `GracefulStop()` so load balancers / Kubernetes drain
  in-flight requests during rolling restarts. Wiring-layer only (`cmd/<svc>/main.go`).
- **O1 — BDD `health.feature`** committed first per ADR-016.
- **O3 — step bindings** at the gRPC boundary (bufconn) asserting SERVING on both
  keys, NOT_FOUND for an unknown service, and NOT_SERVING after the drain.

## Scope

Per the canvas, **O4 (Helm `livenessProbe.grpc` / `readinessProbe.grpc`) and O5
(probe YAML in each service `AGENTS.md`) are deferred as follow-up** to keep this a
focused, reviewable PR. The graceful-lifecycle behaviour they document is fully
implemented here. api-gateway is out of scope (HTTP REST). The #655 custom
healthcheck binary is retained (coexists for docker-compose checks).

## Safeguards honoured

- `NOT_SERVING` is always set **before** `GracefulStop()` (the core requirement).
- No new external dependency — `google.golang.org/grpc/health` is already present.
- No `internal/domain` changes; health/shutdown stays a `cmd/` wiring concern.

## Evidence

- `GOWORK=off go build ./...` — exit 0 for all 6 services.
- `GOWORK=off go test ./... -race` — green for task-broker, engine-adapter (the
  two services with refactored helpers) and the `protos/tests/health_service` BDD
  package.
- pre-commit `golangci-lint` + `gofmt` — Passed on all commits.

Closes #656

🤖 Generated with [Claude Code](https://claude.com/claude-code)
