### PR TITLE
chore(claude): milestone-agnostic delivery commands + lifecycle

### DIFF
--- a/.claude/commands/experts/go-services.md
+++ b/.claude/commands/experts/go-services.md
@@ -258,14 +258,14 @@ nats, _ := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerR
 })
 ```
 
-*(Applied via /m6-learn from #818 (Redis) + #828 (NATS).)*
+*(Applied via /milestone-learn from #818 (Redis) + #828 (NATS).)*
 
 ---
 
 ## Git safety
 
-You run in your own isolated git worktree (EPIC #1001 — `m6-orchestrate` STEP 6 /
-`m6-issue-generate` STEP 2.5): a private checkout with its own `HEAD` and index. Branch
+You run in your own isolated git worktree (EPIC #1001 — `milestone-orchestrate` STEP 6 /
+`issue-deliver` STEP 2.5): a private checkout with its own `HEAD` and index. Branch
 switches, `git add`, and `git stash` here are invisible to sibling agents and theirs to you,
 so no defensive branch-verify before each Bash call, no explicit-path-only staging to dodge
 sibling contamination, and no stash-avoidance is needed.

--- a/.claude/commands/issue-deliver.md
+++ b/.claude/commands/issue-deliver.md
@@ -1,11 +1,11 @@
 ---
-description: Fully autonomous M6 story delivery — claims issue via GitHub label, runs SPDD pipeline for feat: issues, implements, waits for CI, verifies Docker artifacts, merges, and marks done. Cross-machine safe.
+description: Fully autonomous milestone story delivery — claims issue via GitHub label, runs SPDD pipeline for feat: issues, implements, waits for CI, verifies Docker artifacts, merges, and marks done. Cross-machine safe.
 argument-hint: "<story-or-epic-issue-number>"
 ---
 
-# /m6-issue-generate — Autonomous M6 Story Delivery
+# /issue-deliver — Autonomous Milestone Story Delivery
 
-End-to-end, unattended delivery of a single M6 issue: claim → canvas (if feat:) → implement →
+End-to-end, unattended delivery of a single story issue: claim → canvas (if feat:) → implement →
 local checks → push → PR → wait for CI → verify artifacts → squash-merge → cleanup → done.
 
 > **Rules are not restated here.** Commit format, DCO + `Assisted-by` trailers, `GOWORK=off`,
@@ -24,7 +24,7 @@ local checks → push → PR → wait for CI → verify artifacts → squash-mer
 Two layers prevent duplicate work across concurrent sessions on any machine:
 
 1. **Soft claim** — add `status: in-progress` label + self-assign the issue on GitHub (visible
-   immediately to all sessions and to `/m6-plan`). This is a *signal*, not a lock.
+   immediately to all sessions and to `/milestone-plan`). This is a *signal*, not a lock.
 2. **Hard claim** — push an empty branch to GitHub before writing any code. Only one `git push -u
    origin $BRANCH` wins when two sessions race. A rejected push means the story is taken → stop.
 
@@ -35,11 +35,24 @@ Always check both before starting. Never assume an issue is free just because yo
 ## STEP 0 — Pre-flight: read the rules
 
 ```bash
+# ── Active-milestone config (SSoT: state/milestone.yaml) ────────────────────
+# Loaded at runtime; no milestone name, number, or label is hardcoded in this
+# file. Updated only by /milestone-close and /milestone-new.
+CFG=state/milestone.yaml
+MILESTONE_NAME=$(awk '/^active:/{f=1} f && /^  name:/{print $2; exit}' "$CFG")
+MILESTONE_TITLE=$(awk -F'"' '/^active:/{f=1} f && /^  title:/{print $2; exit}' "$CFG")
+MILESTONE_NUMBER=$(awk '/^active:/{f=1} f && /^  github_milestone_number:/{print $2; exit}' "$CFG")
+MILESTONE_VERSION=$(awk '/^active:/{f=1} f && /^  version:/{print $2; exit}' "$CFG")
+PLANNING_DOC=$(awk '/^active:/{f=1} f && /^  planning_doc:/{print $2; exit}' "$CFG")
+MILESTONE_LABEL=$(awk -F'"' '/^    milestone:/{print $2; exit}' "$CFG")
+GH_MILESTONE="${MILESTONE_TITLE} (${MILESTONE_NAME})"   # GitHub milestone title
+# ─────────────────────────────────────────────────────────────────────────────
+
 # Mandatory reads every run — do not skip
 cat CLAUDE.md                            # dev loop, PR-size, SPDD rules
 cat AGENTS.md                            # constitution: layer boundaries, mandates, anti-patterns
 cat state/current-milestone.md           # active blockers, health
-cat docs/milestones/M6-planning.md       # dependency table, EPIC status
+cat "$PLANNING_DOC"       # dependency table, EPIC status
 ```
 
 ---
@@ -152,7 +165,7 @@ Go to **STEP 3-EPIC**. Otherwise skip to **STEP 3.5**.
 
 ## STEP 3.5 — Identify expert persona and start activity log
 
-Determine which expert persona applies to this issue (same routing table as `/m6-orchestrate`):
+Determine which expert persona applies to this issue (same routing table as `/milestone-orchestrate`):
 
 ```bash
 EXPERT_TAG="general"
@@ -237,7 +250,7 @@ fi
 
 # If canvas not Aligned, run SPDD pipeline (STEP 4-CANVAS will handle this)
 # Find the next open story issue for this EPIC (lowest step number, not yet in-progress or done)
