### PR TITLE
ci: supply-chain hardening — SHA pins, least-privilege perms, SLSA L2

### DIFF
--- a/.github/workflows/_test-go.yml
+++ b/.github/workflows/_test-go.yml
@@ -19,9 +19,9 @@ on:
       pr_base_sha:       { required: false, type: string, default: '' }
       pr_head_sha:       { required: false, type: string, default: '' }
 
+# Least-privilege default — jobs that need more escalate per-job below (#1116).
 permissions:
   contents: read
-  pull-requests: write
 
 defaults:
   run:
@@ -37,6 +37,9 @@ jobs:
   test-go:
     name: test-go
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: write   # posts BDD + coverage report comments on the PR
     container:
       image: ghcr.io/zynax-io/zynax/ci-runner@sha256:04074b10bb681e0cbeffd053b9d7cc6aaef4b7b92fd08b3a3c9ee3ede877b782
       options: --user root
@@ -211,7 +214,7 @@ jobs:
       # ── Post BDD PR comment ───────────────────────────────────────────────
       - name: Post BDD contract test report on PR
         if: always() && inputs.event_name == 'pull_request' && steps.go-detect.outputs.has_bdd_impl != '0'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           RUN_NUMBER: ${{ github.run_number }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
@@ -336,7 +339,7 @@ jobs:
 
       - name: Post coverage report on PR
         if: always() && inputs.event_name == 'pull_request'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           RUN_NUMBER: ${{ github.run_number }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -352,7 +352,7 @@ jobs:
             echo "ℹ️  No spec files changed — spec validation skipped."
           fi
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         if: steps.spec-detect.outputs.has_spec == '1'
         with:
           node-version: "20"

--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -15,8 +15,9 @@ on:
         description: 'Version tag to publish (e.g. v0.4.0)'
         required: true
 
+# Least-privilege default — jobs that need more escalate per-job below (#1116).
 permissions:
-  contents: write   # needed to create a GitHub Release
+  contents: read
 
 jobs:
   # ── Build ────────────────────────────────────────────────────────────────
@@ -46,7 +47,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: cmd/zynax/go.mod
           cache-dependency-path: cmd/zynax/go.sum
@@ -106,7 +107,8 @@ jobs:
     name: Publish GitHub Release
     needs: build
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: write   # creates the GitHub Release with CLI archives
     steps:
       - name: Resolve version
         id: ver

--- a/.github/workflows/kb-preview.yml
+++ b/.github/workflows/kb-preview.yml
@@ -35,15 +35,18 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Least-privilege default — jobs that need more escalate per-job below (#1116).
 permissions:
   contents: read
-  pull-requests: write
-  statuses: write
 
 jobs:
   kb-previsualize:
     name: kb-content-previsualized
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: write   # posts the KB content preview comment
+      statuses: write        # sets the kb-content-previsualized commit status
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -73,7 +76,7 @@ jobs:
 
       - name: Post KB content preview comment
         if: steps.extract.outputs.has_additions == 'true'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           ADDITIONS: ${{ steps.extract.outputs.additions }}
         with:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -5,6 +5,7 @@
 #
 # Jobs:
 #   actionlint           → GitHub Actions workflow YAML and expression linting
+#   dependency-review    → blocks new HIGH-severity CVEs in dependency manifests
 #   conventional-commit  → PR title follows Conventional Commits format
 #   proto-check          → buf breaking-change detection + generated stubs freshness
 #   layer-boundaries     → detects cross-layer imports (ADR-001 §separation)
@@ -30,9 +31,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
+# Least-privilege default — jobs that need more escalate per-job below (#1116).
 permissions:
   contents: read
-  pull-requests: write
 
 defaults:
   run:
@@ -53,6 +54,23 @@ jobs:
       - name: Lint all workflow files
         run: actionlint -color
 
+# ── Dependency Review (HIGH CVE gate) ─────────────────────────────────────────
+# Blocks PRs that introduce dependencies with known HIGH/CRITICAL CVEs in
+# go.mod / pyproject.toml manifests, via the GitHub Dependency Graph diff.
+  dependency-review:
+    name: Dependency review (HIGH CVEs)
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read   # reads the dependency diff via the Dependency Graph API
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Block new HIGH-severity vulnerable dependencies
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        with:
+          fail-on-severity: high
+
 # ── Conventional Commit Title ─────────────────────────────────────────────────
   conventional-commit:
     name: Conventional Commit title
@@ -61,8 +79,10 @@ jobs:
     container:
       image: ghcr.io/zynax-io/zynax/ci-runner@sha256:04074b10bb681e0cbeffd053b9d7cc6aaef4b7b92fd08b3a3c9ee3ede877b782
       options: --user root
+    permissions:
+      pull-requests: read   # action-semantic-pull-request reads the PR title
     steps:
-      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/pr-size.yml
+++ b/.github/workflows/pr-size.yml
@@ -20,22 +20,25 @@ concurrency:
   group: pr-size-${{ github.ref }}
   cancel-in-progress: true
 
+# Least-privilege default — jobs that need more escalate per-job below (#1116).
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   pr-size:
     name: PR size label
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: write   # applies/removes size/* labels on the PR
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Label PR by size and enforce 800-line limit
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/proto-generate.yml
+++ b/.github/workflows/proto-generate.yml
@@ -23,9 +23,9 @@ on:
       - "protos/buf.gen.yaml"
       - "infra/docker/Dockerfile.tools"
 
+# Least-privilege default — jobs that need more escalate per-job below (#1116).
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 env:
   BUF_VERSION: "1.69.0"
@@ -34,6 +34,9 @@ jobs:
   regenerate-stubs:
     name: regenerate-stubs
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write        # pushes the chore/proto-regen-* branch with regenerated stubs
+      pull-requests: write   # opens the follow-up stub-regeneration PR
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/proto-stubs-publish.yml
+++ b/.github/workflows/proto-stubs-publish.yml
@@ -24,8 +24,9 @@ on:
       - "protos/zynax/**/*.proto"
       - "protos/generated/**"
 
+# Least-privilege default — jobs that need more escalate per-job below (#1116).
 permissions:
-  contents: write
+  contents: read
 
 env:
   BUF_VERSION: "1.47.2"
@@ -34,6 +35,8 @@ jobs:
   publish-stubs:
     name: publish-stubs
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write   # creates the proto-stubs-* GitHub Release with stub archives
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,11 +36,9 @@ on:
         type: boolean
         default: false
 
+# Least-privilege default — jobs that need more escalate per-job below (#1116).
 permissions:
-  contents: write
-  packages: write
-  id-token: write            # reserved for cosign OIDC signing (#239) — do not remove
-  security-events: write     # required for trivy SARIF upload to GitHub Security tab
+  contents: read
 
 env:
   REGISTRY: ghcr.io
@@ -66,7 +64,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: cmd/zynax/go.mod
           cache-dependency-path: cmd/zynax/go.sum
@@ -127,7 +125,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: cmd/zynax-ci/go.mod
           cache: true
@@ -310,6 +308,10 @@ jobs:
     needs: [resolve-matrix]
     if: needs.resolve-matrix.outputs.any == 'true'
     runs-on: ${{ matrix.platform == 'amd64' && 'ubuntu-24.04' || 'ubuntu-24.04-arm' }}
+    permissions:
+      contents: read
+      packages: write          # pushes per-platform service images to GHCR
+      security-events: write   # uploads trivy SARIF to the GitHub Security tab
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.resolve-matrix.outputs.platform_matrix) }}
@@ -414,6 +416,11 @@ jobs:
     needs: [resolve-matrix, build-platform]
     if: needs.resolve-matrix.outputs.any == 'true'
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write       # creates multi-arch manifests, pushes attestations, prunes GHCR
+      id-token: write       # cosign keyless OIDC signing + SLSA provenance attestation
+      attestations: write   # actions/attest-build-provenance (SLSA L2) on release tags
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.resolve-matrix.outputs.matrix) }}
@@ -530,6 +537,17 @@ jobs:
         env:
           COSIGN_EXPERIMENTAL: "1"
 
