### PR TITLE
feat(automation): expert AgentDef manifests — 8 domain + planner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -357,8 +357,9 @@ validate-workflow-schema: ensure-tools ## Validate Workflow manifests in spec/wo
 	$(TOOLS_RUN) zynax-ci validate workflows spec/workflows/examples/ --schema-dir spec/schemas
 	@echo "✅ Workflow schemas valid"
 
-validate-agent-def-schema: ensure-tools ## Validate AgentDef manifests in spec/workflows/examples/ against agent-def.schema.json
+validate-agent-def-schema: ensure-tools ## Validate AgentDef manifests (spec examples + automation/workflows) against agent-def.schema.json
 	$(TOOLS_RUN) zynax-ci validate agent-defs spec/workflows/examples/ --schema-dir spec/schemas
+	$(TOOLS_RUN) zynax-ci validate agent-defs automation/workflows/experts/ --schema-dir spec/schemas
 	@echo "✅ AgentDef schemas valid"
 
 validate-policy-schema: ensure-tools ## Validate Policy manifests in spec/workflows/examples/ against policy.schema.json

--- a/automation/tests/test_expert_agentdefs.py
+++ b/automation/tests/test_expert_agentdefs.py
@@ -1,0 +1,177 @@
+# SPDX-License-Identifier: Apache-2.0
+# automation/tests/test_expert_agentdefs.py
+#
+# O2 of EPIC #881 (#1097): asserts each expert AgentDef manifest under
+# automation/workflows/experts/ is a faithful 1:1 translation of its
+# near-term source config (docs/archive/dev-advisory/experts/<name>.yaml,
+# archived by #1129; per ADR-028 the archived YAMLs remain the source of
+# truth for context_slice, I/O contract, and aggregation_weight).
+#
+# The planner manifest (planner.yaml) is the planning-task-split expert
+# extended with the identify_next_issue capability (ADR-028); its source of
+# truth is planning-task-split.yaml.
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+try:
+    import jsonschema
+
+    HAS_JSONSCHEMA = True
+except ImportError:
+    HAS_JSONSCHEMA = False
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCHEMA_PATH = REPO_ROOT / "spec/schemas/agent-def.schema.json"
+AGENTDEF_DIR = REPO_ROOT / "automation/workflows/experts"
+SOURCE_DIR = REPO_ROOT / "docs/archive/dev-advisory/experts"
+
+DOMAIN_EXPERTS = [
+    "arch-adr",
+    "persistence-state",
+    "api-contract",
+    "security-supply-chain",
+    "qa-bdd",
+    "docs-agents",
+    "ci-release",
+    "planning-task-split",
+]
+
+# manifest name -> source-of-truth name (planner extends planning-task-split)
+ALL_MANIFESTS = {name: name for name in DOMAIN_EXPERTS}
+ALL_MANIFESTS["planner"] = "planning-task-split"
+
+CORE_OUTPUT_KEYS = {
+    "summary",
+    "recommended_actions",
+    "reasons_decisions",
+    "confidence",
+    "flags",
+}
+
+
+def load_manifest(name):
+    with open(AGENTDEF_DIR / f"{name}.yaml") as f:
+        return yaml.safe_load(f)
+
+
+def load_source(name):
+    with open(SOURCE_DIR / f"{name}.yaml") as f:
+        return yaml.safe_load(f)
+
+
+def get_capability(manifest, capability_name):
+    caps = {c["name"]: c for c in manifest["spec"]["capabilities"]}
+    assert capability_name in caps, f"capability {capability_name!r} missing"
+    return caps[capability_name]
+
+
+def test_exactly_nine_agentdef_manifests():
+    """8 domain experts + planner = 9 manifests (EPIC #881 O2)."""
+    found = sorted(p.stem for p in AGENTDEF_DIR.glob("*.yaml"))
+    assert found == sorted(ALL_MANIFESTS), f"unexpected manifest set: {found}"
+
+
+@pytest.mark.skipif(not HAS_JSONSCHEMA, reason="jsonschema package required")
+@pytest.mark.parametrize("name", sorted(ALL_MANIFESTS))
+def test_agentdef_validates_against_schema(name):
+    """Every manifest validates against agent-def.schema.json."""
+    with open(SCHEMA_PATH) as f:
+        schema = json.load(f)
+    jsonschema.validate(load_manifest(name), schema)
+
+
+@pytest.mark.parametrize("name", sorted(ALL_MANIFESTS))
+def test_review_input_contract_matches_source(name):
+    """review input_schema mirrors the source YAML input_contract."""
+    source = load_source(ALL_MANIFESTS[name])
+    review = get_capability(load_manifest(name), "review")
+    input_schema = review["input_schema"]
+
+    required = set(source["input_contract"]["required"])
+    optional = set(source["input_contract"].get("optional", []))
+
+    assert set(input_schema["required"]) == required
+    assert set(input_schema["properties"]) == required | optional
+
+
+@pytest.mark.parametrize("name", sorted(ALL_MANIFESTS))
+def test_review_output_contract_matches_source(name):
+    """review output_schema mirrors the source YAML output_contract."""
+    source = load_source(ALL_MANIFESTS[name])
+    review = get_capability(load_manifest(name), "review")
+    output_schema = review["output_schema"]
+
+    assert set(output_schema["required"]) == CORE_OUTPUT_KEYS
+    assert set(output_schema["properties"]) == CORE_OUTPUT_KEYS | {"extra_fields"}
+
+    source_extra = source["output_contract"]["extra_fields"]
+    manifest_extra = output_schema["properties"]["extra_fields"]["properties"]
+    assert set(manifest_extra) == set(source_extra)
+
+    # Spot-check core types stayed faithful.
+    assert output_schema["properties"]["summary"]["type"] == "string"
+    assert output_schema["properties"]["confidence"]["enum"] == [
+        "low",
+        "medium",
+        "high",
+    ]
+    assert output_schema["properties"]["flags"]["type"] == "array"
+
+
+@pytest.mark.parametrize("name", sorted(ALL_MANIFESTS))
+def test_context_slice_matches_source(name):
+    """context_slice files + max_tokens are verbatim from the source YAML."""
+    source = load_source(ALL_MANIFESTS[name])
+    review = get_capability(load_manifest(name), "review")
+    slice_schema = review["input_schema"]["properties"]["context_slice"]
+
+    assert set(slice_schema["required"]) == {"files", "max_tokens"}
+    assert (
+        slice_schema["properties"]["files"]["default"]
+        == source["context_slice"]["files"]
+    )
+    assert (
+        slice_schema["properties"]["max_tokens"]["default"]
+        == source["context_slice"]["max_tokens"]
+    )
+
+
+@pytest.mark.parametrize("name", sorted(ALL_MANIFESTS))
+def test_weight_and_max_tokens_labels_match_source(name):
+    """aggregation_weight / max_tokens labels match the source YAML."""
+    source = load_source(ALL_MANIFESTS[name])
+    labels = load_manifest(name)["metadata"]["labels"]
+
+    assert float(labels["aggregation-weight"]) == source["aggregation_weight"]
+    assert int(labels["context-max-tokens"]) == source["context_slice"]["max_tokens"]
+
+
+def test_planner_identify_next_issue_contract():
+    """Planner exposes identify_next_issue with the canvas-declared I/O."""
+    cap = get_capability(load_manifest("planner"), "identify_next_issue")
+
+    assert set(cap["input_schema"]["required"]) == {
+        "milestone",
+        "open_issues",
+        "in_progress",
+        "dependency_table",
+    }
+    assert set(cap["output_schema"]["required"]) == {
+        "next_issue",
+        "blocked_by",
+        "ready_batch",
+        "rationale",
+    }
+
+
+def test_domain_experts_expose_only_review():
+    """Only the planner carries a second capability."""
+    for name in DOMAIN_EXPERTS:
+        caps = [c["name"] for c in load_manifest(name)["spec"]["capabilities"]]
+        assert caps == ["review"], f"{name}: unexpected capabilities {caps}"
+    planner_caps = [c["name"] for c in load_manifest("planner")["spec"]["capabilities"]]
+    assert planner_caps == ["review", "identify_next_issue"]

