### PR TITLE
feat(automation): orchestrator Workflow manifest — fan-out, aggregate, act

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -353,8 +353,9 @@ validate-capability-schemas: ensure-tools ## Validate capability declarations in
 	$(TOOLS_RUN) zynax-ci validate capabilities spec/workflows/examples/ --schema-dir spec/schemas
 	@echo "✅ Capability schemas valid"
 
-validate-workflow-schema: ensure-tools ## Validate Workflow manifests in spec/workflows/examples/ against workflow.schema.json
+validate-workflow-schema: ensure-tools ## Validate Workflow manifests (spec examples + automation/workflows) against workflow.schema.json
 	$(TOOLS_RUN) zynax-ci validate workflows spec/workflows/examples/ --schema-dir spec/schemas
+	$(TOOLS_RUN) zynax-ci validate workflows automation/workflows/ --schema-dir spec/schemas
 	@echo "✅ Workflow schemas valid"
 
 validate-agent-def-schema: ensure-tools ## Validate AgentDef manifests (spec examples + automation/workflows) against agent-def.schema.json

--- a/automation/tests/features/dev_advisory_orchestrator.feature
+++ b/automation/tests/features/dev_advisory_orchestrator.feature
@@ -1,0 +1,120 @@
+# SPDX-License-Identifier: Apache-2.0
+# Zynax — Dev-Advisory Orchestrator Workflow BDD Contract (EPIC #881 O3, #1098)
+#
+# This file is the SPECIFICATION (ADR-016). It describes the behaviour the
+# dev-advisory-orchestrator Workflow manifest must encode: parallel fan-out of
+# the 9 expert review capabilities with strict context isolation, weighted-
+# consensus aggregation, an act state limited to auto_allowed actions, and
+# human escalation. Step implementations arrive with the runtime binding
+# (O5, #1100) and the platform-readiness e2e (O8, #1103).
+#
+# Business context: the orchestrator is the on-platform /m6-orchestrate — a
+# thin coordinator (8K token budget) that sees expert OUTPUTS only, never code
+# files (ADR-028). Aggregation weights are registry labels on the expert
+# AgentDefs; strategy and thresholds are translated 1:1 from the archived
+# orchestrator config (docs/archive/dev-advisory/orchestrator/config.yaml).
+
+Feature: Dev-advisory orchestrator — fan-out, aggregate, act
+  As the Zynax platform maintainer
+  I want a declarative Workflow that fans out to the 9 domain experts,
+  aggregates their reviews into a weighted-consensus verdict, and acts
+  So that issue and PR advisory runs are self-hosted on Zynax itself
+
+  Background:
+    Given the Workflow manifest "automation/workflows/dev-advisory-orchestrator.yaml" is loaded
+    And the 9 expert AgentDef manifests under "automation/workflows/experts/" are registered
+
+  # ─── fan_out ──────────────────────────────────────────────────────────────
+
+  Scenario: Fan-out dispatches all 9 expert review capabilities in parallel
+    Given a pull request against "main" triggers a new workflow instance
+    When the workflow enters the "fan_out" state
+    Then 9 "review" capability dispatches start before any transition is awaited
+    And each dispatch names exactly one expert from the registered AgentDef set
+    And no expert is dispatched more than once
+
+  Scenario: Each expert receives only its own bounded context slice
+    When the "review" capability is dispatched for expert "arch-adr"
+    Then the input payload contains only the context_slice declared by the
+      "arch-adr" AgentDef, bound at dispatch time
+    And no other expert's context slice or output is present in the payload
+
+  Scenario: The orchestrator never reads code files
+    When the workflow aggregates in the "aggregate" state
+    Then the aggregation input contains expert outputs only
+    And no raw repository file content is present in the orchestrator context
+
+  Scenario: Expert timeout produces a partial aggregation, not a stall
+    Given 8 experts complete and one expert exceeds its 5m timeout
+    When the "review.timeout" event arrives
+    Then the workflow transitions to "aggregate" with partial results
+
+  # ─── aggregate ────────────────────────────────────────────────────────────
+
+  Scenario: Aggregation computes a weighted-consensus verdict
+    Given all 9 expert reviews are collected in the workflow context
+    When the "aggregate_reviews" capability completes
+    Then the workflow context holds an "aggregated_verdict" with a confidence
+      of "low", "medium" or "high"
+    And vote weights are derived from each expert's "aggregation-weight"
+      registry label multiplied by its confidence score
+    And only actions with aggregate weight >= 3.0 are included in the verdict
+
+  Scenario: A clean verdict proceeds to act
+    Given the aggregated verdict requires no escalation
+    When the "aggregate_reviews.completed" event arrives
+    Then the workflow transitions to the "act" state
+
+  # ─── escalation ───────────────────────────────────────────────────────────
+
+  Scenario: Two high-confidence contradictions escalate to a human
+    Given 2 high-confidence experts recommend contradictory actions
+    When the "aggregate_reviews.completed" event arrives
+    Then the workflow transitions to the "escalate" state
+    And the "escalate" state is human_in_the_loop
+
+  Scenario: Any tier-2 flag escalates to a human
+    Given any expert raises a tier-2 flag in its flags array
+    When the "aggregate_reviews.completed" event arrives
+    Then the workflow transitions to the "escalate" state
+
+  Scenario: A low-confidence top action escalates to a human
+    Given the top recommended action has aggregate confidence "low"
+    When the "aggregate_reviews.completed" event arrives
+    Then the workflow transitions to the "escalate" state
+
+  Scenario: A human approval resumes the act state
+    Given the workflow is paused in the "escalate" state
+    When the "human.approved" event arrives
+    Then the workflow transitions to the "act" state
+
+  # ─── act — auto_allowed only ──────────────────────────────────────────────
+
+  Scenario: Act executes auto_allowed actions only
+    Given the aggregated verdict recommends "auto-label" and "post-pr-comment"
+    When the workflow enters the "act" state
+    Then both actions are executed automatically
+    And the executed actions are recorded in the workflow context
+
+  Scenario Outline: A prohibited_auto_action is never executed automatically
+    Given the aggregated verdict recommends "<action>"
+    When the workflow enters the "act" state
+    Then "<action>" is not executed
+    And executing "<action>" requires explicit human approval
+
+    Examples:
+      | action          |
+      | merge           |
+      | push            |
+      | bump-dependency |
+      | close-issue     |
+      | delete-branch   |
+      | force-push      |
+
+  # ─── decision log ─────────────────────────────────────────────────────────
+
+  Scenario: Every run records a decision-log entry
+    Given a workflow instance reaches the terminal "done" state
+    Then a decision-log entry is recorded with the verdict, expert votes,
+      and any auto actions taken
+    And the entry conforms to the decision-log schema

