### PR TITLE
test(infra): record kind umbrella verification on migrated Postgres

### DIFF
--- a/docs/spdd/1073-postgres-migration/canvas.md
+++ b/docs/spdd/1073-postgres-migration/canvas.md
@@ -124,6 +124,15 @@ this epic must produce for the Postgres distribution + version decision.
    both ways).
 6. **Bring up the full umbrella on kind** (reuse `scripts/e2e/cluster-up.sh`) and assert all
    services + Temporal reach a healthy rollout on the new Postgres.
+   — ✅ #1078 (verified 2026-06-12 against the gated `e2e smoke` CI runs that delivered O2–O5,
+   both of which invoke `scripts/e2e/cluster-up.sh`:
+   [run 27350760642](https://github.com/zynax-io/zynax/actions/runs/27350760642) on PR #1143 and
+   [run 27352081408](https://github.com/zynax-io/zynax/actions/runs/27352081408) on PR #1145
+   (digest-pinned `postgres:17.10`). Evidence: `zynax-postgresql-0 1/1 Running`,
+   `deployment "zynax-temporal-frontend" successfully rolled out`, all 5 service Deployments
+   "successfully rolled out", schema Job pod `Completed` for both `temporal` +
+   `temporal_visibility`, happy-path COMPLETED / failure-path FAILED-as-expected, and the
+   helm upgrade/rollback smoke PASS on every revision.)
 7. **Remove the e2e `bitnamilegacy` override** from `scripts/e2e/values-e2e.yaml`; confirm the
    `e2e smoke` gate is green end-to-end on the migrated source.
 8. **Document a major-version upgrade/migration note** (data considerations for stateful

--- a/state/current-milestone.md
+++ b/state/current-milestone.md
@@ -56,7 +56,7 @@ As of 2026-06-11: **143 issues closed / 17 open** (CI-overhaul stories #1110–#
 
 ### In progress / remaining
 **e2e-green execution path (#1086 — O1 #1087 ✅ / O2 #1088 ✅ merged via PR #1095; O3 #1089 ✅ satisfied by build-images gate PR #1132)**,
-Postgres off Bitnami (#1073 — O1 ADR-026 ✅, O2–O3 #1076 ✅, O4–O5 #1077 ✅, #1078→#1079 chain),
+Postgres off Bitnami (#1073 — O1 ADR-026 ✅, O2–O3 #1076 ✅, O4–O5 #1077 ✅, O6 #1078 ✅ verified; #1079 remaining),
 CI-E2E gate (#771 — #1070 ✅, #1071 remaining),
 DevAuto Wave 4 (#881 — canvas Aligned, stories #1096–#1104 created; O1 #1096 ✅ ADR-028).
 
@@ -312,14 +312,14 @@ Canvas: SPDD-exempt (docs:/chore:/ci: stories only, until Wave 4 #881 which is B
 
 **Immediate (unblocked):**
 - **#1087** feat(infra): expose api-gateway on host port for e2e (NodePort 30080) — #1086 O1 ✅ ready
-- **#1078** test(infra): verify full umbrella bring-up on migrated Postgres via kind — #1073 O6 ready (O4–O5 #1077 ✅ merged)
+- **#1079** chore(infra): drop e2e bitnamilegacy override + migration note — #1073 O7–O8 ready (O6 #1078 ✅ verified)
 - **#1071** ci(infra): Temporal-vs-Argo engine matrix in e2e-smoke — #771 O2 ✅ ready (#1070 merged)
 - **#867** chore(ci): GHCR retention cap — last 5 builds only
 - **#840** ci(infra): Python adapters in multi-arch release pipeline
 - **#841** ci(infra): audit and minimize image sizes
 
 **M6.E2E-Green chain (O1 #1087 / O2 #1088 / O3 #1089 all ✅):** #1090 (O4, unblocked) → #1091 (O5, needs #1088) → #1092 (O6, needs #1087 #1088 #1090 #1091 #1071).
-**M6.Postgres chain (#1076 ✅, #1077 ✅ merged):** #1078 → #1079 (sequential).
+**M6.Postgres chain (#1076 ✅, #1077 ✅, #1078 ✅ verified):** #1079 next (final step).
 
 **M6.Argo continuation (after #795 merges):**
 - **#796** feat(engine-adapter): Argo engine adapter implementation (#766, O2)


### PR DESCRIPTION
Closes #1078 (#1073 canvas step O6).

## What

Verify-and-record PR: flips canvas O6 of the Postgres migration epic to done and updates `state/current-milestone.md` (next: #1079). No code change — the verification evidence comes from the gated **e2e smoke** CI runs that already exercised the migrated Postgres on kind via `scripts/e2e/cluster-up.sh` (the exact entrypoint named in the acceptance criteria — see `.github/workflows/e2e-smoke.yml`, step "Bring up cluster + deploy stack").

## Evidence (acceptance criteria)

**Runs:**
- PR #1143 (postgres chart on official `postgres:17.10`): [run 27350760642](https://github.com/zynax-io/zynax/actions/runs/27350760642) — job `helm upgrade/rollback (kind)` green, all 10 steps success.
- PR #1145 (Temporal datastore wiring + digest pin): [run 27352081408](https://github.com/zynax-io/zynax/actions/runs/27352081408) — green, deployed `Postgres 17: zynax-postgresql.zynax:5432` with the digest-pinned image from `images/images.yaml`.

**`cluster-up.sh` succeeds on the migrated Postgres image** — both runs log `[cluster-up] cluster 'zynax-e2e' is up` after a full umbrella deploy.

**All 5 services + Temporal healthy; schema Job Completed** (from run 27352081408):
```
deployment "zynax-temporal-frontend" successfully rolled out
deployment "zynax-api-gateway" successfully rolled out
deployment "zynax-workflow-compiler" successfully rolled out
deployment "zynax-engine-adapter" successfully rolled out
deployment "zynax-task-broker" successfully rolled out
deployment "zynax-agent-registry" successfully rolled out
[cluster-up] all 5 service deployments are healthy.
```

**Pod status captured:**
```
zynax-postgresql-0                        1/1   Running     0   6m41s
zynax-temporal-frontend-6f677966b5-q5nzs  1/1   Running     5   6m42s
zynax-temporal-schema-1-2-0-1-k7wk9       0/1   Completed   0   6m42s
```

**Beyond the criteria**, both runs also passed the happy-path (`WORKFLOW_STATUS_COMPLETED`), failure-path (`WORKFLOW_STATUS_FAILED` as expected), and helm upgrade/rollback assertions (post-install / post-upgrade / post-rollback all healthy).

## Out of scope

Removing the e2e `bitnamilegacy` override — #1079 (canvas O7–O8).

Assisted-by: Claude/claude-fable-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)