### PR TITLE
ci: convert release.yml to retag model with atomic digest sync

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,40 +1,55 @@
 # SPDX-License-Identifier: Apache-2.0
 #
-# Release coordinator — single workflow triggered by a version tag.
-# Fans out to parallel build jobs, then creates ONE GitHub Release with
-# all artifacts attached. Replaces the three legacy tag-triggered workflows
-# (cli-release.yml, service-release.yml, zynax-ci-release.yml), which are
-# now workflow_dispatch-only for manual/dry-run use.
+# Release — retag-only promotion pipeline (ADR-027, #1120).
 #
-# Trigger:
-#   git tag v0.4.0 && git push origin v0.4.0
+# Container images are built EXACTLY ONCE, pre-merge, by the build-images
+# job in ci.yml (staging lane ghcr.io/zynax-io/zynax/staging/<svc>:pr-<sha>,
+# Trivy-gated, SBOM'd). This workflow never builds an image — it promotes
+# the verified staging artifact by retag:
 #
-# Dry-run (manual):
+#   merge to main →  staging/<svc>:pr-<pr-sha> → <svc>:main-<merge-sha> + :main + :latest
+#   version tag   →  <svc>:main-<sha>          → <svc>:vX.Y.Z
+#
+# Post-merge has exactly two responsibilities (manifesto P7):
+#   1. retag the verified image to its production names (+ cosign sign), and
+#   2. commit the updated digests to images/images.yaml as a [skip ci] bot
+#      commit — the recorded ADR-023 exception in ADR-027.
+#
+# §3C loop-safety (recorded answer to the spec's open question): the
+# retag-on-merge job fires on EVERY completed CI run on main, including
+# non-PR pushes. A non-PR push has no associated PR and therefore no staging
+# images — the job exits as a no-op. The digest bot commit carries
+# [skip ci], so GitHub never starts CI for it: no CI run → no workflow_run
+# event → no retag → no loop.
+#
+# Version tags additionally build the zynax/zynax-ci Go binaries (these are
+# not container images and are built per-platform here), generate SBOMs for
+# the version-tagged images, and create ONE GitHub Release with generated
+# notes. sdk-publish.yml and proto-stubs-publish.yml stay independently
+# triggered: the PyPI Trusted Publisher registration is bound to the
+# sdk-publish.yml workflow filename, so wiring it via workflow_call would
+# break OIDC publishing until re-registered (recorded deviation from the
+# #1120 scope bullet).
+#
+# Dry-run / re-promotion (manual, idempotent):
 #   Actions → Release → Run workflow → enter tag
 
 name: Release
 
 on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+    branches: [main]
   push:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
       - 'v[0-9]+.[0-9]+.[0-9]+-*'
-    branches:
-      - main
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-  schedule:
-    - cron: '0 3 * * 1'    # Monday 03:00 UTC — weekly base-image CVE safety net
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Version tag (e.g. v0.4.0)'
-        required: false
-      rebuild_all:
-        description: 'Force rebuild all service images regardless of changes'
-        type: boolean
-        default: false
+        description: 'Version tag to (re-)promote (e.g. v0.5.0)'
+        required: true
 
 # Least-privilege default — jobs that need more escalate per-job below (#1116).
 permissions:
@@ -43,12 +58,174 @@ permissions:
 env:
   REGISTRY: ghcr.io
   IMAGE_PREFIX: ghcr.io/zynax-io/zynax
+  STAGING_PREFIX: ghcr.io/zynax-io/zynax/staging
+  # Must match the build-images matrix in ci.yml — update both together.
+  SERVICE_IMAGES: "api-gateway engine-adapter workflow-compiler task-broker agent-registry event-bus memory-service http-adapter llm-adapter langgraph-adapter ci-adapter git-adapter"
   SYFT_VERSION: "1.44.0"
   GHCR_KEEP_VERSIONS: "5"
 
-# ── CLI binary — 5 platforms ──────────────────────────────────────────────────
-
 jobs:
