### PR TITLE
fix(ci): make retag promotion restartable after partial failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,64 +133,70 @@ jobs:
         if: steps.pr.outputs.promote == 'true'
         uses: sigstore/cosign-installer@7e8b541eb2e61bf99390e1afd4be13a184e9ebc5 # v3.10.1
 
+      # The promotion is RESTARTABLE end-to-end (P9): every phase derives its
+      # state from the registry, never from a previous attempt's scratch
+      # files. A single GHCR i/o timeout killed a 12-image promotion mid-loop
+      # (run 27339823924) and the old single-step layout could not resume —
+      # it had already deleted the staging images it had promoted, so a
+      # re-run lost their digests for the images.yaml commit. Phases:
+      #   1. promote  — re-points tags from staging (skip if staging gone)
+      #   2. collect  — digests read from the PROMOTED main-<sha> tags + sign
+      #   3. commit   — images.yaml bot commit from the collected digests
+      #   4. cleanup  — staging deletion + prune, only after the commit
       # imagetools create copies the FULL manifest list — platform manifests
-      # AND attestation manifests (ADR-025) — and is idempotent: re-running
-      # points the same tags at the same digest. One cosign signature per
-      # digest covers every tag pointing at it (main-<sha>, main, latest).
-      # After promote+sign the staging version is dead weight and is deleted
-      # HERE — pr-image-cleanup.yml only handles PRs closed without merging
-      # (deleting on merge-close would race this job and strand the merge
-      # unpromoted; observed live on PR #1137).
-      - name: Retag staging → main-<sha> + main + latest, sign
-        id: retag
+      # AND attestation manifests (ADR-025). One cosign signature per digest
+      # covers every tag pointing at it; re-signing on a re-run just appends
+      # an equivalent signature.
+      - name: Promote staging → main-<sha> + main + latest
         if: steps.pr.outputs.promote == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_SHA: ${{ steps.pr.outputs.pr_sha }}
           MERGE_SHA: ${{ steps.pr.outputs.merge_sha }}
         run: |
           set -euo pipefail
-          : > /tmp/promoted.txt
+          # 3-attempt retry for registry round-trips (transient GHCR timeouts).
+          retry() { local n; for n in 1 2 3; do "$@" && return 0; echo "⚠️  attempt ${n}/3 failed: $*" >&2; sleep 10; done; return 1; }
           read -ra SERVICES <<< "${SERVICE_IMAGES}"
           for svc in "${SERVICES[@]}"; do
             STAGING="${STAGING_PREFIX}/${svc}:pr-${PR_SHA}"
             if ! docker buildx imagetools inspect "${STAGING}" >/dev/null 2>&1; then
-              echo "ℹ️  ${svc}: no staging image pr-${PR_SHA} — skipped (PR did not build images)"
+              echo "ℹ️  ${svc}: no staging image pr-${PR_SHA} — nothing to promote (image-less PR, or already promoted+cleaned by an earlier attempt)"
               continue
             fi
-            docker buildx imagetools create \
+            retry docker buildx imagetools create \
               -t "${IMAGE_PREFIX}/${svc}:main-${MERGE_SHA}" \
               -t "${IMAGE_PREFIX}/${svc}:main" \
               -t "${IMAGE_PREFIX}/${svc}:latest" \
               "${STAGING}"
-            DIGEST=$(docker buildx imagetools inspect \
-              --format '{{json .Manifest.Digest}}' \
-              "${IMAGE_PREFIX}/${svc}:main-${MERGE_SHA}" | tr -d '"')
+            echo "✅ ${svc}: staging pr-${PR_SHA} → main-${MERGE_SHA} / main / latest"
+          done
+
+      - name: Collect promoted digests and sign
+        id: retag
+        if: steps.pr.outputs.promote == 'true'
+        env:
+          MERGE_SHA: ${{ steps.pr.outputs.merge_sha }}
+        run: |
+          set -euo pipefail
+          retry() { local n; for n in 1 2 3; do "$@" && return 0; echo "⚠️  attempt ${n}/3 failed: $*" >&2; sleep 10; done; return 1; }
+          : > /tmp/promoted.txt
+          read -ra SERVICES <<< "${SERVICE_IMAGES}"
+          for svc in "${SERVICES[@]}"; do
+            REF="${IMAGE_PREFIX}/${svc}:main-${MERGE_SHA}"
+            if ! docker buildx imagetools inspect "${REF}" >/dev/null 2>&1; then
+              continue   # not promoted for this merge in any attempt
+            fi
+            DIGEST=$(retry docker buildx imagetools inspect \
+              --format '{{json .Manifest.Digest}}' "${REF}" | tr -d '"')
             cosign sign --yes "${IMAGE_PREFIX}/${svc}@${DIGEST}"
             echo "${svc} ${DIGEST}" >> /tmp/promoted.txt
