### PR TITLE
fix(ci): pr-image-cleanup — treat 404 as no-op, not as version ids

### DIFF
--- a/.github/workflows/pr-image-cleanup.yml
+++ b/.github/workflows/pr-image-cleanup.yml
@@ -74,10 +74,13 @@ jobs:
           PKG="zynax%2Fstaging%2F${SERVICE}"
 
           # 404 (package never created — service never built on any PR) is a
-          # quiet no-op, same as a docs-only PR that built nothing.
+          # quiet no-op, same as a docs-only PR that built nothing. On a non-2xx
+          # response gh api exits non-zero but still prints the JSON error body
+          # to stdout, so reset IDS on failure — an `|| true` INSIDE the
+          # substitution would keep that body and feed garbage to the loop.
           IDS=$(gh api --paginate "/orgs/${OWNER}/packages/container/${PKG}/versions" \
             --jq ".[] | select(.metadata.container.tags[]? == \"${TAG}\") | .id" \
-            2>/dev/null || true)
+            2>/dev/null) || IDS=""
 
           if [ -z "${IDS}" ]; then
             echo "No staging version tagged ${TAG} for ${SERVICE} — nothing to delete."
@@ -85,6 +88,11 @@ jobs:
           fi
 
           for ID in ${IDS}; do
+            # Belt and braces: only numeric version ids reach the DELETE call.
+            if ! [[ "${ID}" =~ ^[0-9]+$ ]]; then
+              echo "Skipping non-numeric version id token: ${ID}"
+              continue
+            fi
             gh api --method DELETE \
               "/orgs/${OWNER}/packages/container/${PKG}/versions/${ID}"
             echo "Deleted staging/${SERVICE} version ${ID} (tag ${TAG})."


### PR DESCRIPTION
## Summary

The first run of `pr-image-cleanup.yml` — triggered by closing PR #1133 itself — failed on all
12 matrix legs ([run 27335139436](https://github.com/zynax-io/zynax/actions/runs/27335139436)).
Root cause: on a 404 (staging package doesn't exist yet — true for every service today),
`gh api` exits non-zero **but still prints the JSON error body to stdout**. The `|| true` inside
the command substitution suppressed the exit code while keeping that body in `IDS`, so the
script looped over JSON tokens and issued a DELETE against a garbage version id → exit 1.

## Fix

- Move the fallback outside the substitution: `IDS=$(gh api …) || IDS=""` — on failure the
  captured error body is discarded and the missing package resolves to the quiet no-op path.
- Belt and braces: the delete loop now skips any non-numeric version id token.

## EPIC canvas

N/A — `fix:` issue, SPDD-exempt. Follow-up to #1119 (PR #1133), spec §3B / ADR-027.

## Test plan

- [x] Buggy vs fixed capture reproduced against the live 404:
      `|| true` inside → `IDS=[{"message":"Package not found."…}]`; `|| IDS=""` outside → `IDS=[]`
- [x] Full fixed script body executed locally (`bash -euo pipefail`) with the exact env of the
      failed `api-gateway` leg — exits 0 with "No staging version tagged … nothing to delete."
- [x] `actionlint -color` (same ci-runner image as the `pr-checks` gate) — exit 0
- [x] Self-verifying on merge: closing this PR fires `pr-image-cleanup.yml` from the merge ref
      (which includes this fix) — the run must come back green with 12 quiet no-ops

🤖 Generated with [Claude Code](https://claude.com/claude-code)
