### PR TITLE
chore: milestone state SSoT yaml + schema + validation. Closes #1110

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -11,6 +11,7 @@
 #   canvas-freshness     → SPDD Canvas present + valid for feat: PRs (ADR-019)
 #   conflict-markers     → scans PR for leftover git conflict markers
 #   gitleaks-scan        → secrets scan across full PR commit range
+#   milestone-state      → ADVISORY: state/milestone.yaml schema check (issue #1110)
 #
 # PR size labeling is in pr-size.yml (separate workflow) to avoid feedback loops.
 #
@@ -314,6 +315,26 @@ jobs:
           cd cmd/zynax-ci
           GOWORK=off go run . images check --root "$GITHUB_WORKSPACE"
           echo "✅ All consumer digests match images/images.yaml"
+
+# ── Milestone State Schema (ADVISORY — non-blocking) ─────────────────────────
+# Validates state/milestone.yaml (machine-readable milestone SSoT, updated only
+# by /milestone-close and /milestone-new) against state/milestone.schema.json.
+# Advisory while the schema stabilizes — promote to a required check once stable.
+  milestone-state:
+    name: Milestone state schema (advisory)
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-24.04
+    continue-on-error: true
+    container:
+      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:04074b10bb681e0cbeffd053b9d7cc6aaef4b7b92fd08b3a3c9ee3ede877b782
+      options: --user root
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Validate state/milestone.yaml against schema
+        run: |
+          uv run --no-project --quiet --with pyyaml --with jsonschema \
+            python3 scripts/validate_milestone_state.py
 
 # ── Secret Scan (gitleaks) ────────────────────────────────────────────────────
   gitleaks-scan:

--- a/Makefile
+++ b/Makefile
@@ -336,7 +336,12 @@ clean-tools: ## Remove tools image
 clean-all: clean dev-down clean-tools ## ⚠ Remove everything
 
 # ── Spec validation ───────────────────────────────────────────────────────────
-.PHONY: validate-spec validate-asyncapi validate-workflow-schema validate-agent-def-schema validate-policy-schema validate-canvas dry-run
+.PHONY: validate-spec validate-asyncapi validate-workflow-schema validate-agent-def-schema validate-policy-schema validate-canvas validate-milestone-state dry-run
+
+validate-milestone-state: ensure-tools ## Validate state/milestone.yaml against state/milestone.schema.json (Docker)
+	$(TOOLS_RUN) uv run --no-project --quiet --with pyyaml --with jsonschema \
+	  python3 scripts/validate_milestone_state.py
+	@echo "✅ Milestone state valid"
 
 validate-spec: validate-asyncapi validate-capability-schemas validate-workflow-schema validate-agent-def-schema validate-policy-schema ## Validate all specs (AsyncAPI + capability schemas + workflow + agent-def + policy manifests)
 