+      # SLSA L2 provenance — signed, verifiable attestation on the merged index
+      # (upgrades the buildx-generated Build L1 provenance — issue #1116).
+      # Verify: gh attestation verify oci://<image>@<digest> --owner zynax-io
+      - name: Attest build provenance (SLSA L2)
+        if: github.ref_type == 'tag' || github.event_name == 'workflow_dispatch'
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-name: ${{ env.IMAGE_PREFIX }}/${{ matrix.service }}
+          subject-digest: ${{ steps.merge.outputs.digest }}
+          push-to-registry: true
+
       - name: Install syft ${{ env.SYFT_VERSION }}
         if: github.ref_type == 'tag' || github.event_name == 'workflow_dispatch'
         run: |
@@ -562,6 +580,8 @@ jobs:
     needs: [build-cli, build-zynax-ci, merge-and-sign]
     if: github.ref_type == 'tag' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write   # creates the GitHub Release with binaries + SBOMs
     steps:
       - name: Resolve version
         id: ver

--- a/.github/workflows/service-release.yml
+++ b/.github/workflows/service-release.yml
@@ -10,9 +10,9 @@
 #   ghcr.io/zynax-io/zynax/<svc>:<version>   (semver — e.g. v0.5.0)
 #   ghcr.io/zynax-io/zynax/<svc>:latest       (floating — updated on every push)
 #
