### PR TITLE
ci: pre-merge build-images gate — staging lane, Hadolint, Trivy, SBOM

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -64,6 +64,8 @@ infra/k8s/
 !services/workflow-compiler/
 !services/task-broker/
 !services/agent-registry/
+!services/event-bus/
+!services/memory-service/
 
 # ── Adapter build allowlist (negations for agents/adapters/*/Dockerfile) ──────
 # Adapter Dockerfiles are built from repo root and need their module source

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,11 @@
 #                │                  test-python ─┴──→ test-unit (wrapper, required check)
 #                └─ lint-python    (parallel; code=false skips both)
 #   dco → security  (independent)
+#   dco → changes → lint-go → build-images  (pre-merge image gate — ADR-027, #1118;
+#                                            PRs only, when docker == 'true')
 #
 # When adding a service/adapter/agent update SERVICE_LIST, GO_ADAPTER_LIST,
-# or AGENT_LIST — no other changes required.
+# AGENT_LIST — and the build-images matrix if it ships as a container image.
 
 name: CI
 
@@ -122,6 +124,7 @@ jobs:
       cli:              ${{ steps.detect.outputs.cli              == 'true' || steps.force-detect.outputs.force == 'true' }}
       adapters_go:      ${{ steps.detect.outputs.adapters_go      == 'true' || steps.force-detect.outputs.force == 'true' }}
       adapters_python:  ${{ steps.detect.outputs.adapters_python  == 'true' || steps.force-detect.outputs.force == 'true' }}
+      docker:           ${{ steps.detect.outputs.docker           == 'true' || steps.force-detect.outputs.force == 'true' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -165,7 +168,7 @@ jobs:
               echo "code=true"; echo "proto=true"; echo "go=true"; echo "python=true"
               echo "engine_adapter=true"; echo "workflow_compiler=true"; echo "api_gateway=true"
               echo "task_broker=true"; echo "agent_registry=true"; echo "cli=true"
-              echo "adapters_go=true"; echo "adapters_python=true"
+              echo "adapters_go=true"; echo "adapters_python=true"; echo "docker=true"
             } >> "$GITHUB_OUTPUT"
             echo "ℹ️  Unknown event '${{ github.event_name }}' — all lanes enabled."
             exit 0
@@ -177,7 +180,7 @@ jobs:
               echo "code=true"; echo "proto=true"; echo "go=true"; echo "python=true"
               echo "engine_adapter=true"; echo "workflow_compiler=true"; echo "api_gateway=true"
               echo "task_broker=true"; echo "agent_registry=true"; echo "cli=true"
-              echo "adapters_go=true"; echo "adapters_python=true"
+              echo "adapters_go=true"; echo "adapters_python=true"; echo "docker=true"
             } >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -185,12 +188,17 @@ jobs:
           code=false proto=false go=false python=false
           engine_adapter=false workflow_compiler=false api_gateway=false
           task_broker=false agent_registry=false cli=false
-          adapters_go=false adapters_python=false
+          adapters_go=false adapters_python=false docker=false
 
           while IFS= read -r f; do
             [ -z "$f" ] && continue
             if echo "$f" | grep -qE '^(services/|agents/|cmd/|protos/|go\.work(\.sum)?$)'; then
               code=true
+            fi
+            # docker: any path that ends up inside a container image (#1118 / ADR-027).
+            # Locked matrix strategy: ALL images build when ANY of these change.
+            if echo "$f" | grep -qE '^(services/|infra/docker/Dockerfile\.|agents/adapters/[^/]+/Dockerfile$)'; then
+              docker=true
             fi
             if echo "$f" | grep -qE '^(protos/|spec/|CLAUDE\.md|AGENTS\.md|.*/AGENTS\.md|docs/ai-assistant-setup\.md|\.ai/|\.claude/)'; then
               proto=true