+
+# ── Retag on merge (workflow_run: CI completed on main) ──────────────────────
+# ~10 s manifest operations instead of a ~5 min rebuild. Idempotent: re-running
+# points the same tags at the same digests and skips the digest commit.
+
+  retag-on-merge:
+    name: Retag staging → main-<sha> + latest
+    if: github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-24.04
+    concurrency:
+      group: retag-main          # serialize promotions across merges
+      cancel-in-progress: false  # never cancel a digest commit mid-flight
+    permissions:
+      contents: write   # digest bot commit to main — ADR-027 §"Explicit exception to ADR-023"
+      packages: write   # retags staging images + prunes old main-<sha> versions
+      id-token: write   # cosign keyless OIDC signing
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: main
+          fetch-depth: 1
+
+      # A CI run on main is the post-merge run: workflow_run.head_sha is the
+      # merge commit. The staging lane is tagged with the PR head SHA —
+      # recover it from the PR associated with the merge commit.
+      - name: Resolve merged PR head SHA
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MERGE_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+          PR_SHA=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${MERGE_SHA}/pulls" \
+            --jq '.[0].head.sha // empty')
+          if [ -z "${PR_SHA}" ]; then
+            echo "ℹ️  No PR associated with ${MERGE_SHA} (non-PR push to main) — nothing to promote."
+            echo "promote=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          {
+            echo "promote=true"
+            echo "pr_sha=${PR_SHA}"
+            echo "merge_sha=${MERGE_SHA}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Log in to GHCR
+        if: steps.pr.outputs.promote == 'true'
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        if: steps.pr.outputs.promote == 'true'
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Install cosign
+        if: steps.pr.outputs.promote == 'true'
+        uses: sigstore/cosign-installer@7e8b541eb2e61bf99390e1afd4be13a184e9ebc5 # v3.10.1
+
+      # imagetools create copies the FULL manifest list — platform manifests
+      # AND attestation manifests (ADR-025) — and is idempotent: re-running
+      # points the same tags at the same digest. One cosign signature per
+      # digest covers every tag pointing at it (main-<sha>, main, latest).
+      - name: Retag staging → main-<sha> + main + latest, sign
+        id: retag
+        if: steps.pr.outputs.promote == 'true'
+        env:
+          PR_SHA: ${{ steps.pr.outputs.pr_sha }}
+          MERGE_SHA: ${{ steps.pr.outputs.merge_sha }}
+        run: |
+          set -euo pipefail
+          : > /tmp/promoted.txt
+          read -ra SERVICES <<< "${SERVICE_IMAGES}"
+          for svc in "${SERVICES[@]}"; do
+            STAGING="${STAGING_PREFIX}/${svc}:pr-${PR_SHA}"
+            if ! docker buildx imagetools inspect "${STAGING}" >/dev/null 2>&1; then
+              echo "ℹ️  ${svc}: no staging image pr-${PR_SHA} — skipped (PR did not build images)"
+              continue
+            fi
+            docker buildx imagetools create \
+              -t "${IMAGE_PREFIX}/${svc}:main-${MERGE_SHA}" \
+              -t "${IMAGE_PREFIX}/${svc}:main" \
+              -t "${IMAGE_PREFIX}/${svc}:latest" \
+              "${STAGING}"
+            DIGEST=$(docker buildx imagetools inspect \
+              --format '{{json .Manifest.Digest}}' \
+              "${IMAGE_PREFIX}/${svc}:main-${MERGE_SHA}" | tr -d '"')
+            cosign sign --yes "${IMAGE_PREFIX}/${svc}@${DIGEST}"
+            echo "${svc} ${DIGEST}" >> /tmp/promoted.txt
+            echo "✅ ${svc} → main-${MERGE_SHA} / main / latest (${DIGEST})"
+          done
+          if [ -s /tmp/promoted.txt ]; then
+            echo "promoted=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "promoted=false" >> "$GITHUB_OUTPUT"
+            echo "ℹ️  No staging images for this merge — promotion not needed."
+          fi
+
+      # Atomic digest sync (ADR-027): the promoted digests land on main in
+      # the same run that promoted them. Service entries in images.yaml carry
+      # no consumers, so this commit only ever touches images/images.yaml —
+      # GITHUB_TOKEN contents:write suffices (no `workflows` permission
+      # needed). If a service digest ever gains consumer files, add an
+      # `images sync` stamp step here and switch to BOT_GITHUB_TOKEN.
+      - name: Commit digest update to main [skip ci]
+        if: steps.retag.outputs.promoted == 'true'
+        env:
+          MERGE_SHA: ${{ steps.pr.outputs.merge_sha }}
+          PR_SHA: ${{ steps.pr.outputs.pr_sha }}
+        run: |
+          set -euo pipefail
+          while read -r svc digest; do
+            python3 scripts/update_image_digest.py \
+              --name "${svc}" --ref "${IMAGE_PREFIX}/${svc}" --digest "${digest}"
+          done < /tmp/promoted.txt
+          if git diff --quiet -- images/images.yaml; then
+            echo "✅ images.yaml already current — no digest commit (idempotent re-run)."
+            exit 0
+          fi
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add images/images.yaml
+          git commit -s \
+            -m "chore(images): sync digests after main-${MERGE_SHA:0:7} [skip ci]" \
+            -m "Automated digest update after merge of PR head ${PR_SHA:0:7} (ADR-027 retag model)."
+          git pull --rebase origin main
+          git push origin HEAD:main || {
+            echo "::error::Digest push to main rejected. The ADR-027 §ADR-023 bot"
+            echo "::error::exception requires main's protection to allow github-actions[bot]"
+            echo "::error::pushes (ruleset bypass for the Actions app) — see PR #1120 notes."
+            exit 1
+          }
+
+      - name: Prune old main-<sha> versions
+        if: steps.retag.outputs.promoted == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          KEEP="${GHCR_KEEP_VERSIONS}"
+          while read -r svc _; do
+            PKG="zynax%2F${svc}"
+            IDS=$(gh api "/orgs/zynax-io/packages/container/${PKG}/versions" --paginate \
+              --jq "[.[] | select(
+                  (.metadata.container.tags | any(test(\"^main-[a-f0-9]\"))) and
+                  (.metadata.container.tags | all(. != \"latest\" and . != \"main\" and (test(\"^v[0-9]\") | not)))
+              ) | {id:.id,ts:.updated_at}] | sort_by(.ts) | reverse | .[${KEEP}:] | .[].id")
+            if [ -z "${IDS}" ]; then
+              echo "ℹ️  ${svc}: nothing to prune (≤${KEEP} main-sha versions)."
+              continue
+            fi
+            echo "${IDS}" | while read -r ID; do
+              gh api -X DELETE "/orgs/zynax-io/packages/container/${PKG}/versions/${ID}" \
+                && echo "Deleted ${svc} version ${ID}"
+            done
+          done < /tmp/promoted.txt
+
+# ── CLI binary — 5 platforms (version tags only; Go binaries, not images) ────
+
   build-cli:
     name: CLI — ${{ matrix.goos }}/${{ matrix.goarch }}
     if: github.ref_type == 'tag' || github.event_name == 'workflow_dispatch'
@@ -154,402 +331,117 @@ jobs:
           path: cmd/zynax-ci/zynax-ci-${{ matrix.suffix }}
           retention-days: 7
 
-# ── Per-service change detection ─────────────────────────────────────────────
-# On branch pushes: detect which services changed (git diff HEAD^1..HEAD).
-# On tag push, schedule, or workflow_dispatch: resolve-matrix forces all services.
+# ── Retag main-<sha> → version (tag pushes / dispatch; no builds) ────────────
+# For each image, walk first-parent history from the tagged commit and promote
+# the most recent main-<sha> tag (full-SHA retag-model tags and legacy 8-char
+# tags both resolve). tools + ci-runner join the matrix: their main builds
+# come from tools-image.yml, but version promotion is retag-only here too.
 
-  changes:
-    name: Detect changed services
-    runs-on: ubuntu-24.04
-    outputs:
-      api_gateway:        ${{ steps.detect.outputs.api_gateway }}
-      engine_adapter:     ${{ steps.detect.outputs.engine_adapter }}
-      workflow_compiler:  ${{ steps.detect.outputs.workflow_compiler }}
-      task_broker:        ${{ steps.detect.outputs.task_broker }}
-      agent_registry:     ${{ steps.detect.outputs.agent_registry }}
-      http_adapter:       ${{ steps.detect.outputs.http_adapter }}
-      llm_adapter:        ${{ steps.detect.outputs.llm_adapter }}
-      langgraph_adapter:  ${{ steps.detect.outputs.langgraph_adapter }}
-      ci_adapter:         ${{ steps.detect.outputs.ci_adapter }}
-      git_adapter:        ${{ steps.detect.outputs.git_adapter }}
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 2
-
-      - name: Detect per-service file changes
-        id: detect
-        run: |
-          api_gateway=false engine_adapter=false workflow_compiler=false
-          task_broker=false agent_registry=false http_adapter=false
-          llm_adapter=false langgraph_adapter=false ci_adapter=false git_adapter=false
-
-          if [ "${{ github.event_name }}" = "push" ] && [ "${{ github.ref_type }}" = "branch" ]; then
-            if ! FILES=$(git diff --name-only HEAD^1...HEAD 2>/tmp/git-diff-err.txt); then
-              echo "⚠️  git diff failed — enabling all services as fail-safe"
-              cat /tmp/git-diff-err.txt
-              api_gateway=true engine_adapter=true workflow_compiler=true
-              task_broker=true agent_registry=true http_adapter=true
-            else
-              while IFS= read -r f; do
-                [ -z "$f" ] && continue
-                echo "$f" | grep -qE '^(services/api-gateway/|protos/generated/go/|infra/docker/Dockerfile\.service)'      && api_gateway=true
-                echo "$f" | grep -qE '^(services/engine-adapter/|protos/generated/go/|infra/docker/Dockerfile\.service)'   && engine_adapter=true
-                echo "$f" | grep -qE '^(services/workflow-compiler/|protos/generated/go/|infra/docker/Dockerfile\.service)' && workflow_compiler=true
-                echo "$f" | grep -qE '^(services/task-broker/|protos/generated/go/|infra/docker/Dockerfile\.service)'      && task_broker=true
-                echo "$f" | grep -qE '^(services/agent-registry/|protos/generated/go/|infra/docker/Dockerfile\.service)'   && agent_registry=true
-                echo "$f" | grep -qE '^(agents/adapters/http/|protos/generated/go/)'           && http_adapter=true
-                echo "$f" | grep -qE '^(agents/adapters/llm/|protos/generated/python/)'       && llm_adapter=true
-                echo "$f" | grep -qE '^(agents/adapters/langgraph/|protos/generated/python/)' && langgraph_adapter=true
-                echo "$f" | grep -qE '^(agents/adapters/ci/|protos/generated/go/)'            && ci_adapter=true
-                echo "$f" | grep -qE '^(agents/adapters/git/|protos/generated/go/)'           && git_adapter=true
-              done <<< "$FILES"
-            fi
-          else
-            echo "ℹ️  event='${{ github.event_name }}' ref_type='${{ github.ref_type }}' — resolve-matrix will decide"
-          fi
-
-          {
-            echo "api_gateway=$api_gateway"
-            echo "engine_adapter=$engine_adapter"
-            echo "workflow_compiler=$workflow_compiler"
-            echo "task_broker=$task_broker"
-            echo "agent_registry=$agent_registry"
-            echo "http_adapter=$http_adapter"
-            echo "llm_adapter=$llm_adapter"
-            echo "langgraph_adapter=$langgraph_adapter"
-            echo "ci_adapter=$ci_adapter"
-            echo "git_adapter=$git_adapter"
-          } >> "$GITHUB_OUTPUT"
-
-  resolve-matrix:
-    name: Resolve image build matrix
-    needs: [changes]
-    runs-on: ubuntu-24.04
-    outputs:
-      matrix:          ${{ steps.build.outputs.matrix }}
-      platform_matrix: ${{ steps.build.outputs.platform_matrix }}
-      any:             ${{ steps.build.outputs.any }}
-    steps:
-      - id: build
-        run: |
-          force="false"
-          [[ "${{ github.ref_type }}" == "tag" ]]                     && force="true"
-          [[ "${{ github.event_name }}" == "schedule" ]]              && force="true"
-          [[ "${{ github.event_name }}" == "workflow_dispatch" ]]     && force="true"
-          [[ "${{ inputs.rebuild_all }}" == "true" ]]                 && force="true"
-
-          # Build per-service entries (service name + optional dockerfile override)
-          declare -A svc_dockerfile
-          entries=()
-          [[ "$force" == "true" || "${{ needs.changes.outputs.api_gateway }}"       == "true" ]] && entries+=(api-gateway)
-          [[ "$force" == "true" || "${{ needs.changes.outputs.engine_adapter }}"    == "true" ]] && entries+=(engine-adapter)
-          [[ "$force" == "true" || "${{ needs.changes.outputs.workflow_compiler }}" == "true" ]] && entries+=(workflow-compiler)
-          [[ "$force" == "true" || "${{ needs.changes.outputs.task_broker }}"       == "true" ]] && entries+=(task-broker)
-          [[ "$force" == "true" || "${{ needs.changes.outputs.agent_registry }}"    == "true" ]] && entries+=(agent-registry)
-          [[ "$force" == "true" || "${{ needs.changes.outputs.http_adapter }}"      == "true" ]] && entries+=(http-adapter)
-          [[ "$force" == "true" || "${{ needs.changes.outputs.llm_adapter }}"       == "true" ]] && entries+=(llm-adapter)
-          [[ "$force" == "true" || "${{ needs.changes.outputs.langgraph_adapter }}" == "true" ]] && entries+=(langgraph-adapter)
-          [[ "$force" == "true" || "${{ needs.changes.outputs.ci_adapter }}"        == "true" ]] && entries+=(ci-adapter)
-          [[ "$force" == "true" || "${{ needs.changes.outputs.git_adapter }}"       == "true" ]] && entries+=(git-adapter)
-          svc_dockerfile[http-adapter]="agents/adapters/http/Dockerfile"
-          svc_dockerfile[llm-adapter]="agents/adapters/llm/Dockerfile"
-          svc_dockerfile[langgraph-adapter]="agents/adapters/langgraph/Dockerfile"
-          svc_dockerfile[ci-adapter]="agents/adapters/ci/Dockerfile"
-          svc_dockerfile[git-adapter]="agents/adapters/git/Dockerfile"
-
-          if [[ ${#entries[@]} -eq 0 ]]; then
-            echo 'matrix={"include":[]}' >> "$GITHUB_OUTPUT"
-            echo 'platform_matrix={"include":[]}' >> "$GITHUB_OUTPUT"
-            echo 'any=false' >> "$GITHUB_OUTPUT"
-            echo "ℹ️  No service images changed — build skipped."
-          else
-            # Service-only matrix (used by merge-and-sign)
-            svc_items=()
-            for svc in "${entries[@]}"; do
-              df="${svc_dockerfile[$svc]:-}"
-              if [[ -n "$df" ]]; then
-                svc_items+=("{\"service\":\"${svc}\",\"dockerfile\":\"${df}\"}")
-              else
-                svc_items+=("{\"service\":\"${svc}\"}")
-              fi
-            done
-            printf -v svc_joined '%s,' "${svc_items[@]}"
-            echo "matrix={\"include\":[${svc_joined%,}]}" >> "$GITHUB_OUTPUT"
-
-            # Platform matrix — cross-product: each service × {amd64, arm64}
-            plat_items=()
-            for svc in "${entries[@]}"; do
-              df="${svc_dockerfile[$svc]:-}"
-              for plat in amd64 arm64; do
-                if [[ -n "$df" ]]; then
-                  plat_items+=("{\"service\":\"${svc}\",\"platform\":\"${plat}\",\"dockerfile\":\"${df}\"}")
-                else
-                  plat_items+=("{\"service\":\"${svc}\",\"platform\":\"${plat}\"}")
-                fi
-              done
-            done
-            printf -v plat_joined '%s,' "${plat_items[@]}"
-            echo "platform_matrix={\"include\":[${plat_joined%,}]}" >> "$GITHUB_OUTPUT"
-
-            echo 'any=true' >> "$GITHUB_OUTPUT"
-            echo "✓ Building ${#entries[@]} service(s) × 2 platforms"
-          fi
-
-# ── Native per-platform service image builds (no QEMU) ───────────────────────
-# Each job builds one service for one platform natively:
-#   amd64 → ubuntu-24.04 runner
-#   arm64 → ubuntu-24.04-arm runner
-# The amd64 job also runs Trivy scan (representative CVE gate for both arches).
-# Digests are uploaded as artifacts for the merge-and-sign fan-in job.
-
-  build-platform:
-    name: Build ${{ matrix.service }} (${{ matrix.platform }})
-    needs: [resolve-matrix]
-    if: needs.resolve-matrix.outputs.any == 'true'
-    runs-on: ${{ matrix.platform == 'amd64' && 'ubuntu-24.04' || 'ubuntu-24.04-arm' }}
-    permissions:
-      contents: read
-      packages: write          # pushes per-platform service images to GHCR
-      security-events: write   # uploads trivy SARIF to the GitHub Security tab
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJson(needs.resolve-matrix.outputs.platform_matrix) }}
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Log in to GHCR
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
-
-      # ── Trivy pre-push scan (amd64 only — representative gate for both arches) ─
-      - name: Build image for trivy scan
-        if: matrix.platform == 'amd64'
-        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
-        with:
-          context: .
-          file: ${{ matrix.dockerfile || 'infra/docker/Dockerfile.service' }}
-          build-args: SVC=${{ matrix.service }}
-          platforms: linux/amd64
-          load: true
-          tags: scan-${{ matrix.service }}:${{ github.sha }}
-          cache-from: type=gha,scope=${{ matrix.service }}-amd64
-
-      - name: Trivy container scan
-        if: matrix.platform == 'amd64'
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
-        env:
-          # Pin the DB to a canonical GHCR digest (the default GCR mirror lagged and
-          # served a since-corrected CRITICAL, red-walling releases — #1022). The digest
-          # makes scans reproducible; renovate bumps it so vuln data stays current.
-          # renovate: datasource=docker depName=ghcr.io/aquasecurity/trivy-db
-          TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db:2@sha256:225c785a3ce630d8f8b75ab23f4d7b0b1402f94a54dfe6441e6711c7deb8dec8
-          # Gate on NVD CVSS when available, falling back to GHSA for the many
-          # Python advisories that have no NVD entry. Stops the gate firing on
-          # score-less, non-NVD vendor "CRITICAL"s that never surface in the
-          # Security tab, while still catching genuine GHSA-scored CRITICAL/HIGH.
-          TRIVY_VULN_SEVERITY_SOURCE: nvd,ghsa
-        with:
-          image-ref: scan-${{ matrix.service }}:${{ github.sha }}
-          version: v0.71.0
-          format: sarif
-          output: trivy-results-${{ matrix.service }}.sarif
-          severity: CRITICAL,HIGH
-          exit-code: 1
-          ignore-unfixed: true
-          trivyignores: .trivyignore
-
-      - name: Upload trivy SARIF to GitHub Security tab
-        if: matrix.platform == 'amd64' && always()
-        uses: github/codeql-action/upload-sarif@03e4368ac7daa2bd82b3e85262f3bf87ee112f57 # v3.36.0
-        with:
-          sarif_file: trivy-results-${{ matrix.service }}.sarif
-          category: container-${{ matrix.service }}
-
-      # ── Native single-platform push ───────────────────────────────────────────
-      # Tag: :<service>-<platform>-<sha> — intermediate; merged by merge-and-sign.
-      # provenance=false on single-arch intermediates — provenance is added
-      # to the merged manifest index in merge-and-sign (ADR-025).
-      - name: Build and push (native ${{ matrix.platform }})
-        id: build
-        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
-        with:
-          context: .
-          file: ${{ matrix.dockerfile || 'infra/docker/Dockerfile.service' }}
-          build-args: SVC=${{ matrix.service }}
-          platforms: linux/${{ matrix.platform }}
-          push: true
-          tags: ${{ env.IMAGE_PREFIX }}/${{ matrix.service }}:${{ matrix.service }}-${{ matrix.platform }}-${{ github.sha }}
-          cache-from: type=gha,scope=${{ matrix.service }}-${{ matrix.platform }}
-          cache-to: type=gha,scope=${{ matrix.service }}-${{ matrix.platform }},mode=max
-          provenance: false
-
-      # Save digest for fan-in (merge-and-sign)
-      - name: Save digest artifact
-        run: |
-          mkdir -p /tmp/digests
-          echo "${{ steps.build.outputs.digest }}" \
-            > "/tmp/digests/${{ matrix.service }}-${{ matrix.platform }}.digest"
-
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: digest-${{ matrix.service }}-${{ matrix.platform }}
-          path: /tmp/digests/${{ matrix.service }}-${{ matrix.platform }}.digest
-          retention-days: 1
-
-# ── Merge manifest indexes + sign + SBOM (fan-in) ────────────────────────────
-# Runs once all platform builds succeed. For each service:
-#   1. docker buildx imagetools create — multi-arch manifest index
-#   2. cosign sign (tag + release only)
-#   3. syft SBOM from merged index (tag + release only)
-# The final multi-arch tags (main / main-sha8 / vX.Y.Z / latest) are applied here.
-# provenance attestations attached by buildx imagetools create (SLSA L1 — ADR-025).
-
-  merge-and-sign:
-    name: Merge & sign — ${{ matrix.service }}
-    needs: [resolve-matrix, build-platform]
-    if: needs.resolve-matrix.outputs.any == 'true'
+  retag-version:
+    name: Version retag — ${{ matrix.service }}
+    if: github.ref_type == 'tag' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-24.04
     permissions:
       contents: read
-      packages: write       # creates multi-arch manifests, pushes attestations, prunes GHCR
-      id-token: write       # cosign keyless OIDC signing + SLSA provenance attestation
-      attestations: write   # actions/attest-build-provenance (SLSA L2) on release tags
+      packages: write       # retags main-<sha> → vX.Y.Z
+      id-token: write       # cosign keyless OIDC + SLSA provenance
+      attestations: write   # actions/attest-build-provenance (SLSA L2 — ADR-025)
     strategy:
       fail-fast: false
-      matrix: ${{ fromJson(needs.resolve-matrix.outputs.matrix) }}
+      matrix:
+        service: [api-gateway, engine-adapter, workflow-compiler, task-broker,
+                  agent-registry, event-bus, memory-service, http-adapter,
+                  llm-adapter, langgraph-adapter, ci-adapter, git-adapter,
+                  tools, ci-runner]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Resolve version
-        id: ver
-        run: |
-          TAG="${{ inputs.tag || github.ref_name }}"
-          echo "version=${TAG}" >> "$GITHUB_OUTPUT"
-
-      - name: Compute final image tags
-        id: img
-        run: |
-          PREFIX="${{ env.IMAGE_PREFIX }}/${{ matrix.service }}"
-          SHA="${{ github.sha }}"
-          if [[ "${{ github.ref_type }}" == "branch" && "${{ github.event_name }}" != "workflow_dispatch" ]]; then
-            echo "tags=${PREFIX}:main,${PREFIX}:main-${SHA:0:8}" >> "$GITHUB_OUTPUT"
-            echo "primary=${PREFIX}:main-${SHA:0:8}" >> "$GITHUB_OUTPUT"
-          else
-            TAG="${{ steps.ver.outputs.version }}"
-            echo "tags=${PREFIX}:${TAG},${PREFIX}:latest" >> "$GITHUB_OUTPUT"
-            echo "primary=${PREFIX}:${TAG}" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Log in to GHCR
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0   # full history + tags for the first-parent walk
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
-
-      # Download per-platform digests written by build-platform jobs
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
-        with:
-          name: digest-${{ matrix.service }}-amd64
-          path: /tmp/digests
-
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
-        with:
-          name: digest-${{ matrix.service }}-arm64
-          path: /tmp/digests
-
-      - name: Merge multi-arch manifest index
-        id: merge
-        run: |
-          PREFIX="${{ env.IMAGE_PREFIX }}/${{ matrix.service }}"
-
-          AMD64_DIGEST=$(cat "/tmp/digests/${{ matrix.service }}-amd64.digest")
-          ARM64_DIGEST=$(cat "/tmp/digests/${{ matrix.service }}-arm64.digest")
-
-          # Build -t flags from comma-separated tag list
-          TAG_ARGS=()
-          IFS=',' read -ra TAGS <<< "${{ steps.img.outputs.tags }}"
-          for t in "${TAGS[@]}"; do
-            TAG_ARGS+=(-t "$t")
-          done
-
-          docker buildx imagetools create \
-            --annotation "index:org.opencontainers.image.description=Zynax ${{ matrix.service }} service" \
-            --annotation "index:org.opencontainers.image.title=${{ matrix.service }}" \
-            --annotation "index:org.opencontainers.image.source=https://github.com/${{ github.repository }}" \
-            --annotation "index:org.opencontainers.image.revision=${{ github.sha }}" \
-            "${TAG_ARGS[@]}" \
-            "${PREFIX}@${AMD64_DIGEST}" \
-            "${PREFIX}@${ARM64_DIGEST}"
-
-          # Capture merged index digest for signing / SBOM
-          MERGED_DIGEST=$(docker buildx imagetools inspect \
-            --format '{{json .Manifest.Digest}}' \
-            "${{ steps.img.outputs.primary }}" | tr -d '"')
-          echo "digest=${MERGED_DIGEST}" >> "$GITHUB_OUTPUT"
-
-      - name: Report image sizes
-        uses: ./.github/actions/report-image-meta
-        with:
-          image-name: zynax-io/zynax/${{ matrix.service }}
-          image-label: ${{ matrix.service }}
-          digest: ${{ steps.merge.outputs.digest }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          image-type: service
-
-      - name: Prune old service builds
-        if: github.ref_type == 'branch'
+      - name: Resolve version and source image
+        id: src
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SVC: ${{ matrix.service }}
         run: |
-          SVC="${{ matrix.service }}"
-          PKG="zynax%2F${SVC}"
-          KEEP="${{ env.GHCR_KEEP_VERSIONS }}"
-          IDS=$(gh api "/orgs/zynax-io/packages/container/${PKG}/versions" --paginate \
-            --jq "[.[] | select(
-                (.metadata.container.tags | any(test(\"^main-[a-f0-9]\"))) and
-                (.metadata.container.tags | all(. != \"latest\" and . != \"main\" and (test(\"^v[0-9]\") | not)))
-            ) | {id:.id,ts:.updated_at}] | sort_by(.ts) | reverse | .[${KEEP}:] | .[].id")
-          [ -z "$IDS" ] && { echo "Nothing to prune (≤${KEEP} main-sha versions)."; exit 0; }
-          echo "$IDS" | while read -r ID; do
-            gh api -X DELETE "/orgs/zynax-io/packages/container/${PKG}/versions/${ID}" && echo "Deleted version ${ID}"
-          done
+          set -euo pipefail
+          TAG="${{ inputs.tag || github.ref_name }}"
+          TAG_SHA=$(git rev-list -n1 "refs/tags/${TAG}")
+          echo "version=${TAG}" >> "$GITHUB_OUTPUT"
+
+          EXISTING=$(gh api "/orgs/zynax-io/packages/container/zynax%2F${SVC}/versions" \
+            --paginate --jq '.[].metadata.container.tags[]' 2>/dev/null | grep '^main-' || true)
+          if [ -z "${EXISTING}" ]; then
+            echo "⚠️  ${SVC}: no promoted main-* image exists — excluded from ${TAG}."
+            echo "src=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          SRC_TAG=""
+          while read -r sha; do
+            if grep -qx "main-${sha}" <<< "${EXISTING}"; then
+              SRC_TAG="main-${sha}"; break
+            fi
+            if grep -qx "main-${sha:0:8}" <<< "${EXISTING}"; then
+              SRC_TAG="main-${sha:0:8}"; break
+            fi
+          done < <(git rev-list --first-parent -n 200 "${TAG_SHA}")
+
+          if [ -z "${SRC_TAG}" ]; then
+            echo "⚠️  ${SVC}: no main-<sha> within 200 first-parent commits of ${TAG} — excluded."
+            echo "src=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "✅ ${SVC}: promoting ${SRC_TAG} → ${TAG}"
+          echo "src=${SRC_TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to GHCR
+        if: steps.src.outputs.src != ''
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        if: steps.src.outputs.src != ''
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Install cosign
-        if: github.ref_type == 'tag' || github.event_name == 'workflow_dispatch'
+        if: steps.src.outputs.src != ''
         uses: sigstore/cosign-installer@7e8b541eb2e61bf99390e1afd4be13a184e9ebc5 # v3.10.1
 
-      - name: Sign merged manifest index
-        if: github.ref_type == 'tag' || github.event_name == 'workflow_dispatch'
-        run: |
-          cosign sign --yes \
-            "${{ env.IMAGE_PREFIX }}/${{ matrix.service }}@${{ steps.merge.outputs.digest }}"
+      - name: Retag to version and sign
+        id: retag
+        if: steps.src.outputs.src != ''
         env:
-          COSIGN_EXPERIMENTAL: "1"
+          SVC: ${{ matrix.service }}
+          SRC: ${{ steps.src.outputs.src }}
+          VERSION: ${{ steps.src.outputs.version }}
+        run: |
+          set -euo pipefail
+          docker buildx imagetools create \
+            -t "${IMAGE_PREFIX}/${SVC}:${VERSION}" \
+            "${IMAGE_PREFIX}/${SVC}:${SRC}"
+          DIGEST=$(docker buildx imagetools inspect \
+            --format '{{json .Manifest.Digest}}' \
+            "${IMAGE_PREFIX}/${SVC}:${VERSION}" | tr -d '"')
+          cosign sign --yes "${IMAGE_PREFIX}/${SVC}@${DIGEST}"
+          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
 
-      # SLSA L2 provenance — signed, verifiable attestation on the merged index
-      # (upgrades the buildx-generated Build L1 provenance — issue #1116).
-      # Verify: gh attestation verify oci://<image>@<digest> --owner zynax-io
+      # SLSA L2 provenance — signed, verifiable attestation on the version
+      # digest (ADR-025, #1116). Verify:
+      #   gh attestation verify oci://<image>@<digest> --owner zynax-io
       - name: Attest build provenance (SLSA L2)
-        if: github.ref_type == 'tag' || github.event_name == 'workflow_dispatch'
+        if: steps.src.outputs.src != ''
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-name: ${{ env.IMAGE_PREFIX }}/${{ matrix.service }}
-          subject-digest: ${{ steps.merge.outputs.digest }}
+          subject-digest: ${{ steps.retag.outputs.digest }}
           push-to-registry: true
 
       - name: Install syft ${{ env.SYFT_VERSION }}
-        if: github.ref_type == 'tag' || github.event_name == 'workflow_dispatch'
+        if: steps.src.outputs.src != ''
         run: |
           curl -sSfL \
             "https://github.com/anchore/syft/releases/download/v${SYFT_VERSION}/syft_${SYFT_VERSION}_linux_amd64.tar.gz" \
@@ -557,17 +449,16 @@ jobs:
           tar -xzf /tmp/syft.tar.gz -C /usr/local/bin syft
           rm /tmp/syft.tar.gz
 
-      # SBOM generated from merged manifest index — covers both arches
-      - name: Generate SBOM (SPDX) from merged index
-        if: github.ref_type == 'tag' || github.event_name == 'workflow_dispatch'
+      - name: Generate SBOM (SPDX) from version digest
+        if: steps.src.outputs.src != ''
         run: |
           syft \
-            "${{ env.IMAGE_PREFIX }}/${{ matrix.service }}@${{ steps.merge.outputs.digest }}" \
+            "${{ env.IMAGE_PREFIX }}/${{ matrix.service }}@${{ steps.retag.outputs.digest }}" \
             -o spdx-json \
             --file "${{ matrix.service }}-sbom.spdx.json"
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        if: github.ref_type == 'tag' || github.event_name == 'workflow_dispatch'
+        if: steps.src.outputs.src != ''
         with:
           name: sbom-${{ matrix.service }}
           path: ${{ matrix.service }}-sbom.spdx.json
@@ -577,7 +468,7 @@ jobs:
 
   release:
     name: Create GitHub Release
-    needs: [build-cli, build-zynax-ci, merge-and-sign]
+    needs: [build-cli, build-zynax-ci, retag-version]
     if: github.ref_type == 'tag' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-24.04
     permissions:
@@ -623,10 +514,15 @@ jobs:
           tag_name: ${{ steps.ver.outputs.version }}
           name: Zynax ${{ steps.ver.outputs.version }}
           prerelease: ${{ steps.ver.outputs.prerelease == 'true' }}
+          generate_release_notes: true
           body: |
             ## Zynax ${{ steps.ver.outputs.version }}
 
             Declarative AI-workflow control plane — CLI, CI toolchain, and service images.
+
+            All service images are retag-promoted from the pre-merge security
+            gate (ADR-027): the digests below are the exact binaries that
+            passed Trivy before merge.
 
             ### Install zynax CLI
 
@@ -690,10 +586,6 @@ jobs:
             ```
 
             SPDX SBOMs for all service and adapter images are attached to this release. Verify image signatures with `cosign verify ghcr.io/zynax-io/zynax/<service>:<version>`.
-
-            ### What's new
-
-            See [CHANGELOG.md](https://github.com/zynax-io/zynax/blob/main/CHANGELOG.md) for full release notes.
           files: |
             dist/cli/*
             dist/zynax-ci/*

--- a/.github/workflows/tools-image.yml
+++ b/.github/workflows/tools-image.yml
@@ -2,7 +2,7 @@
 # Zynax — Developer Tools + CI Runner Images
 #
 # Builds and pushes two images to GHCR on every merge to main that touches
-# the relevant Dockerfiles or zynax-ci source. Also triggered on version tags.
+# the relevant Dockerfiles or zynax-ci source.
 #
 # Images:
 #   ghcr.io/zynax-io/zynax/tools      — developer tools for local `make` commands
@@ -11,12 +11,22 @@
 # Tags (both images):
 #   :latest      (always points to the newest main build)
 #   :main-<sha>  (immutable per-commit tag)
-#   :v*.*.*      (on version tag pushes)
+#   :v*.*.*      — applied by release.yml retag-version (ADR-027): version
+#                  promotion is a retag of the newest main-<sha>, never a
+#                  rebuild. The tags trigger was removed with #1120.
 #
 # Build strategy (#839):
 #   Job A (ubuntu-24.04):      build tools:amd64   + ci-runner:amd64   (by-digest, no tag)
 #   Job B (ubuntu-24.04-arm):  build tools:arm64   + ci-runner:arm64   (by-digest, no tag)
-#   Job C (ubuntu-24.04):      imagetools merge → cosign sign → SBOM → prune
+#   Job C (ubuntu-24.04):      imagetools merge → atomic ci-runner digest
+#                              commit to images.yaml ([skip ci]) → prune
+#
+# Deviation from the full ADR-027 retag model (recorded, #1120): these images
+# stay post-merge builds — there is no pre-merge staging lane for them because
+# they are multi-arch (the staging lane is amd64-only) and the ci-runner is
+# the CI bootstrap image itself. The retag-model elements that DO apply here:
+# version tags are retag-only (release.yml) and the digest sync is an atomic
+# bot commit instead of an [AUTO] tracking issue.
 #
 # No docker/setup-qemu-action — each platform compiles natively for < 15 min wall-clock.
 
@@ -29,8 +39,6 @@ on:
       - 'infra/docker/Dockerfile.tools'
       - 'infra/docker/Dockerfile.ci-runner'
       - 'cmd/zynax-ci/**'
-    tags:
-      - 'v*.*.*'
   workflow_dispatch:
 
 # Least-privilege default — jobs that need more escalate per-job below (#1116).
@@ -41,7 +49,6 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: zynax-io/zynax/tools
   CI_RUNNER_IMAGE: zynax-io/zynax/ci-runner
-  SYFT_VERSION: "1.44.0"
   GHCR_KEEP_VERSIONS: "5"
 
 # ---------------------------------------------------------------------------
@@ -155,15 +162,20 @@ jobs:
     runs-on: ubuntu-24.04
     needs: [build-amd64, build-arm64]
     permissions:
-      contents: read
+      contents: write   # atomic ci-runner digest commit to main (ADR-027 §ADR-023 exception)
       packages: write   # creates multi-arch manifests and prunes old GHCR versions
-      id-token: write   # cosign keyless OIDC signing on tag builds
-      issues: write     # opens the ci-runner digest bump-tracking issue
+      id-token: write   # cosign keyless OIDC signing
     outputs:
       tools-digest:     ${{ steps.create-tools-manifest.outputs.digest }}
       ci-runner-digest: ${{ steps.create-ci-runner-manifest.outputs.digest }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # The digest sync commit stamps workflow files: GITHUB_TOKEN cannot
+          # push those (App `workflows` permission). checkout persists this
+          # token for all later git commands (a remote set-url would be
+          # overridden by the persisted auth header).
+          token: ${{ secrets.BOT_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Log in to GHCR
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
@@ -240,79 +252,61 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           image-type: tooling
           extra-summary: >
-            Update `images/images.yaml` ci-runner digest and run `make sync-images`.
+            ci-runner digest synced to `images/images.yaml` automatically by this run (ADR-027).
 
-      # --- cosign sign (tag builds + workflow_dispatch) ---
+      # --- cosign sign (every main build — parity with release.yml promotions) ---
       - name: Install cosign
-        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
         uses: sigstore/cosign-installer@7e8b541eb2e61bf99390e1afd4be13a184e9ebc5 # v3.10.1
 
       - name: Sign tools image
-        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
         run: |
           cosign sign --yes \
             "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.create-tools-manifest.outputs.digest }}"
 
       - name: Sign ci-runner image
-        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
         run: |
           cosign sign --yes \
             "${{ env.REGISTRY }}/${{ env.CI_RUNNER_IMAGE }}@${{ steps.create-ci-runner-manifest.outputs.digest }}"
 
-      # --- Syft SBOM ---
-      - name: Install syft ${{ env.SYFT_VERSION }}
-        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
-        run: |
-          curl -sSfL \
-            "https://github.com/anchore/syft/releases/download/v${SYFT_VERSION}/syft_${SYFT_VERSION}_linux_amd64.tar.gz" \
-            -o /tmp/syft.tar.gz
-          tar -xzf /tmp/syft.tar.gz -C /usr/local/bin syft
-          rm /tmp/syft.tar.gz
-
-      - name: Generate tools SBOM (SPDX)
-        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
-        run: |
-          syft \
-            "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.create-tools-manifest.outputs.digest }}" \
-            -o spdx-json \
-            --file tools-sbom.spdx.json
-
-      - name: Generate ci-runner SBOM (SPDX)
-        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
-        run: |
-          syft \
-            "${{ env.REGISTRY }}/${{ env.CI_RUNNER_IMAGE }}@${{ steps.create-ci-runner-manifest.outputs.digest }}" \
-            -o spdx-json \
-            --file ci-runner-sbom.spdx.json
-
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
+      # --- Atomic ci-runner digest sync (ADR-027, #1120) ---
+      # Replaces the [AUTO] bump-tracking issue: the new digest lands on main
+      # in the same run that published the image. The ci-runner entry's
+      # consumers are banner-stamped WORKFLOW files, which the default
+      # GITHUB_TOKEN cannot push (GitHub App `workflows` permission) — use
+      # the BOT_GITHUB_TOKEN fine-grained PAT (contents + workflows write).
+      # [skip ci] keeps this commit from triggering any workflow → no loop.
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        if: github.event_name == 'push'
         with:
-          name: sbom-tools
-          path: tools-sbom.spdx.json
-          retention-days: 7
+          go-version-file: cmd/zynax-ci/go.mod
+          cache-dependency-path: cmd/zynax-ci/go.sum
 
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
-        with:
-          name: sbom-ci-runner
-          path: ci-runner-sbom.spdx.json
-          retention-days: 7
-
-      # --- Open ci-runner bump issue ---
-      - name: Open ci-runner bump issue
+      - name: Sync ci-runner digest to images.yaml [skip ci]
         if: github.event_name == 'push'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DIGEST: ${{ steps.create-ci-runner-manifest.outputs.digest }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          SHORT="${DIGEST:7:16}"
-          gh issue create \
-            --title "chore(ci): bump ci-runner digest to ${SHORT}" \
-            --label "type: chore,area: ci" \
-            --body "$(printf '## ci-runner digest bump\n\n**New digest:** `%s`\n**Built by:** %s\n\n## Steps\n\n```bash\n# 1. Edit images/images.yaml — update ci-runner digest\n# 2. make sync-images\n# 3. Verify: make check-images\n# 4. Open PR, CI green, squash-merge, delete branch\n```\n\n## Checklist\n\n- [ ] `images/images.yaml` updated with new digest `%s`\n- [ ] `make sync-images` ran (all consumers stamped)\n- [ ] `make check-images` exits 0\n- [ ] PR merged (squash), branch deleted\n' \
-              "$DIGEST" "$RUN_URL" "$DIGEST")"
+          set -euo pipefail
+          python3 scripts/update_image_digest.py --name ci-runner \
+            --ref ghcr.io/zynax-io/zynax/ci-runner --digest "${DIGEST}"
+          (cd cmd/zynax-ci && GOWORK=off go run . images sync --root "${GITHUB_WORKSPACE}")
+          if git diff --quiet; then
+            echo "✅ ci-runner digest already current — nothing to commit (idempotent re-run)."
+            exit 0
+          fi
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -u
+          git commit -s \
+            -m "chore(images): bump ci-runner digest to ${DIGEST:7:14} [skip ci]" \
+            -m "Automated digest sync after tools-image build on main (ADR-027 — replaces the [AUTO] bump issue)."
+          git pull --rebase origin main
+          git push origin HEAD:main || {
+            echo "::error::Digest push to main rejected. Requires the ADR-027 §ADR-023"
+            echo "::error::bot exception (ruleset bypass) and BOT_GITHUB_TOKEN with"
+            echo "::error::contents+workflows write — see PR #1120 notes."
+            exit 1
+          }
 
       # --- Prune old builds ---
       - name: Prune old tools builds

--- a/docs/milestones/M6-planning.md
+++ b/docs/milestones/M6-planning.md
@@ -2,7 +2,7 @@
 
 # Zynax M6 — K8s Production-Ready Planning
 
-> Generated: 2026-06-02 · Last updated: 2026-06-10 (status reconciled to live issue state: M6 = 143 closed / 14 open; EPICs #626 #670 #765 #766 #767 #768 #769 #770 #772 #773 #837 #855 #873 #1001 complete)
+> Generated: 2026-06-02 · Last updated: 2026-06-11 (status reconciled to live issue state: M6 = 143 closed / 17 open; EPICs #626 #670 #765 #766 #767 #768 #769 #770 #772 #773 #837 #855 #873 #1001 complete; CI-overhaul EPIC #1109 in flight — #1116 #1118 #1120 merged, see `docs/contributing/ci-delivery-overhaul-prompt.md`)
 > Based on live repo state at commit `994efb7` (main).  
 > GitHub Milestone: **"K8s Production-Ready (M6)"** (milestone #6).  
 > All `gh` commands, file reads, and live issue data were gathered in this session — nothing assumed from memory.

--- a/images/images.yaml
+++ b/images/images.yaml
@@ -53,3 +53,40 @@ images:
     consumers:
       - agents/adapters/langgraph/Dockerfile
       - agents/adapters/llm/Dockerfile
+
+  # ── Zynax service images ──────────────────────────────────────────────────
+  # Digest = the manifest digest of :latest (== the newest main-<sha> tag).
+  # Maintained ATOMICALLY by the release.yml retag-on-merge bot commit
+  # (ADR-027) — do not edit these by hand. New services self-register on
+  # their first promotion. consumers stays empty until a file pins a service
+  # digest verbatim; the bot commit only touches this file while that holds.
+
+  - name: api-gateway
+    ref: ghcr.io/zynax-io/zynax/api-gateway
+    digest: sha256:81e086f4dafefbe9d6f2a2f851d5c692358c9726f90f564711418a9027d42acb
+    consumers: []
+
+  - name: engine-adapter
+    ref: ghcr.io/zynax-io/zynax/engine-adapter
+    digest: sha256:f8aad99db35b51d59119da9964f8e39b899ebcb9400e8fc0e7b60a0dde392665
+    consumers: []
+
+  - name: workflow-compiler
+    ref: ghcr.io/zynax-io/zynax/workflow-compiler
+    digest: sha256:01ef2e6262f12a78330f0a3d41b2e81903eb2a9daeed4469d59bb0494a6a7a12
+    consumers: []
+
+  - name: task-broker
+    ref: ghcr.io/zynax-io/zynax/task-broker
+    digest: sha256:e0ca940c6c874f9a6940b538f7a34352ed775733b4eb737477c73f67a9c0cb20
+    consumers: []
+
+  - name: agent-registry
+    ref: ghcr.io/zynax-io/zynax/agent-registry
+    digest: sha256:b8956d1da73516d89e1a64f578f3292ae27ee74224dfc1dde688bc59c7c4eb05
+    consumers: []
+
+  - name: http-adapter
+    ref: ghcr.io/zynax-io/zynax/http-adapter
+    digest: sha256:b12750bf90c3617078ace8b90be54c137dc50a8d4b64916ed31dd11e9f2b27df
+    consumers: []

--- a/scripts/update_image_digest.py
+++ b/scripts/update_image_digest.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Upsert one image digest in images/images.yaml (ADR-024 source of truth).
+
+Used by the release.yml retag-on-merge job and the tools-image.yml digest
+sync (ADR-027 atomic digest commit). Line-based edit — comments and
+formatting in images.yaml are preserved, which a YAML round-trip would not
+guarantee.
+
+  update_image_digest.py --name api-gateway \\
+      --ref ghcr.io/zynax-io/zynax/api-gateway --digest sha256:<64 hex>
+
+If --name has no entry yet, a new one is appended (requires --ref) with an
+empty consumers list, so first-time promotions (e.g. a brand-new service)
+self-register.
+
+Exit code 0 on success (changed or already current), non-zero on bad input.
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+import sys
+
+DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+NAME_LINE_RE = re.compile(r"^\s*-\s+name:\s+(\S+)\s*$")
+DIGEST_LINE_RE = re.compile(r"^(\s*digest:\s*)sha256:[0-9a-f]{64}\s*$")
+
+
+def upsert(text: str, name: str, ref: str | None, digest: str) -> tuple[str, str]:
+    """Return (new_text, action) where action is updated|unchanged|added."""
+    lines = text.splitlines(keepends=True)
+    out: list[str] = []
+    current = None
+    found = False
+    changed = False
+    for line in lines:
+        m = NAME_LINE_RE.match(line)
+        if m:
+            current = m.group(1)
+        if current == name:
+            found = True
+            dm = DIGEST_LINE_RE.match(line)
+            if dm:
+                new_line = f"{dm.group(1)}{digest}\n"
+                if new_line != line:
+                    changed = True
+                line = new_line
+        out.append(line)
+
+    if found:
+        return "".join(out), ("updated" if changed else "unchanged")
+
+    if not ref:
+        sys.exit(f"error: no entry named {name!r} and --ref not provided")
+    if out and not out[-1].endswith("\n"):
+        out[-1] += "\n"
+    out.append(
+        f"\n  - name: {name}\n    ref: {ref}\n    digest: {digest}\n    consumers: []\n"
+    )
+    return "".join(out), "added"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--name", required=True, help="entry name (images.yaml key)")
+    parser.add_argument("--ref", help="image ref without tag/digest (for new entries)")
+    parser.add_argument("--digest", required=True, help="sha256:<64 hex>")
+    parser.add_argument("--file", default="images/images.yaml")
+    args = parser.parse_args()
+
+    if not DIGEST_RE.match(args.digest):
+        sys.exit(f"error: invalid digest {args.digest!r} (want sha256:<64 hex>)")
+
+    path = pathlib.Path(args.file)
+    new_text, action = upsert(path.read_text(), args.name, args.ref, args.digest)
+    if action != "unchanged":
+        path.write_text(new_text)
+    print(f"{action}: {args.name} -> {args.digest}")
+
+
+if __name__ == "__main__":
+    main()

--- a/state/current-milestone.md
+++ b/state/current-milestone.md
@@ -30,7 +30,7 @@ See [docs/milestones/M5-plan.md](../docs/milestones/M5-plan.md).
 ## M6 — Progress (🚧 Active)
 
 Full plan + per-EPIC status: **[docs/milestones/M6-planning.md](../docs/milestones/M6-planning.md)**.
-As of 2026-06-10: **143 issues closed / 14 open**.
+As of 2026-06-11: **143 issues closed / 17 open** (CI-overhaul stories #1110–#1122 added 2026-06-10).
 
 ### EPICs delivered ✅
 | EPIC | Issue | Notes |
@@ -79,7 +79,11 @@ up but fails at the happy-path assertion; this epic closes the execution-path ga
 
 **Ready now for `/milestone-orchestrate`:** #1089 (O3). Then O4 → O6 (with #1091 verification ∥).
 
-## Recently Closed (last updated 2026-06-09)
+## Recently Closed (last updated 2026-06-11)
+
+**M6 CI/CD overhaul (EPIC #1109) — 2026-06-11 session:**
+- **#1118** ci: pre-merge build-images gate — staging lane, Hadolint, Trivy, SBOM (PR #1132)
+- **#1120** ci: release.yml retag model — workflow_run promotion + atomic images.yaml digest sync (ADR-027)
 
 **M6 batch — 2026-06-08 session:**
 - **#799** feat(workflow-compiler): namespace-scoped capability routing (PR #977)


### PR DESCRIPTION
## Summary

Converts `release.yml` from a post-merge multi-arch rebuild pipeline to the ADR-027 retag model: on every merge to main, the Trivy-gated staging image from `build-images` (#1118) is promoted by `docker buildx imagetools create` to `main-<sha>` + `main` + `latest` (~10 s, no rebuild), cosign-signed, and the new digests are committed to `images/images.yaml` as an atomic `[skip ci]` bot commit. Version tags retag-promote (never rebuild) all images — including `tools`/`ci-runner` — and create one GitHub Release with generated notes and SBOMs. `tools-image.yml`'s `[AUTO]` ci-runner bump-issue is replaced by the same atomic digest commit.

Spec: `docs/contributing/ci-delivery-overhaul-prompt.md` §3C · Part 3 of #1107 / EPIC #1109 · Depends on #1118 (merged, PR #1132).

## EPIC canvas

N/A — `ci:` issues are SPDD-exempt. Design is locked in ADR-027 (Accepted, pre-implementation).

## §3C open question — answered and recorded (workflow header + here)

> Does the retag fire on non-PR pushes to main, and can the `[skip ci]` digest commit re-trigger CI→retag (infinite loop)?

The `workflow_run` trigger (`branches: [main]`) fires on **every** completed CI run on main, including non-PR pushes. A non-PR push has no associated PR (`GET /commits/<sha>/pulls` → empty) and therefore no staging images — the job exits as a no-op. The digest commit carries `[skip ci]`, so GitHub never starts CI for it: **no CI run → no `workflow_run` event → no retag → no loop.** The tools-image digest commit additionally cannot re-trigger `tools-image.yml` because it touches none of that workflow's `paths`.

One factual correction to the locked-decision wording: on a squash-merge, `workflow_run.head_sha` is the **merge commit** SHA (the CI run that fires the event is the post-merge run on main), not the PR head SHA. The PR head SHA — needed to locate the `staging/<svc>:pr-<sha>` tag — is recovered via `GET /repos/{owner}/{repo}/commits/{merge_sha}/pulls`. The `workflow_run` trigger itself stays exactly as locked.

## Recorded decisions / deviations

1. **Service digests now live in `images/images.yaml`** (seeded with the current `:latest` digests; `consumers: []`). New services self-register on first promotion via `scripts/update_image_digest.py` (upsert, comment-preserving). Because service entries have no consumers, the per-merge bot commit only ever touches `images/images.yaml` — `GITHUB_TOKEN` `contents: write` suffices (no App `workflows` permission needed).
2. **`:main` tag kept** alongside `main-<sha>`/`latest` — `infra/docker-compose/docker-compose.yml` pulls `:main`.
3. **tools/ci-runner stay post-merge builds** (recorded deviation from the full retag model): they are multi-arch (the staging lane is amd64-only) and ci-runner is the CI bootstrap image. The retag-model elements that do apply: version tags are retag-only (now in `release.yml` `retag-version`; the `tags:` trigger was removed from `tools-image.yml`) and digest sync is an atomic bot commit, not an `[AUTO]` issue. Main builds of tools/ci-runner are now also cosign-signed (parity with promotions).
4. **SDK/proto-stubs publish stay independently triggered** instead of `workflow_call`: the PyPI Trusted Publisher registration is bound to the `sdk-publish.yml` workflow filename — calling it as a reusable workflow would break OIDC publishing until re-registered. `sdk-publish.yml` already fires on the same `v*.*.*` tags.
5. **Promoted service images are amd64-only** (the staging lane is single-arch) — accepted consequence of the locked "remove all multi-arch build jobs" decision; the multi-arch native-build path remains only for tools/ci-runner.
6. **Weekly `schedule:` rebuild trigger removed** from `release.yml` — there is nothing left to rebuild (P3/P7); base-image CVE drift is covered by Renovate digest bumps (real PRs through the staging gate) and `weekly-audit.yml`.

## ⚠ Required admin steps after merge (the workflow fails loudly until done)

The digest bot commit pushes directly to main — the **recorded ADR-023 exception in ADR-027**. Current classic branch protection (required PRs + required signatures + `enforce_admins`) blocks every direct push, including GitHub-signed API commits. To activate the exception:

1. Migrate main's protection from the classic rule to a **repository ruleset** replicating today's rules (required checks ×10, signatures, linear history, PR requirement), with a **bypass entry for the GitHub Actions app** (`gh api repos/zynax-io/zynax/rulesets -X POST` with `bypass_actors: [{"actor_id": 15368, "actor_type": "Integration", "bypass_mode": "always"}]`), then remove the classic rule. Until then, `retag-on-merge` completes promotion + signing and fails only at the digest-push step (clear `::error` pointing here).
2. Create the **`BOT_GITHUB_TOKEN`** repo secret — fine-grained PAT, `contents: write` + `workflows: write` — used only by `tools-image.yml`'s ci-runner digest sync (its consumers are workflow files, which `GITHUB_TOKEN` cannot push). The PAT owner must be covered by the ruleset bypass.

## Acceptance criteria

- [x] Merging a PR: `main-<sha>` + `latest` (+ `main`) exist with digests identical to staging — `imagetools create` is a manifest copy; `cosign sign --yes` on the promoted digest covers all tags  [evidence: `release.yml` `retag-on-merge`; runtime verification on first docker-touching merge after the admin steps]
- [x] `images/images.yaml` updated by a bot commit on the same merge; no `[AUTO]` digest issues filed  [evidence: digest-commit step; `tools-image.yml` issue step deleted; blocked only on admin step 1]
- [x] `release.yml` contains zero `docker/build-push-action` steps  [evidence: `grep -c build-push-action .github/workflows/release.yml` → 0]
- [x] Pushing a `v*` tag produces a GitHub Release with generated notes (`generate_release_notes: true`) + SBOMs, images retagged to the version  [evidence: `retag-version` + `release` jobs]
- [x] Re-running any job is a no-op  [evidence: `imagetools create` re-points tags at the same digest; digest commit skipped on `git diff --quiet`; upsert script prints `unchanged`]

## Test plan

### Build & unit
- [x] No Go/Python service code touched — service builds/tests N/A
- [x] `scripts/update_image_digest.py` exercised locally: update existing entry, upsert new entry (`event-bus`), idempotent re-run (`unchanged`), invalid digest rejected (exit 1), comments preserved  [evidence: local run output in delivery log]

### Lint & security
- [x] `actionlint` on both workflows — exit 0  [evidence: local run]
- [x] `images check` (`GOWORK=off go run . images check`) — ✅ aligned with seeded entries  [evidence: local run]
- [x] pre-commit: gitleaks, ruff, ruff-format — passed  [evidence: commit hook output]

### Contract
- [x] No gRPC boundary touched — BDD N/A

### Engineering hygiene
- [x] `state/current-milestone.md` + `docs/milestones/M6-planning.md` updated in this diff
- [x] Branched off fresh `origin/main` · counted PR size ≈ 90 lines (script; workflows/docs/state/images.yaml are skipPattern-excluded) · DCO + `Assisted-by` trailers on the commit

Closes #1120

Assisted-by: Claude/claude-fable-5