--- a/scripts/validate_milestone_state.py
+++ b/scripts/validate_milestone_state.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Validate state/milestone.yaml against state/milestone.schema.json.
+
+Run via `make validate-milestone-state` (containerized — see Makefile).
+state/milestone.yaml is updated only by /milestone-close and /milestone-new,
+never by hand; this validator is the CI gate for those commands' output.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import yaml
+from jsonschema import Draft202012Validator
+
+STATE_FILE = Path("state/milestone.yaml")
+SCHEMA_FILE = Path("state/milestone.schema.json")
+
+
+def main() -> int:
+    data = yaml.safe_load(STATE_FILE.read_text(encoding="utf-8"))
+    schema = json.loads(SCHEMA_FILE.read_text(encoding="utf-8"))
+
+    Draft202012Validator.check_schema(schema)
+    validator = Draft202012Validator(schema)
+    errors = sorted(validator.iter_errors(data), key=lambda e: list(e.absolute_path))
+
+    if errors:
+        for err in errors:
+            path = "/".join(str(p) for p in err.absolute_path) or "<root>"
+            print(f"FAIL {STATE_FILE}: {path}: {err.message}")
+        return 1
+
+    print(f"OK {STATE_FILE} conforms to {SCHEMA_FILE}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/state/milestone.schema.json
+++ b/state/milestone.schema.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/zynax-io/zynax/blob/main/state/milestone.schema.json",
+  "title": "Zynax milestone state",
+  "description": "Schema for state/milestone.yaml — the machine-readable single source of truth for the active milestone. The file is updated only by /milestone-close and /milestone-new, never by hand.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["active", "history"],
+  "properties": {
+    "active": { "$ref": "#/$defs/activeMilestone" },
+    "history": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/historyMilestone" }
+    }
+  },
+  "$defs": {
+    "milestoneName": {
+      "type": "string",
+      "pattern": "^M\\d+$"
+    },
+    "semverTag": {
+      "type": "string",
+      "pattern": "^v\\d+\\.\\d+\\.\\d+$"
+    },
+    "planningDoc": {
+      "type": "string",
+      "pattern": "^docs/milestones/.+\\.md$"
+    },
+    "activeMilestone": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "title",
+        "github_milestone_number",
+        "version",
+        "status",
+        "planning_doc",
+        "labels",
+        "open_epics"
+      ],
+      "properties": {
+        "name": { "$ref": "#/$defs/milestoneName" },
+        "title": { "type": "string", "minLength": 1 },
+        "github_milestone_number": { "type": "integer", "minimum": 1 },
+        "version": { "$ref": "#/$defs/semverTag" },
+        "status": { "enum": ["active", "closing", "complete"] },
+        "planning_doc": { "$ref": "#/$defs/planningDoc" },
+        "labels": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["milestone"],
+          "properties": {
+            "milestone": { "type": "string", "minLength": 1 }
+          }
+        },
+        "open_epics": {
+          "type": "array",
+          "items": { "type": "integer", "minimum": 1 },
+          "uniqueItems": true
+        }
+      }
+    },
+    "historyMilestone": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "title", "github_milestone_number", "version"],
+      "properties": {
+        "name": { "$ref": "#/$defs/milestoneName" },
+        "title": { "type": "string", "minLength": 1 },
+        "github_milestone_number": { "type": "integer", "minimum": 1 },
+        "version": { "$ref": "#/$defs/semverTag" },
+        "released": {
+          "type": "string",
+          "format": "date",
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+        },
+        "planning_doc": { "$ref": "#/$defs/planningDoc" }
+      }
+    }
+  }
+}

--- a/state/milestone.yaml
+++ b/state/milestone.yaml
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0
+# Zynax — machine-readable milestone state (single source of truth).
+#
+# Updated ONLY by /milestone-close and /milestone-new — never edit by hand.
+# Delivery commands read the active milestone's name, number, labels, and
+# planning doc from this file; no command may hardcode them.
+#
+# Validated against state/milestone.schema.json by `make validate-milestone-state`
+# (containerized) and by the advisory milestone-state-check job in pr-checks.yml.
+
+active:
+  name: M6
+  title: "K8s Production-Ready"
+  github_milestone_number: 6
+  version: v0.5.0
+  status: active # active | closing | complete
+  planning_doc: docs/milestones/M6-planning.md
+  labels:
+    milestone: "milestone: M6"
+  # Static hint only — commands re-query the live list at runtime when GH_TOKEN
+  # is available (gh issue list --milestone <title> --label "type: epic"
+  # --state open) and fall back to this list offline.
+  open_epics: [771, 873, 881, 1073, 1086, 1107, 1108, 1109]
+
+history:
+  - name: M5
+    title: "Adapter Library"
+    github_milestone_number: 5
+    version: v0.4.0
+    released: "2026-05-29"
+    planning_doc: docs/milestones/M5-plan.md
+  - name: M4
+    title: "YAML System + CLI"
+    github_milestone_number: 4
+    version: v0.3.0
+  - name: M3
+    title: "Temporal Execution"
+    github_milestone_number: 3
+    version: v0.2.0
+  - name: M2
+    title: "Workflow IR"
+    github_milestone_number: 2
+    version: v0.1.0
+  - name: M1
+    title: "Contracts Foundation"
+    github_milestone_number: 1
+    version: v0.1.0
+    released: "2026-04-21"