@@ -225,8 +233,9 @@ jobs:
             echo "api_gateway=$api_gateway"; echo "task_broker=$task_broker"
             echo "agent_registry=$agent_registry"; echo "cli=$cli"
             echo "adapters_go=$adapters_go"; echo "adapters_python=$adapters_python"
+            echo "docker=$docker"
           } >> "$GITHUB_OUTPUT"
-          echo "── code=$code  proto=$proto  go=$go  python=$python"
+          echo "── code=$code  proto=$proto  go=$go  python=$python  docker=$docker"
           echo "── engine-adapter=$engine_adapter  workflow-compiler=$workflow_compiler  api-gateway=$api_gateway  task-broker=$task_broker  agent-registry=$agent_registry  cli=$cli  adapters-go=$adapters_go  adapters-python=$adapters_python"
 
 # ── Lint: Proto, AI context scan, spec validation ─────────────────────────────
@@ -698,3 +707,141 @@ jobs:
         run: |
           echo "ℹ️  No Go or Python source found — govulncheck and bandit skipped."
           echo "   trivy dependency and config scans above always run."
+
+# ── Pre-merge image build + scan (shift-left gate — ADR-027, #1118) ───────────
+# Builds every container image ONCE, pre-merge, pushes it to the public GHCR
+# staging lane (staging/<svc>:pr-<head-sha>), then gates the PR on:
+#   Hadolint (Dockerfile lint) → Trivy CRITICAL,HIGH (exit-code 1, .trivyignore
+#   honored) → SARIF to the Security tab → CycloneDX SBOM artifact (30 days).
+# On merge the staging image is RETAGGED, never rebuilt (#1120) — the image in
+# production is the exact binary that passed this gate.
+#
+# Locked matrix strategy (#1118): ALL images build when ANY docker-relevant path
+# changes (a base-image or shared-template change affects every image); the
+# whole matrix is skipped otherwise. Tag uses the PR HEAD sha (not the synthetic
+# merge sha) so the retag job can recover it from workflow_run.head_sha (ADR-027)
+# and e2e-smoke can derive it from the PR context.
+# provenance default kept (SLSA Build L1 — ADR-025): do not set provenance:false.
+  build-images:
+    name: "Build + scan: ${{ matrix.service }}"
+    runs-on: ubuntu-24.04
+    needs: [changes, lint-go]
+    if: >-
+      always() &&
+      needs.changes.result == 'success' &&
+      needs.changes.outputs.docker == 'true' &&
+      needs.lint-go.result != 'failure' &&
+      (github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch')
+    permissions:
+      contents: read
+      packages: write          # pushes staging-lane images to GHCR
+      security-events: write   # uploads trivy SARIF to the GitHub Security tab
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Go services — shared template infra/docker/Dockerfile.service (#668)
+          - { service: api-gateway }
+          - { service: engine-adapter }
+          - { service: workflow-compiler }
+          - { service: task-broker }
+          - { service: agent-registry }
+          - { service: event-bus }
+          - { service: memory-service }
+          # Adapters — per-adapter Dockerfiles (same model — spec Q3C locked)
+          - { service: http-adapter,      dockerfile: agents/adapters/http/Dockerfile }
+          - { service: llm-adapter,       dockerfile: agents/adapters/llm/Dockerfile }
+          - { service: langgraph-adapter, dockerfile: agents/adapters/langgraph/Dockerfile }
+          - { service: ci-adapter,        dockerfile: agents/adapters/ci/Dockerfile }
+          - { service: git-adapter,       dockerfile: agents/adapters/git/Dockerfile }
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Resolve staging image ref
+        id: ref
+        run: |
+          HEAD_SHA="${{ github.event.pull_request.head.sha || github.sha }}"
+          echo "image=ghcr.io/zynax-io/zynax/staging/${{ matrix.service }}:pr-${HEAD_SHA}" >> "$GITHUB_OUTPUT"
+          echo "head_sha=${HEAD_SHA}" >> "$GITHUB_OUTPUT"
+
+      # failure-threshold starts at `error`: the Go template + 3 Go adapters carry
+      # pre-existing DL3003 warnings (RUN cd → WORKDIR). Promote to `warning`
+      # once those are cleaned up.
+      - name: Hadolint — Dockerfile lint
+        uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5 # v3.3.0
+        with:
+          dockerfile: ${{ matrix.dockerfile || 'infra/docker/Dockerfile.service' }}
+          failure-threshold: error
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Log in to GHCR
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # cache scope matches release.yml's amd64 build so PR builds reuse the
+      # layer cache populated on main (same Dockerfile, same context).
+      - name: Build and push to staging lane
+        id: build
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          context: .
+          file: ${{ matrix.dockerfile || 'infra/docker/Dockerfile.service' }}
+          build-args: SVC=${{ matrix.service }}
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.ref.outputs.image }}
+          labels: |
+            org.opencontainers.image.revision=${{ steps.ref.outputs.head_sha }}
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+          cache-from: type=gha,scope=${{ matrix.service }}-amd64
+          cache-to: type=gha,scope=${{ matrix.service }}-amd64,mode=max
+
+      - name: Trivy scan (CRITICAL,HIGH = fail)
+        id: trivy
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        env:
+          # Same DB pin + severity-source policy as release.yml (#1022).
+          # renovate: datasource=docker depName=ghcr.io/aquasecurity/trivy-db
+          TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db:2@sha256:225c785a3ce630d8f8b75ab23f4d7b0b1402f94a54dfe6441e6711c7deb8dec8
+          TRIVY_VULN_SEVERITY_SOURCE: nvd,ghsa
+        with:
+          image-ref: ${{ steps.ref.outputs.image }}
+          version: v0.71.0
+          format: sarif
+          output: trivy-staging-${{ matrix.service }}.sarif
+          severity: CRITICAL,HIGH
+          exit-code: 1
+          ignore-unfixed: false
+          trivyignores: .trivyignore
+
+      # Upload even on a failed scan so findings are visible in the Security tab.
+      - name: Upload Trivy SARIF to GitHub Security tab
+        if: always() && steps.trivy.outcome != 'skipped'
+        uses: github/codeql-action/upload-sarif@03e4368ac7daa2bd82b3e85262f3bf87ee112f57 # v3.36.0
+        with:
+          sarif_file: trivy-staging-${{ matrix.service }}.sarif
+          category: staging-${{ matrix.service }}
+
+      # SBOM from the pushed staging image — generated even when Trivy fails so
+      # the inventory of a blocked PR is still auditable.
+      - name: Generate SBOM (CycloneDX JSON)
+        if: always() && steps.build.outcome == 'success'
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          image: ${{ steps.ref.outputs.image }}
+          format: cyclonedx-json
+          output-file: sbom-${{ matrix.service }}.json
+          upload-artifact: false
+
+      - name: Upload SBOM artifact
+        if: always() && steps.build.outcome == 'success'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: sbom-${{ matrix.service }}-${{ steps.ref.outputs.head_sha }}
+          path: sbom-${{ matrix.service }}.json
+          retention-days: 30

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -11,6 +11,13 @@
 # deliberately excluded from the branch-protection required-check set — only
 # developers landing infra/service changes need to watch it.
 #
