### PR TITLE
ci: expand pr-size.yml exclusions for config and narrative docs

### DIFF
--- a/.github/workflows/pr-size.yml
+++ b/.github/workflows/pr-size.yml
@@ -47,8 +47,11 @@ jobs:
             });
 
             // Exclude generated stubs, lock files, binary fixtures, changelogs,
-            // CI workflow files, and documentation-only paths (AGENTS.md, docs/, state/).
-            const skipPattern = /\.(pb\.go|pb\.py|sum|lock|png|jpg|gif|svg)$|\/generated\/|CHANGELOG\.md$|^\.github\/workflows\/|AGENTS\.md$|^docs\/|^state\/|^\.claude\//;
+            // CI workflow files, documentation-only paths (AGENTS.md, docs/, state/),
+            // config/contract surfaces (images.yaml SoT, Helm charts, spec fixtures,
+            // automation configs, Makefile), and narrative docs (CLAUDE/ROADMAP/README).
+            // Keep this list in sync with CLAUDE.md §PR size.
+            const skipPattern = /\.(pb\.go|pb\.py|sum|lock|png|jpg|gif|svg)$|\/generated\/|CHANGELOG\.md$|^\.github\/workflows\/|AGENTS\.md$|^docs\/|^state\/|^\.claude\/|^images\/images\.yaml$|^infra\/helm\/|^spec\/|^automation\/|^Makefile$|^CLAUDE\.md$|^ROADMAP\.md$|^README\.md$/;
             const lines = files
               .filter(f => !skipPattern.test(f.filename))
               .reduce((total, f) => total + f.additions + f.deletions, 0);

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,11 @@ Each directory has an `AGENTS.md`; see [AGENTS.md §Knowledge Base Index](AGENTS
 ## PR size
 
 ≤ 200 lines ideal · 201–400 acceptable · 401–900 justify in description · > 900 **blocked**.
-Exclusions: generated stubs (`*.pb.go`, `*_pb2.py`), lock files, `.github/workflows/`, schema fixtures.
+Exclusions (mirror of the `skipPattern` in `.github/workflows/pr-size.yml` — keep in sync):
+generated stubs (`*.pb.go`, `*.pb.py`, `/generated/`), lock files (`*.sum`, `*.lock`),
+binary fixtures (`*.png`, `*.jpg`, `*.gif`, `*.svg`), `CHANGELOG.md`, `.github/workflows/`,
+`AGENTS.md`, `docs/`, `state/`, `.claude/`, `images/images.yaml`, `infra/helm/`, `spec/`,
+`automation/`, `Makefile`, `CLAUDE.md`, `ROADMAP.md`, `README.md`.
 One commit per logical change · one PR per issue · never squash unrelated work.
 
 ## Development workflow


### PR DESCRIPTION
## Summary

Expands the `skipPattern` in `.github/workflows/pr-size.yml` so the PR size gate measures
reviewable production code instead of config/contract/prose churn, and updates the
`CLAUDE.md §PR size` exclusion list to mirror the workflow pattern exactly.

Part of #1109 · Spec: `docs/contributing/ci-delivery-overhaul-prompt.md` §1C

## What changed

New `skipPattern` alternatives: `^images/images\.yaml$`, `^infra/helm/`, `^spec/`,
`^automation/`, `^Makefile$`, `^CLAUDE\.md$`, `^ROADMAP\.md$`, `^README\.md$`.

`^docs/spdd/` from the spec list was **not** added — it is already covered by the existing
`^docs\/` alternative. The spec's `/x` multiline regex form was not used because JavaScript
regex literals have no `x` flag (it would be a SyntaxError in `actions/github-script`);
the pattern stays on one line, matching the current style.

## EPIC canvas

N/A — SPDD-exempt (`ci:`).

## Acceptance criteria

- [x] CLAUDE.md exclusion list and `pr-size.yml` skipPattern agree exactly
      [evidence: CLAUDE.md §PR size now enumerates the identical 17 patterns and notes it
      mirrors the workflow skipPattern]
- [x] A test PR touching only excluded paths reports ~0 counted lines
      [evidence: `node -e` harness — all 13 excluded sample paths (images/images.yaml,
      infra/helm/…, spec/…, automation/…, Makefile, CLAUDE.md, ROADMAP.md, README.md,
      docs/spdd/…, workflows, AGENTS.md, go.sum, *.pb.go) match skipPattern → 0 lines;
      all 9 production-code samples still counted. This PR itself touches only
      `.github/workflows/` + `CLAUDE.md`, so its own "PR size label" check should report
      0 counted lines.]

## Test plan

### Validation
- [x] Regex is valid JavaScript — `node -e` compiles and evaluates it, ALL ASSERTIONS PASS
- [x] `pr-size.yml` parses as YAML (`python3 -c "yaml.safe_load(...)"` → YAML OK)
- [x] Build/unit/BDD/coverage — N/A (no Go/Python/proto code touched)

### Engineering hygiene
- [x] Branched off fresh `origin/main` · 13 changed lines · trailers on every commit
- [x] Status-surface reconciliation intentionally skipped (workflow+CLAUDE.md-only scope per issue)