--- a/automation/tests/test_orchestrator_workflow.py
+++ b/automation/tests/test_orchestrator_workflow.py
@@ -1,0 +1,175 @@
+# SPDX-License-Identifier: Apache-2.0
+# automation/tests/test_orchestrator_workflow.py
+#
+# O3 of EPIC #881 (#1098): asserts the dev-advisory-orchestrator Workflow
+# manifest is a faithful translation of the archived orchestrator config
+# (docs/archive/dev-advisory/orchestrator/config.yaml — source of truth per
+# ADR-028) and that its capability references match the 9 expert AgentDef
+# manifests under automation/workflows/experts/ 1:1.
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW_PATH = REPO_ROOT / "automation/workflows/dev-advisory-orchestrator.yaml"
+EXPERT_DIR = REPO_ROOT / "automation/workflows/experts"
+SOURCE_CONFIG = REPO_ROOT / "docs/archive/dev-advisory/orchestrator/config.yaml"
+FEATURE_PATH = REPO_ROOT / "automation/tests/features/dev_advisory_orchestrator.feature"
+
+EXPECTED_STATES = {"fan_out", "aggregate", "act", "escalate", "done"}
+
+
+@pytest.fixture(scope="module")
+def workflow():
+    with open(WORKFLOW_PATH) as f:
+        return yaml.safe_load(f)
+
+
+@pytest.fixture(scope="module")
+def source_config():
+    with open(SOURCE_CONFIG) as f:
+        return yaml.safe_load(f)
+
+
+@pytest.fixture(scope="module")
+def expert_names():
+    return sorted(p.stem for p in EXPERT_DIR.glob("*.yaml"))
+
+
+def state(workflow, name):
+    states = workflow["spec"]["states"]
+    assert name in states, f"state {name!r} missing"
+    return states[name]
+
+
+def test_kind_and_api_version(workflow):
+    """Orchestration is kind: Workflow, apiVersion zynax.io/v1 (ADR-028)."""
+    assert workflow["kind"] == "Workflow"
+    assert workflow["apiVersion"] == "zynax.io/v1"
+    assert workflow["metadata"]["name"] == "dev-advisory-orchestrator"
+    assert workflow["metadata"]["namespace"] == "automation"
+
+
+def test_state_machine_shape(workflow):
+    """fan_out → aggregate → act/escalate → done, starting at fan_out."""
+    assert workflow["spec"]["initial_state"] == "fan_out"
+    assert set(workflow["spec"]["states"]) == EXPECTED_STATES
+    assert state(workflow, "escalate")["type"] == "human_in_the_loop"
+    assert state(workflow, "done")["type"] == "terminal"
+    assert "on" not in state(workflow, "done")
+
+
+def test_fan_out_dispatches_all_nine_experts_exactly_once(workflow, expert_names):
+    """fan_out invokes the review capability once per expert manifest (1:1)."""
+    actions = state(workflow, "fan_out")["actions"]
+    assert len(actions) == 9
+    assert all(a["capability"] == "review" for a in actions)
+    dispatched = sorted(a["input"]["expert"] for a in actions)
+    assert dispatched == expert_names
+
+
+def test_fan_out_inputs_satisfy_review_contract(workflow):
+    """Every dispatch carries the review capability's required inputs.
+
+    context_slice is intentionally absent: it is bound at dispatch time by
+    the context-slice injection binding (O5, #1100) so the expert AgentDefs
+    stay the single source of truth for slices (ADR-028).
+    """
+    for action in state(workflow, "fan_out")["actions"]:
+        action_input = action["input"]
+        for field in ("trigger", "diff_summary", "changed_files"):
+            assert field in action_input, f"{action_input['expert']}: {field}"
+        assert action_input["trigger"] == "pull_request"
+        assert "context_slice" not in action_input
+
+
+def test_fan_out_timeout_matches_source_config(workflow, source_config):
+    """Per-expert timeout mirrors fan_out.timeout_seconds (300s)."""
+    expected = f"{source_config['fan_out']['timeout_seconds'] // 60}m"
+    for action in state(workflow, "fan_out")["actions"]:
+        assert action["timeout"] == expected
+    # On per-expert timeout the orchestrator continues with partial outputs.
+    timeout_edges = [
+        t for t in state(workflow, "fan_out")["on"] if t["event"] == "review.timeout"
+    ]
+    assert len(timeout_edges) == 1
+    assert timeout_edges[0]["goto"] == "aggregate"
+
+
+def test_fan_out_collects_each_expert_output_separately(workflow):
+    """Each dispatch maps its result to a distinct context key (isolation)."""
+    keys = []
+    for action in state(workflow, "fan_out")["actions"]:
+        assert list(action["output"].values()) == ["{{ .result }}"]
+        keys.extend(action["output"].keys())
+    assert len(set(keys)) == 9
+    assert all(k.startswith("context.reviews.") for k in keys)
+
+
+def test_aggregation_matches_source_config(workflow, source_config):
+    """Strategy, minimum weight, and thresholds are verbatim from config."""
+    src = source_config["aggregation"]
+    actions = state(workflow, "aggregate")["actions"]
+    assert len(actions) == 1
+    agg_input = actions[0]["input"]
+
+    assert actions[0]["capability"] == "aggregate_reviews"
+    assert agg_input["strategy"] == src["strategy"]
+    assert agg_input["aggregate_weight_minimum"] == src["aggregate_weight_minimum"]
+    assert agg_input["conflict_resolution"] == src["conflict_resolution"]
+    assert agg_input["escalation_threshold"] == src["escalation_threshold"]
+    # Weights come from expert registry labels — never duplicated here.
+    assert agg_input["weight_label"] == "aggregation-weight"
+    assert "weights" not in agg_input
+
+
+def test_aggregate_routes_to_act_or_escalate(workflow):
+    """Escalation guard routes to escalate; the clean path routes to act."""
+    transitions = state(workflow, "aggregate")["on"]
+    targets = {t["goto"] for t in transitions}
+    assert targets == {"act", "escalate"}
+    escalate_edge = next(t for t in transitions if t["goto"] == "escalate")
+    assert "escalation_required" in escalate_edge["guard"]
+
+
+def test_act_honours_human_in_the_loop_policy(workflow, source_config):
+    """auto_allowed / never_auto are verbatim from the archived config."""
+    src = source_config["human_in_the_loop"]
+    actions = state(workflow, "act")["actions"]
+    assert len(actions) == 1
+    act_input = actions[0]["input"]
+
+    assert act_input["auto_allowed"] == src["auto_allowed"]
+    assert act_input["never_auto"] == src["never_auto"]
+    assert not set(act_input["auto_allowed"]) & set(act_input["never_auto"])
+
+
+def test_no_state_invokes_a_prohibited_auto_action(workflow, source_config):
+    """No workflow action capability is ever a prohibited_auto_action."""
+    never_auto = set(source_config["human_in_the_loop"]["never_auto"])
+    for state_def in workflow["spec"]["states"].values():
+        for action in state_def.get("actions", []):
+            assert action["capability"] not in never_auto
+
+
+def test_escalate_resumes_only_via_human_signal(workflow):
+    """The escalate state transitions only on human.* events."""
+    transitions = state(workflow, "escalate")["on"]
+    assert all(t["event"].startswith("human.") for t in transitions)
+    assert {t["goto"] for t in transitions} == {"act", "done"}
+
+
+def test_done_records_decision_log(workflow):
+    """Every run terminates by recording a decision-log entry."""
+    actions = state(workflow, "done")["actions"]
+    assert [a["capability"] for a in actions] == ["record_decision"]
+
+
+def test_bdd_feature_committed():
+    """ADR-016: the BDD contract ships with the manifest."""
+    text = FEATURE_PATH.read_text()
+    assert "Feature: Dev-advisory orchestrator" in text
+    for keyword in ("fan_out", "aggregate", "prohibited_auto_action", "escalate"):
+        assert keyword in text, f"feature file missing {keyword!r}"