-# This workflow is designed to be extended by #239 (cosign image signing +
-# SLSA provenance). The id-token: write permission below is reserved for that
-# follow-on work and must not be removed.
+# Cosign signing + SLSA provenance (#239) landed in release.yml (the unified
+# tag-triggered coordinator) — this manual dry-run workflow does not sign, so
+# it no longer holds id-token: write (#1116).
 
 name: Service Image Release
 
@@ -23,10 +23,9 @@ on:
         description: 'Version tag to publish (e.g. v0.5.0)'
         required: true
 
+# Least-privilege default — jobs that need more escalate per-job below (#1116).
 permissions:
-  contents: write   # create GitHub Release and upload SBOM assets
-  packages: write   # push container images to GHCR
-  id-token: write   # reserved for cosign OIDC signing (#239) — do not remove
+  contents: read
 
 env:
   REGISTRY: ghcr.io
@@ -42,6 +41,9 @@ jobs:
   build-push-sbom:
     name: Build, push and SBOM — ${{ matrix.service }}
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write   # pushes service container images to GHCR
     strategy:
       fail-fast: false
       matrix:
@@ -112,7 +114,8 @@ jobs:
     name: Create GitHub Release
     needs: build-push-sbom
     runs-on: ubuntu-24.04
-
+    permissions:
+      contents: write   # creates the GitHub Release and uploads SBOM assets
     steps:
       - name: Resolve version
         id: ver

--- a/.github/workflows/tools-image.yml
+++ b/.github/workflows/tools-image.yml
@@ -33,11 +33,9 @@ on:
       - 'v*.*.*'
   workflow_dispatch:
 
+# Least-privilege default — jobs that need more escalate per-job below (#1116).
 permissions:
   contents: read
-  packages: write
-  id-token: write   # cosign keyless OIDC signing on tag builds
-  issues: write     # open bump-tracking issue after ci-runner rebuild
 
 env:
   REGISTRY: ghcr.io
@@ -53,6 +51,9 @@ jobs:
   build-amd64:
     name: Build amd64 (tools + ci-runner)
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write   # pushes per-platform tools/ci-runner images to GHCR
     outputs:
       tools-digest-amd64:     ${{ steps.build-tools-amd64.outputs.digest }}
       ci-runner-digest-amd64: ${{ steps.build-ci-runner-amd64.outputs.digest }}
@@ -101,6 +102,9 @@ jobs:
   build-arm64:
     name: Build arm64 (tools + ci-runner)
     runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: read
+      packages: write   # pushes per-platform tools/ci-runner images to GHCR
     outputs:
       tools-digest-arm64:     ${{ steps.build-tools-arm64.outputs.digest }}
       ci-runner-digest-arm64: ${{ steps.build-ci-runner-arm64.outputs.digest }}
@@ -150,6 +154,11 @@ jobs:
     name: Merge manifests, sign, SBOM, prune
     runs-on: ubuntu-24.04
     needs: [build-amd64, build-arm64]
+    permissions:
+      contents: read
+      packages: write   # creates multi-arch manifests and prunes old GHCR versions
+      id-token: write   # cosign keyless OIDC signing on tag builds
+      issues: write     # opens the ci-runner digest bump-tracking issue
     outputs:
       tools-digest:     ${{ steps.create-tools-manifest.outputs.digest }}
       ci-runner-digest: ${{ steps.create-ci-runner-manifest.outputs.digest }}

--- a/.github/workflows/zynax-ci-release.yml
+++ b/.github/workflows/zynax-ci-release.yml
@@ -13,8 +13,9 @@ on:
         description: 'Tag to build (e.g. v0.4.0)'
         required: true
 
+# Least-privilege default — jobs that need more escalate per-job below (#1116).
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   build:
@@ -39,7 +40,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: cmd/zynax-ci/go.mod
           cache: true
@@ -67,6 +68,8 @@ jobs:
     name: Create GitHub Release
     runs-on: ubuntu-24.04
     needs: [build]
+    permissions:
+      contents: write   # creates the GitHub Release with zynax-ci binaries
     steps:
       - name: Download all artifacts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,24 +1,23 @@
-# Trivy CVE and misconfiguration exceptions
+# Trivy CVE and misconfiguration exceptions — reviewed quarterly (#1116)
 #
-# Format (CVE):         CVE-YYYY-NNNNN
-# Format (misconfig):   DS001, AVD-DS-0001, etc.
-#
-# Every entry MUST include a comment explaining:
-#   - Why the finding is a false positive or accepted risk
-#   - The date it was added and who approved it
-#   - A re-evaluation date (max 6 months out)
+# Every entry MUST be preceded by a comment block with ALL of these fields:
+#   # CVE-YYYY-NNNNN            (or misconfig id: DS001, AVD-DS-0001, ...)
+#   # accepted-until: YYYY-MM-DD (max 6 months out — entry is removed or renewed)
+#   # reason: <why this is a false positive / accepted risk; link to upstream fix>
+#   # affected: <which image / which layer>
 #
 # Process for adding an exception:
 #   1. Open a GitHub issue describing the CVE/misconfig and the justification
 #   2. Get maintainer approval (@zynax-io/maintainers)
