### PR TITLE
docs: deduplicate live milestone status across doc surfaces

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,8 +6,8 @@ any layer.
 
 ## Milestone Status
 
-> Current status, per-track progress, and active blockers:
-> [state/current-milestone.md](state/current-milestone.md) · full plan: [docs/milestones/M5-plan.md](docs/milestones/M5-plan.md).
+> Live status, per-EPIC progress, and active blockers: [state/current-milestone.md](state/current-milestone.md).
+> Milestone goals and sequence: [ROADMAP.md](ROADMAP.md).
 
 ## Key pointers
 
@@ -104,14 +104,16 @@ Full guide: `docs/patterns/spdd-guide.md` · Template: `docs/spdd/CANVAS_TEMPLAT
 
 ## Per-Milestone Scope
 
+> Live progress: [state/current-milestone.md](state/current-milestone.md)
+
 | Milestone | In scope | Out of scope / defer |
 |-----------|----------|----------------------|
 | **M1** (Complete) | Proto contracts, AsyncAPI spec, generated stubs, BDD scenarios, CI gates | Service implementations, DB schemas, runtime |
 | **M2** (Complete) | WorkflowIR structured fields in `workflow_compiler.proto`, `WorkflowCompilerService` skeleton (in-memory), JSON Schema for WorkflowIR | Temporal integration, persistence, CLI |
-| **M3** (⚠ Partial) | Temporal-backed `EngineAdapterService` — `WorkflowEngine` interface, `IRInterpreterWorkflow`, `DispatchCapabilityActivity`, `TemporalEngine`, gRPC wiring | Other engine adapters, K8s deployment · task-broker missing (M5.C #460) |
-| **M4** (⚠ Partial) | api-gateway REST layer, `zynax` CLI, `kind: AgentDef` routing, Docker Compose runner, GitOps watch | Observability, production hardening · agent-registry missing (M5.C #460) |
-| **M5** (✅ Complete, v0.4.0) | M5.A docs alignment, M5.B engine fixes, M5.C capability dispatch (task-broker ✅, agent-registry ✅), M5.D security ✅, M5.E DX ✅, all 5 adapters ✅, e2e-demo ✅ | Persistence, K8s deployment, event-bus (all delivered in M6) |
-| **M6** (🚧 Active) | **Delivered:** mTLS ✅, supply-chain (cosign+SBOM+multi-arch) ✅, Postgres repos (#626) ✅, Helm charts (#765) ✅, EventBus over NATS (#772) ✅, images.yaml SoT + ADR-024 (#855) ✅, self-hosting dev-automation (#873) ✅, orchestrator hardening (#1001) ✅, memory-service KV+vector (#773) ✅, ArgoEngine (#766) ✅, multi-namespace (#767) ✅, policy/rate-limit (#768) ✅, SDK PyPI (#769) ✅, e2e harness (#770) ✅, multi-arch build (#837) ✅, gRPC health (#656) ✅, Prometheus /metrics (#491) ✅. **In progress:** e2e-green gate (#1086), Postgres off Bitnami (#1073), CI-E2E gate (#771), DevAuto Wave 4 (#881) | M7 observability (OTel #467), M8 CNCF submission |
+| **M3** (Partial) | Temporal-backed `EngineAdapterService` — `WorkflowEngine` interface, `IRInterpreterWorkflow`, `DispatchCapabilityActivity`, `TemporalEngine`, gRPC wiring | Other engine adapters, K8s deployment · task-broker delivered later in M5.C |
+| **M4** (Partial) | api-gateway REST layer, `zynax` CLI, `kind: AgentDef` routing, Docker Compose runner, GitOps watch | Observability, production hardening · agent-registry delivered later in M5.C |
+| **M5** (Complete, v0.4.0) | M5.A docs alignment, M5.B engine fixes, M5.C capability dispatch (task-broker, agent-registry), M5.D security baseline, M5.E DX polish, all 5 adapters, e2e-demo | Persistence, K8s deployment, event-bus (all delivered in M6) |
+| **M6** (Active) | K8s production-readiness: mTLS, supply-chain hardening, Postgres-backed repos, Helm charts, EventBus over NATS, images.yaml SoT, self-hosting dev-automation, memory-service, ArgoEngine, multi-namespace, policy/rate-limit, SDK on PyPI, e2e harness, multi-arch builds, gRPC health, Prometheus /metrics | M7 observability (OTel), M8 CNCF submission |
 
 ## AI Anti-Patterns
 

--- a/README.md
+++ b/README.md
@@ -374,14 +374,9 @@ make test        # full suite (unit + BDD + coverage gate)
 
 ## Milestone Status
 
-| Milestone | Status | Version | Docs |
-|-----------|--------|---------|------|
-| **M1 — Contracts Foundation** | **Complete** | v0.1.0 | [Engineering Review](docs/milestones/M1-engineering-review.md) · [Release Notes](docs/milestones/M1-release-notes.md) |
-| **M2 — Workflow IR** | **Complete** | v0.1.0 | [Epic #101](https://github.com/zynax-io/zynax/issues/101) |
-| **M3 — Temporal Execution** | ⚠ **Partial** | v0.2.0 | [Epic #214](https://github.com/zynax-io/zynax/issues/214) · [Canvas](docs/spdd/214-temporal-execution/canvas.md) · task-broker + agent-registry delivered M5.C |
-| **M4 — YAML System + CLI** | ⚠ **Partial** | v0.3.0 | [Epic #314](https://github.com/zynax-io/zynax/issues/314) · [Canvas](docs/spdd/314-yaml-system-cli/canvas.md) · agent-registry delivered M5.C · compose wired (#481 ✅) |
-| **M5 — Adapter Library** | ✅ **Complete** | v0.4.0 | [Plan](docs/milestones/M5-plan.md) · all 5 adapters ✅ · M5.C ✅ · M5.D ✅ · M5.E ✅ · E2E demo ✅ · v0.4.0 released 2026-05-29 |
-| **M6 — K8s Production-Ready** | 🚧 **Active** | v0.5.0 (target) | [Plan](docs/milestones/M6-planning.md) · delivered: Helm charts (#765) ✅ · Postgres repos (#626) ✅ · EventBus (#772) ✅ · images-SoT + ADR-024 (#855) ✅ · mTLS (#464) ✅ · supply-chain (#465) ✅ · orchestrator hardening (#1001) ✅ · memory-service KV+vector (#773) ✅ · Argo engine (#766) ✅ · multi-namespace (#767) ✅ · rate-limiting/policy (#768) ✅ · SDK PyPI (#769) ✅ · e2e harness (#770) ✅ · multi-arch build (#837) ✅ · gRPC health (#656) ✅ · Prometheus /metrics (#491) ✅ · in progress: e2e-green gate (#1086), Postgres off Bitnami (#1073), CI-E2E gate (#771), DevAuto Wave 4 (#881) |
+Active milestone: **M6 — K8s Production-Ready** 🚧 — live status in
+[state/current-milestone.md](state/current-milestone.md) · milestone goals and sequence in
+[ROADMAP.md](ROADMAP.md).
 
 **M1** delivered the contracts-only foundation: 8 gRPC services defined as protobuf contracts,
 AsyncAPI spec covering 11 event channels, generated Go + Python stubs, 140+ BDD contract

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -58,7 +58,7 @@ Each roadmap milestone maps to a GitHub Milestone:
 
 ---
 
-## Milestone 1 — Contracts Foundation ✅ Complete (v0.1.0)
+## Milestone 1 — Contracts Foundation (v0.1.0)
 
 **Goal:** All communication contracts defined. Nothing builds on sand.
 
@@ -74,11 +74,9 @@ Each roadmap milestone maps to a GitHub Milestone:
 
 ---
 
-## Milestone 2 — Workflow IR ✅ Complete (v0.1.0)
+## Milestone 2 — Workflow IR (v0.1.0)
 
 **Goal:** YAML manifests compile to a canonical, engine-agnostic Intermediate Representation.
-
-> See [Epic #101](https://github.com/zynax-io/zynax/issues/101) for the full issue list.
 
 - [x] JSON Schema for all manifest kinds: `Workflow`, `AgentDef`, `Policy`
 - [x] `workflow-compiler` service: Go implementation
@@ -92,7 +90,7 @@ Each roadmap milestone maps to a GitHub Milestone:
 
 ---
 
-## Milestone 3 — Engine Adapters ⚠ Partial (v0.2.0)
+## Milestone 3 — Engine Adapters (v0.2.0)
 
 **Goal:** Workflow IR executes on Temporal. Engine abstraction proven.
 
@@ -100,16 +98,16 @@ Each roadmap milestone maps to a GitHub Milestone:
 - [x] `engine-adapter` service: `WorkflowEngine` interface, `TemporalEngine`, `IRInterpreterWorkflow`
 - [x] `DispatchCapabilityActivity`: Temporal Activity → task-broker gRPC
 - [x] All 5 `EngineAdapterService` RPCs (Submit/Signal/Cancel/GetWorkflowStatus/WatchWorkflow)
-- [x] cel-go guard evaluation (bespoke evaluator replaced by #538 in M5.B)
+- [x] cel-go guard evaluation (bespoke evaluator replaced in M5.B)
 
-**Not delivered (moved to M5.C):**
-- [ ] `task-broker` service (delivered M5.C #479)
-- [ ] End-to-end capability dispatch (requires agent-registry; pending #480)
-- CloudEvents publishing is a log stub (pending event-bus implementation, M6+)
+**Not delivered in M3** (completed later):
+- `task-broker` service (delivered in M5.C)
+- End-to-end capability dispatch (required agent-registry; delivered in M5.C)
+- CloudEvents publishing was a log stub (event-bus delivered in M6)
 
 ---
 
-## Milestone 4 — YAML System + CLI ⚠ Partial (v0.3.0)
+## Milestone 4 — YAML System + CLI (v0.3.0)
 
 **Goal:** Users can `zynax apply workflow.yaml` and see it run.
 
@@ -119,125 +117,76 @@ Each roadmap milestone maps to a GitHub Milestone:
 - [x] Local Docker Compose runner (`make run-local`)
 - [x] GitOps watch mode (`zynax apply --watch`)
 
-**Not delivered (moved to M5.C):**
-- [ ] `agent-registry` service (#480 — required for `kind: AgentDef` routing)
-- Capability dispatch: workflows submit but actions fail (no registry)
+**Not delivered in M4** (completed later):
+- `agent-registry` service, required for `kind: AgentDef` routing (delivered in M5.C)
+- End-to-end capability dispatch (delivered in M5.C)
 
 ---
 
-## Milestone 5 — Adapter Library ✅ Complete (v0.4.0)
+## Milestone 5 — Adapter Library (v0.4.0)
 
 **Goal:** Existing systems become capabilities without SDK adoption. First green E2E demo.
 
-> Released 2026-05-29. Label: `milestone: M5` · Epic: [#377](https://github.com/zynax-io/zynax/issues/377)
-> Full plan: [docs/milestones/M5-plan.md](docs/milestones/M5-plan.md)
+> Released 2026-05-29. Label: `milestone: M5`
+> Full plan and per-track delivery detail: [docs/milestones/M5-plan.md](docs/milestones/M5-plan.md)
 
 ### M5 Definition of Done (7/7 criteria met)
 
 1. [x] `make run-local && zynax apply spec/workflows/examples/e2e-demo.yaml` → `WORKFLOW_STATUS_COMPLETED`
 2. [x] v0.4.0 tag with downloadable CLI + GHCR images (released 2026-05-29)
-3. [x] All 5 adapters merged (http ✅ git ✅ ci ✅ llm ✅ langgraph ✅)
-4. [x] Python SDK `Agent` base class implemented (#474 / #535 #536 #537)
-5. [x] cel-go replaces bespoke guard evaluator (#476 / #538 #539 #540)
+3. [x] All 5 adapters merged (http, git, ci, llm, langgraph)
+4. [x] Python SDK `Agent` base class implemented
+5. [x] cel-go replaces bespoke guard evaluator
 6. [x] SECURITY.md matches shipped reality
-7. [x] CI < 10 minutes per PR (#552)
+7. [x] CI < 10 minutes per PR
 
-### M5.A — Truth Pass ([#458](https://github.com/zynax-io/zynax/issues/458)) ✅
+### M5 tracks delivered
 
-- [x] Remove CNCF Sandbox Candidate badge (#472)
-- [x] Audit CHANGELOG for phantom entries (#473)
-- [x] Python SDK Agent base class (#474 / #535 #536 #537)
-- [x] Fix SECURITY.md — remove mTLS/SBOM/cosign false claims
-- [x] Add per-service status table to README (#579)
-
-### M5.B — Engine Correctness Hardening ([#459](https://github.com/zynax-io/zynax/issues/459)) ✅
-
-- [x] Fix `resolveTemplate` map-iteration non-determinism (#475)
-- [x] Replace bespoke guard evaluator with `cel-go`, fail-closed (#476 / #538 #539 #540)
-- [x] Return full `CompilationError` list from `CompileWorkflow` (#477)
-- [x] Fix SSE `WriteTimeout` breaking `zynax logs` at 30 s (#478)
-
-### M5.C — Capability Dispatch End-to-End ([#460](https://github.com/zynax-io/zynax/issues/460)) ✅
-
-- [x] `task-broker` MVP: in-memory `TaskBrokerService`, 5 RPCs, 92.7% domain coverage (#479)
-- [x] `agent-registry` MVP: domain (#527) → gRPC wiring (#528) → in-memory round-robin (#480)
-- [x] Docker Compose wiring: task-broker + agent-registry in `make run-local` (#481)
-
-### M5.D — Control Plane Security Baseline ([#461](https://github.com/zynax-io/zynax/issues/461)) ✅
-
-- [x] Bearer-token auth middleware (#482)
-- [x] Log event publish failures (#483)
-- [x] X-Request-ID propagation (#484)
-- [x] Idempotent `zynax apply` — manifest hash (#485)
-- [x] Consolidate Docker Compose files (#486)
-
-### M5.E — Developer Experience Polish ([#462](https://github.com/zynax-io/zynax/issues/462)) ✅
-
-- [x] Idempotent apply and compose consolidation (#485 #486)
-
-### M5.F — CI/CD Performance Sprint ([#542](https://github.com/zynax-io/zynax/issues/542)) ✅
-
-- [x] Concurrency + stale-run cancellation (#545)
-- [x] Unified release workflow — fix race condition (#557)
-- [x] v0.4.0 tag pushed and GitHub Release live
-- [x] All service/adapter images public on GHCR (#562)
-- [x] CI runner container image (#551 #552)
-- [x] Force-full-pipeline trigger (#554)
-- [x] Per-service change detection (#549 #550)
-- [x] DRY/KISS CI refactor (#555)
-
-### Adapter Library ([#377](https://github.com/zynax-io/zynax/issues/377)) ✅
-
-- [x] `http-adapter`: REST API proxy — all step issues merged (#380)
-- [x] `git-adapter`: `open_pr`, `request_review`, `get_diff` — all steps merged (#381); coverage ≥85% (#713)
-- [x] `ci-adapter`: `trigger_workflow`, `get_run_status` — all steps merged (#382)
-- [x] `llm-adapter`: OpenAI / Bedrock / Ollama `chat_completion` — all steps merged (#383)
-- [x] `langgraph-adapter`: LangGraph StateGraph as Zynax capabilities — all steps merged (#384); wired in e2e-demo
+- **M5.A — Truth Pass**: docs aligned with shipped reality; per-service status table in README
+- **M5.B — Engine Correctness Hardening**: deterministic template resolution, cel-go fail-closed guards, full `CompilationError` lists, SSE timeout fix
+- **M5.C — Capability Dispatch End-to-End**: `task-broker` + `agent-registry` MVPs, Docker Compose wiring
+- **M5.D — Control Plane Security Baseline**: bearer-token auth, X-Request-ID propagation, idempotent `zynax apply`
+- **M5.E — Developer Experience Polish**: idempotent apply, compose consolidation
+- **M5.F — CI/CD Performance Sprint**: concurrency cancellation, unified release workflow, ci-runner container, per-service change detection
+- **Adapter Library**: `http-adapter`, `git-adapter`, `ci-adapter`, `llm-adapter`, `langgraph-adapter`
 
 ---
 
-## Milestone 6 — Kubernetes Production-Ready 🚧 Active (v0.5.0 target)
+## Milestone 6 — Kubernetes Production-Ready (v0.5.0 target)
 
 **Goal:** Production deployment on Kubernetes. Argo engine support.
 
 > Label: `milestone: M6` · Target: v0.5.0 · Plan: [docs/milestones/M6-planning.md](docs/milestones/M6-planning.md)
-> Progress: 143 issues closed / 14 open as of 2026-06-10.
+> Live per-EPIC status: [state/current-milestone.md](state/current-milestone.md)
 
-**Process health (complete):**
-- [x] K8s startup/readiness/liveness probe semantics in api-gateway + engine-adapter (PR #821)
-- [x] Stateless workflow-compiler — drop in-memory IR store (PR #774)
-- [x] Inter-service mTLS — env-var cert paths + gRPC credential wiring (PR #831)
-- [x] Supply chain hardening — cosign signing, SPDX SBOM, multi-arch release images (PR #833)
-- [x] ADR-023 — restrict direct pushes to main; rebase-merge only (PR #847)
-- [x] ci-runner digest bump script + `make bump-ci-runner` (PR #848)
-- [x] Post-build bump issue automation in tools-image.yml (PR #849)
-- [x] `/resume-m6` rewrite — FF discipline, doc-PR path, branch cleanup (PR #850)
-- [x] Merge policy documented in CONTRIBUTING.md + AGENTS.md (PR #851)
+**Scope — process health:**
+- K8s startup/readiness/liveness probe semantics across services
+- Stateless workflow-compiler (no in-memory IR store)
+- Inter-service mTLS — env-var cert paths + gRPC credential wiring
+- Supply chain hardening — cosign signing, SPDX SBOM, multi-arch release images
+- Merge discipline (ADR-023) + ci-runner bump tooling + merge policy docs
 
-**Feature EPICs — delivered:**
-- [x] EventBusService — NATS JetStream gRPC wrapper (EPIC I #772; ADR-022 accepted)
-- [x] Helm charts for all 7 services + subcharts (EPIC Helm #765)
-- [x] Postgres-backed repositories — horizontal scale (EPIC H #626)
-- [x] Config convergence — env-var canonicalisation (EPIC F #670)
-- [x] Container image source-of-truth — `images.yaml` + drift gate (EPIC Images #855; ADR-024)
-- [x] Self-hosting dev-automation — orchestrator + expert mesh (EPIC DevAuto #873, Waves 0–2)
-- [x] Orchestrator concurrency hardening — worktree isolation + idempotent dispatch (EPIC #1001)
-- [x] `ArgoEngine` adapter + multi-engine dispatch (EPIC Argo #766, #798)
-- [x] Multi-namespace support in workflow-compiler (EPIC NS #767)
-- [x] Policy enforcement: routing policies, rate limits, capability quotas (EPIC E #768)
-- [x] Prometheus `/metrics` per-request counters in all services (#491; OTel traces → M7 #467)
-- [x] `zynax-sdk` Python package published to PyPI (EPIC SDK #769)
-- [x] Memory service — Redis KV + pgvector context (EPIC J #773)
-- [x] End-to-end harness — kind + Helm + reference workflows (EPIC G #770)
-- [x] Native multi-arch build pipeline — QEMU eliminated (EPIC Build #837)
-- [x] gRPC Health Checking Protocol in all services (#74, #656)
-- [x] DevAuto Wave 3 — post-merge completeness mesh (#880)
-
-**Feature EPICs — in progress / pending:**
-- [ ] e2e-green: e2e-smoke gate executes a workflow end-to-end (EPIC #1086 — O1+O2 merged via PR #1095)
-- [ ] Postgres off deprecated Bitnami images (EPIC #1073 — ADR-026 merged)
-- [ ] CI-E2E: e2e smoke + upgrade gate on infra/services changes (EPIC #771)
-- [ ] DevAuto Wave 4 — self-hosted issue-delivery engine (#881 — canvas Aligned, stories #1096–#1104)
+**Scope — feature EPICs:**
+- EventBusService — NATS JetStream gRPC wrapper (ADR-022)
+- Helm charts for all services + subcharts
+- Postgres-backed repositories — horizontal scale
+- Config convergence — env-var canonicalisation
+- Container image source-of-truth — `images.yaml` + drift gate (ADR-024)
+- Self-hosting dev-automation — orchestrator + expert mesh
+- Orchestrator concurrency hardening — worktree isolation + idempotent dispatch
+- `ArgoEngine` adapter + multi-engine dispatch
+- Multi-namespace support in workflow-compiler
+- Policy enforcement: routing policies, rate limits, capability quotas
+- Prometheus `/metrics` per-request counters in all services (OTel traces → M7)
+- `zynax-sdk` Python package published to PyPI
+- Memory service — Redis KV + pgvector context
+- End-to-end harness — kind + Helm + reference workflows
+- Native multi-arch build pipeline — QEMU eliminated
+- gRPC Health Checking Protocol in all services
+- e2e-green: e2e-smoke gate executes a workflow end-to-end
+- Postgres off deprecated Bitnami images (ADR-026)
+- CI-E2E: e2e smoke + upgrade gate on infra/services changes
+- Self-hosted issue-delivery engine (DevAuto Wave 4)
 
 ---
 

--- a/state/current-milestone.md
+++ b/state/current-milestone.md
@@ -1,3 +1,5 @@
+<!-- Canonical status file. Updated by /milestone-close and /repo-clean. Do not edit by hand. -->
+
 # Current Milestone State
 
 > This file tracks the active execution state. Update it when milestones close,
@@ -77,108 +79,6 @@ up but fails at the happy-path assertion; this epic closes the execution-path ga
 
 **Ready now for `/m6-orchestrate`:** #1089 (O3). Then O4 → O6 (with #1091 verification ∥).
 
-## M5 — Progress
-
-M5 is structured into seven tracks. See full execution plan: **[docs/milestones/M5-plan.md](../docs/milestones/M5-plan.md)**.
-
-### Track Overview
-
-| Track | Epic | Status |
-|-------|------|--------|
-| **M5.F CI Sprint** | [#542](https://github.com/zynax-io/zynax/issues/542) | ✅ Complete (closed) — #555 ✅ all child issues done |
-| **M5.F.R Release Pipeline** | [#556](https://github.com/zynax-io/zynax/issues/556) | ✅ Complete (closed) |
-| M5.A Truth Pass | [#458](https://github.com/zynax-io/zynax/issues/458) | ✅ Complete — #472 ✅ #473 ✅ #474 ✅ #572 ✅ #579 ✅ |
-| M5.B Engine Correctness | [#459](https://github.com/zynax-io/zynax/issues/459) | ✅ Complete (closed) — #475 ✅ #476 ✅ #477 ✅ #478 ✅ |
-| M5.C Capability Dispatch | [#460](https://github.com/zynax-io/zynax/issues/460) | ✅ Complete — e2e-demo.yaml created; run `make run-local && zynax apply spec/workflows/examples/e2e-demo.yaml` |
-| M5.D Security Baseline | [#461](https://github.com/zynax-io/zynax/issues/461) | ✅ Complete (closed) |
-| M5.E DX Polish | [#462](https://github.com/zynax-io/zynax/issues/462) | ✅ Complete (closed) |
-| Adapter Library | [#377](https://github.com/zynax-io/zynax/issues/377) | ✅ Complete (closed) — all five adapters merged |
-| Containerized Make | [#442](https://github.com/zynax-io/zynax/issues/442) | ✅ Complete (closed) |
-
----
-
-## IMMEDIATE — Adapters (P2, unblocked by #481 ✅)
-
-### BATCH 0 — ✅ All done
-~~#547 #544 #548 #545 #589 #546 #557 #558 #559 #560~~
-
-### BATCH 1 — ✅ All done
-
-| Issue | Title | Size | Status |
-|-------|-------|------|--------|
-| ~~[#561](https://github.com/zynax-io/zynax/issues/561)~~ | ~~Push service/adapter images to GHCR on every main merge~~ | S | ✅ Done |
-| ~~[#601](https://github.com/zynax-io/zynax/issues/601)~~ | ~~Fix Go builder base image 1.25→1.26.3-alpine in service Dockerfiles~~ | XS | ✅ Done |
-| ~~[#562](https://github.com/zynax-io/zynax/issues/562)~~ | ~~Make GHCR service/adapter images publicly readable~~ | XS | ✅ Done — 5 service/adapter images public; zynax/tools deleted (see below) |
-| (admin) | **Confirm zynax/tools published + set public** | — | ✅ Done — tools-image.yml succeeded 2026-05-20; package set public |
-| [#563](https://github.com/zynax-io/zynax/issues/563) | Deduplicate tools image — remove tools-publish.yml + delete old zynax-tools package | XS | ✅ Done |
-| [#566](https://github.com/zynax-io/zynax/issues/566) | README packages section with GHCR image pull commands | S | ✅ Done |
-| [#552](https://github.com/zynax-io/zynax/issues/552) | Switch all GH Actions jobs to ci-runner container mode | M | ✅ Done |
-
----
-
-## Active Work (M5.C)
-
-### task-broker (#479) ✅ Complete (closed)
-
-All steps done: impl PRs #520 #522 #523, quality #530 ✅ #531 ✅ #532 ✅. Domain 92.7%.
-
-### agent-registry (#480) ✅ Complete (closed)
-
-All steps done: #526 ✅ #527 ✅ #528 ✅ #481 ✅. Compose wired.
-
----
-
-## Active Work (Other Tracks)
-
-| Issue | Track | Title | Status |
-|-------|-------|-------|--------|
-| [#381](https://github.com/zynax-io/zynax/issues/381) | Adapters | git-adapter impl | ✅ Complete — #400 #401 #402 #403 all merged |
-| [#713](https://github.com/zynax-io/zynax/issues/713) | Adapters | git-adapter quality epic (coverage ≥85%) | ✅ Complete — #714 ✅ #715 ✅ #716 ✅ #717 ✅ #718 ✅ all merged |
-| ~~[#382](https://github.com/zynax-io/zynax/issues/382)~~ | Adapters | ci-adapter impl | ✅ Closed — all steps done (#404–#408) |
-| ~~[#383](https://github.com/zynax-io/zynax/issues/383)~~ | Adapters | llm-adapter impl | ✅ Closed — #409 BDD #410 #411 #412 #413 (PR #742) all merged |
-| ~~[#384](https://github.com/zynax-io/zynax/issues/384)~~ | Adapters | langgraph-adapter impl | ✅ Closed — #414 BDD #415 #416 #417 #418 (PR #743) all merged |
-
----
-
-## Known Blockers
-
-- **git-adapter coverage** — ✅ complete; #714–#718 all merged; coverage ≥85% live on CI; git re-added to GO_ADAPTER_LIST.
-- **adapter implementations** (#405–#418) — ✅ all done; git/ci/llm/langgraph all merged.
-- **E2E demo** — ✅ `e2e-demo.yaml` created; langgraph `echo` capability wired; run `make run-local && zynax apply spec/workflows/examples/e2e-demo.yaml` to observe dispatch + completion in Temporal UI (http://localhost:7088).
-- **v0.4.0 tag** — ✅ pushed 2026-05-29; GitHub Release live with CLI binaries, GHCR service images, and SBOMs.
-
----
-
-## Architecture Gaps (open issues to file)
-
-The 2026-05-20 principal architect review identified gaps not yet tracked as issues.
-See `docs/milestones/M5-plan.md §Architecture Gaps` for the full list.
-Priority gaps to file immediately:
-
-| Gap | Severity |
-|-----|----------|
-| ~~G1: constant-time bearer compare~~ | ✅ fixed #567 |
-| ~~G2: ReadHeaderTimeout + MaxBytesReader~~ | ✅ fixed #568 |
-| ~~G4: no RetryPolicy on Temporal Activities (#569)~~ | ✅ fixed #569 |
-| ~~G16: background-context goroutines in task-broker (#570)~~ | ✅ fixed #570 |
-| ~~G19: competitive positioning doc (Kagent/Dapr) (#575)~~ | ✅ fixed |
-| ~~G17: stub services in SERVICE_LIST (#574)~~ | ✅ fixed |
-| ~~G23: Phantom AGENT_LIST entries (#577)~~ | ✅ fixed |
-| ~~G22: Summarizer phantom (#576)~~ | ✅ fixed |
-
----
-
-## Recently Closed
-
-- **#567** — Bearer constant-time compare (G1 fix) ✅. **#568** — ReadHeaderTimeout + MaxBytesReader (G2 fix) ✅.
-- **#461 M5.D** — Control Plane Security Baseline: all 5 child issues merged (#482–#486).
-- **#462 M5.E** — Developer Experience Polish: all child issues merged (#485–#486).
-- **#442** — Fully Containerized Makefile: all 4 child issues merged (#443–#446).
-- **#529** — docs(agent-registry): REASONS Canvas for #480.
-- **#533** — docs(task-broker): REASONS Canvas for #479.
-- **#526** — BDD trim (agent-registry), **#532** — handler unit tests (task-broker), **#554** — force-full-pipeline trigger.
-- **SECURITY.md** — false mTLS/SBOM/cosign claims removed (2026-05-20, part of M5.A truth pass).
-
 ## Recently Closed (last updated 2026-06-09)
 
 **M6 batch — 2026-06-08 session:**
@@ -206,41 +106,6 @@ Priority gaps to file immediately:
 - **#474** #459 #479 #480 #543 #556 — epics closed; all children had merged prior sessions
 - **#577** #574 #576 #712 #714 — phantom agent cleanup, summarizer removal, git adapter
 - **#865** ci: OCI manifest annotations · **#868** ADR-025 SLSA provenance
-
-## Active Work (BATCH 7.1 — git-adapter coverage — ✅ COMPLETE)
-
-| Issue | Title | Status |
-|-------|-------|--------|
-| [#715](https://github.com/zynax-io/zynax/issues/715) | Cover requestReview + progressEvent | ✅ Done — PR #722 merged |
-| [#716](https://github.com/zynax-io/zynax/issues/716) | Cover execute/sanitise/githubErrCode/parsePayload | ✅ Done — PR #723 merged |
-| [#717](https://github.com/zynax-io/zynax/issues/717) | Cover RegisterAgent retry + isTransient + cmd | ✅ Done — PR #724 merged |
-| [#718](https://github.com/zynax-io/zynax/issues/718) | Re-add git to GO_ADAPTER_LIST | ✅ Done — PR #725 merged |
-
-## Active Work (BATCH 7 — adapter O5 step) — ✅ COMPLETE
-
-| Issue | Title | Status |
-|-------|-------|--------|
-| [#412](https://github.com/zynax-io/zynax/issues/412) | llm-adapter registry client + bootstrap | ✅ Done — merged |
-| [#417](https://github.com/zynax-io/zynax/issues/417) | langgraph-adapter registry client + bootstrap | ✅ Done — merged |
-| [#413](https://github.com/zynax-io/zynax/issues/413) | llm-adapter Dockerfile + docker-compose + AGENTS.md | ✅ Done — PR #742 merged |
-| [#418](https://github.com/zynax-io/zynax/issues/418) | langgraph-adapter Dockerfile + docker-compose + AGENTS.md | ✅ Done — PR #743 merged |
-
-## Active Work (BATCH 8 — Code Quality)
-
-| Issue | Title | Status |
-|-------|-------|--------|
-| [#373](https://github.com/zynax-io/zynax/issues/373) | Thread ctx in workflow-compiler gRPC handlers | ✅ Done |
-| [#374](https://github.com/zynax-io/zynax/issues/374) | ctx-first mandate in services/AGENTS.md + Temporal comment | ✅ Done |
-| [#375](https://github.com/zynax-io/zynax/issues/375) | Enable ruff D (Google docstrings) in agents/sdk | ✅ Done |
-
-## Active Work (BATCH 9 — Documentation Quality)
-
-| Issue | Title | Status |
-|-------|-------|--------|
-| [#232](https://github.com/zynax-io/zynax/issues/232) | Architecture fitness functions doc | ✅ Done — PR #750 merged |
-| [#248](https://github.com/zynax-io/zynax/issues/248) | AI-output review checklist in PR template | ✅ Done — PR #751 pending |
-| [#228](https://github.com/zynax-io/zynax/issues/228) | Google-style docstrings on SDK public symbols | ✅ Done |
-| [#229](https://github.com/zynax-io/zynax/issues/229) | Strip explanatory comments in agents/sdk | ✅ Done |
 
 ---
 


### PR DESCRIPTION
## Summary

Deduplicates live milestone status so exactly one surface — `state/current-milestone.md` —
carries live per-EPIC status (spec: `docs/contributing/ci-delivery-overhaul-prompt.md` §0C).
Historical/narrative content stays in place; only duplicated live-status content is removed.

Part of #1108

## Per-surface changes

| Surface | Change |
|---------|--------|
| `CLAUDE.md §Per-Milestone Scope` | narrative rows kept; ✅/🚧/⚠ badges + issue numbers removed; live-progress link added |
| `CLAUDE.md §Milestone Status` | shrunk to two lines + two links (state file + ROADMAP) |
| `README.md` | inline milestone progress table replaced by a one-liner + links |
| `ROADMAP.md` | per-EPIC status and all issue numbers removed; milestone names, version targets, GitHub Milestone table, plan links kept |
| `state/current-milestone.md` | canonical-status header comment added; stale M5-era Progress/Active Work/BATCH/Known Blockers/Architecture Gaps sections pruned (history lives in git) |

## EPIC canvas

N/A — SPDD-exempt (`docs:`).

## Acceptance criteria

- [x] `grep -c '✅\|🚧\|⚠' CLAUDE.md` returns 0 (whole file, including the milestone-scope table)
- [x] No EPIC/issue numbers in ROADMAP.md milestone checklist — `grep -n '#[0-9]' ROADMAP.md` returns nothing
- [x] Exactly one surface (`state/current-milestone.md`) carries live per-EPIC status; CLAUDE.md/README/ROADMAP link to it

## Test plan

### Build & unit
- N/A — docs-only diff (no Go/Python/proto files touched)

### Lint & security
- [x] pre-commit hooks on commit: gitleaks passed; ruff/gofmt/golangci-lint/mypy skipped (no matching files)

### Contract
- N/A — no gRPC boundary touched

### Engineering hygiene
- [x] Branched off fresh `origin/main` · docs-only · −260/+71 lines · DCO + `Assisted-by` trailers on the commit
- [x] Scope limited to the named surfaces; `docs/milestones/*` and canvases untouched