-            echo "✅ ${svc} → main-${MERGE_SHA} / main / latest (${DIGEST})"
-
-            # Promotion copied the manifest into zynax/<svc>; drop the staging
-            # version (same API pattern as pr-image-cleanup.yml — 404 and
-            # already-deleted are quiet no-ops for idempotent re-runs).
-            PKG="zynax%2Fstaging%2F${svc}"
-            IDS=$(gh api --paginate "/orgs/zynax-io/packages/container/${PKG}/versions" \
-              --jq ".[] | select(.metadata.container.tags[]? == \"pr-${PR_SHA}\") | .id" \
-              2>/dev/null) || IDS=""
-            for ID in ${IDS}; do
-              if ! [[ "${ID}" =~ ^[0-9]+$ ]]; then
-                continue
-              fi
-              gh api --method DELETE \
-                "/orgs/zynax-io/packages/container/${PKG}/versions/${ID}" \
-                && echo "🧹 ${svc}: staging version ${ID} (pr-${PR_SHA}) deleted"
-            done
+            echo "✅ ${svc}@${DIGEST} signed"
           done
           if [ -s /tmp/promoted.txt ]; then
             echo "promoted=true" >> "$GITHUB_OUTPUT"
           else
             echo "promoted=false" >> "$GITHUB_OUTPUT"
-            echo "ℹ️  No staging images for this merge — promotion not needed."
+            echo "ℹ️  No images promoted for this merge — nothing to record."
           fi
 
       # Atomic digest sync (ADR-027): the promoted digests land on main in
@@ -226,6 +232,37 @@ jobs:
             echo "::error::pushes (ruleset bypass for the Actions app) — see PR #1120 notes."
             exit 1
           }
+
+      # Staging cleanup runs LAST — once the digests are committed, the
+      # promoted manifests live in zynax/<svc> and the staging versions are
+      # dead weight. pr-image-cleanup.yml only handles PRs closed without
+      # merging (deleting on merge-close raced this job — PR #1137/#1138).
+      # 404 / already-deleted are quiet no-ops for idempotent re-runs.
+      - name: Delete promoted staging versions
+        if: steps.retag.outputs.promoted == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_SHA: ${{ steps.pr.outputs.pr_sha }}
+        run: |
+          set -euo pipefail
+          while read -r svc _; do
+            PKG="zynax%2Fstaging%2F${svc}"
+            IDS=$(gh api --paginate "/orgs/zynax-io/packages/container/${PKG}/versions" \
+              --jq ".[] | select(.metadata.container.tags[]? == \"pr-${PR_SHA}\") | .id" \
+              2>/dev/null) || IDS=""
+            if [ -z "${IDS}" ]; then
+              echo "ℹ️  ${svc}: no staging version tagged pr-${PR_SHA} — already cleaned."
+              continue
+            fi
+            for ID in ${IDS}; do
+              if ! [[ "${ID}" =~ ^[0-9]+$ ]]; then
+                continue
+              fi
+              gh api --method DELETE \
+                "/orgs/zynax-io/packages/container/${PKG}/versions/${ID}" \
+                && echo "🧹 ${svc}: staging version ${ID} (pr-${PR_SHA}) deleted"
+            done
+          done < /tmp/promoted.txt
 
       - name: Prune old main-<sha> versions
         if: steps.retag.outputs.promoted == 'true'

--- a/images/images.yaml
+++ b/images/images.yaml
@@ -63,32 +63,32 @@ images:
 
   - name: api-gateway
     ref: ghcr.io/zynax-io/zynax/api-gateway
-    digest: sha256:81e086f4dafefbe9d6f2a2f851d5c692358c9726f90f564711418a9027d42acb
+    digest: sha256:18f4ac6c8644806bdd21fdda7cf8311db8d7f9a6749387c4f9fd78675043b469
     consumers: []
 
   - name: engine-adapter
     ref: ghcr.io/zynax-io/zynax/engine-adapter
