### PR TITLE
ci: authenticate release digest push with BOT_GITHUB_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,6 +86,13 @@ jobs:
         with:
           ref: main
           fetch-depth: 1
+          # The digest push must bypass main's ruleset. GitHub's API does not
+          # accept the built-in Actions app as a repo-ruleset bypass actor, so
+          # the bypass is granted to the repository-admin role and the push
+          # authenticates with BOT_GITHUB_TOKEN (admin-owned fine-grained PAT,
+          # contents:write). Falls back to GITHUB_TOKEN, which fails loudly at
+          # the push step until the secret exists.
+          token: ${{ secrets.BOT_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
 
       # A CI run on main is the post-merge run: workflow_run.head_sha is the
       # merge commit. The staging lane is tagged with the PR head SHA —
@@ -167,10 +174,9 @@ jobs:
 
       # Atomic digest sync (ADR-027): the promoted digests land on main in
       # the same run that promoted them. Service entries in images.yaml carry
-      # no consumers, so this commit only ever touches images/images.yaml —
-      # GITHUB_TOKEN contents:write suffices (no `workflows` permission
-      # needed). If a service digest ever gains consumer files, add an
-      # `images sync` stamp step here and switch to BOT_GITHUB_TOKEN.
+      # no consumers, so this commit only ever touches images/images.yaml.
+      # If a service digest ever gains consumer files, add an `images sync`
+      # stamp step here (BOT_GITHUB_TOKEN already covers workflow stamps).
       - name: Commit digest update to main [skip ci]
         if: steps.retag.outputs.promoted == 'true'
         env:


### PR DESCRIPTION
## Summary

Follow-up to #1135 (issue #1120). GitHub's API rejects the built-in Actions app as a repo-ruleset bypass actor ("must be part of the ruleset source or owner organization"), so main's new `main-protection` ruleset grants bypass to the **repository-admin role** instead. The retag job's digest push must therefore authenticate with the admin-owned `BOT_GITHUB_TOKEN` fine-grained PAT — the same `BOT_GITHUB_TOKEN || GITHUB_TOKEN` pattern `tools-image.yml` already uses. Until the secret exists, the push step fails loudly with instructions (by design).

Also corrects the now-stale comment claiming `GITHUB_TOKEN` suffices for the digest push.

## Test plan
- [x] `actionlint` — exit 0 (local)
- [x] One-line behavioral change in checkout `token:`; comment updates only otherwise

Assisted-by: Claude/claude-fable-5