### PR TITLE
fix(ci): stop staging cleanup racing the retag promotion

### DIFF
--- a/.github/workflows/pr-image-cleanup.yml
+++ b/.github/workflows/pr-image-cleanup.yml
@@ -17,14 +17,20 @@
 # must be resolved through the API either way — doing the DELETE with the
 # same API keeps third-party action surface at zero (supply chain, #1116).
 #
-# Ordering vs the retag model (§3C, #1120): as of #1119 nothing post-merge
-# consumes the staging image (release.yml builds from scratch), so deleting on
-# close is unconditionally safe. When #1120 converts release.yml to retag the
-# staging manifest into the production package, the retag job MUST tolerate or
-# precede this cleanup — retagging copies the manifest into a DIFFERENT GHCR
-# package (zynax/<svc>, not zynax/staging/<svc>), so once promoted the staging
-# version is dead weight; #1120 must sequence its retag before this delete
-# (e.g. workflow_run chaining) or re-trigger the build. Tracked on #1120.
+# Ordering vs the retag model (§3C, #1120): release.yml's retag-on-merge job
+# promotes the staging manifest AFTER the post-merge CI run completes — several
+# minutes after the PR closes. Deleting on merge would therefore race (and
+# win) against the promotion, leaving nothing to retag (observed live on
+# PR #1137). Split of responsibilities:
+#   - PRs closed WITHOUT merging → cleaned up here (the only consumer of the
+#     staging image was the PR itself).
+#   - Merged PRs → release.yml retag-on-merge deletes each staging version
+#     right after promoting + signing it (the manifest is copied into the
+#     production package zynax/<svc>, so the staging version is dead weight
+#     the moment promotion lands).
+# A merged PR whose post-merge CI never goes green keeps its staging images
+# until the run is fixed/re-run — that is intentional: they are still the
+# only promotable artifact for that merge.
 
 name: PR Image Cleanup
 
@@ -42,6 +48,9 @@ concurrency:
 jobs:
   cleanup:
     name: "Delete staging: ${{ matrix.service }}"
+    # Merged PRs are cleaned by release.yml retag-on-merge AFTER promotion —
+    # deleting here would race the retag and strand the merge unpromoted.
+    if: github.event.pull_request.merged == false
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,10 +137,15 @@ jobs:
       # AND attestation manifests (ADR-025) — and is idempotent: re-running
       # points the same tags at the same digest. One cosign signature per
       # digest covers every tag pointing at it (main-<sha>, main, latest).
+      # After promote+sign the staging version is dead weight and is deleted
+      # HERE — pr-image-cleanup.yml only handles PRs closed without merging
+      # (deleting on merge-close would race this job and strand the merge
+      # unpromoted; observed live on PR #1137).
       - name: Retag staging → main-<sha> + main + latest, sign
         id: retag
         if: steps.pr.outputs.promote == 'true'
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_SHA: ${{ steps.pr.outputs.pr_sha }}
           MERGE_SHA: ${{ steps.pr.outputs.merge_sha }}
         run: |
@@ -164,6 +169,22 @@ jobs:
             cosign sign --yes "${IMAGE_PREFIX}/${svc}@${DIGEST}"
             echo "${svc} ${DIGEST}" >> /tmp/promoted.txt
             echo "✅ ${svc} → main-${MERGE_SHA} / main / latest (${DIGEST})"
+
+            # Promotion copied the manifest into zynax/<svc>; drop the staging
+            # version (same API pattern as pr-image-cleanup.yml — 404 and
+            # already-deleted are quiet no-ops for idempotent re-runs).
+            PKG="zynax%2Fstaging%2F${svc}"
+            IDS=$(gh api --paginate "/orgs/zynax-io/packages/container/${PKG}/versions" \
+              --jq ".[] | select(.metadata.container.tags[]? == \"pr-${PR_SHA}\") | .id" \
+              2>/dev/null) || IDS=""
+            for ID in ${IDS}; do
+              if ! [[ "${ID}" =~ ^[0-9]+$ ]]; then
+                continue
+              fi
+              gh api --method DELETE \
+                "/orgs/zynax-io/packages/container/${PKG}/versions/${ID}" \
+                && echo "🧹 ${svc}: staging version ${ID} (pr-${PR_SHA}) deleted"
+            done
           done
           if [ -s /tmp/promoted.txt ]; then
             echo "promoted=true" >> "$GITHUB_OUTPUT"

--- a/infra/docker/Dockerfile.service
+++ b/infra/docker/Dockerfile.service
@@ -6,6 +6,7 @@
 # image once into the GHCR staging lane (ci.yml build-images: Hadolint + Trivy
 # + SBOM); merges and version tags only RETAG that artifact (release.yml) —
 # the image in production is the exact binary that passed the pre-merge gate.
+# Staging copies are deleted after promotion (merged PRs) or on close (#1119).
 #        Covers all five Go services: api-gateway, workflow-compiler, engine-adapter,
 #        task-broker, agent-registry.
 #


### PR DESCRIPTION
## Summary

Live-testing #1120 on PR #1137 exposed an ordering race: `pr-image-cleanup.yml` (#1119) fires the moment a PR closes and deleted the staging images **minutes before** `retag-on-merge` (which waits for the post-merge CI run) could promote them — all 12 services logged `no staging image … skipped` and nothing was promoted. The cleanup file's own header had this tracked against #1120.

**Fix (root cause, no band-aid):**
- `pr-image-cleanup.yml` now runs only for PRs **closed without merging** (`if: github.event.pull_request.merged == false`).
- `retag-on-merge` deletes each staging version itself **right after** promote+sign (same gh-api deletion pattern; 404/absent are quiet no-ops). GHCR stays bounded for both close paths, with no race.
- A merged PR whose post-merge CI never goes green intentionally keeps its staging images — they remain the only promotable artifact for that merge.

The Dockerfile header note is extended in the same diff, which flips `changes.docker` → this PR rebuilds all 12 staging images and its own merge live-tests the corrected promotion path end-to-end.

**Expected red (non-required):** `Build + scan: llm-adapter` / `langgraph-adapter` — known unfixed CVEs in `python:3.12-slim` (pending `.trivyignore` decision).

## Test plan
- [x] `actionlint` on both workflows — exit 0 (local)
- [x] Merge of this PR must produce: `main-<sha>`/`main`/`latest` for all 12 images, cosign signatures, `images.yaml` digest bot-commit, staging versions deleted post-promotion

Assisted-by: Claude/claude-fable-5