-    digest: sha256:f8aad99db35b51d59119da9964f8e39b899ebcb9400e8fc0e7b60a0dde392665
+    digest: sha256:8287b2b9e4331e3405ba1e324cab0b2c5661c89aa5e962e1c3399b4b6b007cf6
     consumers: []
 
   - name: workflow-compiler
     ref: ghcr.io/zynax-io/zynax/workflow-compiler
-    digest: sha256:01ef2e6262f12a78330f0a3d41b2e81903eb2a9daeed4469d59bb0494a6a7a12
+    digest: sha256:550c1ceb3588c4f5c6dfc28206f055b880a690a1fc8897bce012a98fe89c5846
     consumers: []
 
   - name: task-broker
     ref: ghcr.io/zynax-io/zynax/task-broker
-    digest: sha256:e0ca940c6c874f9a6940b538f7a34352ed775733b4eb737477c73f67a9c0cb20
+    digest: sha256:04150a5ddeefdacafda72ecc36bbd4ce1b1cc840d4ff59a3ae0e47c0e56cdfa7
     consumers: []
 
   - name: agent-registry
     ref: ghcr.io/zynax-io/zynax/agent-registry
-    digest: sha256:b8956d1da73516d89e1a64f578f3292ae27ee74224dfc1dde688bc59c7c4eb05
+    digest: sha256:4e2fe04b56e07511fa71fb41eae9e28704bc5a8c34365ffae57beeaf4e724a87
     consumers: []
 
   - name: http-adapter
     ref: ghcr.io/zynax-io/zynax/http-adapter
-    digest: sha256:b12750bf90c3617078ace8b90be54c137dc50a8d4b64916ed31dd11e9f2b27df
+    digest: sha256:11ba61296214af0084dc26cb47061225fe5746d3e088a1a4c0ed6a99a07dceb6
     consumers: []
 
   - name: langgraph-adapter
@@ -104,4 +104,19 @@ images:
   - name: git-adapter
     ref: ghcr.io/zynax-io/zynax/git-adapter
     digest: sha256:e10cf38788271f924f18a7725dc8948e7516f5cd2a7954310cbaeef034040c06
+    consumers: []
+
+  - name: event-bus
+    ref: ghcr.io/zynax-io/zynax/event-bus
+    digest: sha256:93037e87bf2f0a3cd8151002bb4d8fdd119f775a1af92f84028f4c26e88b49cf
+    consumers: []
+
+  - name: memory-service
+    ref: ghcr.io/zynax-io/zynax/memory-service
+    digest: sha256:5efc07582d8413acf9797ad06d5fcc089eb5a229d504eb261a021a1c7ff7f8bf
+    consumers: []
+
+  - name: llm-adapter
+    ref: ghcr.io/zynax-io/zynax/llm-adapter
+    digest: sha256:0e565d8872a67ce707120a89bd6c388cbe04614b8d16ff3a6130f821d4b0a267
     consumers: []


### PR DESCRIPTION
## Summary

Run 27339823924 (merge of #1138) hit a transient GHCR i/o timeout after promoting 10 of 12 images. The single-step layout couldn't resume: the staging images it had already promoted were deleted in the same loop iteration, so the re-run lost their digests for the images.yaml commit (only 3 of 12 entries were recorded).

**Fix:** the retag job is now four phases, each deriving state from the registry (P9):
1. **promote** — re-points tags from staging (skips if staging already cleaned by an earlier attempt)
2. **collect + sign** — digests read from the promoted `main-<sha>` tags, never the staging lane
3. **digest commit** — from the collected set
4. **staging cleanup + prune** — only after the commit landed

Registry round-trips get a 3-attempt retry (the timeout that triggered this was a single failed `imagetools inspect`).

`images/images.yaml` is reconciled in the same diff to the digests actually promoted across both attempts of that run (9 stale/missing entries; verified against live `:latest` digests; `images check` green).

## Test plan
- [x] `actionlint` — exit 0 (local)
- [x] `zynax-ci images check` — aligned (local)
- [x] All 12 entries in images.yaml match live GHCR `:latest` digests  [evidence: upsert script output in delivery log]

Assisted-by: Claude/claude-fable-5