+# Image lane (#1118 / ADR-027): when the PR touches docker-relevant paths, the
+# pre-merge build-images job in ci.yml pushes staging/<svc>:pr-<head-sha> images;
+# this workflow waits for them and deploys THOSE (the exact binaries under
+# review) instead of the :main lane. PRs with no docker changes — and runs where
+# the staging images never appear (build-images failed, or the staging packages
+# are not public yet) — fall back to :main with a warning.
+#
 # All third-party Actions are pinned to a full 40-char commit SHA.
 
 name: e2e smoke
@@ -45,6 +52,38 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0   # lane resolution diffs base...head
+
+      - name: Resolve service image lane (staging when this PR built images)
+        if: github.event_name == 'pull_request'
+        run: |
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          # Same docker-relevance pattern as the `changes` job in ci.yml — keep in sync.
+          if ! git diff --name-only "${BASE_SHA}...${HEAD_SHA}" \
+               | grep -qE '^(services/|infra/docker/Dockerfile\.|agents/adapters/[^/]+/Dockerfile$)'; then
+            echo "No docker-relevant changes — deploying the :main image lane."
+            exit 0
+          fi
+          echo "Docker-relevant changes — waiting for staging images (pr-${HEAD_SHA})…"
+          DEADLINE=$(( $(date +%s) + 1200 ))   # build-images runs in parallel in ci.yml
+          for svc in api-gateway workflow-compiler engine-adapter task-broker agent-registry; do
+            IMG="ghcr.io/zynax-io/zynax/staging/${svc}:pr-${HEAD_SHA}"
+            until docker manifest inspect "${IMG}" >/dev/null 2>&1; do
+              if [ "$(date +%s)" -ge "${DEADLINE}" ]; then
+                echo "::warning::staging image ${IMG} did not appear — falling back to the :main lane. Check the build-images job and that the staging packages are public."
+                exit 0
+              fi
+              sleep 20
+            done
+            echo "  ✓ ${IMG}"
+          done
+          {
+            echo "E2E_IMAGE_PREFIX=ghcr.io/zynax-io/zynax/staging"
+            echo "E2E_IMAGE_TAG=pr-${HEAD_SHA}"
+          } >> "$GITHUB_ENV"
+          echo "All staging images present — deploying the staging lane."
 
       - name: Install kind + kubectl + Helm
         # The e2e scripts own cluster bootstrap (cluster-up.sh creates the kind