--- a/automation/tests/test_platform_readiness.py
+++ b/automation/tests/test_platform_readiness.py
@@ -1,8 +1,9 @@
 # automation/tests/test_platform_readiness.py
 import json
-import yaml
-import pytest
 from pathlib import Path
+
+import pytest
+import yaml
 
 try:
     import jsonschema
@@ -11,22 +12,23 @@ try:
 except ImportError:
     HAS_JSONSCHEMA = False
 
-SCHEMA_PATH = "spec/schemas/agent-def.schema.json"
-ORCHESTRATOR_YAML = "automation/workflows/dev-advisory-orchestrator.yaml"
-EXPERT_YAMLS = list(Path("automation/workflows/experts/").glob("*.yaml"))
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCHEMA_PATH = REPO_ROOT / "spec/schemas/agent-def.schema.json"
+ORCHESTRATOR_YAML = REPO_ROOT / "automation/workflows/dev-advisory-orchestrator.yaml"
+EXPERT_YAMLS = list((REPO_ROOT / "automation/workflows/experts").glob("*.yaml"))
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "Wave 4 aspirational: requires M6.H (Postgres-backed repos, #626) + "
-        "M6.I (event-bus implementation, #772) + automation/workflows/ AgentDef "
-        "YAMLs to exist. Fails until all three prerequisites land."
-    ),
-)
 class TestPlatformReadiness:
+    @pytest.mark.xfail(
+        strict=True,
+        reason=(
+            "Wave 4: requires automation/workflows/dev-advisory-orchestrator.yaml "
+            "(EPIC #881 O3, #1098 — kind: Workflow per ADR-028). Reworked against "
+            "workflow.schema.json when the manifest lands; flips in O8 (#1103)."
+        ),
+    )
     def test_orchestrator_agentdef_schema_valid(self):
-        """AgentDef YAML validates against Zynax JSON schema."""
+        """Orchestrator manifest validates against Zynax JSON schema."""
         assert HAS_JSONSCHEMA, "jsonschema package required"
         with open(SCHEMA_PATH) as f:
             schema = json.load(f)
@@ -34,9 +36,9 @@ class TestPlatformReadiness:
             doc = yaml.safe_load(f)
         jsonschema.validate(doc, schema)
 
+    @pytest.mark.skipif(not HAS_JSONSCHEMA, reason="jsonschema package required")
     def test_expert_agentdefs_schema_valid(self):
-        """All 9 expert AgentDef YAMLs validate against schema."""
-        assert HAS_JSONSCHEMA, "jsonschema package required"
+        """All 9 expert AgentDef YAMLs validate against schema (O2, #1097)."""
         assert len(EXPERT_YAMLS) == 9, f"Expected 9 experts, got {len(EXPERT_YAMLS)}"
         with open(SCHEMA_PATH) as f:
             schema = json.load(f)
@@ -45,9 +47,17 @@ class TestPlatformReadiness:
                 doc = yaml.safe_load(f)
             jsonschema.validate(doc, schema)
 
+    @pytest.mark.xfail(
+        strict=True,
+        reason=(
+            "Wave 4: requires a running Zynax platform (Postgres #626 + EventBus "
+            "#772) and the orchestrator workflow (O3, #1098). Flips to a real e2e "
+            "in O8 (#1103)."
+        ),
+    )
     def test_orchestrator_executes_on_platform(self, zynax_client):
-        """Orchestrator AgentDef loads and executes on a running Zynax platform."""
-        result = zynax_client.apply(ORCHESTRATOR_YAML)
+        """Orchestrator workflow loads and executes on a running Zynax platform."""
+        result = zynax_client.apply(str(ORCHESTRATOR_YAML))
         assert result.workflow_id is not None
         status = zynax_client.wait_for_completion(result.workflow_id, timeout=60)
         assert status == "COMPLETED"

--- a/automation/workflows/experts/api-contract.yaml
+++ b/automation/workflows/experts/api-contract.yaml
@@ -1,0 +1,148 @@
+# SPDX-License-Identifier: Apache-2.0
+# automation/workflows/experts/api-contract.yaml
+#
+# API/contract expert — reviews proto changes for backward-compatibility
+# (buf breaking), AsyncAPI event schema correctness, capability registration
+# conformance, and the contract-before-implementation rule (ADR-016).
+#
+# kind: AgentDef translation (ADR-028) of the near-term expert config
+# docs/archive/dev-advisory/experts/api-contract.yaml — the source of truth
+# for context_slice, I/O contract, and aggregation_weight (translated 1:1).
+# The context slice is bound at dispatch time into the `context_slice` field
+# of the review capability's input_payload (strict isolation, ADR-028).
+# Runtime binding (spec.runtime) lands in O5 (#1100).
+#
+# Plane: platform (Wave 4)
+# Issue: #1097 (EPIC #881 — O2)
+
+apiVersion: zynax.io/v1alpha1
+kind: AgentDef
+
+metadata:
+  name: api-contract
+  namespace: automation
+  labels:
+    plane: platform
+    epic: "881"
+    aggregation-weight: "1.5"
+    context-max-tokens: "4000"
+
+spec:
+  capabilities:
+    - name: review
+      description: >
+        Review proto and spec changes for breaking changes, AsyncAPI event
+        schema correctness, capability registration conformance, proto naming
+        rules, and missing BDD contracts at new gRPC boundaries (ADR-016).
+      input_schema:
+        type: object
+        required: [trigger, diff_summary, changed_files, context_slice]
+        properties:
+          trigger:
+            type: string
+            description: Event that initiated this review.
+            enum: [pull_request, push, post_merge]
+          diff_summary:
+            type: string
+            description: git diff --stat output for the change under review.
+          changed_files:
+            type: array
+            description: List of changed file paths.
+            items:
+              type: string
+          context_slice:
+            type: object
+            description: >
+              Bounded context slice injected at dispatch time (ADR-028).
+              Only the files declared below, hard-capped at max_tokens.
+              Strict isolation - never another expert's slice or output.
+            required: [files, max_tokens]
+            properties:
+              files:
+                type: array
+                description: >
+                  Verbatim from docs/archive/dev-advisory/experts/api-contract.yaml.
+                items:
+                  type: string
+                default:
+                  - "protos/zynax/v1/**/*.proto"
+                  - "protos/buf.yaml"
+                  - "protos/buf.gen.yaml"
+                  - "spec/schemas/**/*.json"
+                  - "spec/asyncapi/zynax-events.yaml"
+                  - "spec/workflows/capability-registrations/**/*.yaml"
+                  - "protos/AGENTS.md"
+              max_tokens:
+                type: integer
+                description: Hard context budget (tokens) per invocation.
+                default: 4000
+          pr_number:
+            type: integer
+            description: Pull request number (pull_request trigger only).
+          pr_title:
+            type: string
+            description: Pull request title (pull_request trigger only).
+      output_schema:
+        type: object
+        required: [summary, recommended_actions, reasons_decisions, confidence, flags]
+        properties:
+          summary:
+            type: string
+            description: Plain text summary, max 200 words.
+          recommended_actions:
+            type: array
+            description: Ordered list of specific actions with rationale.
+            items:
+              type: object
+              required: [action, rationale, priority]
+              properties:
+                action:
+                  type: string
+                rationale:
+                  type: string
+                priority:
+                  type: string
+                  enum: [low, medium, high]
+          reasons_decisions:
+            type: array
+            description: Reasoning chain for each recommendation.
+            items:
+              type: string
+          confidence:
+            type: string
+            description: Overall confidence level for this expert's output.
+            enum: [low, medium, high]
+          flags:
+            type: array
+            description: Tier-2 security flags or blocker flags (empty if none).
+            items:
+              type: string
+          extra_fields:
+            type: object
+            description: Expert-specific additional output fields.
+            properties:
+              breaking_changes:
+                type: array
+                description: Field removals, renames, type changes.
+                items:
+                  type: string
+              missing_bdd_contract:
+                type: boolean
+                description: True if new gRPC boundary lacks a .feature file (ADR-016).
+              asyncapi_schema_errors:
+                type: array
+                description: AsyncAPI event schema validation errors.
+                items:
+                  type: string
+              capability_registration_issues:
+                type: array
+                description: Capability registration conformance issues.
+                items:
+                  type: string
+              proto_naming_violations:
+                type: array
+                description: Proto naming rule violations.
+                items:
+                  type: string
+      timeout_seconds: 300
+      max_retries: 1

