### PR TITLE
chore(infra): document ADR-027 staging-lane delivery in Dockerfile

### DIFF
--- a/infra/docker/Dockerfile.service
+++ b/infra/docker/Dockerfile.service
@@ -1,6 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # Shared service image template. Build context must be repo root.
 # Usage: docker build -f infra/docker/Dockerfile.service --build-arg SVC=<name> .
+#
+# Delivery (ADR-027 shift-left pipeline): every Docker-touching PR builds this
+# image once into the GHCR staging lane (ci.yml build-images: Hadolint + Trivy
+# + SBOM); merges and version tags only RETAG that artifact (release.yml) —
+# the image in production is the exact binary that passed the pre-merge gate.
 #        Covers all five Go services: api-gateway, workflow-compiler, engine-adapter,
 #        task-broker, agent-registry.
 #


### PR DESCRIPTION
## Summary

Records the build-once/retag-promotion contract (ADR-027) in the shared service Dockerfile header.

This docker-touching change doubles as the **first full end-to-end test of the new delivery pipeline**: all 12 images build into the staging lane pre-merge, and the squash-merge exercises `retag-on-merge` (promotion + cosign + atomic `images.yaml` digest bot-commit) with the new `main-protection` ruleset bypass and `BOT_GITHUB_TOKEN`.

**Expected red (non-required) legs:** `Build + scan: langgraph-adapter` and `llm-adapter` fail Trivy on unfixed upstream CVEs in `python:3.12-slim` (perl-base CVE-2026-8376/CVE-2026-42496 CRITICAL, ncurses CVE-2025-69720 HIGH) — known issue pending a `.trivyignore` decision; these checks are not in the required set.

## Test plan
- [x] Comment-only Dockerfile change — no instruction modified, layer cache unaffected
- [x] All required checks green; staging images `staging/<svc>:pr-<head-sha>` pushed for all 12 services/adapters

Assisted-by: Claude/claude-fable-5