### PR TITLE
ci: pr-image-cleanup workflow — delete staging images on PR close

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -739,6 +739,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Keep in sync with the cleanup matrix in pr-image-cleanup.yml (#1119) —
+        # every service pushed to the staging lane must be deleted on PR close.
         include:
           # Go services — shared template infra/docker/Dockerfile.service (#668)
           - { service: api-gateway }

--- a/.github/workflows/pr-image-cleanup.yml
+++ b/.github/workflows/pr-image-cleanup.yml
@@ -1,0 +1,91 @@
+# SPDX-License-Identifier: Apache-2.0
+# PR image cleanup — delete staging-lane images when a PR closes (#1119, ADR-027).
+#
+# The pre-merge build-images job in ci.yml pushes staging/<svc>:pr-<head-sha>
+# images to GHCR for every docker-relevant PR. Without cleanup that lane grows
+# unbounded. This workflow fires on PR close — merged AND abandoned — and
+# deletes the package versions tagged with the closed PR's head SHA, keeping
+# GHCR storage bounded with zero manual hygiene.
+#
+# A PR that never built staging images (e.g. docs-only) simply finds no
+# matching version and exits 0 — fail-fast is off and a missing package or
+# version is never an error.
+#
+# Tag-targeted deletion uses the GitHub REST API directly via the runner's
+# preinstalled `gh` CLI: actions/delete-package-versions cannot select a
+# container version by tag (long-open upstream request), so the version id
+# must be resolved through the API either way — doing the DELETE with the
+# same API keeps third-party action surface at zero (supply chain, #1116).
+#
+# Ordering vs the retag model (§3C, #1120): as of #1119 nothing post-merge
+# consumes the staging image (release.yml builds from scratch), so deleting on
+# close is unconditionally safe. When #1120 converts release.yml to retag the
+# staging manifest into the production package, the retag job MUST tolerate or
+# precede this cleanup — retagging copies the manifest into a DIFFERENT GHCR
+# package (zynax/<svc>, not zynax/staging/<svc>), so once promoted the staging
+# version is dead weight; #1120 must sequence its retag before this delete
+# (e.g. workflow_run chaining) or re-trigger the build. Tracked on #1120.
+
+name: PR Image Cleanup
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  packages: write
+
+concurrency:
+  group: pr-image-cleanup-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  cleanup:
+    name: "Delete staging: ${{ matrix.service }}"
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        # Keep in sync with the build-images matrix in ci.yml (#1118) — every
+        # service that pushes to the staging lane must be cleaned up here.
+        service:
+          - api-gateway
+          - engine-adapter
+          - workflow-compiler
+          - task-broker
+          - agent-registry
+          - event-bus
+          - memory-service
+          - http-adapter
+          - llm-adapter
+          - langgraph-adapter
+          - ci-adapter
+          - git-adapter
+    steps:
+      - name: Delete staging package version for pr-<head-sha>
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          SERVICE: ${{ matrix.service }}
+          OWNER: ${{ github.repository_owner }}
+        run: |
+          set -euo pipefail
+          TAG="pr-${HEAD_SHA}"
+          PKG="zynax%2Fstaging%2F${SERVICE}"
+
+          # 404 (package never created — service never built on any PR) is a
+          # quiet no-op, same as a docs-only PR that built nothing.
+          IDS=$(gh api --paginate "/orgs/${OWNER}/packages/container/${PKG}/versions" \
+            --jq ".[] | select(.metadata.container.tags[]? == \"${TAG}\") | .id" \
+            2>/dev/null || true)
+
+          if [ -z "${IDS}" ]; then
+            echo "No staging version tagged ${TAG} for ${SERVICE} — nothing to delete."
+            exit 0
+          fi
+
+          for ID in ${IDS}; do
+            gh api --method DELETE \
+              "/orgs/${OWNER}/packages/container/${PKG}/versions/${ID}"
+            echo "Deleted staging/${SERVICE} version ${ID} (tag ${TAG})."
+          done


### PR DESCRIPTION
## Summary

Implements spec §3B of the shift-left pipeline (ADR-027, part of #1109 / Part 3 of #1107): a new
`pr-image-cleanup.yml` fires on PR close — merged AND abandoned — and deletes the
`staging/<svc>:pr-<head-sha>` GHCR package versions for all 12 services (7 Go + 5 adapters),
keeping the staging lane pushed by `build-images` (#1118) bounded with zero manual hygiene.

## EPIC canvas

N/A — `ci:` issue, SPDD-exempt. Governing decision record:
`docs/adr/ADR-027-shift-left-pipeline.md`. Spec: `docs/contributing/ci-delivery-overhaul-prompt.md` §3B.

## Deviation from issue scope (documented)

The issue prescribed `actions/delete-package-versions` (SHA-pinned). That action **cannot select a
container version by its tag** (long-open upstream request) — the version id must be resolved
through the REST API regardless. The workflow therefore does both resolve and DELETE with the
runner's preinstalled `gh` CLI: same capability, zero third-party action surface (supply-chain
posture of #1116 — nothing new to SHA-pin).

## Acceptance criteria

- [x] Closing a PR that built staging images removes its `pr-<sha>` versions within minutes —
      `pull_request: [closed]` trigger, per-service matrix resolves the version id by tag and
      DELETEs it [evidence: jq tag-selection validated against live GHCR version metadata
      (`.metadata.container.tags`) on `zynax/api-gateway`]
- [x] Closing a docs-only PR (no staging images) succeeds quietly — `fail-fast: false`; 404
      (package never created) and no-matching-tag both exit 0 with a log line [evidence: live
      404 path exercised — `zynax/staging/*` packages don't exist yet; workflow treats it as
      a no-op]
- [x] Retag-to-main (§3C) is unaffected — **verified by ordering analysis:** #1120 is still open;
      `release.yml` today builds from scratch on push to main and never consumes the staging
      image, so deletion on close cannot break promotion. The ordering contract for when #1120
      lands (retag must precede cleanup, or re-trigger the build) is documented in the workflow
      header and will be flagged on #1120.

## Test plan

### Build & unit
- N/A — workflow-only change; no Go/Python source touched.

### Lint & security
- [x] `actionlint -color` (same ci-runner image as the `pr-checks` gate) — exit 0, no findings
- [x] gitleaks pre-commit hook — passed on commit
- [x] No new third-party actions introduced (nothing to SHA-pin); `permissions: packages: write` only

### Contract
- N/A — no gRPC boundary touched.

### Engineering hygiene
- [x] Planning-doc / current-milestone: N/A — the shift-left EPIC (#1107–#1109) is tracked on
      GitHub issues + spec doc only, same as precedent PR #1132 (#1118); `state/current-milestone.md`
      is marked "do not edit by hand" (owned by `/repo-clean`)
- [x] `ci.yml` build-images matrix and cleanup matrix carry reciprocal keep-in-sync comments
- [x] Branched off fresh `origin/main` · 93 lines added · DCO + `Assisted-by` trailers on the commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)