--- a/automation/workflows/experts/arch-adr.yaml
+++ b/automation/workflows/experts/arch-adr.yaml
@@ -1,0 +1,144 @@
+# SPDX-License-Identifier: Apache-2.0
+# automation/workflows/experts/arch-adr.yaml
+#
+# Architecture/ADR expert — reviews changed files for layer-boundary
+# violations, ADR conformance, and architectural drift.
+#
+# kind: AgentDef translation (ADR-028) of the near-term expert config
+# docs/archive/dev-advisory/experts/arch-adr.yaml — the source of truth for
+# context_slice, I/O contract, and aggregation_weight (translated 1:1).
+# The context slice is bound at dispatch time into the `context_slice` field
+# of the review capability's input_payload (strict isolation, ADR-028).
+# Runtime binding (spec.runtime) lands in O5 (#1100).
+#
+# Plane: platform (Wave 4)
+# Issue: #1097 (EPIC #881 — O2)
+
+apiVersion: zynax.io/v1alpha1
+kind: AgentDef
+
+metadata:
+  name: arch-adr
+  namespace: automation
+  labels:
+    plane: platform
+    epic: "881"
+    aggregation-weight: "1.5"
+    context-max-tokens: "4000"
+
+spec:
+  capabilities:
+    - name: review
+      description: >
+        Review a change for layer-boundary violations (L1->L3 coupling,
+        shared-DB, hard dependencies), conflicts with accepted ADRs, and
+        one-way-door changes that require a new ADR. Context is bounded to
+        the constitution files and the ADR register; no service code is
+        loaded.
+      input_schema:
+        type: object
+        required: [trigger, diff_summary, changed_files, context_slice]
+        properties:
+          trigger:
+            type: string
+            description: Event that initiated this review.
+            enum: [pull_request, push, post_merge]
+          diff_summary:
+            type: string
+            description: git diff --stat output for the change under review.
+          changed_files:
+            type: array
+            description: List of changed file paths.
+            items:
+              type: string
+          context_slice:
+            type: object
+            description: >
+              Bounded context slice injected at dispatch time (ADR-028).
+              Only the files declared below, hard-capped at max_tokens.
+              Strict isolation - never another expert's slice or output.
+            required: [files, max_tokens]
+            properties:
+              files:
+                type: array
+                description: >
+                  Verbatim from docs/archive/dev-advisory/experts/arch-adr.yaml.
+                items:
+                  type: string
+                default:
+                  - "AGENTS.md"
+                  - "services/AGENTS.md"
+                  - "agents/AGENTS.md"
+                  - "protos/AGENTS.md"
+                  - "cmd/zynax/AGENTS.md"
+                  - "docs/adr/INDEX.md"
+                  - "docs/adr/*.md"
+              max_tokens:
+                type: integer
+                description: Hard context budget (tokens) per invocation.
+                default: 4000
+          pr_number:
+            type: integer
+            description: Pull request number (pull_request trigger only).
+          pr_title:
+            type: string
+            description: Pull request title (pull_request trigger only).
+      output_schema:
+        type: object
+        required: [summary, recommended_actions, reasons_decisions, confidence, flags]
+        properties:
+          summary:
+            type: string
+            description: Plain text summary, max 200 words.
+          recommended_actions:
+            type: array
+            description: Ordered list of specific actions with rationale.
+            items:
+              type: object
+              required: [action, rationale, priority]
+              properties:
+                action:
+                  type: string
+                rationale:
+                  type: string
+                priority:
+                  type: string
+                  enum: [low, medium, high]
+          reasons_decisions:
+            type: array
+            description: Reasoning chain for each recommendation.
+            items:
+              type: string
+          confidence:
+            type: string
+            description: Overall confidence level for this expert's output.
+            enum: [low, medium, high]
+          flags:
+            type: array
+            description: Tier-2 security flags or blocker flags (empty if none).
+            items:
+              type: string
+          extra_fields:
+            type: object
+            description: Expert-specific additional output fields.
+            properties:
+              layer_violations:
+                type: array
+                description: L1->L3 coupling, shared-DB, hard-dependency violations.
+                items:
+                  type: string
+              adr_conflicts:
+                type: array
+                description: Changed files that contradict an accepted ADR.
+                items:
+                  type: string
+              new_adr_required:
+                type: boolean
+                description: True if change is a one-way door needing an ADR.
+              relevant_adrs:
+                type: array
+                description: List of ADR IDs relevant to this change.
+                items:
+                  type: string
+      timeout_seconds: 300
+      max_retries: 1

--- a/automation/workflows/experts/ci-release.yaml
+++ b/automation/workflows/experts/ci-release.yaml
@@ -1,0 +1,175 @@
+# SPDX-License-Identifier: Apache-2.0
+# automation/workflows/experts/ci-release.yaml
+#
+# CI/release expert — reviews workflow changes, image build/push pipelines,
+# images.yaml SoT drift, SBOM/cosign release steps, and post-merge triggers.
+# Explicitly covers post-merge completeness: image tests, drift check, and
+# security rescan triggers (Wave 3).
+#
+# kind: AgentDef translation (ADR-028) of the near-term expert config
+# docs/archive/dev-advisory/experts/ci-release.yaml — the source of truth
+# for context_slice, I/O contract, and aggregation_weight (translated 1:1).
+# The context slice is bound at dispatch time into the `context_slice` field
+# of the review capability's input_payload (strict isolation, ADR-028).
+# Runtime binding (spec.runtime) lands in O5 (#1100).
+#
+# Plane: platform (Wave 4)
+# Issue: #1097 (EPIC #881 — O2)
+
+apiVersion: zynax.io/v1alpha1
+kind: AgentDef
+
+metadata:
+  name: ci-release
+  namespace: automation
+  labels:
+    plane: platform
+    epic: "881"
+    aggregation-weight: "1.0"
+    context-max-tokens: "3000"
+
+spec:
+  capabilities:
+    - name: review
+      description: >
+        Review CI workflow changes, image build/push pipelines, images.yaml
+        single-source-of-truth drift, SBOM/cosign release steps, and
+        post-merge trigger completeness (image tests, drift check, security
+        rescan).
+      input_schema:
+        type: object
+        required: [trigger, diff_summary, changed_files, context_slice]
+        properties:
+          trigger:
+            type: string
+            description: Event that initiated this review.
+            enum: [pull_request, push, post_merge]
+          diff_summary:
+            type: string
+            description: git diff --stat output for the change under review.
+          changed_files:
+            type: array
+            description: List of changed file paths.
+            items:
+              type: string
+          context_slice:
+            type: object
+            description: >
+              Bounded context slice injected at dispatch time (ADR-028).
+              Only the files declared below, hard-capped at max_tokens.
+              Strict isolation - never another expert's slice or output.
+            required: [files, max_tokens]
+            properties:
+              files:
+                type: array
+                description: >
+                  Verbatim from docs/archive/dev-advisory/experts/ci-release.yaml.
+                items:
+                  type: string
+                default:
+                  - ".github/workflows/*.yml"
+                  - "images/images.yaml"
+                  - "Makefile"
+                  - "tools/Dockerfile"
+                  - "services/*/Dockerfile"
+                  - "release/**/*"
+              max_tokens:
+                type: integer
+                description: Hard context budget (tokens) per invocation.
+                default: 3000
+          pr_number:
+            type: integer
+            description: Pull request number (pull_request trigger only).
+          pr_title:
+            type: string
+            description: Pull request title (pull_request trigger only).
+          workflow_run_conclusion:
+            type: string
+            description: Conclusion of the completed workflow (post_merge trigger).
+            enum: [success, failure, cancelled]
+          workflow_run_name:
+            type: string
+            description: Name of the completed workflow (post_merge trigger).
+          image_build_logs:
+            type: string
+            description: Truncated logs from service-release.yml run.
+          drift_check_result:
+            type: string
+            description: Output from images.yaml drift check (post_merge trigger).
+      output_schema:
+        type: object
+        required: [summary, recommended_actions, reasons_decisions, confidence, flags]
+        properties:
+          summary:
+            type: string
+            description: Plain text summary, max 200 words.
+          recommended_actions:
+            type: array
+            description: Ordered list of specific actions with rationale.
+            items:
+              type: object
+              required: [action, rationale, priority]
+              properties:
+                action:
+                  type: string
+                rationale:
+                  type: string
+                priority:
+                  type: string
+                  enum: [low, medium, high]
+          reasons_decisions:
+            type: array
+            description: Reasoning chain for each recommendation.
+            items:
+              type: string
+          confidence:
+            type: string
+            description: Overall confidence level for this expert's output.
+            enum: [low, medium, high]
+          flags:
+            type: array
+            description: Tier-2 security flags or blocker flags (empty if none).
+            items:
+              type: string
+          extra_fields:
+            type: object
+            description: Expert-specific additional output fields.
+            properties:
+              post_merge_triggers:
+                type: object
+                description: Post-merge completeness fields (Wave 3 triggers).
+                properties:
+                  image_test_required:
+                    type: boolean
+                    description: True when service-release.yml completes.
+                  drift_check_required:
+                    type: boolean
+                    description: True on every main push.
+                  security_rescan_required:
+                    type: boolean
+                    description: True on services/ or dependency merge.
+              broken_workflow_steps:
+                type: array
+                description: Workflow steps that are malformed or missing.
+                items:
+                  type: string
+              images_yaml_drift:
+                type: array
+                description: Images not pinned to digest in images.yaml.
+                items:
+                  type: string
+              missing_cosign_sign_step:
+                type: boolean
+                description: True if a release workflow lacks cosign signing.
+              missing_sbom_step:
+                type: boolean
+                description: True if a release workflow lacks SBOM generation.
+              pr_size_gate_status:
+                type: string
+                description: PR size gate status (pass, fail, or not_run).
+                enum: [pass, fail, not_run]
+              release_pipeline_complete:
+                type: boolean
+                description: True if all O1-O7 of M6.Images SoT are present.
+      timeout_seconds: 300
+      max_retries: 1