--- a/scripts/e2e/cluster-up.sh
+++ b/scripts/e2e/cluster-up.sh
@@ -20,6 +20,12 @@
 #   CERT_MANAGER_VERSION  cert-manager release tag    (default: v1.14.5)
 #   KIND_NODE_IMAGE       kind node image (digest-pinnable)
 #   WAIT_TIMEOUT          per-resource rollout wait   (default: 600s)
+#   E2E_IMAGE_TAG         service image tag override — set by e2e-smoke.yml to
+#                         pr-<head-sha> so the cluster runs the exact staging
+#                         images built pre-merge (#1118 / ADR-027). Unset =
+#                         values-e2e.yaml default (:main lane).
+#   E2E_IMAGE_PREFIX      registry prefix for E2E_IMAGE_TAG
+#                         (default: ghcr.io/zynax-io/zynax/staging)
 #
 # Minimum host resources: 4 CPU, 8 GB RAM (see scripts/e2e/README.md).
 
@@ -163,6 +169,20 @@ log "deploying zynax-umbrella as release '${RELEASE_NAME}' in namespace '${NAMES
 # the release shape is identical across revisions): service image tags pinned to
 # `main`, event-bus/memory-service disabled (no image yet), and the Postgres /
 # Temporal credential wiring.
+# E2E_IMAGE_TAG (set by e2e-smoke.yml for docker-touching PRs) repoints the 5
+# deployed services at the pre-merge staging lane — helm-upgrade.sh applies the
+# same overrides so the release shape stays identical across revisions.
+IMAGE_OVERRIDES=()
+if [[ -n "${E2E_IMAGE_TAG:-}" ]]; then
+  E2E_IMAGE_PREFIX="${E2E_IMAGE_PREFIX:-ghcr.io/zynax-io/zynax/staging}"
+  log "service image lane override: ${E2E_IMAGE_PREFIX}/<svc>:${E2E_IMAGE_TAG}"
+  for svc in api-gateway workflow-compiler engine-adapter task-broker agent-registry; do
+    IMAGE_OVERRIDES+=(
+      --set "zynax-${svc}.image.repository=${E2E_IMAGE_PREFIX}/${svc}"
+      --set "zynax-${svc}.image.tag=${E2E_IMAGE_TAG}"
+    )
+  done
+fi
 # NOTE: no --wait here. engine-adapter cannot become Ready until the Temporal
 # `default` namespace is registered (step 3.5), and a Helm --wait would deadlock
 # waiting on it. Readiness is asserted explicitly by the rollout loop in step 4.
