### PR TITLE
fix(agents): migrate llm/langgraph adapters to alpine base

### DIFF
--- a/agents/adapters/langgraph/Dockerfile
+++ b/agents/adapters/langgraph/Dockerfile
@@ -2,8 +2,8 @@
 # Build context: repo root  (docker build -f agents/adapters/langgraph/Dockerfile .)
 #
 # Two-stage build:
-#   builder  — python:3.12-slim + uv; installs locked dependencies into /app/.venv
-#   runtime  — python:3.12-slim; copies venv + source + proto stubs; runs as zynax (UID 1001)
+#   builder  — python:3.12-alpine + uv; installs locked dependencies into /app/.venv
+#   runtime  — python:3.12-alpine; copies venv + source + proto stubs; runs as zynax (UID 1001)
 #
 # Required env vars at runtime: LANGGRAPH_MOUNTS (JSON), REGISTRY_ADDR, AGENT_ID, ADAPTER_ENDPOINT
 # Optional: ZYNAX_LANGGRAPH_ADAPTER_GRPC_PORT (default 50058)
@@ -13,20 +13,26 @@
 # The module must be importable from the container's PYTHONPATH. Mount graph
 # modules via a volume or build a custom image extending this one.
 #
+# ── Base image: alpine (musl), not Debian slim ────────────────────────────────
+# Debian trixie's python:3.12-slim carries perl-base and ncurses with unfixed
+# CRITICAL/HIGH CVEs that red-wall the pre-merge Trivy gate (ADR-027) — packages
+# this adapter never uses. Alpine drops them entirely. The historical objection
+# (manylinux-only native wheels forcing musl source builds) no longer holds:
+# every native dep in uv.lock — including langgraph's pydantic-core/orjson —
+# ships musllinux wheels, and protobuf falls back to its pure-python wheel.
+# `--no-build` enforces wheels-only, so a future lock bump that loses a musl
+# wheel fails loudly at build time instead of attempting a source compile.
+#
 # ── Final image size ──────────────────────────────────────────────────────────
-# Compressed (amd64): ~78 MB (within the 80 MB target). The runtime stage carries
-# only the python:3.12-slim base + the frozen uv venv (no-dev) + source + proto
+# Compressed (amd64): ~39 MB (was ~78 MB on slim; 80 MB target). The runtime stage carries
+# only the python:3.12-alpine base + the frozen uv venv (no-dev) + source + proto
 # stubs + bundled example graphs; the uv/build layer stays in the builder stage.
-# We deliberately stay on python:3.12-slim rather than -alpine: langgraph/langchain
-# pull in pydantic-core and other native wheels that ship as manylinux (glibc)
-# builds and would force slow, fragile musl source compilation on Alpine.
-# `uv sync --no-dev --frozen` already yields a minimal deterministic dep set.
 
-# BEGIN zynax-ci:images:python-slim
-ARG PYTHON_SLIM_DIGEST=sha256:090ba77e2958f6af52a5341f788b50b032dd4ca28377d2893dcf1ecbdfdfe203
-# END zynax-ci:images:python-slim
+# BEGIN zynax-ci:images:python-alpine
+ARG PYTHON_ALPINE_DIGEST=sha256:4d5e6e9fdab73ef5833d6c9c4e12503e838b7e19a56362d51b7206b2739ca103
+# END zynax-ci:images:python-alpine
 # renovate: datasource=docker depName=python versioning=docker
-FROM python:3.12-slim@${PYTHON_SLIM_DIGEST} AS builder
+FROM python:3.12-alpine@${PYTHON_ALPINE_DIGEST} AS builder
 
 WORKDIR /app
 
@@ -36,15 +42,15 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 
 # Install locked dependencies (without the project itself — source is copied separately)
 COPY agents/adapters/langgraph/pyproject.toml agents/adapters/langgraph/uv.lock ./