--- a/automation/workflows/experts/docs-agents.yaml
+++ b/automation/workflows/experts/docs-agents.yaml
@@ -1,0 +1,144 @@
+# SPDX-License-Identifier: Apache-2.0
+# automation/workflows/experts/docs-agents.yaml
+#
+# Docs/AGENTS expert — reviews documentation correctness, AGENTS.md
+# consistency across all layers, and README/CONTRIBUTING/ARCHITECTURE
+# alignment with implemented reality.
+#
+# kind: AgentDef translation (ADR-028) of the near-term expert config
+# docs/archive/dev-advisory/experts/docs-agents.yaml — the source of truth
+# for context_slice, I/O contract, and aggregation_weight (translated 1:1).
+# The context slice is bound at dispatch time into the `context_slice` field
+# of the review capability's input_payload (strict isolation, ADR-028).
+# Runtime binding (spec.runtime) lands in O5 (#1100).
+#
+# Plane: platform (Wave 4)
+# Issue: #1097 (EPIC #881 — O2)
+
+apiVersion: zynax.io/v1alpha1
+kind: AgentDef
+
+metadata:
+  name: docs-agents
+  namespace: automation
+  labels:
+    plane: platform
+    epic: "881"
+    aggregation-weight: "1.0"
+    context-max-tokens: "3000"
+
+spec:
+  capabilities:
+    - name: review
+      description: >
+        Review documentation correctness: AGENTS.md consistency across all
+        layers, README/CONTRIBUTING/ARCHITECTURE alignment with implemented
+        reality, and missing knowledge-base pointer rows for new directories
+        or patterns.
+      input_schema:
+        type: object
+        required: [trigger, diff_summary, changed_files, context_slice]
+        properties:
+          trigger:
+            type: string
+            description: Event that initiated this review.
+            enum: [pull_request, push, post_merge]
+          diff_summary:
+            type: string
+            description: git diff --stat output for the change under review.
+          changed_files:
+            type: array
+            description: List of changed file paths.
+            items:
+              type: string
+          context_slice:
+            type: object
+            description: >
+              Bounded context slice injected at dispatch time (ADR-028).
+              Only the files declared below, hard-capped at max_tokens.
+              Strict isolation - never another expert's slice or output.
+            required: [files, max_tokens]
+            properties:
+              files:
+                type: array
+                description: >
+                  Verbatim from docs/archive/dev-advisory/experts/docs-agents.yaml.
+                items:
+                  type: string
+                default:
+                  - "AGENTS.md"
+                  - "services/AGENTS.md"
+                  - "agents/AGENTS.md"
+                  - "protos/AGENTS.md"
+                  - "cmd/zynax/AGENTS.md"
+                  - "README.md"
+                  - "CONTRIBUTING.md"
+                  - "docs/ARCHITECTURE.md"
+                  - "docs/adr/INDEX.md"
+              max_tokens:
+                type: integer
+                description: Hard context budget (tokens) per invocation.
+                default: 3000
+          pr_number:
+            type: integer
+            description: Pull request number (pull_request trigger only).
+          pr_title:
+            type: string
+            description: Pull request title (pull_request trigger only).
+      output_schema:
+        type: object
+        required: [summary, recommended_actions, reasons_decisions, confidence, flags]
+        properties:
+          summary:
+            type: string
+            description: Plain text summary, max 200 words.
+          recommended_actions:
+            type: array
+            description: Ordered list of specific actions with rationale.
+            items:
+              type: object
+              required: [action, rationale, priority]
+              properties:
+                action:
+                  type: string
+                rationale:
+                  type: string
+                priority:
+                  type: string
+                  enum: [low, medium, high]
+          reasons_decisions:
+            type: array
+            description: Reasoning chain for each recommendation.
+            items:
+              type: string
+          confidence:
+            type: string
+            description: Overall confidence level for this expert's output.
+            enum: [low, medium, high]
+          flags:
+            type: array
+            description: Tier-2 security flags or blocker flags (empty if none).
+            items:
+              type: string
+          extra_fields:
+            type: object
+            description: Expert-specific additional output fields.
+            properties:
+              agents_md_out_of_date:
+                type: boolean
+                description: True if AGENTS.md does not reflect changed code.
+              false_capability_claims:
+                type: array
+                description: Claims in docs not backed by implementation.
+                items:
+                  type: string
+              missing_pointer_rows:
+                type: array
+                description: New dirs/patterns with no AGENTS.md entry.
+                items:
+                  type: string
+              doc_file_unchanged_for_impacting_change:
+                type: boolean
+                description: Code changed but no doc update.
+      timeout_seconds: 300
+      max_retries: 1