--- a/automation/tests/test_platform_readiness.py
+++ b/automation/tests/test_platform_readiness.py
@@ -14,23 +14,21 @@ except ImportError:
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCHEMA_PATH = REPO_ROOT / "spec/schemas/agent-def.schema.json"
+WORKFLOW_SCHEMA_PATH = REPO_ROOT / "spec/schemas/workflow.schema.json"
 ORCHESTRATOR_YAML = REPO_ROOT / "automation/workflows/dev-advisory-orchestrator.yaml"
 EXPERT_YAMLS = list((REPO_ROOT / "automation/workflows/experts").glob("*.yaml"))
 
 
 class TestPlatformReadiness:
-    @pytest.mark.xfail(
-        strict=True,
-        reason=(
-            "Wave 4: requires automation/workflows/dev-advisory-orchestrator.yaml "
-            "(EPIC #881 O3, #1098 — kind: Workflow per ADR-028). Reworked against "
-            "workflow.schema.json when the manifest lands; flips in O8 (#1103)."
-        ),
-    )
-    def test_orchestrator_agentdef_schema_valid(self):
-        """Orchestrator manifest validates against Zynax JSON schema."""
-        assert HAS_JSONSCHEMA, "jsonschema package required"
-        with open(SCHEMA_PATH) as f:
+    @pytest.mark.skipif(not HAS_JSONSCHEMA, reason="jsonschema package required")
+    def test_orchestrator_workflow_schema_valid(self):
+        """Orchestrator manifest validates against workflow.schema.json.
+
+        Delivered by O3 (#1098): the orchestrator is kind: Workflow per
+        ADR-028, so it validates against the Workflow schema (the experts
+        keep validating against agent-def.schema.json below).
+        """
+        with open(WORKFLOW_SCHEMA_PATH) as f:
             schema = json.load(f)
         with open(ORCHESTRATOR_YAML) as f:
             doc = yaml.safe_load(f)