-RUN uv sync --no-dev --no-install-project --frozen
+RUN uv sync --no-dev --no-install-project --frozen --no-build
 
 # renovate: datasource=docker depName=python versioning=docker
-FROM python:3.12-slim@${PYTHON_SLIM_DIGEST}
+FROM python:3.12-alpine@${PYTHON_ALPINE_DIGEST}
 
 WORKDIR /app
 
 # Non-root user (ADR-002)
-RUN useradd -r -u 1001 -g nogroup zynax
+RUN adduser -S -H -u 1001 -G nogroup zynax
 
 # Strip the base image's build-time-only packages (pip/setuptools/wheel). They are
 # never used at runtime — the app runs the uv venv via `python -m` — and are a

--- a/agents/adapters/llm/Dockerfile
+++ b/agents/adapters/llm/Dockerfile
@@ -2,27 +2,33 @@
 # Build context: repo root  (docker build -f agents/adapters/llm/Dockerfile .)
 #
 # Two-stage build:
-#   builder  — python:3.12-slim + uv; installs locked dependencies into /app/.venv
-#   runtime  — python:3.12-slim; copies venv + source + proto stubs; runs as zynax (UID 1001)
+#   builder  — python:3.12-alpine + uv; installs locked dependencies into /app/.venv
+#   runtime  — python:3.12-alpine; copies venv + source + proto stubs; runs as zynax (UID 1001)
 #
 # Required env vars at runtime: LLM_PROVIDER, REGISTRY_ADDR, AGENT_ID, ADAPTER_ENDPOINT
 # Provider-specific: OPENAI_API_KEY | AWS_REGION | OLLAMA_BASE_URL
 # Optional: LLM_MODEL, LLM_MAX_TOKENS, ZYNAX_LLM_ADAPTER_GRPC_PORT (default 50057)
 #
+# ── Base image: alpine (musl), not Debian slim ────────────────────────────────
+# Debian trixie's python:3.12-slim carries perl-base and ncurses with unfixed
+# CRITICAL/HIGH CVEs that red-wall the pre-merge Trivy gate (ADR-027) — packages
+# this adapter never uses. Alpine drops them entirely. The historical objection
+# (manylinux-only native wheels forcing musl source builds) no longer holds:
+# every native dep in uv.lock ships musllinux wheels (grpcio, pydantic-core,
+# aiohttp, …) and protobuf falls back to its pure-python wheel. `--no-build`
+# enforces wheels-only, so a future lock bump that loses a musl wheel fails
+# loudly at build time instead of attempting a source compile.
+#
 # ── Final image size ──────────────────────────────────────────────────────────
-# Compressed (amd64): ~75 MB (within the 80 MB target). The runtime stage carries
-# only the python:3.12-slim base + the frozen uv venv (no-dev) + source + proto
-# stubs; the uv/build layer is left behind in the builder stage. We deliberately
-# stay on python:3.12-slim rather than -alpine: the provider SDKs (openai, boto3,
-# grpcio) ship manylinux wheels that install cleanly on glibc but force slow,
-# fragile source compilation on Alpine's musl. `uv sync --no-dev --frozen` already
-# yields a minimal, deterministic dependency set; no build caches reach the image.
+# Compressed (amd64): ~48 MB (was ~75 MB on slim; 80 MB target). The runtime stage carries
+# only the python:3.12-alpine base + the frozen uv venv (no-dev) + source + proto
+# stubs; the uv/build layer is left behind in the builder stage.
 
-# BEGIN zynax-ci:images:python-slim
-ARG PYTHON_SLIM_DIGEST=sha256:090ba77e2958f6af52a5341f788b50b032dd4ca28377d2893dcf1ecbdfdfe203
-# END zynax-ci:images:python-slim
+# BEGIN zynax-ci:images:python-alpine
+ARG PYTHON_ALPINE_DIGEST=sha256:4d5e6e9fdab73ef5833d6c9c4e12503e838b7e19a56362d51b7206b2739ca103
+# END zynax-ci:images:python-alpine
 # renovate: datasource=docker depName=python versioning=docker