--- a/automation/workflows/experts/persistence-state.yaml
+++ b/automation/workflows/experts/persistence-state.yaml
@@ -1,0 +1,145 @@
+# SPDX-License-Identifier: Apache-2.0
+# automation/workflows/experts/persistence-state.yaml
+#
+# Persistence/state expert — reviews domain model changes, migration files,
+# and in-memory vs. Postgres repo patterns for ADR-008/021 conformance.
+#
+# kind: AgentDef translation (ADR-028) of the near-term expert config
+# docs/archive/dev-advisory/experts/persistence-state.yaml — the source of
+# truth for context_slice, I/O contract, and aggregation_weight (1:1).
+# The context slice is bound at dispatch time into the `context_slice` field
+# of the review capability's input_payload (strict isolation, ADR-028).
+# Runtime binding (spec.runtime) lands in O5 (#1100).
+#
+# Plane: platform (Wave 4)
+# Issue: #1097 (EPIC #881 — O2)
+
+apiVersion: zynax.io/v1alpha1
+kind: AgentDef
+
+metadata:
+  name: persistence-state
+  namespace: automation
+  labels:
+    plane: platform
+    epic: "881"
+    aggregation-weight: "1.0"
+    context-max-tokens: "3000"
+
+spec:
+  capabilities:
+    - name: review
+      description: >
+        Review domain model changes, SQL migrations, and repository adapters
+        for correctness and ADR-008 (no shared DB) / ADR-021 (repo interface)
+        conformance. Context is bounded to domain internals; no gRPC or
+        non-persistence adapter files are loaded.
+      input_schema:
+        type: object
+        required: [trigger, diff_summary, changed_files, context_slice]
+        properties:
+          trigger:
+            type: string
+            description: Event that initiated this review.
+            enum: [pull_request, push, post_merge]
+          diff_summary:
+            type: string
+            description: git diff --stat output for the change under review.
+          changed_files:
+            type: array
+            description: List of changed file paths.
+            items:
+              type: string
+          context_slice:
+            type: object
+            description: >
+              Bounded context slice injected at dispatch time (ADR-028).
+              Only the files declared below, hard-capped at max_tokens.
+              Strict isolation - never another expert's slice or output.
+            required: [files, max_tokens]
+            properties:
+              files:
+                type: array
+                description: >
+                  Verbatim from docs/archive/dev-advisory/experts/persistence-state.yaml.
+                items:
+                  type: string
+                default:
+                  - "services/*/internal/domain/**/*.go"
+                  - "services/*/internal/adapters/postgres/**/*.go"
+                  - "services/*/internal/adapters/redis/**/*.go"
+                  - "services/*/migrations/**/*.sql"
+                  - "docs/adr/ADR-008-*.md"
+                  - "docs/adr/ADR-021-*.md"
+              max_tokens:
+                type: integer
+                description: Hard context budget (tokens) per invocation.
+                default: 3000
+          pr_number:
+            type: integer
+            description: Pull request number (pull_request trigger only).
+          pr_title:
+            type: string
+            description: Pull request title (pull_request trigger only).
+      output_schema:
+        type: object
+        required: [summary, recommended_actions, reasons_decisions, confidence, flags]
+        properties:
+          summary:
+            type: string
+            description: Plain text summary, max 200 words.
+          recommended_actions:
+            type: array
+            description: Ordered list of specific actions with rationale.
+            items:
+              type: object
+              required: [action, rationale, priority]
+              properties:
+                action:
+                  type: string
+                rationale:
+                  type: string
+                priority:
+                  type: string
+                  enum: [low, medium, high]
+          reasons_decisions:
+            type: array
+            description: Reasoning chain for each recommendation.
+            items:
+              type: string
+          confidence:
+            type: string
+            description: Overall confidence level for this expert's output.
+            enum: [low, medium, high]
+          flags:
+            type: array
+            description: Tier-2 security flags or blocker flags (empty if none).
+            items:
+              type: string
+          extra_fields:
+            type: object
+            description: Expert-specific additional output fields.
+            properties:
+              in_memory_repo_used:
+                type: boolean
+                description: True if change introduces or modifies an in-memory repo.
+              postgres_migration_present:
+                type: boolean
+                description: True if a SQL migration file is included.
+              adr008_violations:
+                type: array
+                description: Shared-DB violations (ADR-008).
+                items:
+                  type: string
+              adr021_violations:
+                type: array
+                description: Repo-interface violations (ADR-021).
+                items:
+                  type: string
+              domain_invariants_at_risk:
+                type: array
+                description: Domain invariants this change puts at risk.
+                items:
+                  type: string
+      timeout_seconds: 300
+      max_retries: 1

--- a/automation/workflows/experts/planner.yaml
+++ b/automation/workflows/experts/planner.yaml
@@ -1,0 +1,215 @@
+# SPDX-License-Identifier: Apache-2.0
+# automation/workflows/experts/planner.yaml
+#
+# Planner — the planning-task-split expert extended with the
+# identify_next_issue capability (the /m6-plan brain): given the live
+# milestone state, open issues, and the dependency table, it identifies
+# which issue goes next and which batch is ready to run in parallel.
+#
+# Per ADR-028 (and Canvas #881 Appendix A) the Planner is the
+# planning-task-split expert extended with identify_next_issue; it exposes
+# `review` + `identify_next_issue`. It is materialised as its own AgentDef
+# so the expert mesh stays at 9 manifests (8 domain + planner) and the
+# identify_next_issue capability has exactly one provider. context_slice,
+# max_tokens, and aggregation_weight are carried verbatim from
+# docs/archive/dev-advisory/experts/planning-task-split.yaml.
+# Runtime binding (spec.runtime) lands in O5 (#1100).
+#
+# Plane: platform (Wave 4)
+# Issue: #1097 (EPIC #881 — O2)
+
+apiVersion: zynax.io/v1alpha1
+kind: AgentDef
+
+metadata:
+  name: planner
+  namespace: automation
+  labels:
+    plane: platform
+    epic: "881"
+    aggregation-weight: "1.0"
+    context-max-tokens: "3000"
+
+spec:
+  capabilities:
+    - name: review
+      description: >
+        Review a change against the active milestone plan (identical contract
+        to the planning-task-split expert, whose configuration this agent
+        extends): issue scope conformance, PR size gate, scope creep, and
+        missing prerequisite issues.
+      input_schema:
+        type: object
+        required: [trigger, diff_summary, changed_files, context_slice]
+        properties:
+          trigger:
+            type: string
+            description: Event that initiated this review.
+            enum: [pull_request, push, post_merge]
+          diff_summary:
+            type: string
+            description: git diff --stat output for the change under review.
+          changed_files:
+            type: array
+            description: List of changed file paths.
+            items:
+              type: string
+          context_slice:
+            type: object
+            description: >
+              Bounded context slice injected at dispatch time (ADR-028).
+              Only the files declared below, hard-capped at max_tokens.
+              Strict isolation - never another expert's slice or output.
+            required: [files, max_tokens]
+            properties:
+              files:
+                type: array
+                description: >
+                  Verbatim from docs/archive/dev-advisory/experts/planning-task-split.yaml.
+                items:
+                  type: string
+                default:
+                  - "state/current-milestone.md"
+                  - "docs/milestones/M6-planning.md"
+                  - "docs/milestones/M5-plan.md"
+              max_tokens:
+                type: integer
+                description: Hard context budget (tokens) per invocation.
+                default: 3000
+          pr_number:
+            type: integer
+            description: Pull request number (pull_request trigger only).
+          pr_title:
+            type: string
+            description: Pull request title (pull_request trigger only).
+          pr_labels:
+            type: array
+            description: List of current PR labels.
+            items:
+              type: string
+          open_issues:
+            type: array
+            description: List of last 50 open issues (title + number + labels).
+            items:
+              type: object
+          pr_linked_issues:
+            type: array
+            description: List of issue numbers referenced in PR body.
+            items:
+              type: integer
+      output_schema:
+        type: object
+        required: [summary, recommended_actions, reasons_decisions, confidence, flags]
+        properties:
+          summary:
+            type: string
+            description: Plain text summary, max 200 words.
+          recommended_actions:
+            type: array
+            description: Ordered list of specific actions with rationale.
+            items:
+              type: object
+              required: [action, rationale, priority]
+              properties:
+                action:
+                  type: string
+                rationale:
+                  type: string
+                priority:
+                  type: string
+                  enum: [low, medium, high]
+          reasons_decisions:
+            type: array
+            description: Reasoning chain for each recommendation.
+            items:
+              type: string
+          confidence:
+            type: string
+            description: Overall confidence level for this expert's output.
+            enum: [low, medium, high]
+          flags:
+            type: array
+            description: Tier-2 security flags or blocker flags (empty if none).
+            items:
+              type: string
+          extra_fields:
+            type: object
+            description: Expert-specific additional output fields.
+            properties:
+              scope_creep_detected:
+                type: boolean
+                description: True if PR touches files outside stated issue scope.
+              missing_prerequisite_issues:
+                type: array
+                description: Issues that should be open/closed first.
+                items:
+                  type: string
+              pr_size_lines:
+                type: integer
+                description: Total changed lines (excluding generated files).
+              pr_size_status:
+                type: string
+                description: PR size verdict per the size gate bands.
+                enum: [ok, warn, justify, blocked]
+              multiple_logical_changes:
+                type: boolean
+                description: True if commits appear to bundle unrelated work.
+              milestone_alignment:
+                type: string
+                description: Milestone alignment verdict.
+                enum: [on-track, at-risk, out-of-scope]
+      timeout_seconds: 300
+      max_retries: 1
+
+    - name: identify_next_issue
+      description: >
+        The /m6-plan brain: given the active milestone, the open issues, the
+        in-progress set, and the dependency table, identify the single next
+        issue to deliver and the dependency-free batch that can run in
+        parallel. Consumed by the issue-delivery workflow's plan state (O4).
+      input_schema:
+        type: object
+        required: [milestone, open_issues, in_progress, dependency_table]
+        properties:
+          milestone:
+            type: string
+            description: Active milestone identifier (e.g. "M6").
+          open_issues:
+            type: array
+            description: Open issues in the milestone (number, title, labels).
+            items:
+              type: object
+          in_progress:
+            type: array
+            description: Issues currently claimed/in progress (all machines).
+            items:
+              type: object
+          dependency_table:
+            type: array
+            description: >
+              Issue dependency edges (issue, depends_on[]) derived from the
+              milestone plan and SPDD canvas O-step ordering.
+            items:
+              type: object
+      output_schema:
+        type: object
+        required: [next_issue, blocked_by, ready_batch, rationale]
+        properties:
+          next_issue:
+            type: integer
+            description: Issue number to deliver next (0 if none is ready).
+          blocked_by:
+            type: array
+            description: Issue numbers currently blocking the next candidate.
+            items:
+              type: integer
+          ready_batch:
+            type: array
+            description: Issue numbers with no unmet dependencies (parallel-safe).
+            items:
+              type: integer
+          rationale:
+            type: string
+            description: Reasoning for the selection and batch composition.
+      timeout_seconds: 300
+      max_retries: 1