--- a/automation/workflows/dev-advisory-orchestrator.yaml
+++ b/automation/workflows/dev-advisory-orchestrator.yaml
@@ -1,0 +1,269 @@
+# SPDX-License-Identifier: Apache-2.0
+# automation/workflows/dev-advisory-orchestrator.yaml
+#
+# Dev-advisory orchestrator — the on-platform `/m6-orchestrate`.
+#
+# kind: Workflow state machine (ADR-028): fan_out (parallel dispatch of the
+# 9 expert `review` capabilities) → aggregate (weighted consensus) → act
+# (auto_allowed actions only) | escalate (human-in-the-loop).
+#
+# Source of truth for aggregation strategy, escalation thresholds, and the
+# human-in-the-loop policy: docs/archive/dev-advisory/orchestrator/config.yaml
+# (translated 1:1, ADR-028). Aggregation weights are NOT duplicated here —
+# they live as `aggregation-weight` registry labels on the expert AgentDefs
+# (automation/workflows/experts/*.yaml).
+#
+# Context isolation (ADR-028): the orchestrator sees expert OUTPUTS only,
+# never code files (8K token budget — mirrors the Claude command). Each
+# expert's bounded context_slice is bound into the `review` input_payload at
+# dispatch time by the context-slice injection binding (O5, #1100), keyed by
+# the `expert` input field below — slices are never inlined here, so the
+# expert manifests remain the single source of truth.
+#
+# Capability providers: `review` is provided by the 9 expert AgentDefs (O2,
+# #1097). The orchestration-side capabilities (aggregate_reviews,
+# execute_auto_actions, notify_human, record_decision) get providers with the
+# runtime binding (O5, #1100) and the platform-readiness e2e (O8, #1103).
+#
+# Plane: platform (Wave 4)
+# Issue: #1098 (EPIC #881 — O3)
+
+kind: Workflow
+apiVersion: zynax.io/v1
+
+metadata:
+  name: dev-advisory-orchestrator
+  namespace: automation
+  labels:
+    plane: platform
+    epic: "881"
+    context-max-tokens: "8000"
+  annotations:
+    description: >-
+      Fan out the 9 domain-expert review capabilities in parallel with strict
+      context isolation, aggregate their outputs into a weighted-consensus
+      verdict, then act (auto_allowed actions only) or escalate to a human.
+    issue: "1098"
+
+spec:
+  initial_state: fan_out
+
+  # New instance per PR against main (the near-term dev-advisory trigger,
+  # now on-platform). Manual runs need no trigger: `zynax apply` starts one.
+  triggers:
+    - event: github.pull_request.opened
+      filter:
+        repo: "zynax-io/zynax"
+        base_branch: "main"
+    - event: github.pull_request.synchronize
+      filter:
+        repo: "zynax-io/zynax"
+        base_branch: "main"
+
+  states:
+    # ── fan_out — dispatch all 9 expert reviews in parallel ────────────────
+    # All actions start before the state machine waits for a transition
+    # (workflow.schema.json semantics) — the EventBus (ADR-022) carries the
+    # durable fan-out and collection. Per-expert timeout 5m mirrors
+    # fan_out.timeout_seconds: 300; on timeout the orchestrator continues
+    # with partial outputs.
+    fan_out:
+      actions:
+        - capability: review
+          timeout: 5m
+          input:
+            expert: api-contract
+            trigger: pull_request
+            diff_summary: "{{ .trigger.diff_summary }}"
+            changed_files: "{{ .trigger.changed_files }}"
+            pr_number: "{{ .trigger.pr_number }}"
+            pr_title: "{{ .trigger.pr_title }}"
+          output:
+            context.reviews.api_contract: "{{ .result }}"
+        - capability: review
+          timeout: 5m
+          input:
+            expert: arch-adr
+            trigger: pull_request
+            diff_summary: "{{ .trigger.diff_summary }}"
+            changed_files: "{{ .trigger.changed_files }}"
+            pr_number: "{{ .trigger.pr_number }}"
+            pr_title: "{{ .trigger.pr_title }}"
+          output:
+            context.reviews.arch_adr: "{{ .result }}"
+        - capability: review
+          timeout: 5m
+          input:
+            expert: ci-release
+            trigger: pull_request
+            diff_summary: "{{ .trigger.diff_summary }}"
+            changed_files: "{{ .trigger.changed_files }}"
+            pr_number: "{{ .trigger.pr_number }}"
+            pr_title: "{{ .trigger.pr_title }}"
+          output:
+            context.reviews.ci_release: "{{ .result }}"
+        - capability: review
+          timeout: 5m
+          input:
+            expert: docs-agents
+            trigger: pull_request
+            diff_summary: "{{ .trigger.diff_summary }}"
+            changed_files: "{{ .trigger.changed_files }}"
+            pr_number: "{{ .trigger.pr_number }}"
+            pr_title: "{{ .trigger.pr_title }}"
+          output:
+            context.reviews.docs_agents: "{{ .result }}"
+        - capability: review
+          timeout: 5m
+          input:
+            expert: persistence-state
+            trigger: pull_request
+            diff_summary: "{{ .trigger.diff_summary }}"
+            changed_files: "{{ .trigger.changed_files }}"
+            pr_number: "{{ .trigger.pr_number }}"
+            pr_title: "{{ .trigger.pr_title }}"
+          output:
+            context.reviews.persistence_state: "{{ .result }}"
+        - capability: review
+          timeout: 5m
+          input:
+            expert: planner
+            trigger: pull_request
+            diff_summary: "{{ .trigger.diff_summary }}"
+            changed_files: "{{ .trigger.changed_files }}"
+            pr_number: "{{ .trigger.pr_number }}"
+            pr_title: "{{ .trigger.pr_title }}"
+          output:
+            context.reviews.planner: "{{ .result }}"
+        - capability: review
+          timeout: 5m
+          input:
+            expert: planning-task-split
+            trigger: pull_request
+            diff_summary: "{{ .trigger.diff_summary }}"
+            changed_files: "{{ .trigger.changed_files }}"
+            pr_number: "{{ .trigger.pr_number }}"
+            pr_title: "{{ .trigger.pr_title }}"
+          output:
+            context.reviews.planning_task_split: "{{ .result }}"
+        - capability: review
+          timeout: 5m
+          input:
+            expert: qa-bdd
+            trigger: pull_request
+            diff_summary: "{{ .trigger.diff_summary }}"
+            changed_files: "{{ .trigger.changed_files }}"
+            pr_number: "{{ .trigger.pr_number }}"
+            pr_title: "{{ .trigger.pr_title }}"
+          output:
+            context.reviews.qa_bdd: "{{ .result }}"
+        - capability: review
+          timeout: 5m
+          input:
+            expert: security-supply-chain
+            trigger: pull_request
+            diff_summary: "{{ .trigger.diff_summary }}"
+            changed_files: "{{ .trigger.changed_files }}"
+            pr_number: "{{ .trigger.pr_number }}"
+            pr_title: "{{ .trigger.pr_title }}"
+          output:
+            context.reviews.security_supply_chain: "{{ .result }}"
+      "on":
+        # Barrier: the last review completion moves to aggregation.
+        - event: review.completed
+          goto: aggregate
+          guard: "{{ len .context.reviews }} == 9"
+        # Per-expert timeout: continue with whatever outputs were collected.
+        - event: review.timeout
+          goto: aggregate
+          set:
+            context.partial_results: "true"
+
+    # ── aggregate — weighted consensus over expert outputs only ────────────
+    # Strategy, thresholds, and minimum are verbatim from the archived
+    # orchestrator config (aggregation: block). Vote weight =
+    # aggregation_weight (registry label) × confidence (low=1 medium=2 high=3).
+    aggregate:
+      actions:
+        - capability: aggregate_reviews
+          timeout: 5m
+          input:
+            strategy: weighted_consensus
+            reviews: "{{ .context.reviews }}"
+            weight_label: aggregation-weight # read from expert registry labels
+            aggregate_weight_minimum: 3.0
+            conflict_resolution: highest_confidence_wins
+            escalation_threshold:
+              conflicting_high_confidence: 2 # ≥2 high-conf experts contradict
+              any_critical_flag: true # any tier-2 flag in any flags[]
+              top_action_confidence: low # top action's aggregate confidence
+          output:
+            context.aggregated_verdict: "{{ .result.aggregated_verdict }}"
+            context.escalation_required: "{{ .result.escalation_required }}"
+            context.escalation_reason: "{{ .result.escalation_reason }}"
+            context.expert_votes: "{{ .result.expert_votes }}"
+            context.decision_log_artifact: "{{ .result.decision_log_artifact }}"
+      "on":
+        - event: aggregate_reviews.completed
+          goto: escalate
+          guard: "{{ .context.escalation_required }} == true"
+        - event: aggregate_reviews.completed
+          goto: act
+
+    # ── act — execute auto_allowed actions only ────────────────────────────
+    # auto_allowed / never_auto are verbatim from the archived orchestrator
+    # config (human_in_the_loop: block). A prohibited_auto_action (never_auto)
+    # is NEVER executed automatically, at any wave, on any path.
+    act:
+      actions:
+        - capability: execute_auto_actions
+          timeout: 5m
+          input:
+            verdict: "{{ .context.aggregated_verdict }}"
+            auto_allowed:
+              - auto-label
+              - auto-assign
+              - draft-issue
+              - post-pr-comment
+            never_auto: # prohibited_auto_actions — human approval required
+              - merge
+              - push
+              - bump-dependency
+              - close-issue
+              - delete-branch
+              - force-push
+          output:
+            context.auto_actions_taken: "{{ .result.executed_actions }}"
+      "on":
+        - event: execute_auto_actions.completed
+          goto: done
+
+    # ── escalate — human-in-the-loop ───────────────────────────────────────
+    # Entered when ≥2 high-confidence experts contradict, any tier-2 flag is
+    # raised, or the top action's aggregate confidence is low.
+    escalate:
+      type: human_in_the_loop
+      actions:
+        - capability: notify_human
+          input:
+            reason: "{{ .context.escalation_reason }}"
+            verdict: "{{ .context.aggregated_verdict }}"
+            expert_votes: "{{ .context.expert_votes }}"
+      "on":
+        - event: human.approved
+          goto: act
+        - event: human.rejected
+          goto: done
+
+    # ── done — terminal; record the decision log ───────────────────────────
+    # A decision-log entry is recorded for every run, on every path
+    # (docs/archive/dev-advisory/orchestrator/decision-log-schema.yaml).
+    done:
+      type: terminal
+      actions:
+        - capability: record_decision
+          input:
+            decision_log_artifact: "{{ .context.decision_log_artifact }}"
+            verdict: "{{ .context.aggregated_verdict }}"
+            expert_votes: "{{ .context.expert_votes }}"
+            auto_actions_taken: "{{ .context.auto_actions_taken }}"