-#   3. Add entry below with the issue URL in the comment
-#   4. Set a calendar reminder for the re-evaluation date
+#   3. Add entry below with the issue URL in the reason
+#   4. Renew or remove at the accepted-until date (quarterly review)
 #
 # ── Active exceptions ──────────────────────────────────────────────────────────
 #
-# DS002 – Dockerfile.tools runs as root (no USER instruction).
-#         This is a developer tooling image used only in CI and local dev,
-#         never deployed as a production container. Running as root is
-#         required for tool installation steps.
-#         Added: 2026-05-01  Re-evaluate: 2026-11-01
+# DS002
+# accepted-until: 2026-11-01
+# reason: Dockerfile.tools runs as root (no USER instruction). Developer tooling
+#         image used only in CI and local dev, never deployed as a production
+#         container. Root is required for tool installation steps.
+# affected: ghcr.io/zynax-io/zynax/tools (infra/docker/Dockerfile.tools)
 DS002


### PR DESCRIPTION
Part of #1109.

## Summary

Supply-chain hardening across all workflow files per spec §3D
(`docs/contributing/ci-delivery-overhaul-prompt.md`): SHA-pinned actions,
least-privilege per-job permissions, a dependency-review HIGH-CVE gate,
SLSA L2 provenance on release-tag images, and a stricter `.trivyignore`
exception template.

## What changed

1. **SHA pins** — pinned the last mutable refs (`actions/cache@v4` ×9,
   `actions/upload-artifact@v4` ×1 in `dev-advisory.yml`) to the exact
   commits the floating tags resolve to today (`v4.3.0` / `v4.6.2` — no
   version upgrades). Tightened imprecise pin comments (`# v6`, `# v9`) to
   exact versions (`v6.4.0`, `v6.1.1`, `v9.0.0`) resolved via the GitHub
   tags API.
2. **Least-privilege permissions** — every workflow now defaults to
   `permissions: contents: read` at workflow level; write scopes are
   escalated per-job only, each with a rationale comment
   (`packages: write` build/push, `id-token: write` cosign/OIDC,
   `pull-requests: write` comments/labels, `issues: write` [AUTO] issues,
   `security-events: write` SARIF upload, `contents: write` releases/bot
   branches). Removed the stale `id-token: write` from
   `service-release.yml` — cosign (#239) landed in `release.yml`; this
   manual dry-run workflow never signs.
3. **dependency-review** — new `dependency-review` job in `pr-checks.yml`
   (`actions/dependency-review-action` v5.0.0, SHA-pinned,
   `fail-on-severity: high`).
4. **SLSA L2** — `actions/attest-build-provenance` (v4.1.0, SHA-pinned) on
   `release.yml merge-and-sign`, attesting the merged multi-arch index
   digest on tag/dispatch builds with `push-to-registry: true`
   (`id-token: write` + `attestations: write` granted on that job only).
5. **.trivyignore** — header template now requires CVE id,
   `accepted-until: YYYY-MM-DD`, reason, and affected image; the existing
   DS002 exception was reformatted to the new template (scan behavior
   unchanged).

Conflict coordination: `dev-advisory.yml` (deleted by #1112) received pins
only, and `post-merge-completeness.yml` (renamed by #1113) was edited last;
this branch will be rebased again right before merge and changes re-applied
or dropped per upstream state.

## Acceptance criteria

- [x] `grep -rE 'uses:.*@(v[0-9]|main|master)' .github/workflows/` → 0 matches  [evidence: exit=1, no output]
- [x] Every workflow has an explicit `permissions:` block; no `write-all`  [evidence: per-file grep, 0 files missing]
- [x] dependency-review job present in pr-checks.yml, fail-on-severity high
- [x] actionlint passes  [evidence: `actionlint -color` in ci-runner container, exit 0]
- [x] SLSA L2 attestation on the versioned-image publish job (release.yml merge-and-sign)
- [x] `.trivyignore` template requires accepted-until + reason + affected

## Test plan

### Lint & gates
- [x] `actionlint -color` (ci-runner container) — exit 0
- [x] `make check-images` — "All consumer files are aligned with images/images.yaml" (banner-marked regions untouched)
- [x] No mutable-tag `uses:` refs; no `write-all`

### Build & unit
- N/A — no Go/Python/proto code touched (workflow YAML + .trivyignore only)

### Engineering hygiene
- [x] Branched off fresh `origin/main`, rebased before PR
- [x] `.github/workflows/` is PR-size-exempt; one commit, DCO + Assisted-by trailers