-FROM python:3.12-slim@${PYTHON_SLIM_DIGEST} AS builder
+FROM python:3.12-alpine@${PYTHON_ALPINE_DIGEST} AS builder
 
 WORKDIR /app
 
@@ -32,15 +38,15 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 
 # Install locked dependencies (without the project itself — source is copied separately)
 COPY agents/adapters/llm/pyproject.toml agents/adapters/llm/uv.lock ./
-RUN uv sync --no-dev --no-install-project --frozen
+RUN uv sync --no-dev --no-install-project --frozen --no-build
 
 # renovate: datasource=docker depName=python versioning=docker
-FROM python:3.12-slim@${PYTHON_SLIM_DIGEST}
+FROM python:3.12-alpine@${PYTHON_ALPINE_DIGEST}
 
 WORKDIR /app
 
 # Non-root user (ADR-002)
-RUN useradd -r -u 1001 -g nogroup zynax
+RUN adduser -S -H -u 1001 -G nogroup zynax
 
 # Strip the base image's build-time-only packages (pip/setuptools/wheel). They are
 # never used at runtime — the app runs the uv venv via `python -m` — and are a

--- a/images/images.yaml
+++ b/images/images.yaml
@@ -46,10 +46,14 @@ images:
       - agents/adapters/http/Dockerfile
       - infra/docker/Dockerfile.service
 
-  - name: python-slim
+  # Alpine (musl) replaced Debian slim for the Python adapters: trixie's
+  # perl-base/ncurses carried unfixed CRITICAL/HIGH CVEs the adapters never
+  # use, and every locked native dep ships musllinux wheels (protobuf falls
+  # back to its pure-python wheel), so the install stays wheels-only.
+  - name: python-alpine
     ref: python
-    tag: "3.12-slim"
-    digest: sha256:090ba77e2958f6af52a5341f788b50b032dd4ca28377d2893dcf1ecbdfdfe203
+    tag: "3.12-alpine"
+    digest: sha256:4d5e6e9fdab73ef5833d6c9c4e12503e838b7e19a56362d51b7206b2739ca103
     consumers:
       - agents/adapters/langgraph/Dockerfile
       - agents/adapters/llm/Dockerfile


### PR DESCRIPTION
## Summary

Kills the unfixed Debian-trixie CVEs that red-walled the Trivy gate by moving the two Python adapter images from `python:3.12-slim` to `python:3.12-alpine` (digest-pinned via images.yaml, `python-slim` entry replaced by `python-alpine`).

**Why the old 'deliberately stay on slim' rationale no longer holds:** every native dependency in both `uv.lock` files ships musllinux wheels (grpcio, pydantic-core, aiohttp, orjson, …) and protobuf falls back to its pure-python wheel — verified by lockfile audit. `uv sync --no-build` now enforces wheels-only so any future regression fails loudly at build time. `useradd` → busybox `adduser`.

## Local verification (full CI gate config reproduced)

- Both images **build** locally from repo root (wheels-only, no compiler in either stage)
- **Import smoke test**: `llm_adapter, grpc, protobuf, openai` and `langgraph_adapter, grpc, pydantic_core, langgraph` all load on musl
- **Trivy** (v0.71.0, same pinned DB `225c785a`, `TRIVY_VULN_SEVERITY_SOURCE=nvd,ghsa`, CRITICAL,HIGH, `--exit-code 1`): **exit 0, zero findings on both** — perl-base/ncurses CVEs (CVE-2026-8376, CVE-2026-42496, CVE-2026-9538, CVE-2026-42497, CVE-2025-69720) gone structurally
- **Hadolint**: only the pre-existing DL3059 info (below the `error` CI threshold)
- Compressed size: llm 75→48 MB, langgraph 78→39 MB

The PR's own `Build + scan` legs re-verify all of this in CI — **all 12 legs are expected green for the first time**.

Assisted-by: Claude/claude-fable-5