@@ -170,7 +190,8 @@ helm upgrade --install "${RELEASE_NAME}" "${UMBRELLA_CHART}" \
   --namespace "${NAMESPACE}" \
   --create-namespace \
   -f "${SCRIPT_DIR}/values-e2e.yaml" \
-  --set zynax-cert-manager.enabled=true
+  --set zynax-cert-manager.enabled=true \
+  "${IMAGE_OVERRIDES[@]}"
 
 # ── 3.5 register the Temporal 'default' namespace ────────────────────────────────
 

--- a/scripts/e2e/helm-upgrade.sh
+++ b/scripts/e2e/helm-upgrade.sh
@@ -69,6 +69,17 @@ HELM_SET_FLAGS=(
   -f "${SCRIPT_DIR}/values-e2e.yaml"
   --set zynax-cert-manager.enabled=true
 )
+# Staging-lane override (#1118 / ADR-027) — mirrors cluster-up.sh so the upgrade
+# and rollback exercise the SAME images the install deployed.
+if [[ -n "${E2E_IMAGE_TAG:-}" ]]; then
+  E2E_IMAGE_PREFIX="${E2E_IMAGE_PREFIX:-ghcr.io/zynax-io/zynax/staging}"
+  for svc in api-gateway workflow-compiler engine-adapter task-broker agent-registry; do
+    HELM_SET_FLAGS+=(
+      --set "zynax-${svc}.image.repository=${E2E_IMAGE_PREFIX}/${svc}"
+      --set "zynax-${svc}.image.tag=${E2E_IMAGE_TAG}"
+    )
+  done
+fi
 
 # ── helpers ──────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Implements spec §3A of the shift-left pipeline (ADR-027): a pre-merge `build-images` matrix job in `ci.yml` builds every container image once — 7 Go services + 5 adapters — pushes it to the public GHCR staging lane (`staging/<svc>:pr-<head-sha>`), and gates the PR on Hadolint → Trivy (`CRITICAL,HIGH`, `exit-code: 1`, `.trivyignore` honored) → SARIF upload → CycloneDX SBOM artifact (30-day retention). `e2e-smoke.yml` now deploys the staging-lane images for docker-touching PRs instead of `:main`, so the cluster runs the exact binaries under review.

## EPIC canvas

N/A — `ci:` issue, SPDD-exempt. Governing decision record: `docs/adr/ADR-027-shift-left-pipeline.md` (Accepted). Part of #1109 (Part 3 of #1107).

## Acceptance criteria