--- a/docs/spdd/881-self-hosted-issue-delivery/canvas.md
+++ b/docs/spdd/881-self-hosted-issue-delivery/canvas.md
@@ -243,7 +243,13 @@ event-bus, (orchestrator) engine-adapter.
    with a `review` capability; extend `planning-task-split` with `identify_next_issue`. *Verify:* all 9
    validate against `agent-def.schema.json` via `make validate-spec`; one unit test per manifest asserts
    the capability I/O contract matches the source YAML's `output_contract`.
-3. **O3 — Orchestrator Workflow manifest (`feat`).** Author `dev-advisory-orchestrator.yaml` as
+3. **O3 — Orchestrator Workflow manifest (`feat`).** ✅ Delivered (#1098 —
+   `automation/workflows/dev-advisory-orchestrator.yaml`: `fan_out` → `aggregate` → `act`/`escalate`
+   → `done` (terminal, records the decision log); BDD contract at
+   `automation/tests/features/dev_advisory_orchestrator.feature`; aggregation/escalation/never_auto
+   translated 1:1 from the archived orchestrator config; context slices bound at dispatch per ADR-028,
+   never inlined; orchestrator-schema readiness test flipped from xfail to a real pass).
+   Author `dev-advisory-orchestrator.yaml` as
    `kind: Workflow`: `fan_out` (parallel dispatch of 9 `review` capabilities) → `aggregate`
    (weighted_consensus from `orchestrator/config.yaml`) → `act`/`escalate`. *Verify:* validates against
    `workflow.schema.json`; a BDD `.feature` covers the fan-out→aggregate→verdict path (ADR-016).

