### PR TITLE
chore(ci): record #1089 satisfied by shift-left build-images

### DIFF
--- a/docs/spdd/1086-e2e-green/canvas.md
+++ b/docs/spdd/1086-e2e-green/canvas.md
@@ -102,8 +102,11 @@ EPIC #770 (harness) and #771 (CI-E2E gate).
    `POST /api/v1/apply` succeeds. (Gap 1)
 2. **[O2]** Add a minimal echo/mock capability worker + a minimal reference workflow; prove a
    dispatch round-trips and the workflow reaches `succeeded`. (Gap 2; depends O1)
-3. **[O3]** Add event-bus + memory-service to the `release.yml` build matrix and publish their
-   images. (Gap 3a)
+3. **[O3]** ✅ Add event-bus + memory-service to the pre-merge `build-images` matrix in `ci.yml`
+   and publish their images. (Gap 3a; rescoped 2026-06-11 from `release.yml` to the shift-left
+   model — ADR-027, #1118/#1120. Satisfied by PR #1132: all 12 Build+scan legs green,
+   `ghcr.io/zynax-io/zynax/{event-bus,memory-service}:main` promoted by retag, digests in
+   `images/images.yaml`. Issue #1089 closed with evidence.)
 4. **[O4]** Re-enable event-bus + memory-service in the e2e deploy and turn on the CloudEvent +
    memory-`Get` assertions. (Gap 3b; depends O1, O2, O3)
 5. **[O5]** Right-size the `e2e smoke` runner / per-pod resource requests so the full stack fits

--- a/state/current-milestone.md
+++ b/state/current-milestone.md
@@ -55,7 +55,7 @@ As of 2026-06-11: **143 issues closed / 17 open** (CI-overhaul stories #1110–#
 | DevAuto Wave 3 | #880 | post-merge completeness mesh |
 
 ### In progress / remaining
-**e2e-green execution path (#1086 — O1 #1087 ✅ / O2 #1088 ✅ merged via PR #1095; O3 #1089 ready)**,
+**e2e-green execution path (#1086 — O1 #1087 ✅ / O2 #1088 ✅ merged via PR #1095; O3 #1089 ✅ satisfied by build-images gate PR #1132)**,
 Postgres off Bitnami (#1073 — O1 ADR-026 ✅, #1076→#1079 chain),
 CI-E2E gate (#771 — #1070 ✅, #1071 remaining),
 DevAuto Wave 4 (#881 — canvas Aligned, stories #1096–#1104 created).
@@ -72,12 +72,12 @@ up but fails at the happy-path assertion; this epic closes the execution-path ga
 |------|-------|------|------|-----------|
 | O1 | [#1087](https://github.com/zynax-io/zynax/issues/1087) expose api-gateway on host (NodePort 30080) | feat(infra) | S | ✅ merged (PR #1095) |
 | O2 | [#1088](https://github.com/zynax-io/zynax/issues/1088) minimal capability worker + reference workflow → succeeded | feat(infra) | M | ✅ merged (PR #1095) |
-| O3 | [#1089](https://github.com/zynax-io/zynax/issues/1089) event-bus + memory-service in release.yml matrix | ci(infra) | M | — (ready) |
+| O3 | [#1089](https://github.com/zynax-io/zynax/issues/1089) event-bus + memory-service in pre-merge build-images matrix | ci(infra) | M | ✅ satisfied by PR #1132 (shift-left, ADR-027) — closed with evidence |
 | O4 | [#1090](https://github.com/zynax-io/zynax/issues/1090) enable event-bus + memory-service in e2e + assertions | test(infra) | M | #1089 |
 | O5 | [#1091](https://github.com/zynax-io/zynax/issues/1091) right-size e2e-smoke runner / pod resources | ci(infra) | S | resources merged (PR #1094); verify on full gate run |
 | O6 | [#1092](https://github.com/zynax-io/zynax/issues/1092) promote gate advisory → stable/required | ci | S | #1090 #1091 #1071 |
 
-**Ready now for `/milestone-orchestrate`:** #1089 (O3). Then O4 → O6 (with #1091 verification ∥).
+**Ready now for `/milestone-orchestrate`:** #1090 (O4 — O3 #1089 closed). Then O6 (with #1091 verification ∥).
 
 ## Recently Closed (last updated 2026-06-11)
 
@@ -310,14 +310,13 @@ Canvas: SPDD-exempt (docs:/chore:/ci: stories only, until Wave 4 #881 which is B
 
 **Immediate (unblocked):**
 - **#1087** feat(infra): expose api-gateway on host port for e2e (NodePort 30080) — #1086 O1 ✅ ready
-- **#1089** ci(infra): event-bus + memory-service in release.yml matrix — #1086 O3 ✅ ready
 - **#1076** refactor(infra): replace postgres subchart image source — #1073 O2 ✅ ready (ADR-026 chose official postgres:17)
 - **#1071** ci(infra): Temporal-vs-Argo engine matrix in e2e-smoke — #771 O2 ✅ ready (#1070 merged)
 - **#867** chore(ci): GHCR retention cap — last 5 builds only
 - **#840** ci(infra): Python adapters in multi-arch release pipeline
 - **#841** ci(infra): audit and minimize image sizes
 
-**M6.E2E-Green chain (after O1/O3):** #1088 (O2, needs #1087) → #1090 (O4, needs #1087 #1088 #1089) → #1091 (O5, needs #1088) → #1092 (O6, needs #1087 #1088 #1090 #1091 #1071).
+**M6.E2E-Green chain (O1 #1087 / O2 #1088 / O3 #1089 all ✅):** #1090 (O4, unblocked) → #1091 (O5, needs #1088) → #1092 (O6, needs #1087 #1088 #1090 #1091 #1071).
 **M6.Postgres chain (after #1076):** #1077 → #1078 → #1079 (sequential).
 
 **M6.Argo continuation (after #795 merges):**


### PR DESCRIPTION
## Summary

Closes the bookkeeping for #1089 (EPIC #1086, canvas step O3). Verification on 2026-06-11 shows every acceptance criterion of the rescoped story is already met by the shift-left build-images gate (PR #1132 / #1118, ADR-027) plus the retag promotion (#1120) — no code change is needed.

## Evidence

- `.github/workflows/ci.yml` `build-images` matrix includes `event-bus` and `memory-service` (matrix `include` entries alongside the other Go services).
- All 12 `Build + scan` legs green on CI run [27347811145](https://github.com/zynax-io/zynax/actions/runs/27347811145), including `Build + scan: event-bus` and `Build + scan: memory-service` (Hadolint + Trivy + SBOM).
- `ghcr.io/zynax-io/zynax/event-bus:main` resolves at `sha256:9ff709dbf25cd07d00474a08250e6ddca4b953af8b958d24249530f626c7eff0`; `ghcr.io/zynax-io/zynax/memory-service:main` at `sha256:301459fd596739f0a1c52523a3d63689614c9d8d658c83154f0fa9b50dc6bbb7` — promoted by release run [27348196997](https://github.com/zynax-io/zynax/actions/runs/27348196997), cosign-signed (`.sig` tags present on GHCR).
- `images/images.yaml` carries matching digests (retag bot sync, commit 2dd4a86).

## Changes

- `docs/spdd/1086-e2e-green/canvas.md`: O3 marked done with the 2026-06-11 rescope note (release.yml matrix → pre-merge build-images).
- `state/current-milestone.md`: #1089 rows updated (table, in-progress summary, next-session queue); O4 #1090 now unblocked.

Refs #1089

Assisted-by: Claude/claude-fable-5