--- a/automation/workflows/experts/planning-task-split.yaml
+++ b/automation/workflows/experts/planning-task-split.yaml
@@ -1,0 +1,160 @@
+# SPDX-License-Identifier: Apache-2.0
+# automation/workflows/experts/planning-task-split.yaml
+#
+# Planning/task-split expert — reviews changes against the active milestone
+# plan, checks issue scope conformance (one PR per issue, one commit per
+# logical change), and detects scope creep or missing prerequisite issues.
+#
+# kind: AgentDef translation (ADR-028) of the near-term expert config
+# docs/archive/dev-advisory/experts/planning-task-split.yaml — the source of
+# truth for context_slice, I/O contract, and aggregation_weight (1:1).
+# The planner extension of this expert (the /m6-plan brain with the
+# identify_next_issue capability) lives in planner.yaml in this directory.
+# The context slice is bound at dispatch time into the `context_slice` field
+# of the review capability's input_payload (strict isolation, ADR-028).
+# Runtime binding (spec.runtime) lands in O5 (#1100).
+#
+# Plane: platform (Wave 4)
+# Issue: #1097 (EPIC #881 — O2)
+
+apiVersion: zynax.io/v1alpha1
+kind: AgentDef
+
+metadata:
+  name: planning-task-split
+  namespace: automation
+  labels:
+    plane: platform
+    epic: "881"
+    aggregation-weight: "1.0"
+    context-max-tokens: "3000"
+
+spec:
+  capabilities:
+    - name: review
+      description: >
+        Review a change against the active milestone plan: issue scope
+        conformance (one PR per issue, one commit per logical change),
+        PR size gate, scope creep, and missing prerequisite issues.
+      input_schema:
+        type: object
+        required: [trigger, diff_summary, changed_files, context_slice]
+        properties:
+          trigger:
+            type: string
+            description: Event that initiated this review.
+            enum: [pull_request, push, post_merge]
+          diff_summary:
+            type: string
+            description: git diff --stat output for the change under review.
+          changed_files:
+            type: array
+            description: List of changed file paths.
+            items:
+              type: string
+          context_slice:
+            type: object
+            description: >
+              Bounded context slice injected at dispatch time (ADR-028).
+              Only the files declared below, hard-capped at max_tokens.
+              Strict isolation - never another expert's slice or output.
+            required: [files, max_tokens]
+            properties:
+              files:
+                type: array
+                description: >
+                  Verbatim from docs/archive/dev-advisory/experts/planning-task-split.yaml.
+                items:
+                  type: string
+                default:
+                  - "state/current-milestone.md"
+                  - "docs/milestones/M6-planning.md"
+                  - "docs/milestones/M5-plan.md"
+              max_tokens:
+                type: integer
+                description: Hard context budget (tokens) per invocation.
+                default: 3000
+          pr_number:
+            type: integer
+            description: Pull request number (pull_request trigger only).
+          pr_title:
+            type: string
+            description: Pull request title (pull_request trigger only).
+          pr_labels:
+            type: array
+            description: List of current PR labels.
+            items:
+              type: string
+          open_issues:
+            type: array
+            description: List of last 50 open issues (title + number + labels).
+            items:
+              type: object
+          pr_linked_issues:
+            type: array
+            description: List of issue numbers referenced in PR body.
+            items:
+              type: integer
+      output_schema:
+        type: object
+        required: [summary, recommended_actions, reasons_decisions, confidence, flags]
+        properties:
+          summary:
+            type: string
+            description: Plain text summary, max 200 words.
+          recommended_actions:
+            type: array
+            description: Ordered list of specific actions with rationale.
+            items:
+              type: object
+              required: [action, rationale, priority]
+              properties:
+                action:
+                  type: string
+                rationale:
+                  type: string
+                priority:
+                  type: string
+                  enum: [low, medium, high]
+          reasons_decisions:
+            type: array
+            description: Reasoning chain for each recommendation.
+            items:
+              type: string
+          confidence:
+            type: string
+            description: Overall confidence level for this expert's output.
+            enum: [low, medium, high]
+          flags:
+            type: array
+            description: Tier-2 security flags or blocker flags (empty if none).
+            items:
+              type: string
+          extra_fields:
+            type: object
+            description: Expert-specific additional output fields.
+            properties:
+              scope_creep_detected:
+                type: boolean
+                description: True if PR touches files outside stated issue scope.
+              missing_prerequisite_issues:
+                type: array
+                description: Issues that should be open/closed first.
+                items:
+                  type: string
+              pr_size_lines:
+                type: integer
+                description: Total changed lines (excluding generated files).
+              pr_size_status:
+                type: string
+                description: PR size verdict per the size gate bands.
+                enum: [ok, warn, justify, blocked]
+              multiple_logical_changes:
+                type: boolean
+                description: True if commits appear to bundle unrelated work.
+              milestone_alignment:
+                type: string
+                description: Milestone alignment verdict.
+                enum: [on-track, at-risk, out-of-scope]
+      timeout_seconds: 300
+      max_retries: 1