-STORY_ISSUES=$(gh issue list --milestone "K8s Production-Ready (M6)" --state open \
+STORY_ISSUES=$(gh issue list --milestone "$GH_MILESTONE" --state open \
   --json number,title,body,labels \
   --jq ".[] | select(.body | test(\"#${ISSUE_N}\")) | {n:.number,title:.title,labels:[.labels[].name]}")
 
@@ -311,9 +324,17 @@ if [ -z "$CANVAS_DIR" ] || [ "$CANVAS_STATUS" != "Aligned" ]; then
 fi
 
 # Create story issues if not yet created for this EPIC
-STORY_COUNT=$(gh issue list --milestone "K8s Production-Ready (M6)" --state all \
+STORY_COUNT=$(gh issue list --milestone "$GH_MILESTONE" --state all \
   --json body --jq "[.[] | select(.body | test(\"#${EPIC_N}\"))] | length")
 [ "$STORY_COUNT" -eq 0 ] && /spdd-story "$EPIC_N"
+
+# Locked decision (#1107): /spdd-story is milestone-agnostic — it applies NO
+# milestone label. The CALLER (this command) injects the active milestone label
+# and GitHub milestone on every story it just created.
+for STORY in $(gh issue list --state open --limit 100 --json number,body \
+  --jq ".[] | select(.body | test(\"#${EPIC_N}\")) | .number"); do
+  gh issue edit "$STORY" --add-label "$MILESTONE_LABEL" --milestone "$GH_MILESTONE"
+done
 ```
 
 ---
@@ -327,7 +348,7 @@ echo "[$EXPERT_TAG #$ISSUE_N $(date +%H:%M:%S)] CLAIM: creating branch + hard cl
 
 # Deterministic claim key (load-bearing). The branch ref pushed here is a PURE
 # function of the issue number — `<type>/<N>`, with NO slug. This is the SAME ref
-# `/m6-orchestrate` derives for the same issue, so the two entry points share one
+# `/milestone-orchestrate` derives for the same issue, so the two entry points share one
 # mutex: when two sessions race the same story they push the identical ref and only
 # one `git push` wins. A title-derived slug must NOT be part of the claim key — two
 # sessions could otherwise derive two different branches and both win.
@@ -387,7 +408,7 @@ body's scope and acceptance criteria. Read all referenced files before writing a
 issue/PR state, not by memory or the previous doc snapshot. Doc drift is silent (no CI gate
 flags a stale milestone label) and compounds every iteration, so reconcile at delivery time:
 
-1. `docs/milestones/M6-planning.md` — flip this story's row ⬜→✅ (and its EPIC header to
+1. `"$PLANNING_DOC"` — flip this story's row ⬜→✅ (and its EPIC header to
    `Implemented`/COMPLETE if this was the last open O-step); refresh the "Last updated" line.
 2. `state/current-milestone.md` — update EPIC progress + the "as of" date.
 3. Canvas O-step — mark ✅. **If this issue closed the EPIC's last O-step, flip the canvas
@@ -401,9 +422,9 @@ flags a stale milestone label) and compounds every iteration, so reconcile at de
 **Consistency check before opening the PR** (catches drift the row-flip missed):
 ```bash
 # Each milestone's marker must agree across all status surfaces.
-grep -nE 'M6|🚧|📅|✅|🟡' README.md ROADMAP.md ARCHITECTURE.md CLAUDE.md \
-  state/current-milestone.md docs/milestones/M6-planning.md | grep -iE 'planned|active|complete'
-# An EPIC marked Implemented in M6-planning must have its canvas Status: Implemented:
+grep -nE "${MILESTONE_NAME}|🚧|📅|✅|🟡" README.md ROADMAP.md ARCHITECTURE.md CLAUDE.md \
+  state/current-milestone.md "$PLANNING_DOC" | grep -iE 'planned|active|complete'
+# An EPIC marked Implemented in the planning doc must have its canvas Status: Implemented:
 for c in docs/spdd/*/canvas.md; do grep -H -m1 '^\*\*Status:\*\*' "$c"; done
 ```
 
@@ -495,7 +516,7 @@ cat > /tmp/pr-body-${ISSUE_N}.md << 'EOF'
 - [x] `make test-bdd` — all scenarios pass  [evidence / N/A]
 
 ### Engineering hygiene
-- [x] `M6-planning.md` row ⬜→✅ in this diff
+- [x] Planning-doc row ⬜→✅ in this diff
 - [x] `current-milestone.md` updated in this diff
 - [x] Canvas O-step ✅; `/spdd-sync` run if impl diverged
 - [x] Branched off fresh `origin/main` · PR ≤900 lines · trailers on every commit
@@ -510,7 +531,7 @@ ${COMMIT_TYPE}(<scope>): <subject>
 
 Closes #${ISSUE_N}
 
-Assisted-by: Claude/claude-sonnet-4-6
+Assisted-by: Claude/<model-id-of-this-session>
 EOF
 )"
 
@@ -530,7 +551,7 @@ PR_URL=$(gh pr create \
   --base main \
   --title "${COMMIT_TYPE}(<scope>): <subject>" \
   --assignee "@me" \
-  --label "type: ${COMMIT_TYPE},milestone: M6,area: <area>" \
+  --label "type: ${COMMIT_TYPE}" --label "$MILESTONE_LABEL" --label "area: <area>" \
   --body-file "/tmp/pr-body-${ISSUE_N}.md")
 
 PR_N=$(echo "$PR_URL" | grep -oP '\d+$')
@@ -546,8 +567,18 @@ CURRENT_STEP="10-CI"; check_ctx_budget
 echo "[$EXPERT_TAG #$ISSUE_N $(date +%H:%M:%S)] CI_WAIT: PR #$PR_N — waiting for required checks  [ctx: ~${CTX_TOKENS}K | compress=${CTX_COMPRESSIONS} | msgs=${CTX_MSGS}]"
 ```
 
-Unlike `/resume-m6`, this command waits for CI to complete before merging. This is intentional —
+Unlike `/resume-milestone`, this command waits for CI to complete before merging. This is intentional —
 the command's contract is end-to-end autonomous delivery, not a fire-and-forget push.
+
+> **Foreground only — never end the turn here.** The CI wait MUST be a blocking foreground
+> call in your current turn (`gh pr checks "$PR_N" --watch --interval 30`, or the poll loop
+> below). Never arm a *background* watch and end your turn "to wait for the notification" —
+> in an agent session that strands the delivery at an open PR (observed 2026-06-11: six of
+> seven agents stranded exactly this way). You are not done until STEP 14's report prints.
+>
+> **Merge-ready signal:** all *required* checks green is the gate. `mergeStateStatus` of
+> `CLEAN` is ready; `UNSTABLE` with only non-required checks pending is ALSO ready — do not
+> deadlock waiting for advisory checks. `BEHIND` means rebase onto origin/main and re-run.
 
 ```bash
 echo "Waiting for CI on PR #$PR_N (this may take 5–20 minutes)..."
@@ -697,7 +728,7 @@ gh issue edit "$ISSUE_N" --remove-label "status: in-progress" 2>/dev/null || tru
 
 # EPIC completion check: if all stories for the parent EPIC are now closed, close the EPIC too
 if [ -n "$EPIC_N" ] && [ "$EPIC_N" != "$ISSUE_N" ]; then
-  OPEN_STORIES=$(gh issue list --milestone "K8s Production-Ready (M6)" --state open \
+  OPEN_STORIES=$(gh issue list --milestone "$GH_MILESTONE" --state open \
     --json body --jq "[.[] | select(.body | test(\"#${EPIC_N}\"))] | length")
   if [ "$OPEN_STORIES" -eq 0 ]; then
     gh issue close "$EPIC_N" --reason completed \
@@ -711,11 +742,11 @@ if [ -n "$EPIC_N" ] && [ "$EPIC_N" != "$ISSUE_N" ]; then
 
       All O-steps merged for EPIC #${EPIC_N}.
 
-      Assisted-by: Claude/claude-sonnet-4-6"
+      Assisted-by: Claude/<model-id-of-this-session>"
       git push -u origin HEAD
       gh pr create --title "docs(spdd): mark EPIC #${EPIC_N} canvas Implemented" \
         --body "All O-steps for EPIC #${EPIC_N} have been merged. Closing canvas." \
-        --label "type: docs,milestone: M6"
+        --label "type: docs" --label "$MILESTONE_LABEL"
     }
   fi
 fi
@@ -730,7 +761,7 @@ PR:          #$PR_N — MERGED
 CI:          All required checks passed ✓
 Artifacts:   $([ "$TOUCHES_IMAGE" -gt 0 ] && echo "Docker images verified ✓" || echo "N/A (no image-touching files)")
 Issue state: CLOSED ✓
-Next:        Run /m6-plan to see what to pick up next.
+Next:        Run /milestone-plan to see what to pick up next.
 EOF
 
 # Remove the isolated worktree — all work is merged, nothing to keep

--- a/.claude/commands/milestone-close.md
+++ b/.claude/commands/milestone-close.md
@@ -1,0 +1,127 @@
+---
+description: Close the active milestone — verify EPICs done, truth-pass docs, signed version tag, GitHub Release, rotate state/milestone.yaml active→history. The only sanctioned writer of milestone.yaml besides /milestone-new.
+argument-hint: "[--dry-run]  verify + report only, change nothing"
+---
+
+# /milestone-close — Milestone Lifecycle: Close
+
+Close the active milestone end-to-end. This command (with `/milestone-new`) is the ONLY
+sanctioned writer of `state/milestone.yaml` — every other command reads it.
+
+> **Destructive surface:** pushes a signed version tag and creates a public GitHub Release.
+> Run `--dry-run` first in any session where the milestone state is uncertain.
+
+---
+
+## STEP 0 — Load config + sync
+
+```bash
+git fetch origin --prune && git checkout main && git pull --rebase origin main
+[ -z "$(git status --porcelain)" ] || { echo "dirty tree — STOP"; exit 1; }
+
+# ── Active-milestone config (SSoT: state/milestone.yaml) ────────────────────
+CFG=state/milestone.yaml
+MILESTONE_NAME=$(awk '/^active:/{f=1} f && /^  name:/{print $2; exit}' "$CFG")
+MILESTONE_TITLE=$(awk -F'"' '/^active:/{f=1} f && /^  title:/{print $2; exit}' "$CFG")
+MILESTONE_NUMBER=$(awk '/^active:/{f=1} f && /^  github_milestone_number:/{print $2; exit}' "$CFG")
+MILESTONE_VERSION=$(awk '/^active:/{f=1} f && /^  version:/{print $2; exit}' "$CFG")
+PLANNING_DOC=$(awk '/^active:/{f=1} f && /^  planning_doc:/{print $2; exit}' "$CFG")
+MILESTONE_LABEL=$(awk -F'"' '/^    milestone:/{print $2; exit}' "$CFG")
+GH_MILESTONE="${MILESTONE_TITLE} (${MILESTONE_NAME})"
+# ─────────────────────────────────────────────────────────────────────────────
+echo "Closing: $GH_MILESTONE → $MILESTONE_VERSION"
+```
+
+## STEP 1 — Verify every EPIC is actually closed (abort if not)
+
+```bash
+# Live query is authoritative; the static open_epics list is only a hint.
+OPEN_EPICS=$(gh issue list --milestone "$GH_MILESTONE" --label "type: epic" \
+  --state open --limit 50 --json number,title --jq '.[] | "#\(.number) \(.title)"')
+if [ -n "$OPEN_EPICS" ]; then
+  echo "ABORT — open EPICs remain in $GH_MILESTONE:"
+  echo "$OPEN_EPICS"
+  exit 1
+fi
+
+# Also report (not gate) any open non-EPIC stragglers, so the human can decide
+# to move them to the next milestone before re-running.
+gh issue list --milestone "$GH_MILESTONE" --state open --limit 100 --json number,title \
+  --jq '.[] | "straggler: #\(.number) \(.title)"'
+```
+
+If `--dry-run`: print the verification result and STOP here.
+
+## STEP 2 — Truth-pass all doc surfaces
+
+Run `/repo-clean` (plans first, executes on approval) to reconcile every status surface
+(README / ROADMAP / ARCHITECTURE / CLAUDE / state / planning doc / canvases) to live GitHub
+state. Do not proceed until its PR is merged.
+
+## STEP 3 — Signed version tag
+
+```bash
+git checkout main && git pull --rebase origin main
+git tag -s "$MILESTONE_VERSION" -m "Release $MILESTONE_VERSION"
+git push origin "$MILESTONE_VERSION"
+# The tag push triggers the release workflow (retag model — ADR-027):
+# images retagged to the version, cosign-signed, SBOMs attached.
+```
+
+## STEP 4 — GitHub Release
+
+```bash
+# Wait for the tag-triggered workflow to finish before creating the release notes
+gh run list --limit 5 --json name,status,headBranch
+gh release create "$MILESTONE_VERSION" --generate-notes \
+  --title "$MILESTONE_VERSION: $MILESTONE_TITLE"
+```
+
+## STEP 5 — Close the GitHub milestone
+
+```bash
+gh api -X PATCH "repos/{owner}/{repo}/milestones/${MILESTONE_NUMBER}" -f state=closed
+```
+
+## STEP 6 — Rotate active → history in state/milestone.yaml
+
+Edit `state/milestone.yaml` (this command is a sanctioned writer):
+1. Prepend the active block to `history:` with `released: <today YYYY-MM-DD>`.
+2. Leave `active:` EMPTY of milestone content except a placeholder comment —
+   `/milestone-new` fills it. (If the next milestone is already decided, run
+   `/milestone-new` immediately after and let it write the block.)
+3. Clear `open_epics`.
+4. Run `make validate-milestone-state` — must pass before committing.
+
+## STEP 7 — Update state/current-milestone.md header
+
+Mark the closed milestone Complete with its version; note that the next milestone is not
+yet open (or hand off to `/milestone-new`).
+
+## STEP 8 — Commit + PR (never direct to main — ADR-023)
+
+```bash
+git checkout -b "chore/release-${MILESTONE_VERSION}"
+git add state/milestone.yaml state/current-milestone.md
+git commit -s -m "chore(release): close ${MILESTONE_NAME}, rotate milestone state
+
+${GH_MILESTONE} released as ${MILESTONE_VERSION}.
+
+Assisted-by: Claude/<model-id-of-this-session>"
+git push -u origin HEAD
+gh pr create --title "chore(release): close ${MILESTONE_NAME} — ${MILESTONE_VERSION}" \
+  --body "Rotates active→history in state/milestone.yaml after the ${MILESTONE_VERSION} release." \
+  --label "type: chore" --label "$MILESTONE_LABEL"
+gh pr checks --watch --interval 30   # FOREGROUND — never end the turn while CI runs
+gh pr merge --squash
+```
+
+## STEP 9 — Done report
+
+```
+=== Milestone closed: <name> ===
+Release:   <version> — <release URL>
+Milestone: <GitHub milestone URL> (closed)
+Config:    state/milestone.yaml rotated (PR #N merged)
+Next:      run /milestone-new to scaffold the next milestone.
+```

--- a/.claude/commands/milestone-learn.md
+++ b/.claude/commands/milestone-learn.md
@@ -3,22 +3,22 @@ description: Expert knowledge synthesizer — reads docs/ai-learnings/*.md, spaw
 argument-hint: "[--domain go-services|ci-release|...] [--apply]  default: synthesize all"
 ---
 
-# /m6-learn — Expert Knowledge Synthesizer
+# /milestone-learn — Expert Knowledge Synthesizer
 
 Read accumulated session learnings → spawn synthesizer subagent → output proposed additions
 to expert prompt files → write pending entries to APPLY_LOG.md → stop for human review.
 
 Two modes:
-- **`/m6-learn`** (default) — synthesize and write proposals to APPLY_LOG.md as PENDING.
-- **`/m6-learn --apply`** — apply PENDING entries already approved by the human in APPLY_LOG.md,
+- **`/milestone-learn`** (default) — synthesize and write proposals to APPLY_LOG.md as PENDING.
+- **`/milestone-learn --apply`** — apply PENDING entries already approved by the human in APPLY_LOG.md,
   then commit expert files + log update together.
 
 > **This command never auto-commits in synthesis mode.** Human edits APPLY_LOG.md entries
-> (`pending` → `applied` / `rejected`) then runs `/m6-learn --apply` to commit.
+> (`pending` → `applied` / `rejected`) then runs `/milestone-learn --apply` to commit.
 
 ---
 
-## APPLY mode (`/m6-learn --apply`)
+## APPLY mode (`/milestone-learn --apply`)
 
 Check if any PENDING entries in APPLY_LOG.md were approved (`applied`) by the human.
 If yes: edit the expert files to add approved text, mark entries as `committed` in the log,
@@ -26,7 +26,7 @@ commit everything, open a PR, and stop.
 
 ```bash
 LOG="docs/ai-learnings/APPLY_LOG.md"
-[ ! -f "$LOG" ] && echo "No APPLY_LOG.md found — run /m6-learn first." && exit 1
+[ ! -f "$LOG" ] && echo "No APPLY_LOG.md found — run /milestone-learn first." && exit 1
 
 # Find the most recent run with approved-but-not-yet-committed entries
 APPROVED=$(python3 - "$LOG" <<'PYEOF'
@@ -65,15 +65,15 @@ git checkout -b "$LEARN_BRANCH"
 git add .claude/commands/experts/ docs/ai-learnings/APPLY_LOG.md
 git commit -s -m "docs(automation): apply expert learnings — $(date +%Y-%m-%d)
 
-Synthesized from session learnings via /m6-learn.
+Synthesized from session learnings via /milestone-learn.
 See docs/ai-learnings/APPLY_LOG.md for applied entries.
 
-Assisted-by: Claude/claude-sonnet-4-6"
+Assisted-by: Claude/<model-id-of-this-session>"
 git push -u origin "$LEARN_BRANCH"
 gh pr create \
   --title "docs(automation): apply expert learnings — $(date +%Y-%m-%d)" \
-  --body "Applying approved /m6-learn proposals. See APPLY_LOG.md for details." \
-  --label "type: docs,milestone: M6"
+  --body "Applying approved /milestone-learn proposals. See APPLY_LOG.md for details." \
+  --label "type: docs" --label "$MILESTONE_LABEL"
 ```
 
 **Stop here if mode is `--apply`.** Do not continue to synthesis steps.
@@ -158,7 +158,7 @@ done
 
 ```
 Agent({
-  description: "M6 learning synthesizer",
+  description: "Expert learning synthesizer",
   subagent_type: "claude",
   prompt: """
     You are a learning synthesizer for the Zynax engineering AI system.
@@ -187,14 +187,14 @@ Agent({
         persisting between calls (use literal paths, not vars), `env` prefix denied, multiline
         `-m` denied (use `git commit -F`), CI-wait must be `gh pr checks --watch` not a loop.
         These are REAL and must persist, but they belong in the **dispatch-prompt preamble of
-        m6-orchestrate.md / m6-issue-generate.md** (injected into every agent), NOT scattered
+        milestone-orchestrate.md / issue-deliver.md** (injected into every agent), NOT scattered
         into the expert guides. Do NOT auto-reject: surface as `pending` with a note that the
-        fix is a manual command-file edit (outside `/m6-learn --apply`'s expert-file scope).
+        fix is a manual command-file edit (outside `/milestone-learn --apply`'s expert-file scope).
       - `domain` — genuine engineering knowledge (API shape, query planner behaviour, proto
         field name, test pattern, gRPC code mapping).
       Prefer the `Category:` line the session already emitted; if absent, infer it.
     - Do NOT promote `structural-workaround` proposals to the expert guides while worktree
-      isolation is in effect (m6-orchestrate STEP 6 / STEP 7.5; EPIC #1001). List them under a
+      isolation is in effect (milestone-orchestrate STEP 6 / STEP 7.5; EPIC #1001). List them under a
       separate "Structural (suppressed — root cause fixed by worktree isolation)" heading so
       the human can confirm, but default their Status to `rejected` in the apply-log.
 
@@ -210,7 +210,7 @@ Agent({
       Seen in: #NNN, #NNN (N sessions). Recurrence: N.
     ```
 
-    Then, output a APPLY_LOG_ENTRY block (used by /m6-learn to append to the log):
+    Then, output a APPLY_LOG_ENTRY block (used by /milestone-learn to append to the log):
 
     ```apply-log
     ## Run <YYYY-MM-DD HH:MM> — domains: <list>
@@ -279,10 +279,10 @@ echo "Run entry written to docs/ai-learnings/APPLY_LOG.md"
                then manually edit the target expert file to add the text
    - Reject:   change Status from "pending" to "rejected"
                leave Delta as "—"
-   - Defer:    leave Status as "pending" (will re-appear in next /m6-learn run)
+   - Defer:    leave Status as "pending" (will re-appear in next /milestone-learn run)
 
 3. After editing expert file(s) and APPLY_LOG.md, run:
-   /m6-learn --apply
+   /milestone-learn --apply
    This stages, commits, and opens a PR for the approved entries.
 
 === APPLY_LOG.md written to docs/ai-learnings/APPLY_LOG.md ===
@@ -293,13 +293,13 @@ echo "Run entry written to docs/ai-learnings/APPLY_LOG.md"
 ## Learning loop lifecycle
 
 ```
-/m6-orchestrate
+/milestone-orchestrate
   → expert sessions run → ## Session Learnings blocks produced
   → orchestrator appends raw learnings to docs/ai-learnings/<domain>.md
   → opens docs: PR for the raw learnings
 
 After ≥3 new session blocks:
-/m6-learn
+/milestone-learn
   → reads learnings + expert files + APPLY_LOG.md
   → synthesizer clusters patterns (recurrence ≥2, dedup vs applied)
   → prints proposals
@@ -309,7 +309,7 @@ Human reviews:
   → edits APPLY_LOG.md: pending → applied/rejected
   → manually edits expert files to add approved text
 
-/m6-learn --apply
+/milestone-learn --apply
   → finds approved-but-not-committed entries in APPLY_LOG.md
   → updates log entries to committed
   → commits expert files + APPLY_LOG.md
@@ -323,8 +323,8 @@ Human reviews:
 ```markdown
 # Expert Learning Apply Log
 
-> Append-only. Each run of /m6-learn adds one entry. Human edits Status column.
-> Delta column records what changed in the expert file (filled in by /m6-learn --apply).
+> Append-only. Each run of /milestone-learn adds one entry. Human edits Status column.
+> Delta column records what changed in the expert file (filled in by /milestone-learn --apply).
 
 ---
 
@@ -346,10 +346,10 @@ Human reviews:
 > `env-constraint` rows (runtime/sandbox constraints worktree isolation does NOT fix — e.g.
 > background-subagent compound-Bash denial, non-persistent shell state) are NOT auto-rejected:
 > leave them `pending` and apply them by hand to the dispatch-prompt preamble in
-> `m6-orchestrate.md` / `m6-issue-generate.md` — they are outside `/m6-learn --apply`'s
+> `milestone-orchestrate.md` / `issue-deliver.md` — they are outside `/milestone-learn --apply`'s
 > expert-file scope, so `--apply` will not commit them.
 
-Status lifecycle: `pending` → `applied` (human sets) → `committed` (/m6-learn --apply sets)
+Status lifecycle: `pending` → `applied` (human sets) → `committed` (/milestone-learn --apply sets)
 Or: `pending` → `rejected` (human sets, stays rejected)
 
 ---

--- a/.claude/commands/milestone-new.md
+++ b/.claude/commands/milestone-new.md
@@ -1,0 +1,104 @@
+---
+description: Scaffold the next milestone — GitHub milestone, planning doc skeleton, state/milestone.yaml active block. The only sanctioned writer of milestone.yaml besides /milestone-close.
+argument-hint: "<name> <version> \"<title>\"  (next milestone per ROADMAP.md)"
+---
+
+# /milestone-new — Milestone Lifecycle: Open
+
+Scaffold the next milestone. This command (with `/milestone-close`) is the ONLY sanctioned
+writer of `state/milestone.yaml` — every other command reads it.
+
+Inputs (from arguments; ask the operator if missing): short name (e.g. the next sequential
+code), semver version target, human title. Cross-check against `ROADMAP.md` — the roadmap
+defines the milestone sequence; this command instantiates it, never invents it.
+
+---
+
+## STEP 0 — Preconditions
+
+```bash
+git fetch origin --prune && git checkout main && git pull --rebase origin main
+[ -z "$(git status --porcelain)" ] || { echo "dirty tree — STOP"; exit 1; }
+
+# The previous milestone must be rotated to history (active block empty/placeholder).
+# If /milestone-close has not run, STOP and run it first.
+grep -A2 '^active:' state/milestone.yaml
+```
+
+## STEP 1 — GitHub milestone
+
+```bash
+NEW_NAME="$1"; NEW_VERSION="$2"; NEW_TITLE="$3"
+GH_TITLE="${NEW_TITLE} (${NEW_NAME})"
+
+# Reuse if it already exists (idempotent), else create
+NUMBER=$(gh api "repos/{owner}/{repo}/milestones?state=all" \
+  --jq ".[] | select(.title == \"$GH_TITLE\") | .number")
+if [ -z "$NUMBER" ]; then
+  NUMBER=$(gh api -X POST "repos/{owner}/{repo}/milestones" \
+    -f title="$GH_TITLE" -f state=open --jq .number)
+fi
+echo "GitHub milestone #$NUMBER: $GH_TITLE"
+
+# Milestone label (idempotent)
+gh label create "milestone: ${NEW_NAME}" --color "BFD4F2" \
+  --description "${NEW_TITLE} milestone" 2>/dev/null || true
+```
+
+## STEP 2 — Planning doc skeleton
+
+Create `docs/milestones/<name>-planning.md` from the structure of the previous planning doc
+(read the most recent `planning_doc` in `state/milestone.yaml` history): goal statement,
+EPIC table (empty), dependency notes, risk table, exit criteria tied to the version target.
+
+## STEP 3 — Write the active block in state/milestone.yaml
+
+```yaml
+active:
+  name: <name>
+  title: "<title>"
+  github_milestone_number: <number>
+  version: <version>
+  status: active
+  planning_doc: docs/milestones/<name>-planning.md
+  labels:
+    milestone: "milestone: <name>"
+  open_epics: []   # filled as EPICs are created
+```
+
+```bash
+make validate-milestone-state   # must pass before committing
+```
+
+## STEP 4 — Update state/current-milestone.md
+
+New header section for the milestone: status Active, link to the planning doc, empty
+progress table.
+
+## STEP 5 — Commit + PR (never direct to main — ADR-023)
+
+```bash
+git checkout -b "chore/open-${NEW_NAME}"
+git add state/milestone.yaml state/current-milestone.md "docs/milestones/${NEW_NAME}-planning.md"
+git commit -s -m "chore(release): open ${NEW_NAME} — ${NEW_TITLE}
+
+Scaffolds the GitHub milestone, planning doc, and milestone.yaml active block.
+
+Assisted-by: Claude/<model-id-of-this-session>"
+git push -u origin HEAD
+gh pr create --title "chore(release): open ${NEW_NAME} — ${NEW_TITLE}" \
+  --body "Opens milestone ${GH_TITLE} (target ${NEW_VERSION})." \
+  --label "type: chore" --label "milestone: ${NEW_NAME}"
+gh pr checks --watch --interval 30   # FOREGROUND — never end the turn while CI runs
+gh pr merge --squash
+```
+
+## STEP 6 — Done report
+
+```
+=== Milestone opened: <name> — <title> ===
+GitHub:   milestone #<number> + label "milestone: <name>"
+Planning: docs/milestones/<name>-planning.md (skeleton — fill EPIC table next)
+Config:   state/milestone.yaml active block written (PR #N merged)
+Next:     create EPIC issues, then /milestone-plan.
+```

--- a/.claude/commands/milestone-orchestrate.md
+++ b/.claude/commands/milestone-orchestrate.md
@@ -1,9 +1,9 @@
 ---
-description: Parallel M6 orchestrator — reads state, claims up to 3 issues per batch, routes each to the right domain expert subagent, runs them in parallel, collects results and learnings. Orchestrator never reads code files directly.
+description: Parallel milestone orchestrator — reads state, claims up to 3 issues per batch, routes each to the right domain expert subagent, runs them in parallel, collects results and learnings. Orchestrator never reads code files directly.
 argument-hint: "[--batch-size N]  default: 3"
 ---
 
-# /m6-orchestrate — Parallel M6 Delivery Orchestrator
+# /milestone-orchestrate — Parallel Milestone Delivery Orchestrator
 
 Thin coordination layer: read state → claim issues → fan out to expert subagents in parallel →
 collect results → persist learnings → report.
@@ -51,9 +51,22 @@ git -C "$REPO" fetch origin --prune
 git -C "$REPO" worktree add "$COORD_WT" origin/main   # detached at origin/main
 cd "$COORD_WT"
 
+# ── Active-milestone config (SSoT: state/milestone.yaml) ────────────────────
+# Loaded at runtime; no milestone name, number, or label is hardcoded in this
+# file. Updated only by /milestone-close and /milestone-new.
+CFG=state/milestone.yaml
+MILESTONE_NAME=$(awk '/^active:/{f=1} f && /^  name:/{print $2; exit}' "$CFG")
+MILESTONE_TITLE=$(awk -F'"' '/^active:/{f=1} f && /^  title:/{print $2; exit}' "$CFG")
+MILESTONE_NUMBER=$(awk '/^active:/{f=1} f && /^  github_milestone_number:/{print $2; exit}' "$CFG")
+MILESTONE_VERSION=$(awk '/^active:/{f=1} f && /^  version:/{print $2; exit}' "$CFG")
+PLANNING_DOC=$(awk '/^active:/{f=1} f && /^  planning_doc:/{print $2; exit}' "$CFG")
+MILESTONE_LABEL=$(awk -F'"' '/^    milestone:/{print $2; exit}' "$CFG")
+GH_MILESTONE="${MILESTONE_TITLE} (${MILESTONE_NAME})"   # GitHub milestone title
+# ─────────────────────────────────────────────────────────────────────────────
+
 # Read only these four files — nothing else (from the coordinator worktree)
 cat state/current-milestone.md           # blockers, active work
-cat docs/milestones/M6-planning.md       # EPIC status + dependency table
+cat "$PLANNING_DOC"       # EPIC status + dependency table
 ```
 
 ```bash
@@ -61,7 +74,7 @@ cat docs/milestones/M6-planning.md       # EPIC status + dependency table
 BATCH_SIZE=${ARGUMENTS:-3}               # default 3 parallel issues
 
 OPEN=$(gh issue list \
-  --milestone "K8s Production-Ready (M6)" \
+  --milestone "$GH_MILESTONE" \
   --state open --limit 300 \
   --json number,title,body,labels,assignees)
 
@@ -106,11 +119,11 @@ done <<< "$OPEN_PRS_JSON"
 
 ## STEP 3 — Select READY batch
 
-Using the same classification logic as `/m6-plan`:
+Using the same classification logic as `/milestone-plan`:
 
 ```bash
 # For each open issue: classify as READY / IN_PROGRESS / BLOCKED
-# Priority order from M6-planning.md EPIC table
+# Priority order from the EPIC table in "$PLANNING_DOC"
 # Select top $BATCH_SIZE READY issues for this session
 
 # Quick filter:
@@ -216,7 +229,7 @@ Then spawn:
 
 ```
 Agent({
-  description: "M6 story #N — <issue title>",
+  description: "Story #N — <issue title>",
   subagent_type: "claude",
   run_in_background: true,
   prompt: """
@@ -262,7 +275,7 @@ Agent({
 
     ---
 
-    Your task: implement M6 story issue #N end-to-end.
+    Your task: implement story issue #N end-to-end.
 
     ## Issue details
     <full issue body from gh issue view N>
@@ -275,7 +288,7 @@ Agent({
        If already claimed: remove your worktree (cleanup below), stop, and report.
     2. From inside "$WT", claim with the DETERMINISTIC KEY before any code: the branch
        ref is `<type>/<N>` — a pure function of the issue number, NO slug. Push it empty
-       (atomic hard claim). This is the same key /m6-issue-generate derives, so it is the
+       (atomic hard claim). This is the same key /issue-deliver derives, so it is the
        sole mutex: if a sibling already pushed `<type>/<N>` your push is rejected → stop,
        run cleanup, report "claim lost". Apply any human-readable slug only AFTER the push
        wins (rename + push the slugged ref); never let a slug into the claim push.
@@ -300,7 +313,7 @@ Agent({
     - Affected services: <comma-separated list, e.g. "memory-service,event-bus" or "none">
     ```
 
-    ## Session Learnings (required — emit verbatim in this shape so /m6-learn can parse it)
+    ## Session Learnings (required — emit verbatim in this shape so /milestone-learn can parse it)
     ```
     ## Session Learnings
     - domain: <go-services|ci-release|infra-helm|python-adapters|bdd-contract|spdd-canvas>
@@ -559,11 +572,11 @@ git commit -s -m "docs(ai-learnings): append session learnings — issues $BATCH
 
 $(date +%Y-%m-%d) batch: $BATCH_SIZE issues.
 
-Assisted-by: Claude/claude-sonnet-4-6"
+Assisted-by: Claude/<model-id-of-this-session>"
 git push -u origin "$LEARN_BRANCH"
 LEARN_PR=$(gh pr create --title "docs(ai-learnings): append session learnings — $(date +%Y-%m-%d)" \
   --body "Appending learnings from batch: issues $BATCH_ISSUES" \
-  --label "type: docs,milestone: M6" | tail -1)
+  --label "type: docs" --label "$MILESTONE_LABEL" | tail -1)
 gh pr merge "$LEARN_PR" --squash --auto
 ```
 
@@ -591,7 +604,7 @@ Batch size: N issues
 | #NNN | none (docs-only) | — | — | — | — | SKIP |
 
 Learnings: appended to docs/ai-learnings/ — PR #NNN opened for review.
-Next: run /m6-plan to see the next available batch.
+Next: run /milestone-plan to see the next available batch.
 ```
 
 After the report, remove the coordinator worktree (the per-run agent/post-merge trees were
@@ -611,7 +624,7 @@ git -C "$REPO" worktree prune
 | What orchestrator reads | What it NEVER reads |
 |---|---|
 | `state/current-milestone.md` | Any `services/*/` Go files |
-| `docs/milestones/M6-planning.md` | Any canvas body |
+| `"$PLANNING_DOC"` | Any canvas body |
 | GitHub issue list (JSON) | Any test output |
 | Open PR list (JSON) | Any workflow file contents |
 | Remote branch list | Any proto definitions |
@@ -639,7 +652,7 @@ tree, so cross-agent branch/staging/commit corruption is structurally impossible
   coordinator can only ever reclaim *this* run's trees. Globbing `/tmp/zynax-orch-*` is forbidden.
 - **User's checkout is never mutated:** the orchestrator does all its own git work in the
   coordinator worktree; `main` stays checked out (untouched) in the user's primary worktree.
-- Distinct from `/m6-issue-generate`'s `/tmp/zynax-auto-<N>` — no namespace collision.
+- Distinct from `/issue-deliver`'s `/tmp/zynax-auto-<N>` — no namespace collision.
 
 ---
 
@@ -651,15 +664,15 @@ not replace the authoritative one:
 
 | Layer | Where | Mechanism | Strength |
 |-------|-------|-----------|----------|
-| 1 — Deterministic claim key | STEP 6 dispatch prompt (+ `/m6-issue-generate` STEP 5) | Branch ref `<type>/<N>` is a pure function of the issue number; the atomic empty-branch push is the **sole mutex** shared by both entry points. Slug applied only post-claim. | Prevents two live branches for one issue. |
+| 1 — Deterministic claim key | STEP 6 dispatch prompt (+ `/issue-deliver` STEP 5) | Branch ref `<type>/<N>` is a pure function of the issue number; the atomic empty-branch push is the **sole mutex** shared by both entry points. Slug applied only post-claim. | Prevents two live branches for one issue. |
 | 2 — Pre-spawn reconcile | STEP 5 | Re-query `gh issue view` + merged-PR search before spawning; skip + drop soft claim if already delivered. | Cheap early-out; can be defeated by API lag. |
 | 3 — Completion-time merge-SHA dedupe | STEP 7 | `SEEN_ISSUES` / `SEEN_MERGE_SHAS`; on each completion re-query the authoritative merged PR; close the loser PR and skip its verifier when a different PR already delivered the issue. | **Authoritative** — operates on a merge fact (a SHA on `main`), immune to API lag. |
 
 - **Completion-time is authoritative.** Layers 1–2 reduce the race window; only layer 3 acts on
   a fact that cannot be wrong. Never treat the claim key or the pre-spawn reconcile as sufficient
   on its own.
-- **The claim key is the single mutex across both entry points.** `/m6-orchestrate` and
-  `/m6-issue-generate` derive the identical `<type>/<N>` ref, so a race between them collides on
+- **The claim key is the single mutex across both entry points.** `/milestone-orchestrate` and
+  `/issue-deliver` derive the identical `<type>/<N>` ref, so a race between them collides on
   one push. A slug must never enter the claim push.
 - **A loser PR is closed, never merged.** When two PRs target one issue, layer 3 keeps the first
   merged (the winner) and closes the redundant one; `gh pr merge` flags and the push-to-main
@@ -688,4 +701,4 @@ Heuristics:
 | Condition | Action |
 |-----------|--------|
 | `CTX_TOKENS > 60K` | Stop claiming new issues — only collect existing agent results |
-| `CTX_TOKENS > 100K` OR `CTX_COMPRESSIONS >= 1` | **STOP. Report collected results so far.** Let the human run `/m6-plan` for the next batch. |
+| `CTX_TOKENS > 100K` OR `CTX_COMPRESSIONS >= 1` | **STOP. Report collected results so far.** Let the human run `/milestone-plan` for the next batch. |

--- a/.claude/commands/milestone-plan.md
+++ b/.claude/commands/milestone-plan.md
@@ -1,12 +1,12 @@
 ---
-description: M6 delivery planner — reads live GitHub + canvas state, computes dependency-aware parallel groups, and outputs /m6-issue-generate commands to run. Respects in-progress issues across all machines.
+description: Milestone delivery planner — reads live GitHub + canvas state, computes dependency-aware parallel groups, and outputs /issue-deliver commands to run. Respects in-progress issues across all machines.
 argument-hint: "[--verbose]"
 ---
 
-# /m6-plan — M6 Delivery Planner
+# /milestone-plan — Milestone Delivery Planner
 
-Read live M6 state, build a dependency graph, detect in-progress sessions on any machine,
-and output the next set of `/m6-issue-generate` commands to run — in parallel where safe,
+Read the active milestone's live state, build a dependency graph, detect in-progress sessions on any machine,
+and output the next set of `/issue-deliver` commands to run — in parallel where safe,
 sequentially where dependencies require it.
 
 > **This command is read-only.** It never writes code, creates branches, or modifies issues.
@@ -20,26 +20,39 @@ sequentially where dependencies require it.
 git fetch origin --prune
 git checkout main && git pull --rebase origin main 2>/dev/null || true
 
+# ── Active-milestone config (SSoT: state/milestone.yaml) ────────────────────
+# Loaded at runtime; no milestone name, number, or label is hardcoded in this
+# file. Updated only by /milestone-close and /milestone-new.
+CFG=state/milestone.yaml
+MILESTONE_NAME=$(awk '/^active:/{f=1} f && /^  name:/{print $2; exit}' "$CFG")
+MILESTONE_TITLE=$(awk -F'"' '/^active:/{f=1} f && /^  title:/{print $2; exit}' "$CFG")
+MILESTONE_NUMBER=$(awk '/^active:/{f=1} f && /^  github_milestone_number:/{print $2; exit}' "$CFG")
+MILESTONE_VERSION=$(awk '/^active:/{f=1} f && /^  version:/{print $2; exit}' "$CFG")
+PLANNING_DOC=$(awk '/^active:/{f=1} f && /^  planning_doc:/{print $2; exit}' "$CFG")
+MILESTONE_LABEL=$(awk -F'"' '/^    milestone:/{print $2; exit}' "$CFG")
+GH_MILESTONE="${MILESTONE_TITLE} (${MILESTONE_NAME})"   # GitHub milestone title
+# ─────────────────────────────────────────────────────────────────────────────
+
 # Read planning docs
-cat docs/milestones/M6-planning.md
+cat "$PLANNING_DOC"
 cat state/current-milestone.md
 ```
 
 ---
 
-## STEP 2 — Snapshot all M6 issues from GitHub
+## STEP 2 — Snapshot all active-milestone issues from GitHub
 
 ```bash
-# All open M6 issues (stories + EPICs)
+# All open milestone issues (stories + EPICs)
 OPEN=$(gh issue list \
-  --milestone "K8s Production-Ready (M6)" \
+  --milestone "$GH_MILESTONE" \
   --state open \
   --limit 300 \
   --json number,title,body,labels,assignees,state)
 
-# All closed M6 issues
+# All closed milestone issues
 CLOSED=$(gh issue list \
-  --milestone "K8s Production-Ready (M6)" \
+  --milestone "$GH_MILESTONE" \
   --state closed \
   --limit 300 \
   --json number,title,labels)
@@ -99,7 +112,7 @@ for CANVAS in docs/spdd/*/canvas.md; do
 done
 ```
 
-For EPICs with canvas `Status: Draft` or no canvas at all, `/m6-issue-generate` will run the SPDD
+For EPICs with canvas `Status: Draft` or no canvas at all, `/issue-deliver` will run the SPDD
 pipeline automatically — but note them as "canvas work needed" in the plan output.
 
 ---
@@ -110,23 +123,13 @@ Group READY issues into parallel batches based on independence. Two issues are *
 - Neither references the other in its dependency list
 - They touch different services/files (use issue title scope hints: `(api-gateway)` vs `(infra)`)
 
-**Priority order** (from M6 EPIC table in planning doc):
-1. M6.Helm #765 children (#779–#792)
-2. M6.Images SoT children (#859–#862) — #859 depends on #858 (merged)
-3. M6.Images GHCR hygiene (#868 → #865 → #866 → #867 → #869) — strict order
-4. M6.Build #837 children
-5. M6.DevAuto #873 children (waves 0–3 before wave 4)
-6. M6.NS #767 children (#799 #800)
-7. M6.Argo #766 children (#795–#798)
-8. M6.SDK #769 children (#805–#808)
-9. M6.Policy #768 children (#801–#804)
-10. M6.J #773 children — **BLOCKED on #626** (check if unblocked first)
-11. M6.I #772 children — needs canvas first
+**Priority order** comes from the EPIC table in `$PLANNING_DOC` — top-to-bottom table order
+is the priority. Never hardcode EPIC or issue numbers in this file; the planning doc and the
+issue bodies are the source of truth.
 
-Apply **hard sequential constraints**:
-- GHCR hygiene: always `#868 → #865 → #866 → #867 → #869` (each depends on previous)
-- DevAuto Wave 4 (#881): BLOCKED until #626 and #772 are complete
-- M6.J all children: BLOCKED until #626 closed
+Apply **hard sequential constraints** derived from issue bodies: any chain expressed as
+"Depends on #N" / "Pending #N" forms a strict order; an EPIC whose body names an open blocker
+is BLOCKED for all its children (re-check the blocker live before skipping).
 
 ---
 
@@ -135,21 +138,21 @@ Apply **hard sequential constraints**:
 Produce output in this format:
 
 ```
-=== M6 Delivery Plan — <date> ===
+=== ${MILESTONE_NAME} Delivery Plan — <date> ===
 
 ## In-progress (skip — running on a machine or session)
   #NNN  <title>  [assignee: <login> | branch: <branch>]
   ...
 
 ## READY — Parallel batch 1 (run simultaneously in separate terminals)
-  Terminal 1:  /m6-issue-generate NNN   # <commit-type>(<scope>): <title>
-  Terminal 2:  /m6-issue-generate NNN   # <commit-type>(<scope>): <title>
-  Terminal 3:  /m6-issue-generate NNN   # <commit-type>(<scope>): <title>
+  Terminal 1:  /issue-deliver NNN   # <commit-type>(<scope>): <title>
+  Terminal 2:  /issue-deliver NNN   # <commit-type>(<scope>): <title>
+  Terminal 3:  /issue-deliver NNN   # <commit-type>(<scope>): <title>
 
   Note: Batch 2 becomes available once Batch 1 issues are closed.
 
 ## READY — Parallel batch 2 (run after batch 1 completes)
-  /m6-issue-generate NNN   # depends on #NNN from batch 1
+  /issue-deliver NNN   # depends on #NNN from batch 1
 
 ## BLOCKED — waiting on dependencies
   #NNN  <title>  [blocked by: #NNN (<title>)]
@@ -159,19 +162,19 @@ Produce output in this format:
   #NNN  <title>  [blocked by: <description of blocker>]
   ...
 
-## Canvas work needed (run before /m6-issue-generate for these EPICs)
-  EPIC #NNN: no canvas → /m6-issue-generate NNN will auto-create it
-  EPIC #NNN: canvas Status: Draft → /m6-issue-generate NNN will auto-align it
+## Canvas work needed (run before /issue-deliver for these EPICs)
+  EPIC #NNN: no canvas → /issue-deliver NNN will auto-create it
+  EPIC #NNN: canvas Status: Draft → /issue-deliver NNN will auto-align it
   ...
 
 ## EPIC completion summary
   EPIC #NNN <title>: N/M stories done (M-N remaining)
   ...
 
-## M6 exit criteria progress
+## ${MILESTONE_NAME} exit criteria progress
   [ ] All K8s EPIC stories merged (Helm ✓/✗, mTLS ✓, supply-chain ✓, ...)
   [ ] v0.5.0 release tag pushed
-  [ ] GitHub milestone "K8s Production-Ready (M6)" closed
+  [ ] GitHub milestone "${GH_MILESTONE}" closed
 ```
 
 ---
@@ -208,34 +211,34 @@ Based on the plan, provide a single clear recommendation:
 - If in-progress count is < 3 and batch 1 has available issues → recommend which terminals to open
 - If all batch 1 is in-progress → "wait for current sessions to complete, or start batch 2 if independent"
 - If no READY issues → report the blocking bottleneck (EPIC, canvas, external decision)
-- If M6 is complete → report exit criteria and recommend tagging v0.5.0
+- If the milestone is complete → report exit criteria and recommend tagging ${MILESTONE_VERSION}
 
 Example output:
 ```
 ## Recommended next action
 Run the following in 3 parallel terminals (all independent):
-  Terminal 1:  /m6-issue-generate 859
-  Terminal 2:  /m6-issue-generate 868
-  Terminal 3:  /m6-issue-generate 874
+  Terminal 1:  /issue-deliver 859
+  Terminal 2:  /issue-deliver 868
+  Terminal 3:  /issue-deliver 874
 
-Then: once #868 closes, run /m6-issue-generate 865 (GHCR hygiene chain).
+Then: once #868 closes, run /issue-deliver 865 (GHCR hygiene chain).
 ```
 
 ---
 
-## Shared-state contract with /m6-issue-generate
+## Shared-state contract with /issue-deliver
 
 | Event | Who updates | What changes |
 |-------|-------------|-------------|
-| Session starts on issue N | `/m6-issue-generate` | Adds `status: in-progress` label + self-assign |
-| Branch pushed (hard claim) | `/m6-issue-generate` | Remote branch `<type>/<N>-*` appears |
-| PR opened | `/m6-issue-generate` | Open PR with headRefName `<type>/<N>-*` |
-| CI completes + PR merged | `/m6-issue-generate` | PR closed, issue closed, branch deleted, label removed |
+| Session starts on issue N | `/issue-deliver` | Adds `status: in-progress` label + self-assign |
+| Branch pushed (hard claim) | `/issue-deliver` | Remote branch `<type>/<N>-*` appears |
+| PR opened | `/issue-deliver` | Open PR with headRefName `<type>/<N>-*` |
+| CI completes + PR merged | `/issue-deliver` | PR closed, issue closed, branch deleted, label removed |
 | Session crashes mid-run | Manual cleanup | Remove `status: in-progress` label; delete stale branch |
 
-`/m6-plan` reads all three signals (label + branch + PR) to detect in-progress work. The **branch**
+`/milestone-plan` reads all three signals (label + branch + PR) to detect in-progress work. The **branch**
 is the authoritative hard claim; the **label** is a soft signal visible before any branch push.
-Because label assignment is not atomic with branch push, `/m6-plan` always cross-checks both.
+Because label assignment is not atomic with branch push, `/milestone-plan` always cross-checks both.
 
 ---
 

--- a/.claude/commands/repo-clean.md
+++ b/.claude/commands/repo-clean.md
@@ -20,7 +20,7 @@ repository — then leave it well-linked and traceable. This is a *truth-pass*, 
 
 > **Rules are not restated.** Domain and contribution rules live in [AGENTS.md](AGENTS.md),
 > [CLAUDE.md](CLAUDE.md), and [docs/git-workflow.md](docs/git-workflow.md). The reconcile logic
-> mirrors [.claude/commands/m6-issue-generate.md](.claude/commands/m6-issue-generate.md) STEP 6.
+> mirrors [.claude/commands/issue-deliver.md](.claude/commands/issue-deliver.md) STEP 6.
 > This file is the *cleanup loop* only.
 
 ---
@@ -36,7 +36,7 @@ repository — then leave it well-linked and traceable. This is a *truth-pass*, 
 - **File changes go through PRs (never `main` directly).** Branch protection requires SSH commit
   signing, DCO `Signed-off-by`, and **squash** merge. A pass produces up to **two** PRs, kept
   separate by concern: (1) the **truth-pass PR** — doc surfaces + `images.yaml`; (2) the
-  **expert-learnings PR** — opened by `/m6-learn --apply` for `.claude/commands/experts/*`. Issue
+  **expert-learnings PR** — opened by `/milestone-learn --apply` for `.claude/commands/experts/*`. Issue
   closes happen directly via `gh` and **reference the truth-pass PR**.
 - **Hard constraints (from [AGENTS.md §Hard Constraints](AGENTS.md#hard-constraints) + repo memory):**
   - Commit type must be `docs:` for a pure doc reconcile, `ci:`/`chore:` if it only touches
@@ -141,13 +141,13 @@ Marker vocabulary: `📅 Planned → 🚧 Active → ✅ Complete` (milestones);
 > `Explore` subagent ("report every milestone/service/canvas marker that disagrees with this live
 > state: <paste STEP 1 summary>") so the main context stays lean. All edits stay in the main agent.
 
-### C. Knowledge drift — synthesize session learnings (`/m6-learn`)
+### C. Knowledge drift — synthesize session learnings (`/milestone-learn`)
 The orchestrate/issue-generate flows append `## Session Learnings` blocks to
 [docs/ai-learnings/*.md](docs/ai-learnings/). A clean snapshot folds those into the expert guides.
 Invoke the synthesizer in its default (human-gated) mode:
 
 ```
-/m6-learn
+/milestone-learn
 ```
 
 It clusters the accumulated learnings, dedupes against existing
@@ -156,7 +156,7 @@ It clusters the accumulated learnings, dedupes against existing
 auto-commits in synthesis mode**. Read back the new PENDING rows and fold their one-line summaries
 into the PLAN (STEP 3) so the human can approve/reject them in the same review.
 
-> **`/m6-learn` owns its own git.** It commits expert-file changes on its own
+> **`/milestone-learn` owns its own git.** It commits expert-file changes on its own
 > `docs/expert-learnings-*` branch and opens a **separate** PR (different files, different concern —
 > expert prompts, not status surfaces). Do **not** fold expert-guide edits into the truth-pass doc
 > PR. Because it manages its own branch, invoke it as a skill against the real checkout, not inside
@@ -239,11 +239,11 @@ Print one traceable plan. Stop here and wait for the human's "go" unless `--exec
 - images/images.yaml  (only if real drift)
 - README.md, ROADMAP.md, ... (list)
 
-### Proposed expert-guide learnings (separate /m6-learn PR)
+### Proposed expert-guide learnings (separate /milestone-learn PR)
 | # | domain | proposed addition | sessions |
 |---|--------|-------------------|----------|
 | .. | ci-release | ... | ... |
-(PENDING in APPLY_LOG.md — human marks applied/rejected before /m6-learn --apply)
+(PENDING in APPLY_LOG.md — human marks applied/rejected before /milestone-learn --apply)
 
 ### Branches to clean (local L / remote R)
 | branch | where | state | action | reason |
@@ -288,7 +288,7 @@ Print one traceable plan. Stop here and wait for the human's "go" unless `--exec
 5. **Apply approved learnings.** For every `APPLY_LOG.md` entry the human marked approved
    (`applied` / `pending-commit`), run:
    ```
-   /m6-learn --apply
+   /milestone-learn --apply
    ```
    This edits the expert guides, marks the log entries `committed`, and opens its **own**
    `docs/expert-learnings-*` PR — kept separate from the truth-pass doc PR. If no entries were
@@ -346,6 +346,6 @@ cd "$REPO" && git worktree remove "$WT" --force 2>/dev/null || true
   --merged` (squash-merge hides merges from ancestry). FLAG unmerged orphans; never auto-delete them.
 - If `make check-images` / `make sync-images` can't run (no Docker), say so and fall back to
   dedup-close only for digest-drift — do not hand-edit digests.
-- One truth-pass = one doc PR + (optionally) one `/m6-learn` PR. These two are separate **by
+- One truth-pass = one doc PR + (optionally) one `/milestone-learn` PR. These two are separate **by
   design** — status surfaces vs. expert prompts. Don't fold either into the other, and don't fold
   unrelated code fixes into either.

--- a/.claude/commands/resume-milestone.md
+++ b/.claude/commands/resume-milestone.md
@@ -1,9 +1,9 @@
 ---
-description: Resume Zynax M6 work — one canvas per EPIC, /spdd-story creates all story issues in GitHub, /spdd-generate implements one O-step at a time, stop after the cluster is merged.
+description: Resume work on the active milestone (state/milestone.yaml) — one canvas per EPIC, /spdd-story creates all story issues in GitHub, /spdd-generate implements one O-step at a time, stop after the cluster is merged.
 argument-hint: "[optional: epic issue number or story issue number to prefer, e.g. 765 766]"
 ---
 
-# Resume M6 — K8s Production-Ready (v0.5.0)
+# Resume Milestone — active milestone from state/milestone.yaml
 
 Pick the next ready EPIC, decompose it into story issues via `/spdd-story`, ship each story as its
 own PR in O-step order, merge them in order, leave every state file consistent, then stop.
@@ -31,7 +31,7 @@ issue). Open all story-PRs in the cluster, enable auto-merge on the first PR, an
 block waiting for CI. The STEP 1.5 merge pass at the start of the *next* session merges green PRs in
 O-step order and enables auto-merge on the next one. `Closes #<story-N>` in the PR body closes the
 story issue automatically on squash-merge. Every PR flips its own story-issue row in
-`docs/milestones/M6-planning.md` and updates `state/current-milestone.md` in its own diff.
+`"$PLANNING_DOC"` and updates `state/current-milestone.md` in its own diff.
 
 ---
 
@@ -58,50 +58,59 @@ story issue automatically on squash-merge. Every PR flips its own story-issue ro
 
 ## STEP 1 — Orient & resume (run first)
 
-**1.1 Sync main**
+**1.1 Sync main + load milestone config**
 ```bash
 git fetch origin --prune && git checkout main && git pull --rebase origin main
 [ "$(git rev-parse main)" = "$(git rev-parse origin/main)" ] || { echo "main diverged — STOP"; exit 1; }
 [ -z "$(git status --porcelain)" ] || { echo "dirty tree — STOP"; git status; exit 1; }
+
+# ── Active-milestone config (SSoT: state/milestone.yaml) ────────────────────
+# Loaded at runtime; no milestone name, number, or label is hardcoded in this
+# file. Updated only by /milestone-close and /milestone-new.
+CFG=state/milestone.yaml
+MILESTONE_NAME=$(awk '/^active:/{f=1} f && /^  name:/{print $2; exit}' "$CFG")
+MILESTONE_TITLE=$(awk -F'"' '/^active:/{f=1} f && /^  title:/{print $2; exit}' "$CFG")
+MILESTONE_NUMBER=$(awk '/^active:/{f=1} f && /^  github_milestone_number:/{print $2; exit}' "$CFG")
+MILESTONE_VERSION=$(awk '/^active:/{f=1} f && /^  version:/{print $2; exit}' "$CFG")
+PLANNING_DOC=$(awk '/^active:/{f=1} f && /^  planning_doc:/{print $2; exit}' "$CFG")
+MILESTONE_LABEL=$(awk -F'"' '/^    milestone:/{print $2; exit}' "$CFG")
+GH_MILESTONE="${MILESTONE_TITLE} (${MILESTONE_NAME})"   # GitHub milestone title
+# ─────────────────────────────────────────────────────────────────────────────
 ```
 
 **1.2 Read** — mandatory every session:
 - `state/current-milestone.md`
-- `docs/milestones/M6-planning.md` (M6 epic/story tables + risk table)
+- `"$PLANNING_DOC"` (epic/story tables + risk table)
 - `CLAUDE.md`
 
 | Read when | File |
 |---|---|
-| Any EPIC touching event-bus | ADR-022 Accepted (#764 closed) — EPIC I (#772) needs canvas via `/spdd-reasons-canvas 772` |
-| Any memory-service work | Confirm single-store choice is in J.2 canvas safeguards |
 | Proto or BDD boundary touched | `protos/AGENTS.md` + `docs/patterns/bdd-contract-testing.md` |
 | Helm chart work | `infra/AGENTS.md` + `docs/patterns/helm-charts.md` |
-| Any ADR-governed decision | `docs/adr/INDEX.md` — ADR-022 (event-bus) Accepted; all 22 ADRs stable |
-| M6.Images SoT work (#855, #856–#862) | `cmd/zynax-ci/AGENTS.md` + `images/images.yaml` (created in O1); O1 is `chore:` (implement directly); O2+O3 are the keystone cluster (`feat:`+`ci:`) |
-| M6.Images GHCR hygiene (#865–#869) | Root cause confirmed: all images have `"annotations": null` on OCI index (no description shown); `unknown/unknown` = SLSA provenance attestation (expected, do NOT disable); deliver #868 ADR-025 first, then #865 annotations, then #866 gate, #867 retention, #869 docs |
-| M6.Build work (#837, #841) | Native arm64 runners; B.1–B.3 story issues must be created from EPIC body before implementing |
-| M6.DevAuto work (#873, #874–#883) | Read `automation/STATUS-AND-DIRECTION.md` first; two-plane model — near-term Waves 0–3 (ci:/chore:/docs:, SPDD-exempt) vs aspirational Wave 4 (#881, BLOCKED on #626 + #772); failing test in #882 gates Wave 4 |
+| Any ADR-governed decision | `docs/adr/INDEX.md` — check the ADR that governs the area before changing it |
+| Image / GHCR / release work | `images/images.yaml` (SoT — ADR-024) + ADR-025 (attestations) + ADR-027 (retag model) |
+| EPIC-specific caveats | The EPIC's row + notes in `"$PLANNING_DOC"` — milestone-specific guidance lives there, never here |
 
 Run `/help` to confirm all SPDD commands are available.
 
-**1.3 Reconcile M6 milestone ⟷ planning doc**
+**1.3 Reconcile GitHub milestone ⟷ planning doc**
 ```bash
-gh issue list --milestone "K8s Production-Ready (M6)" --state open   --limit 200 --json number,title,labels,state
-gh issue list --milestone "K8s Production-Ready (M6)" --state closed --limit 200 --json number,title,labels,state
+gh issue list --milestone "$GH_MILESTONE" --state open   --limit 200 --json number,title,labels,state
+gh issue list --milestone "$GH_MILESTONE" --state closed --limit 200 --json number,title,labels,state
 ```
 Open issue ⇒ ⬜ row; closed issue ⇒ ✅ row. Any mismatch → fix via a dedicated `docs:` branch
 and PR (never a direct commit to `main`):
 ```bash
 git checkout -b docs/milestone-sync-$(date +%Y%m%d)
-# edit M6-planning.md and/or current-milestone.md
-git add docs/milestones/M6-planning.md state/current-milestone.md
-git commit -s -m "docs(milestones): reconcile M6 planning table — <what changed>
+# edit "$PLANNING_DOC" and/or current-milestone.md
+git add "$PLANNING_DOC" state/current-milestone.md
+git commit -s -m "docs(milestones): reconcile ${MILESTONE_NAME} planning table — <what changed>
 
 Assisted-by: Claude/<model>"
 git push -u origin HEAD
-gh pr create --title "docs(milestones): reconcile M6 planning table" \
+gh pr create --title "docs(milestones): reconcile ${MILESTONE_NAME} planning table" \
   --body "Reconcile open/closed issue state with delivery table." \
-  --label "type: docs,milestone: M6"
+  --label "type: docs" --label "$MILESTONE_LABEL"
 gh pr checks <PR> --watch
 git fetch origin main && git rebase origin/main && git push --force-with-lease
 gh pr merge <PR> --squash
@@ -156,27 +165,22 @@ Otherwise pick new work below.
 
 ## STEP 2 — Pick an EPIC
 
-**Priority order** (highest first — but always check blockers first):
+**Priority order** lives in the EPIC table of `"$PLANNING_DOC"` — top-to-bottom table order is
+the priority. Never hardcode EPIC or issue numbers in this command file; the planning doc and
+the live issue bodies are the source of truth.
 
-| Priority | EPIC | Issue | Status gate |
-|---|---|---|---|
-| ✅ | M6.A Health probes | #463 | **COMPLETE** — #487 merged in PR #821 |
-| ✅ | M6.D Stateless compiler | #466 | **COMPLETE** — #490 merged in PR #774 |
-| ✅ | M6.B mTLS | #464 | **COMPLETE** — #488 merged in PR #831 |
-| ✅ | M6.C Supply chain | #465 | **COMPLETE** — #489 merged in PR #833 |
-| 1 | M6.Helm | #765 | canvas `Aligned` `docs/spdd/765-helm-charts/canvas.md`; children #779–#792 |
-| 2 | M6.H Postgres repos | #626 | canvas `Aligned` `docs/spdd/626-postgres-repos/canvas.md`; children #793 #794 |
-| 3 | M6.F Config convergence | #670 | refactor/ci — SPDD-exempt; children #667 #668 #669 |
-| 4 | M6.Images — SoT | #855 | canvas `Aligned` `docs/spdd/855-images-sot/canvas.md`; SoT children: #856–#862 (O1 `chore:` direct; O2+O3 keystone cluster); **GHCR hygiene children: #865–#869 — SPDD-exempt; deliver in order #868 → #865 → #866 → #867 → #869** |
-| 4a | M6.Build | #837 | SPDD-exempt (ci:/chore:); B.1–B.3 story issues not yet created — create from EPIC body; B.4 = #841 (image size audit); goal: zero QEMU, native arm64 runners, Python adapters in release pipeline |
-| 4b | M6.DevAuto | #873 | Near-term waves 0–3 are SPDD-exempt (ci:/chore:/docs:); Wave 4 (#881) is feat: — needs canvas + BLOCKED on #626 + #772; start with DevAuto.1 (#874) → DevAuto.2 (#875) → DevAuto.3 (#876) → Wave 0 (#877); assets in `automation/` only |
-| 5 | M6.NS Multi-namespace | #767 | canvas `Aligned` `docs/spdd/767-multi-namespace/canvas.md`; children #799 #800; D.1 done (#774) |
-| 6 | M6.Argo | #766 | canvas `Aligned` `docs/spdd/766-argo-engine/canvas.md`; children #795–#798 |
-| 7 | M6.SDK PyPI | #769 | canvas `Aligned` `docs/spdd/769-sdk-pypi/canvas.md`; children #805–#808 |
-| 8 | M6.Policy | #768 | canvas `Aligned` `docs/spdd/768-policy-enforcement/canvas.md`; children #801–#804 |
-| 9 | M6.J memory-service | #773 | canvas `Aligned` `docs/spdd/773-memory-service/canvas.md`; children #814–#819; **BLOCKED on #626** |
-| 10 | M6.I event-bus | #772 | ADR-022 Accepted (#764 closed) — no canvas yet; run `/spdd-reasons-canvas 772` first |
-| 11 | M6.G e2e harness | #770 | canvas `Aligned` `docs/spdd/770-e2e-harness/canvas.md`; children #809–#813; BLOCKED on EPIC A + I + J + B |
+```bash
+# Live EPIC list (cross-check against the planning-doc table; this is the
+# runtime truth when the static open_epics hint in state/milestone.yaml is stale)
+gh issue list --milestone "$GH_MILESTONE" --label "type: epic" --state open \
+  --limit 50 --json number,title,labels
+```
+
+For each candidate EPIC, the status gate is determined live:
+- canvas at `docs/spdd/<EPIC_N>-*/canvas.md` with `Status: Aligned` → implementable
+- canvas `Status: Draft` or missing (and EPIC is `feat:`) → STEP 3A first
+- `refactor:/ci:/chore:` EPIC → SPDD-exempt → STEP 3D
+- body names an open blocker ("Depends on #N" / "Pending #N" with #N open) → BLOCKED, skip
 
 **Pre-filter: skip EPICs already claimed by another session**
 
@@ -227,10 +231,10 @@ Review output: verify ADR constraints, tier classification, Tier 2 flags.
 ```
 Canvas is written to `docs/spdd/<EPIC_N>-<slug>/canvas.md` (Status: Draft).
 
-**Canvas must include** for M6 EPICs:
+**Canvas must include** for infra EPICs:
 - **R**: exact K8s DoD (observable outcomes, not just "charts exist")
 - **E**: every new resource type, every gRPC contract touched
-- **A**: what we WILL do and what we WON'T (e.g. "no OTel traces — that is M7")
+- **A**: what we WILL do and what we WON'T (e.g. "no OTel traces — that is a later milestone")
 - **S-Structure**: every file created or modified, K8s resource kind for infra EPICs
 - **O**: one O-step per story PR, each ≤400 lines — number them to match story issue titles
 - **N**: GOWORK=off, DCO+Assisted-by, test coverage gate, liveness threshold env var etc.
@@ -247,7 +251,7 @@ Must PASS before committing. Any Tier 2 findings → move to `canvas.private.md`
 
 Check whether story issues already exist before creating:
 ```bash
-gh issue list --milestone "K8s Production-Ready (M6)" --state all \
+gh issue list --milestone "$GH_MILESTONE" --state all \
   --json number,title,body --jq '.[] | select(.body | test("#<EPIC_N>"))' | head -40
 ```
 
@@ -258,8 +262,8 @@ If stories are missing, run:
 
 `/spdd-story` will create one GitHub issue per O-step. **Each story issue MUST have:**
 - Title: `feat(<scope>): <story-title> (#<EPIC_N>, step <N>)` — conventional-commit form
-- Labels: `type: feature`, `area: <area>`, `milestone: M6`, `size/<S|M|L>`, `spdd: canvas-step`
-- Milestone: `K8s Production-Ready (M6)`
+- Labels: `type: feature`, `area: <area>`, `$MILESTONE_LABEL`, `size/<S|M|L>`, `spdd: canvas-step`
+- Milestone: `$GH_MILESTONE`
 - Body includes:
   - Story (as-a / I-want / so-that)
   - Canvas reference: `docs/spdd/<EPIC_N>-<slug>/canvas.md` O-step N
@@ -269,11 +273,11 @@ If stories are missing, run:
   - Size estimate
   - Dependencies (previous O-step issue, if any)
   - Test plan checklist (see template below)
-  - `Assisted-by: Claude/claude-sonnet-4-6`
+  - `Assisted-by: Claude/<model-id-of-this-session>`
 
 Verify all stories were created:
 ```bash
-gh issue list --label "milestone: M6" --state open --json number,title \
+gh issue list --label "$MILESTONE_LABEL" --state open --json number,title \
   --jq '.[] | select(.title | test("#<EPIC_N>"))'
 ```
 
@@ -281,7 +285,7 @@ gh issue list --label "milestone: M6" --state open --json number,title \
 
 ```bash
 # Find which O-steps are already merged (look for closed story issues)
-gh issue list --label "milestone: M6" --state closed --json number,title,body \
+gh issue list --label "$MILESTONE_LABEL" --state closed --json number,title,body \
   --jq '.[] | select(.body | test("#<EPIC_N>.*step")) | {n:.number,title}'
 
 # Collect all open/draft PR head-refs and remote branches (parallel-session filter)
@@ -292,7 +296,7 @@ CLAIMED=$(printf '%s\n%s\n' \
   | sort -u)
 
 # List open story issues for this EPIC (lowest step number first), skip already-claimed ones
-gh issue list --label "milestone: M6" --state open --json number,title,body \
+gh issue list --label "$MILESTONE_LABEL" --state open --json number,title,body \
   --jq '.[] | select(.body | test("#<EPIC_N>.*step")) | {n:.number,title}' \
   | head -10
 # For each candidate story #N: check if any branch matching <type>/<N>-* is in $CLAIMED
@@ -309,8 +313,8 @@ No canvas required. Implement directly from the issue body. Each story issue sti
 test plan template and labels — create them via:
 ```bash
 gh issue create --title "<type>(<scope>): <title> (#<EPIC_N>, step <N>)" \
-  --label "type: <refactor|ci|chore>,area: <area>,milestone: M6,size/<S|M>" \
-  --milestone "K8s Production-Ready (M6)" \
+  --label "type: <refactor|ci|chore>,area: <area>" --label "$MILESTONE_LABEL" --label "size/<S|M>" \
+  --milestone "$GH_MILESTONE" \
   --body "$(cat <<'EOF'
 ## Context
 Closes the <N>th step of <EPIC_N> (<epic title>).
@@ -332,7 +336,7 @@ Closes the <N>th step of <EPIC_N> (<epic title>).
 
 ## Size estimate: <XS/S/M>
 
-Assisted-by: Claude/claude-sonnet-4-6
+Assisted-by: Claude/<model-id-of-this-session>
 EOF
 )"
 ```
@@ -403,7 +407,7 @@ Capture all output — paste into PR body test plan checkboxes.
 ## STEP 6 — State consistency (per story PR, in its own diff)
 
 Each story PR updates:
-1. `docs/milestones/M6-planning.md` — flip this story's row ⬜→✅; bump "Last updated"
+1. `"$PLANNING_DOC"` — flip this story's row ⬜→✅; bump "Last updated"
 2. `state/current-milestone.md` — update EPIC progress; note if EPIC is now fully done
 3. Epic canvas O-step — mark it ✅; run `/spdd-sync <canvas>` if implementation diverged
 4. `services/<svc>/AGENTS.md` — only if a new gRPC method, K8s resource type, or env var was added
@@ -434,7 +438,7 @@ echo -n "<type>(<scope>): <subject>" | wc -c   # ≤ 72
 gh pr create --base <main|branch-below> \
   --title "<type>(<scope>): <subject>" \
   --assignee "@me" \
-  --label "type: <kind>,milestone: M6,area: <area>" \
+  --label "type: <kind>" --label "$MILESTONE_LABEL" --label "area: <area>" \
   --body-file pr-body-<N>.md
 ```
 
@@ -479,8 +483,8 @@ STEP 1.5 pass will check `mergeStateStatus` and merge when green.
 
 **Post-merge cleanup happens automatically:**
 - Story issue closes via `Closes #<N>` in PR body (squash-merge carries it)
-- `M6-planning.md` row ⬜→✅ is in the PR diff — merged with the code
-- After the merge pass, verify: `grep -nE "#?$STORY\b" docs/milestones/M6-planning.md` — row must be ✅
+- Planning-doc row ⬜→✅ is in the PR diff — merged with the code
+- After the merge pass, verify: `grep -nE "#?$STORY\b" "$PLANNING_DOC"` — row must be ✅
 
 ---
 
@@ -489,7 +493,7 @@ STEP 1.5 pass will check `mergeStateStatus` and merge when green.
 When ALL O-steps of an EPIC are merged:
 ```bash
 # Check all story issues for this EPIC are closed
-gh issue list --label "milestone: M6" --state open --json number,title,body \
+gh issue list --label "$MILESTONE_LABEL" --state open --json number,title,body \
   --jq '.[] | select(.body | test("#<EPIC_N>.*step"))'  # should be empty
 
 # Update epic issue itself
@@ -517,7 +521,7 @@ Mark the EPIC canvas `Status: Implemented` (small docs: commit). Post the sessio
 | EPIC has canvas Aligned but no story issues | STEP 3B: create stories, then STEP 4 |
 | EPIC has no canvas | STEP 3A: full pipeline |
 | EPIC is BLOCKED (#764 for EPIC I, #626 for EPIC J, #626+#772 for DevAuto.8 #881) | Pick next unblocked EPIC |
-| All EPICs exhausted | Report M6 exit-criteria; ask re: milestone close / M7 |
+| All EPICs exhausted | Report milestone exit-criteria; recommend /milestone-close |
 
 ---
 
@@ -559,11 +563,11 @@ Mark the EPIC canvas `Status: Implemented` (small docs: commit). Post the sessio
 - [ ] <criterion mapped to acceptance criteria above>  [evidence: test / file:line / log]
 
 ### Engineering hygiene
-- [ ] **`M6-planning.md` row ⬜→✅ in this diff** (mandatory)
+- [ ] **Planning-doc row ⬜→✅ in this diff** (mandatory)
 - [ ] **`current-milestone.md` updated in this diff** (mandatory)
 - [ ] Canvas O-step <N> marked ✅; `/spdd-sync` run if impl diverged
 - [ ] Branched from fresh `origin/main` · PR ≤900 lines · trailers on every commit
-- [ ] No out-of-scope edits · observability (traces/dashboards) deferred to M7
+- [ ] No out-of-scope edits · observability (traces/dashboards) deferred to a later milestone
 ```
 
 ---
@@ -579,8 +583,8 @@ Mark the EPIC canvas `Status: Implemented` (small docs: commit). Post the sessio
 |---|---|---|---|---|---|
 | #A | <url> | <feat/…> | <S/M> | O-step N | MERGED |
 
-**State files:** M6-planning rows ⬜→✅ <list> · current-milestone <change> · canvas O-steps ✅ <list> · AGENTS.md <svc/N/A>
-**Verify (all ✓ to continue):** story issues CLOSED ✓ · PRs MERGED ✓ · M6-planning lockstep ✓ · no stray PRs/branches, tree clean ✓
+**State files:** planning-doc rows ⬜→✅ <list> · current-milestone <change> · canvas O-steps ✅ <list> · AGENTS.md <svc/N/A>
+**Verify (all ✓ to continue):** story issues CLOSED ✓ · PRs MERGED ✓ · planning-doc lockstep ✓ · no stray PRs/branches, tree clean ✓
 **Blockers:** <list any blocking issues — e.g. "#764 EBUS-DECISION unresolved — EPIC I stays blocked">
 **Repo state:** main HEAD <sha> "<subject>" · my open PRs <list/none> · health <green | red on #PR>
 **Next:** EPIC <#N title> · O-step <N> (#story-issue) · review first: <canvas / issue / N/A>

--- a/state/current-milestone.md
+++ b/state/current-milestone.md
@@ -77,7 +77,7 @@ up but fails at the happy-path assertion; this epic closes the execution-path ga
 | O5 | [#1091](https://github.com/zynax-io/zynax/issues/1091) right-size e2e-smoke runner / pod resources | ci(infra) | S | resources merged (PR #1094); verify on full gate run |
 | O6 | [#1092](https://github.com/zynax-io/zynax/issues/1092) promote gate advisory → stable/required | ci | S | #1090 #1091 #1071 |
 
-**Ready now for `/m6-orchestrate`:** #1089 (O3). Then O4 → O6 (with #1091 verification ∥).
+**Ready now for `/milestone-orchestrate`:** #1089 (O3). Then O4 → O6 (with #1091 verification ∥).
 
 ## Recently Closed (last updated 2026-06-09)
 


### PR DESCRIPTION
## Summary

Generalizes the delivery tooling to be milestone-agnostic (spec §0B of
`docs/contributing/ci-delivery-overhaul-prompt.md`). Every delivery command now loads the
active milestone's name, GitHub number, label, version, and planning doc from
`state/milestone.yaml` (merged in #1127) at runtime. Closing M6 and opening the next
milestone becomes `/milestone-close` + `/milestone-new` — no command-file migration.

## EPIC canvas

N/A — SPDD-exempt (`chore:`). Part of #1108 (Part 0 of #1107).

## What changed

| Old | New |
|-----|-----|
| `m6-plan.md` | `milestone-plan.md` — priority from planning-doc EPIC table, no hardcoded issue numbers |
| `m6-orchestrate.md` | `milestone-orchestrate.md` |
| `m6-issue-generate.md` | `issue-deliver.md` — + injects milestone label on spdd-story output (locked decision #1107); + **foreground-only CI wait** rule (fixes the 6-of-7 stranded-agent failure observed 2026-06-11); + UNSTABLE-is-mergeable note |
| `resume-m6.md` | `resume-milestone.md` — M6 EPIC priority table replaced by live planning-doc/`gh` lookup |
| `m6-learn.md` | `milestone-learn.md` (decided in-PR: renamed here rather than separately, so the `m6-*` namespace is fully retired) |
| *(new)* | `milestone-close.md` — verify EPICs closed → truth-pass → signed tag → Release → rotate active→history |
| *(new)* | `milestone-new.md` — GitHub milestone + planning-doc skeleton + active block |

Also: stale `m6-*` cross-references fixed in `repo-clean.md` and `experts/go-services.md`;
live-guidance mention in `state/current-milestone.md` updated (historical log entries about
`/resume-m6` left intact). `.claude/settings.json` contains no skill registrations — verified,
nothing to update there.

## Acceptance criteria

- [x] `grep -rE '\bM[0-9]\b'` over all seven new/renamed command files → **0 matches** [verified pre-commit]
- [x] No file under `.claude/commands/` matches `m6-*`; `grep -rn "m6-" .claude/` → 0 [verified]
- [x] Commands source milestone identity exclusively from `state/milestone.yaml` (prelude in every file)
- [x] New files staged with `git add -f`; no literal emails added (gitleaks PII gate) [verified pre-commit]

## Test plan

- [x] Pre-commit hooks pass (secrets scan) [commit output]
- [x] Config prelude parses the real `state/milestone.yaml`: awk extraction verified against the merged file from #1127
- [x] (N/A) Go/Python/BDD — no code paths touched; `.claude/` is PR-size-exempt

Assisted-by: Claude/claude-fable-5