### PR DESCRIPTION
## Summary

Adds `state/milestone.yaml` — the machine-readable single source of truth for the active
milestone — plus its JSON Schema, a containerized `validate-milestone-state` make target,
and an advisory (non-blocking) schema-check job in `pr-checks.yml`.

Part of #1108 (Part 0 of #1107) · Spec: `docs/contributing/ci-delivery-overhaul-prompt.md` §0A

## EPIC canvas

N/A — SPDD-exempt (`chore:`).

## What's in the file (real data)

- `active`: M6 "K8s Production-Ready", `github_milestone_number: 6`, `v0.5.0`,
  `planning_doc: docs/milestones/M6-planning.md`, label `milestone: M6`,
  `open_epics: [771, 873, 881, 1073, 1086, 1107, 1108, 1109]` (from live
  `gh issue list --milestone "K8s Production-Ready (M6)" --label "type: epic" --state open`)
- `history`: M5 (5, v0.4.0, released 2026-05-29, `docs/milestones/M5-plan.md`),
  M4 (4, v0.3.0), M3 (3, v0.2.0), M2 (2, v0.1.0), M1 (1, v0.1.0, released 2026-04-21).
  `released` is omitted for M2–M4: no tagged GitHub release exists for v0.1.0–v0.3.0
  (versions were retro-assigned; milestones were bulk-closed 2026-05-07).

## Locked decision

`open_epics` is a **static hint** — the YAML comment states that delivery commands re-query
the GitHub API at runtime when `GH_TOKEN` is available and fall back to the static list.

## Acceptance criteria

- [x] `make validate-milestone-state` passes locally and in CI
      [evidence: `OK state/milestone.yaml conforms to state/milestone.schema.json` — see test plan]
- [x] Schema rejects a missing `github_milestone_number` and an unknown `status` value
      [evidence: negative-test output in test plan]
- [x] File header says it is updated by `/milestone-close` + `/milestone-new`, never by hand
      [evidence: `state/milestone.yaml` lines 4–5]

## Test plan

### Validation gate

- [x] `make validate-milestone-state` — exit 0:
      ```
      OK state/milestone.yaml conforms to state/milestone.schema.json
      ✅ Milestone state valid
      ```
- [x] Negative test 1 — `del data["active"]["github_milestone_number"]`:
      ```
      REJECTED missing github_milestone_number: 'github_milestone_number' is a required property
      ```
- [x] Negative test 2 — `data["active"]["status"] = "paused"`:
      ```
      REJECTED unknown status: 'paused' is not one of ['active', 'closing', 'complete']
      ```
      (both run in the tools container with the same `uv run --with pyyaml --with jsonschema` env)

### Lint & security

- [x] `actionlint -color .github/workflows/pr-checks.yml` — exit 0, no findings (ci-runner container)
- [x] `ruff check scripts/validate_milestone_state.py` — `All checks passed!`
- [x] pre-commit (gitleaks, ruff, ruff-format) — all passed on commit

### Build & unit / Contract

- N/A — no Go/Python service code, no gRPC boundary touched.

### Engineering hygiene

- [x] Advisory CI step uses `continue-on-error: true` — non-blocking until schema stabilizes
- [x] `pr-checks.yml` already listed in `images/images.yaml` ci-runner `consumers:`; digest matches SoT
- [x] Branched off fresh `origin/main` · PR well under size limit · DCO + `Assisted-by` trailer on the commit
- [x] M6-planning.md untouched by design — issue #1110 is not in its tables (scope-limited change)