- [x] PR touching docker-relevant paths runs build+scan for the full matrix; docs-only PR skips it — `docker` change-detection flag (`services/`, `infra/docker/Dockerfile.*`, `agents/adapters/*/Dockerfile`); locked strategy: all 12 legs build on any hit, matrix skipped otherwise. *This PR itself touches no docker path, so `build-images` is correctly skipped here* — first live run happens on the next docker-touching PR (or via `workflow_dispatch` with `force=true`).
- [x] PR with an injected HIGH CVE fails Trivy and cannot merge — `exit-code: 1`, `severity: CRITICAL,HIGH`, `ignore-unfixed: false`, same pinned trivy-db + `nvd,ghsa` severity-source policy as release.yml (#1022). Becomes merge-blocking once branch protection is updated (below). Injected-CVE drill to be run on the first docker-touching PR after landing.
- [x] Trivy findings visible in the GitHub Security tab (SARIF category `staging-<svc>`, uploaded `if: always()`); SBOM artifact downloadable (`sbom-<svc>-<head-sha>`, 30-day retention).
- [x] e2e-smoke pulls `staging/<svc>:pr-<head-sha>` and no longer deploys stale `:main` for docker-touching PRs — lane-resolution step waits up to 20 min for the staging images, falls back to `:main` with a warning if they never appear (bootstrap-safe). `cluster-up.sh` and `helm-upgrade.sh` take the same `E2E_IMAGE_PREFIX`/`E2E_IMAGE_TAG` overrides so the release shape is identical across install/upgrade/rollback.

## Test plan

### Local verification
- [x] `bash -n` on both e2e scripts — exit 0
- [x] YAML parse of both workflows — OK
- [x] `actionlint` on `ci.yml` + `e2e-smoke.yml` — no new findings (the single SC2034 shellcheck warning is pre-existing on main, line-shifted only)
- [x] `hadolint --failure-threshold error` against all 6 Dockerfiles the matrix lints — exit 0 for all (at `warning` it fails 4/6 on pre-existing DL3003 `RUN cd` patterns, hence the job starts at `error` with a comment to promote once DL3003 is cleaned)
- [x] `docker build -f infra/docker/Dockerfile.service --build-arg SVC=event-bus .` — **OK** (first-ever build of this image; required the `.dockerignore` allowlist fix in this PR)
- [x] `docker build -f infra/docker/Dockerfile.service --build-arg SVC=memory-service .` — **OK**

### Build & unit / lint & security
- [x] No Go/Python/proto sources touched — `lint-go`/`lint-python`/`test-unit` lanes skip by change detection; `security` (trivy fs + config) runs in CI on this PR

### Contract
- [x] N/A — no gRPC boundary touched

### Engineering hygiene
- [x] Planning-doc / current-milestone rows: N/A — the #1110–#1122 spec stories are tracked in `docs/contributing/ci-delivery-overhaul-prompt.md` + GitHub, not in `M6-planning.md` (verified; no row exists to flip)
- [x] Branched off fresh `origin/main` · counted PR size ≈36 lines (workflows excluded) · DCO + `Assisted-by` trailers

## Post-merge actions (manual, documented per issue scope)

1. **Branch protection** — add each matrix leg to `required_status_checks` once the job has run green at least once:
   ```
   Build + scan: api-gateway · engine-adapter · workflow-compiler · task-broker ·
   agent-registry · event-bus · memory-service · http-adapter · llm-adapter ·
   langgraph-adapter · ci-adapter · git-adapter
   ```
   (Use repo Settings → Branches, or `gh api -X PATCH repos/zynax-io/zynax/branches/main/protection/required_status_checks` adding the 12 contexts.) ⚠ Note: because `build-images` is path-gated, making it *required* will block non-docker PRs unless GitHub's "required if reported" semantics are acceptable — recommend requiring it only after #1120 lands and the team has observed a few runs.
2. **Staging package visibility** — after the first docker-touching PR pushes the staging packages, set each `staging/<svc>` GHCR package **public** (locked decision #1107 Q1). Until then, e2e's staging-lane wait will warn and fall back to `:main`.
3. **Injected-CVE drill** (AC2) — on a throwaway PR, add a deliberately vulnerable layer to one Dockerfile, confirm the Trivy leg fails, then close the PR.

## Notes for reviewers

- `services/event-bus/Dockerfile` is stale (predates `libs/zynaxobs`; doesn't copy it, so it cannot build). The matrix deliberately uses the shared template `infra/docker/Dockerfile.service` for all 7 Go services — the stale file can be removed in a follow-up.
- This supersedes the build half of #1089 (event-bus + memory-service are already in this matrix); #1121 (spec Part 4) reconciles that issue.
- `id-token: write` was *not* granted to `build-images`: no cosign step exists in this job (signing happens at promotion, #1120) — least privilege per P12.