--- a/automation/workflows/experts/qa-bdd.yaml
+++ b/automation/workflows/experts/qa-bdd.yaml
@@ -1,0 +1,146 @@
+# SPDX-License-Identifier: Apache-2.0
+# automation/workflows/experts/qa-bdd.yaml
+#
+# QA/BDD expert — reviews Gherkin feature files, BDD test coverage at gRPC
+# boundaries, and coverage reports. Enforces ADR-016: .feature file committed
+# before any implementation for new gRPC boundaries.
+#
+# kind: AgentDef translation (ADR-028) of the near-term expert config
+# docs/archive/dev-advisory/experts/qa-bdd.yaml — the source of truth for
+# context_slice, I/O contract, and aggregation_weight (translated 1:1).
+# The context slice is bound at dispatch time into the `context_slice` field
+# of the review capability's input_payload (strict isolation, ADR-028).
+# Runtime binding (spec.runtime) lands in O5 (#1100).
+#
+# Plane: platform (Wave 4)
+# Issue: #1097 (EPIC #881 — O2)
+
+apiVersion: zynax.io/v1alpha1
+kind: AgentDef
+
+metadata:
+  name: qa-bdd
+  namespace: automation
+  labels:
+    plane: platform
+    epic: "881"
+    aggregation-weight: "1.0"
+    context-max-tokens: "3000"
+
+spec:
+  capabilities:
+    - name: review
+      description: >
+        Review Gherkin feature files, BDD coverage at gRPC boundaries, and
+        coverage reports. Enforces ADR-016 (.feature committed before any
+        implementation for new gRPC boundaries) and the 90% domain coverage
+        floor.
+      input_schema:
+        type: object
+        required: [trigger, diff_summary, changed_files, context_slice]
+        properties:
+          trigger:
+            type: string
+            description: Event that initiated this review.
+            enum: [pull_request, push, post_merge]
+          diff_summary:
+            type: string
+            description: git diff --stat output for the change under review.
+          changed_files:
+            type: array
+            description: List of changed file paths.
+            items:
+              type: string
+          context_slice:
+            type: object
+            description: >
+              Bounded context slice injected at dispatch time (ADR-028).
+              Only the files declared below, hard-capped at max_tokens.
+              Strict isolation - never another expert's slice or output.
+            required: [files, max_tokens]
+            properties:
+              files:
+                type: array
+                description: >
+                  Verbatim from docs/archive/dev-advisory/experts/qa-bdd.yaml.
+                items:
+                  type: string
+                default:
+                  - "protos/tests/**/*.feature"
+                  - "protos/tests/**/*_test.go"
+                  - "docs/adr/ADR-016-*.md"
+                  - "coverage/**/*.out"
+                  - "coverage/**/*.xml"
+              max_tokens:
+                type: integer
+                description: Hard context budget (tokens) per invocation.
+                default: 3000
+          pr_number:
+            type: integer
+            description: Pull request number (pull_request trigger only).
+          pr_title:
+            type: string
+            description: Pull request title (pull_request trigger only).
+          coverage_report:
+            type: string
+            description: Coverage summary (post_merge trigger).
+      output_schema:
+        type: object
+        required: [summary, recommended_actions, reasons_decisions, confidence, flags]
+        properties:
+          summary:
+            type: string
+            description: Plain text summary, max 200 words.
+          recommended_actions:
+            type: array
+            description: Ordered list of specific actions with rationale.
+            items:
+              type: object
+              required: [action, rationale, priority]
+              properties:
+                action:
+                  type: string
+                rationale:
+                  type: string
+                priority:
+                  type: string
+                  enum: [low, medium, high]
+          reasons_decisions:
+            type: array
+            description: Reasoning chain for each recommendation.
+            items:
+              type: string
+          confidence:
+            type: string
+            description: Overall confidence level for this expert's output.
+            enum: [low, medium, high]
+          flags:
+            type: array
+            description: Tier-2 security flags or blocker flags (empty if none).
+            items:
+              type: string
+          extra_fields:
+            type: object
+            description: Expert-specific additional output fields.
+            properties:
+              bdd_coverage_gaps:
+                type: array
+                description: gRPC methods lacking a .feature scenario.
+                items:
+                  type: string
+              feature_file_missing:
+                type: boolean
+                description: True if new boundary has no .feature file (ADR-016).
+              domain_coverage_below_threshold:
+                type: boolean
+                description: True if domain/ coverage drops below 90%.
+              flaky_tests_detected:
+                type: array
+                description: Test names that appear to be non-deterministic.
+                items:
+                  type: string
+              new_scenarios_added:
+                type: integer
+                description: Count of new Gherkin scenarios in this diff.
+      timeout_seconds: 300
+      max_retries: 1

--- a/automation/workflows/experts/security-supply-chain.yaml
+++ b/automation/workflows/experts/security-supply-chain.yaml
@@ -1,0 +1,166 @@
+# SPDX-License-Identifier: Apache-2.0
+# automation/workflows/experts/security-supply-chain.yaml
+#
+# Security/supply-chain expert — reviews workflow security steps, SBOM/cosign
+# attestation, Scorecard posture, CodeQL alerts, and dependency audit results.
+# Raises tier-2 flags immediately; never auto-remediates.
+#
+# kind: AgentDef translation (ADR-028) of the near-term expert config
+# docs/archive/dev-advisory/experts/security-supply-chain.yaml — the source
+# of truth for context_slice, I/O contract, and aggregation_weight (1:1).
+# The context slice is bound at dispatch time into the `context_slice` field
+# of the review capability's input_payload (strict isolation, ADR-028).
+# Runtime binding (spec.runtime) lands in O5 (#1100).
+#
+# Plane: platform (Wave 4)
+# Issue: #1097 (EPIC #881 — O2)
+
+apiVersion: zynax.io/v1alpha1
+kind: AgentDef
+
+metadata:
+  name: security-supply-chain
+  namespace: automation
+  labels:
+    plane: platform
+    epic: "881"
+    aggregation-weight: "1.5"
+    context-max-tokens: "3000"
+
+spec:
+  capabilities:
+    - name: review
+      description: >
+        Review CI workflow security posture, SBOM and cosign attestation
+        steps, Scorecard and CodeQL findings, and dependency audit results.
+        Tier-2 flags raised here escalate immediately to a human; this
+        expert never auto-remediates.
+      input_schema:
+        type: object
+        required: [trigger, diff_summary, changed_files, context_slice]
+        properties:
+          trigger:
+            type: string
+            description: Event that initiated this review.
+            enum: [pull_request, push, post_merge]
+          diff_summary:
+            type: string
+            description: git diff --stat output for the change under review.
+          changed_files:
+            type: array
+            description: List of changed file paths.
+            items:
+              type: string
+          context_slice:
+            type: object
+            description: >
+              Bounded context slice injected at dispatch time (ADR-028).
+              Only the files declared below, hard-capped at max_tokens.
+              Strict isolation - never another expert's slice or output.
+            required: [files, max_tokens]
+            properties:
+              files:
+                type: array
+                description: >
+                  Verbatim from docs/archive/dev-advisory/experts/security-supply-chain.yaml.
+                items:
+                  type: string
+                default:
+                  - ".github/workflows/*.yml"
+                  - "SECURITY.md"
+                  - "images/images.yaml"
+                  - "tools/Dockerfile"
+                  - "services/*/Dockerfile"
+              max_tokens:
+                type: integer
+                description: Hard context budget (tokens) per invocation.
+                default: 3000
+          pr_number:
+            type: integer
+            description: Pull request number (pull_request trigger only).
+          pr_title:
+            type: string
+            description: Pull request title (pull_request trigger only).
+          scorecard_output:
+            type: string
+            description: JSON output from ossf/scorecard-action (post_merge trigger).
+          codeql_alerts:
+            type: array
+            description: List of open CodeQL alert summaries.
+            items:
+              type: string
+          govulncheck_output:
+            type: string
+            description: Text output from govulncheck (post_merge trigger).
+          bandit_output:
+            type: string
+            description: JSON output from bandit (post_merge trigger).
+          pip_audit_output:
+            type: string
+            description: JSON output from pip-audit (post_merge trigger).
+      output_schema:
+        type: object
+        required: [summary, recommended_actions, reasons_decisions, confidence, flags]
+        properties:
+          summary:
+            type: string
+            description: Plain text summary, max 200 words.
+          recommended_actions:
+            type: array
+            description: Ordered list of specific actions with rationale.
+            items:
+              type: object
+              required: [action, rationale, priority]
+              properties:
+                action:
+                  type: string
+                rationale:
+                  type: string
+                priority:
+                  type: string
+                  enum: [low, medium, high]
+          reasons_decisions:
+            type: array
+            description: Reasoning chain for each recommendation.
+            items:
+              type: string
+          confidence:
+            type: string
+            description: Overall confidence level for this expert's output.
+            enum: [low, medium, high]
+          flags:
+            type: array
+            description: >
+              Tier-2 flags raised here escalate immediately to a human
+              (empty list if none).
+            items:
+              type: string
+          extra_fields:
+            type: object
+            description: Expert-specific additional output fields.
+            properties:
+              cosign_verification_status:
+                type: string
+                description: Cosign verification status.
+                enum: [pass, fail, not_applicable]
+              sbom_present:
+                type: boolean
+                description: True if SBOM artifact exists in release.
+              scorecard_score:
+                type: number
+                description: OpenSSF Scorecard score 0.0-10.0 (null if not available).
+              new_cve_findings:
+                type: array
+                description: CVE IDs from govulncheck/pip-audit.
+                items:
+                  type: string
+              workflow_permission_issues:
+                type: array
+                description: Overly-broad GitHub Actions permissions.
+                items:
+                  type: string
+              secret_exposure_risk:
+                type: boolean
+                description: True if diff touches secrets handling paths.
+      timeout_seconds: 300
+      max_retries: 1

