### PR TITLE
docs(automation): ADR-028 AgentDef-vs-Workflow split + schema path fix

### DIFF
--- a/automation/tests/test_platform_readiness.py
+++ b/automation/tests/test_platform_readiness.py
@@ -11,7 +11,7 @@ try:
 except ImportError:
     HAS_JSONSCHEMA = False
 
-SCHEMA_PATH = "spec/schemas/agent-def.json"
+SCHEMA_PATH = "spec/schemas/agent-def.schema.json"
 ORCHESTRATOR_YAML = "automation/workflows/dev-advisory-orchestrator.yaml"
 EXPERT_YAMLS = list(Path("automation/workflows/experts/").glob("*.yaml"))
 

--- a/docs/adr/ADR-028-agentdef-vs-workflow-self-hosted-automation.md
+++ b/docs/adr/ADR-028-agentdef-vs-workflow-self-hosted-automation.md
@@ -1,0 +1,150 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# ADR-028 — AgentDef-vs-Workflow Split for Self-Hosted Automation + Context-Slice Injection Contract
+
+| Field | Value |
+|-------|-------|
+| **Status** | Accepted |
+| **Date** | 2026-06-11 |
+| **Deciders** | Oscar Gómez Manresa |
+| **Scope** | `automation/workflows/**` (Wave 4 platform manifests), `spec/schemas/agent-def.schema.json`, `spec/schemas/workflow.schema.json`, `automation/tests/test_platform_readiness.py` — EPIC #881 |
+| **Related** | ADR-011 (declarative YAML control plane), ADR-014 (event-driven state machine), ADR-019 (SPDD governance), ADR-021 (Postgres-backed repos), ADR-022 (EventBus architecture) |
+
+---
+
+## Context
+
+EPIC #881 (M6.DevAuto Wave 4) makes the maintainer's issue-delivery pipeline
+**self-hosted**: the orchestrator and the domain experts that today live as
+Claude Code slash commands and subagent prompts become Zynax manifests that run
+on the Zynax platform itself — task-broker, agent-registry, EventBus, Postgres.
+The headline demo is Zynax reading one of its own GitHub issues, routing it to
+the right expert with a bounded context slice, and driving it to an implemented
+change.
+
+The blocker is that **the manifest model was undecided**:
+
+1. **The original #881 sketch matches neither shipped schema.** It used
+   `spec.steps`, `spec.trigger`, and `parallel: true` — a hybrid that conflates
+   *what an agent can do* with *how work is orchestrated*. Meanwhile two schemas
+   shipped and are enforced by `make validate-spec`:
+   - `spec/schemas/agent-def.schema.json` — a **capability provider**
+     (`kind: AgentDef`): `spec.capabilities[]` with per-capability
+     `input_schema`/`output_schema`, plus `spec.runtime` (image, env, replicas).
+     Registered with AgentRegistryService; dispatched by the task broker.
+   - `spec/schemas/workflow.schema.json` — a **state machine**
+     (`kind: Workflow`): `spec.initial_state` + `spec.triggers` + `spec.states`,
+     where states invoke capabilities via `actions[]` and transition on
+     CloudEvents. Compiled by WorkflowCompilerService.
+2. **The near-term expert configs are not platform manifests.** The Wave 1–3
+   expert YAMLs (delivered under `automation/experts/` in #875/#876, archived to
+   `docs/archive/dev-advisory/experts/` when `dev-advisory.yml` was retired in
+   #1129) each declare a `context_slice` (`{files[], max_tokens}`), an
+   `input_contract`/`output_contract`, and an `aggregation_weight`. They are the
+   source of truth for each expert's knowledge boundary, but they are consumed
+   by GitHub Actions, not loadable by `zynax apply`.
+3. **This is a one-way door.** Every Wave 4 manifest (9 expert AgentDefs, the
+   orchestrator workflow, the issue-delivery workflow, the learning
+   synthesizer) is shaped by which `kind` each concept maps to. Reversing the
+   mapping after O2–O8 land would mean rewriting every manifest and its tests.
+
+---
+
+## Decision
+
+**1. Two kinds, no third schema.** Experts, the planner, and the learning
+synthesizer are **`kind: AgentDef`** — capability providers validated by
+`spec/schemas/agent-def.schema.json`. **All orchestration** (the dev-advisory
+fan-out→aggregate→act loop and the issue-delivery
+intake→plan→route→inject→implement→verify→decide loop) is **`kind: Workflow`**
+— state machines validated by `spec/schemas/workflow.schema.json`. The original
+#881 `spec.steps`/`spec.trigger`/`parallel: true` sketch is **superseded**. We
+will not invent a third manifest schema and will not extend
+`agent-def.schema.json` with orchestration fields.
+
+Concretely:
+
+| Concept | kind | Capability / states |
+|---------|------|---------------------|
+| 8 domain experts (`arch-adr`, `persistence-state`, `api-contract`, `security-supply-chain`, `qa-bdd`, `docs-agents`, `ci-release`, `planning-task-split`) | AgentDef | `review` |
+| Planner (`planning-task-split`, extended) | AgentDef | `review` + `identify_next_issue` |
+| Learning synthesizer | AgentDef | `synthesize_learnings` (human-gated apply) |
+| Dev-advisory orchestrator | Workflow | `fan_out` → `aggregate` → `act`/`escalate` |
+| Issue-delivery engine | Workflow | `intake` → `plan` → `route` → `inject` → `implement` → `verify` → `decide` |
+
+Parallelism is expressed the way `workflow.schema.json` already defines it: all
+`actions[]` of a state start before the state machine waits for a transition —
+the `fan_out` state lists the expert `review` invocations and the EventBus
+(ADR-022) carries the durable fan-out/collection. No `parallel:` flag is needed.
+
+**2. Context-slice injection contract.** Each expert AgentDef declares a
+bounded context slice — `{files[], max_tokens}` — translated 1:1 from its
+near-term YAML (now `docs/archive/dev-advisory/experts/<name>.yaml`). This is
+the on-platform analogue of injecting a `.claude/commands/experts/*.md` prompt
+into a fresh Claude Code subagent. The contract:
+
+- **Bounded:** an expert receives only its declared `files[]`, hard-capped at
+  its declared `max_tokens` (overflow policy: truncate oldest files).
+- **Strictly isolated:** no expert ever sees another expert's slice or output
+  (`fan_out.context_budget.isolation: strict`, carried over verbatim from the
+  Wave 2 orchestrator config).
+- **Orchestrator exception:** the orchestrator workflow aggregates expert
+  *outputs only* — never raw code files — within its own token budget.
+- **Transport:** the slice is bound at dispatch time into the capability
+  `input_payload` (the `context_slice` field of the `review` capability's
+  `input_schema`), routed by the task broker over the EventBus.
+
+**3. Both planes coexist.** The Wave 0–3 GitHub Actions plane remains in place
+and unchanged; Wave 4 manifests are loaded only by `zynax apply` and are never
+wired into main CI as required checks until `test_platform_readiness.py`
+passes against a real platform.
+
+---
+
+## Rationale
+
+| Option | Assessment |
+|--------|------------|
+| **A — Split across the two shipped kinds** (AgentDef = capability provider, Workflow = orchestration) | ✅ Chosen — maps honestly onto schemas that already exist, are CI-enforced (`make validate-spec`), and are consumed by shipped services (agent-registry, workflow-compiler, task-broker, engine-adapter). Zero schema changes; Wave 4 exercises the platform exactly as any user manifest would — which is the point of self-hosting. |
+| **B — Extend `agent-def.schema.json` with `steps`/`trigger`/`parallel` (the original #881 sketch)** | ✗ Rejected — conflates agent and workflow concerns in one kind; duplicates the state-machine semantics ADR-014 already standardised; requires schema + registry + compiler changes for a capability the Workflow kind already provides; the demo would then prove a bespoke path, not the real platform. |
+| **C — Invent a third manifest schema for "automation" resources** | ✗ Rejected — a third source of truth with its own validation, compiler, and lifecycle; violates the §Safeguards rule of the #881 canvas ("never invent a third manifest schema") and adds maintenance surface for no expressive gain. |
+
+The context-slice contract is recorded here (not in a separate ADR) because it
+is the load-bearing half of the same decision: AgentDefs are only safe to fan
+out in parallel *because* their context is bounded and isolated — that is what
+makes the thin-orchestrator pattern work both off-platform (Claude Code
+subagents) and on-platform (capability dispatch).
+
+---
+
+## Consequences
+
+### Positive
+
+- O2–O8 of EPIC #881 have a fixed target: 9 AgentDefs + 2 Workflows + 1
+  synthesizer AgentDef, all validating against shipped schemas with no schema
+  PRs in the critical path.
+- The self-hosting demo doubles as a real integration test of agent-registry,
+  task-broker, EventBus, and workflow-compiler — the manifests use only public,
+  documented surface.
+- The expert knowledge boundary stays in one place: the archived near-term
+  YAMLs remain the source of truth for slices/contracts, translated 1:1 into
+  AgentDef capabilities.
+
+### Negative / trade-offs
+
+- The expressive limits of `workflow.schema.json` are now binding for
+  automation: anything the state machine cannot express (e.g. dynamic expert
+  sets) needs a schema evolution PR first, not an automation-side workaround.
+- Context slices are declared per-expert in two related shapes (archived
+  near-term YAML and AgentDef `input_schema`) until the GitHub Actions plane is
+  eventually retired — drift between them must be checked in O2's unit tests.
+
+### Neutral / follow-up required
+
+| Action | Tracking |
+|--------|---------|
+| Translate 9 expert YAMLs → `automation/workflows/experts/*.yaml` AgentDefs | EPIC #881 O2 (#1097) |
+| Author orchestrator + issue-delivery Workflows | EPIC #881 O3/O4 (#1098, #1099) |
+| Runtime context-slice binding with isolation test | EPIC #881 O5 (#1100) |
+| Flip `test_platform_readiness.py` from xfail to a real e2e | EPIC #881 O8 (#1103) |

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -38,6 +38,7 @@ a PR against `docs/adr/`.
 | [ADR-025](ADR-025-slsa-provenance-attestation.md) | SLSA provenance attestation: keep vs disable | Accepted | 2026-06-08 | `tools-image.yml`, `release.yml` — all `docker/build-push-action` steps |
 | [ADR-026](ADR-026-postgres-distribution.md) | Postgres distribution + target major version (official `postgres:17` + thin chart) | Accepted | 2026-06-10 | `helm/charts/postgres/`, `images/images.yaml`, all production Postgres — EPIC #1073 |
 | [ADR-027](ADR-027-shift-left-pipeline.md) | Shift-left pipeline model — build once pre-merge, promote by retag | Accepted | 2026-06-11 | `ci.yml` build-images, `release.yml` retag jobs, GHCR staging lane — EPIC #1109 |
+| [ADR-028](ADR-028-agentdef-vs-workflow-self-hosted-automation.md) | AgentDef-vs-Workflow split for self-hosted automation + context-slice injection contract | Accepted | 2026-06-11 | `automation/workflows/**`, `spec/schemas/agent-def.schema.json`, `spec/schemas/workflow.schema.json` — EPIC #881 |
 
 ---
 

--- a/docs/spdd/881-self-hosted-issue-delivery/canvas.md
+++ b/docs/spdd/881-self-hosted-issue-delivery/canvas.md
@@ -182,8 +182,8 @@ learning-synthesizer (kind: AgentDef).synthesize_learnings
 
 **Governing ADRs:** ADR-008 (no shared DB), ADR-015 (engine behind interface), ADR-016 (contract before
 implementation / BDD), ADR-019 (REASONS Canvas before feat code), ADR-021 (repo interfaces),
-ADR-022 (EventBus architecture), ADR-023 (no direct push to main). **New:** ADR-NNN *AgentDef-vs-Workflow
-split for self-hosted automation + context-slice injection contract* (authored in O1 — this is a one-way
+ADR-022 (EventBus architecture), ADR-023 (no direct push to main). **New:** ADR-028 *AgentDef-vs-Workflow
+split for self-hosted automation + context-slice injection contract* (authored in O1 ✅ — this is a one-way
 door: choosing `kind: Workflow` for orchestration shapes every manifest below).
 
 ---
@@ -215,7 +215,7 @@ automation/
 
 spec/schemas/agent-def.schema.json    ← validates expert AgentDefs (capabilities + runtime)
 spec/schemas/workflow.schema.json     ← validates orchestrator + issue-delivery workflows
-docs/adr/ADR-NNN-agentdef-vs-workflow-self-hosted-automation.md  ← NEW (one-way door)        [O1]
+docs/adr/ADR-028-agentdef-vs-workflow-self-hosted-automation.md  ← NEW (one-way door)        [O1 ✅]
 ```
 
 Config env prefix: `ZYNAX_AUTOMATION_` · Runtime services consumed: task-broker, agent-registry,
@@ -228,7 +228,9 @@ event-bus, (orchestrator) engine-adapter.
 > Each step is **one reviewable PR / one child issue**. Independently verifiable. `/spdd-story 881`
 > creates these as GitHub issues once this Canvas is **Aligned**.
 
-1. **O1 — Schema decision + ADR + readiness-path fix (`docs`/`fix`).** Author ADR-NNN recording the
+1. **O1 — Schema decision + ADR + readiness-path fix (`docs`/`fix`).** ✅ Delivered (#1096 — ADR-028;
+   near-term expert YAMLs now live at `docs/archive/dev-advisory/experts/`, archived by #1129).
+   Author ADR-NNN recording the
    AgentDef-vs-Workflow split and the context-slice injection contract. Fix the wrong schema path in
    `test_platform_readiness.py` (`agent-def.json` → `agent-def.schema.json`). *Verify:* ADR merged;
    `make validate-spec` still green; test still xfails (no behaviour change yet).

--- a/state/current-milestone.md
+++ b/state/current-milestone.md
@@ -58,7 +58,7 @@ As of 2026-06-11: **143 issues closed / 17 open** (CI-overhaul stories #1110–#
 **e2e-green execution path (#1086 — O1 #1087 ✅ / O2 #1088 ✅ merged via PR #1095; O3 #1089 ✅ satisfied by build-images gate PR #1132)**,
 Postgres off Bitnami (#1073 — O1 ADR-026 ✅, #1076→#1079 chain),
 CI-E2E gate (#771 — #1070 ✅, #1071 remaining),
-DevAuto Wave 4 (#881 — canvas Aligned, stories #1096–#1104 created).
+DevAuto Wave 4 (#881 — canvas Aligned, stories #1096–#1104 created; O1 #1096 ✅ ADR-028).
 
 ---
 
@@ -300,7 +300,7 @@ Canvas: SPDD-exempt (docs:/chore:/ci: stories only, until Wave 4 #881 which is B
 | DevAuto.5 ci: Wave 1 orchestrator aggregation | [#878](https://github.com/zynax-io/zynax/issues/878) | ⬜ Ready |
 | DevAuto.6 ci: Wave 2 | [#879](https://github.com/zynax-io/zynax/issues/879) | ⬜ Pending |
 | DevAuto.7 ci: Wave 3 | [#880](https://github.com/zynax-io/zynax/issues/880) | ⬜ Pending |
-| DevAuto.8 feat: Wave 4 aspirational | [#881](https://github.com/zynax-io/zynax/issues/881) | ⬜ **BLOCKED on #626 + #772 — now UNBLOCKED** |
+| DevAuto.8 feat: Wave 4 aspirational | [#881](https://github.com/zynax-io/zynax/issues/881) | 🔄 In progress — O1 [#1096](https://github.com/zynax-io/zynax/issues/1096) ✅ (ADR-028); O2–O9 #1097–#1104 |
 | DevAuto.9 test: xfail gate | [#882](https://github.com/zynax-io/zynax/issues/882) | ⬜ Pending |
 | DevAuto.10 docs: AGENTS.md pointer + README | [#883](https://github.com/zynax-io/zynax/issues/883) | ⬜ Pending |
 


### PR DESCRIPTION
## Summary

O1 of EPIC #881 (Wave 4 self-hosted issue-delivery) — first O-step of the Aligned canvas `docs/spdd/881-self-hosted-issue-delivery/canvas.md`.

- **ADR-028** (`docs/adr/ADR-028-agentdef-vs-workflow-self-hosted-automation.md`): records the manifest-model decision — experts/planner/synthesizer are `kind: AgentDef` (capability providers, `spec/schemas/agent-def.schema.json`); all orchestration is `kind: Workflow` (state machine, `spec/schemas/workflow.schema.json`). The original #881 `spec.steps`/`parallel` sketch is superseded. One-way door. Also documents the **context-slice injection contract**: bounded `{files[], max_tokens}`, strict isolation — the on-platform analogue of Claude-Code expert `.md` injection.
- Registered ADR-028 in `docs/adr/INDEX.md`.
- **Schema path fix**: `automation/tests/test_platform_readiness.py` `spec/schemas/agent-def.json` → `spec/schemas/agent-def.schema.json`. Test stays `xfail` — no behaviour change.
- Status surfaces: O1 marked ✅ in the 881 canvas (ADR-NNN placeholders resolved to ADR-028) and `state/current-milestone.md` (Wave 4 line + DevAuto.8 row).

### Canvas discrepancy noted

The canvas cites `automation/experts/*.yaml` as the source of truth for expert context slices; those files were archived to `docs/archive/dev-advisory/experts/` by #1129 (merged after the canvas was authored). ADR-028 cites the current archived path; the canvas wins on all design content (AgentDef/Workflow split, isolation contract) which is unchanged.

## Acceptance criteria (issue #1096)

- [x] ADR-028 authored and added to `docs/adr/INDEX.md`
- [x] Schema path corrected in the readiness test
- [x] `make validate-spec` green (AsyncAPI + capability + workflow + AgentDef + policy schemas all OK, run locally); test still xfails

## Test plan

- `python3 -m pytest automation/tests/test_platform_readiness.py -v` → **3 xfailed** (strict xfail preserved; no behaviour change)
- `make validate-spec` → all five validators green locally
- CI: docs-only + test-path change; no Go/proto surface touched

Closes #1096

Assisted-by: Claude/claude-fable-5