--- a/state/current-milestone.md
+++ b/state/current-milestone.md
@@ -58,7 +58,7 @@ As of 2026-06-11: **143 issues closed / 17 open** (CI-overhaul stories #1110–#
 **e2e-green execution path (#1086 — O1 #1087 ✅ / O2 #1088 ✅ merged via PR #1095; O3 #1089 ✅ satisfied by build-images gate PR #1132; O4 #1090 ✅ event-bus + memory-service enabled with required assertions — next: #1091 verification, #1092 promotion)**,
 Postgres off Bitnami (#1073 — O1 ADR-026 ✅, O2–O3 #1076 ✅, O4–O5 #1077 ✅, O6 #1078 ✅ verified; #1079 remaining),
 CI-E2E gate (#771 — #1070 ✅, #1071 remaining),
-DevAuto Wave 4 (#881 — canvas Aligned, stories #1096–#1104 created; O1 #1096 ✅ ADR-028; O2 #1097 ✅ 9 expert AgentDefs).
+DevAuto Wave 4 (#881 — canvas Aligned, stories #1096–#1104 created; O1 #1096 ✅ ADR-028; O2 #1097 ✅ 9 expert AgentDefs; O3 #1098 ✅ orchestrator Workflow manifest).
 
 ---
 
@@ -302,7 +302,7 @@ Canvas: SPDD-exempt (docs:/chore:/ci: stories only, until Wave 4 #881 which is B
 | DevAuto.5 ci: Wave 1 orchestrator aggregation | [#878](https://github.com/zynax-io/zynax/issues/878) | ⬜ Ready |
 | DevAuto.6 ci: Wave 2 | [#879](https://github.com/zynax-io/zynax/issues/879) | ⬜ Pending |
 | DevAuto.7 ci: Wave 3 | [#880](https://github.com/zynax-io/zynax/issues/880) | ⬜ Pending |
-| DevAuto.8 feat: Wave 4 aspirational | [#881](https://github.com/zynax-io/zynax/issues/881) | 🔄 In progress — O1 [#1096](https://github.com/zynax-io/zynax/issues/1096) ✅ (ADR-028); O2 [#1097](https://github.com/zynax-io/zynax/issues/1097) ✅ (9 expert AgentDefs); O3–O9 #1098–#1104 |
+| DevAuto.8 feat: Wave 4 aspirational | [#881](https://github.com/zynax-io/zynax/issues/881) | 🔄 In progress — O1 [#1096](https://github.com/zynax-io/zynax/issues/1096) ✅ (ADR-028); O2 [#1097](https://github.com/zynax-io/zynax/issues/1097) ✅ (9 expert AgentDefs); O3 [#1098](https://github.com/zynax-io/zynax/issues/1098) ✅ (orchestrator Workflow); O4–O9 #1099–#1104 |
 | DevAuto.9 test: xfail gate | [#882](https://github.com/zynax-io/zynax/issues/882) | ⬜ Pending |
 | DevAuto.10 docs: AGENTS.md pointer + README | [#883](https://github.com/zynax-io/zynax/issues/883) | ⬜ Pending |
 


### PR DESCRIPTION
## Summary

O3 of EPIC #881 (Wave 4 self-hosted issue-delivery) — Canvas: `docs/spdd/881-self-hosted-issue-delivery/canvas.md` §O step 3, design locked by ADR-028.

Authors `automation/workflows/dev-advisory-orchestrator.yaml` as `kind: Workflow` — the on-platform `/m6-orchestrate`:

- **`fan_out`** — parallel dispatch of the 9 expert `review` capabilities, 1:1 with the O2 AgentDef manifests under `automation/workflows/experts/` (`expert` input field is the dispatch-time routing key). Per-expert `5m` timeout mirrors the archived config's `fan_out.timeout_seconds: 300`, with partial-results continuation on `review.timeout`. Context slices are **not** inlined: per ADR-028 they are bound into the `review` `input_payload` at dispatch time (O5, #1100), so the expert manifests stay the single source of truth. The orchestrator aggregates expert **outputs only**, never code files (8K budget label, mirrors the Claude command).
- **`aggregate`** — `weighted_consensus` with `aggregate_weight_minimum: 3.0`, `conflict_resolution: highest_confidence_wins`, and the three escalation thresholds (≥2 high-confidence contradictions, any tier-2 flag, low top-action confidence) translated 1:1 from `docs/archive/dev-advisory/orchestrator/config.yaml`. Vote weights are read from the `aggregation-weight` registry labels on the expert AgentDefs — never duplicated in the workflow.
- **`act` / `escalate`** — `act` carries `auto_allowed` (auto-label, auto-assign, draft-issue, post-pr-comment) and `never_auto` (merge, push, bump-dependency, close-issue, delete-branch, force-push) verbatim; `escalate` is `human_in_the_loop` and resumes only on `human.*` events. The terminal `done` state records the decision-log entry on every path.

Orchestration-side capability providers (`aggregate_reviews`, `execute_auto_actions`, `notify_human`, `record_decision`) land with the runtime binding (O5, #1100) and the platform-readiness e2e (O8, #1103), as noted in the manifest header.

## Acceptance criteria (evidence)

- [x] **Validates against `spec/schemas/workflow.schema.json` (`make validate-spec`)** — `validate-workflow-schema` now also walks `automation/workflows/` (the `zynax-ci` batch walk is non-recursive, so the experts subdir stays AgentDef-validated as before); local run: `OK automation/workflows/dev-advisory-orchestrator.yaml`.
- [x] **BDD `.feature` covers fan_out→aggregate→verdict (ADR-016)** — `automation/tests/features/dev_advisory_orchestrator.feature`: parallel fan-out + strict isolation, weighted-consensus verdict with confidence, all three escalation triggers, human resume, decision log.
- [x] **Never auto-executes a `prohibited_auto_action`** — `never_auto` pinned verbatim in the `act` input; a scenario outline covers all six prohibited actions; `test_no_state_invokes_a_prohibited_auto_action` asserts no workflow action capability is ever a prohibited action, and `test_act_honours_human_in_the_loop_policy` asserts both lists match the archived config 1:1.

## Test plan

- `make validate-spec` — green (AsyncAPI + capability + workflow incl. the new manifest + agent-def + policy).
- `python3 -m pytest automation/tests/` — 63 passed, 1 xfailed. The orchestrator-schema readiness test flips from strict xfail to a genuine pass, reworked against `workflow.schema.json` per ADR-028 (the O8 live-platform e2e stays strict-xfail until #1103).
- New `automation/tests/test_orchestrator_workflow.py` asserts 1:1 fidelity: 9 experts dispatched exactly once, review input contract honoured, aggregation/escalation/human-in-the-loop blocks verbatim from the archived orchestrator config, decision log recorded at terminal state.

## Notes for review

- `"on"` is quoted in the manifest so YAML 1.1 parsers (pyyaml) don't coerce the transition key to boolean `True`; the Go validator (yaml.v3) accepts both spellings.
- The fan-out targets all 9 manifests (8 domain experts + planner) — same count reconciliation as O2 (PR #1147): the planner is the planning-task-split extension and participates in review with its own labelled weight.
- Status surfaces updated: canvas O3 ✅, `state/current-milestone.md` Wave 4 rows. O4 (#1099, issue-delivery intake/plan/route) is being delivered in parallel and is untouched here.

Closes #1098

Assisted-by: Claude/claude-fable-5