--- a/docs/spdd/881-self-hosted-issue-delivery/canvas.md
+++ b/docs/spdd/881-self-hosted-issue-delivery/canvas.md
@@ -234,7 +234,11 @@ event-bus, (orchestrator) engine-adapter.
    AgentDef-vs-Workflow split and the context-slice injection contract. Fix the wrong schema path in
    `test_platform_readiness.py` (`agent-def.json` → `agent-def.schema.json`). *Verify:* ADR merged;
    `make validate-spec` still green; test still xfails (no behaviour change yet).
-2. **O2 — 8 domain-expert AgentDef manifests + planner AgentDef (`feat`).** Translate each
+2. **O2 — 8 domain-expert AgentDef manifests + planner AgentDef (`feat`).** ✅ Delivered (#1097 —
+   9 AgentDefs under `automation/workflows/experts/`; the planner is materialised as `planner.yaml`,
+   the `planning-task-split` extension carrying `review` + `identify_next_issue` per ADR-028, so the
+   capability has exactly one provider; source YAMLs read from `docs/archive/dev-advisory/experts/`).
+   Translate each
    `automation/experts/<name>.yaml` into `automation/workflows/experts/<name>.yaml` as `kind: AgentDef`
    with a `review` capability; extend `planning-task-split` with `identify_next_issue`. *Verify:* all 9
    validate against `agent-def.schema.json` via `make validate-spec`; one unit test per manifest asserts

--- a/state/current-milestone.md
+++ b/state/current-milestone.md
@@ -58,7 +58,7 @@ As of 2026-06-11: **143 issues closed / 17 open** (CI-overhaul stories #1110–#
 **e2e-green execution path (#1086 — O1 #1087 ✅ / O2 #1088 ✅ merged via PR #1095; O3 #1089 ✅ satisfied by build-images gate PR #1132)**,
 Postgres off Bitnami (#1073 — O1 ADR-026 ✅, O2–O3 #1076 ✅, O4–O5 #1077 ✅, O6 #1078 ✅ verified; #1079 remaining),
 CI-E2E gate (#771 — #1070 ✅, #1071 remaining),
-DevAuto Wave 4 (#881 — canvas Aligned, stories #1096–#1104 created; O1 #1096 ✅ ADR-028).
+DevAuto Wave 4 (#881 — canvas Aligned, stories #1096–#1104 created; O1 #1096 ✅ ADR-028; O2 #1097 ✅ 9 expert AgentDefs).
 
 ---
 
@@ -302,7 +302,7 @@ Canvas: SPDD-exempt (docs:/chore:/ci: stories only, until Wave 4 #881 which is B
 | DevAuto.5 ci: Wave 1 orchestrator aggregation | [#878](https://github.com/zynax-io/zynax/issues/878) | ⬜ Ready |
 | DevAuto.6 ci: Wave 2 | [#879](https://github.com/zynax-io/zynax/issues/879) | ⬜ Pending |
 | DevAuto.7 ci: Wave 3 | [#880](https://github.com/zynax-io/zynax/issues/880) | ⬜ Pending |
-| DevAuto.8 feat: Wave 4 aspirational | [#881](https://github.com/zynax-io/zynax/issues/881) | 🔄 In progress — O1 [#1096](https://github.com/zynax-io/zynax/issues/1096) ✅ (ADR-028); O2–O9 #1097–#1104 |
+| DevAuto.8 feat: Wave 4 aspirational | [#881](https://github.com/zynax-io/zynax/issues/881) | 🔄 In progress — O1 [#1096](https://github.com/zynax-io/zynax/issues/1096) ✅ (ADR-028); O2 [#1097](https://github.com/zynax-io/zynax/issues/1097) ✅ (9 expert AgentDefs); O3–O9 #1098–#1104 |
 | DevAuto.9 test: xfail gate | [#882](https://github.com/zynax-io/zynax/issues/882) | ⬜ Pending |
 | DevAuto.10 docs: AGENTS.md pointer + README | [#883](https://github.com/zynax-io/zynax/issues/883) | ⬜ Pending |
 


### PR DESCRIPTION
## Summary

O2 of EPIC #881 (Wave 4 self-hosted issue-delivery) — Canvas: `docs/spdd/881-self-hosted-issue-delivery/canvas.md` §O step 2, design locked by ADR-028.

Translates the eight near-term expert configs (source of truth, archived at `docs/archive/dev-advisory/experts/` by #1129) into `kind: AgentDef` platform manifests under `automation/workflows/experts/`, each exposing a `review` capability whose input/output schema mirrors the source YAML `input_contract`/`output_contract` 1:1. The planner (the `/m6-plan` brain) ships as `planner.yaml` — the planning-task-split expert extended with `identify_next_issue` (`review` + `identify_next_issue` per the ADR-028 capability table) — keeping the mesh at 9 manifests (8 domain + planner) with exactly one provider of `identify_next_issue`.

Per the ADR-028 context-slice injection contract, each manifest carries its bounded `context_slice` (`files[]` + `max_tokens`, verbatim from source) as dispatch-time defaults of the `review` capability's `context_slice` input field; `aggregation_weight` and `max_tokens` are also surfaced as registry labels. `spec.runtime` intentionally omitted — the runtime binding is O5 (#1100).

## Acceptance criteria (evidence)

- [x] **9 AgentDef manifests under `automation/workflows/experts/` validate against `agent-def.schema.json` (`make validate-spec`)** — `validate-agent-def-schema` now also walks `automation/workflows/experts/` (the `zynax-ci` batch walk is non-recursive, so the dir is named explicitly); local run: all 9 `OK`, plus the existing spec example.
- [x] **One unit test per manifest asserts capability I/O matches the source YAML `output_contract`** — `automation/tests/test_expert_agentdefs.py`, parametrized per manifest (9 instances each for input contract, output contract, context slice, weight/tokens, schema validity = 45 manifest assertions + planner `identify_next_issue` contract test).
- [x] **`max_tokens`/`aggregation_weight` match the source `<name>.yaml`** — asserted per manifest against `docs/archive/dev-advisory/experts/<name>.yaml` (the archived location of `automation/experts/`; the planner maps to `planning-task-split.yaml`).

## Test plan

- `make validate-spec` — green (AsyncAPI + capability + workflow + agent-def incl. the 9 new manifests + policy).
- `python3 -m pytest automation/tests/ -v` — 49 passed, 2 xfailed. The two remaining strict xfails are the orchestrator-dependent readiness tests (O3 #1098 manifest, O8 #1103 live-platform e2e); the expert-schema readiness assertion now genuinely passes with the 9 manifests, so the class-level xfail was narrowed to those two tests (otherwise it would strict-XPASS).

## Notes for review

- Canvas count reconciliation: §S structure tree lists 8 files while the DoD, issue AC, readiness test, and the "9 × expert AgentDef.review" fan-out all require 9 manifests. ADR-028's capability table resolves this: the Planner is "planning-task-split, extended" exposing `review + identify_next_issue` — materialised here as a 9th manifest (`planner.yaml`) so both counts and single-provider routing hold. Recorded in the canvas O2 delivery note (same PR).
- Status surfaces updated: canvas O2 ✅, `state/current-milestone.md` Wave 4 rows.

Closes #1097

Assisted-by: Claude/claude-fable-5
