### PR TITLE
feat(automation): issue-intake + planning Workflow — read issue, identify next (#1099)

### DIFF
--- a/automation/tests/features/issue_delivery.feature
+++ b/automation/tests/features/issue_delivery.feature
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: Apache-2.0
+# automation/tests/features/issue_delivery.feature
+#
+# BDD contract for the intake → plan → route leg of the issue-delivery
+# Workflow (EPIC #881 O4, #1099 — ADR-016: contract before implementation).
+# Steps are bound by automation/tests/test_issue_delivery.py, which evaluates
+# the declarative manifest (automation/workflows/issue-delivery.yaml) against
+# fixture issues — no running platform required for this leg.
+
+Feature: Issue-delivery workflow — intake, planning, and expert routing
+  As the self-hosted automation plane
+  I want the issue-delivery workflow to read an issue, identify the next
+  issue via the planner, and route to exactly one expert AgentDef
+  So that one GitHub issue can be driven to an implemented change on-platform
+
+  Background:
+    Given the workflow manifest "automation/workflows/issue-delivery.yaml"
+    And the manifest validates against "spec/schemas/workflow.schema.json"
+
+  Scenario: Manifest declares the O4 state machine
+    Then the initial state is "intake"
+    And the states are exactly "intake, plan, route, routed, blocked, failed"
+    And the states "routed, blocked, failed" are terminal
+
+  Scenario: Plan state calls the planner with its exact capability contract
+    When the "plan" state dispatches its capability
+    Then the capability is "identify_next_issue"
+    And the action input keys are exactly the planner's required inputs
+      | milestone | open_issues | in_progress | dependency_table |
+    And the action outputs map every required planner output into the context
+      | next_issue | blocked_by | ready_batch | rationale |
+
+  Scenario: A fixture issue is classified and routed to the right expert
+    Given a fixture issue titled "feat(automation): issue-intake + planning Workflow"
+    And the planner replies next_issue 1099 with no blockers
+    When the workflow runs the intake, plan and route states
+    Then the decision is next_issue 1099, expert "planning-task-split", blocked_by empty
+
+  Scenario Outline: The routing table selects one expert per issue class
+    Given a fixture issue titled "<title>"
+    And the planner replies next_issue 1099 with no blockers
+    When the workflow runs the intake, plan and route states
+    Then the selected expert is "<expert>"
+
+    Examples:
+      | title                                                | expert                |
+      | feat(protos): add memory service RPC                 | api-contract          |
+      | fix(task-broker): lease renewal race                 | persistence-state     |
+      | ci(actions): pin runner image digests                | ci-release            |
+      | fix(security): rotate cosign signing key             | security-supply-chain |
+      | test(bdd): cover dispatch timeout path               | qa-bdd                |
+      | docs(adr): record engine decision                    | arch-adr              |
+      | docs(readme): refresh quickstart                     | docs-agents           |
+      | chore(automation): tidy milestone state              | planning-task-split   |
+
+  Scenario: A dependency-blocked plan ends in the blocked terminal state
+    Given a fixture issue titled "feat(protos): add memory service RPC"
+    And the planner replies next_issue 0 blocked by issues "1097, 1098"
+    When the workflow runs the intake, plan and route states
+    Then the workflow ends in state "blocked"
+    And blocked_by is "1097, 1098"

--- a/automation/tests/test_issue_delivery.py
+++ b/automation/tests/test_issue_delivery.py
@@ -1,0 +1,276 @@
+# SPDX-License-Identifier: Apache-2.0
+# automation/tests/test_issue_delivery.py
+#
+# O4 of EPIC #881 (#1099): asserts the intake → plan → route leg of the
+# issue-delivery Workflow (automation/workflows/issue-delivery.yaml).
+# Binds the scenarios in automation/tests/features/issue_delivery.feature.
+#
+# The routing table lives declaratively in the manifest (route state,
+# first-match-wins guarded transitions — mirroring /m6-orchestrate STEP 5 and
+# the engine's resolveTransition semantics), so these tests evaluate the
+# manifest itself against fixture issues: no running platform is required.
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+try:
+    import jsonschema
+
+    HAS_JSONSCHEMA = True
+except ImportError:
+    HAS_JSONSCHEMA = False
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW_PATH = REPO_ROOT / "automation/workflows/issue-delivery.yaml"
+SCHEMA_PATH = REPO_ROOT / "spec/schemas/workflow.schema.json"
+PLANNER_PATH = REPO_ROOT / "automation/workflows/experts/planner.yaml"
+EXPERTS_DIR = REPO_ROOT / "automation/workflows/experts"
+
+O4_STATES = {"intake", "plan", "route", "routed", "blocked", "failed"}
+TERMINAL_STATES = {"routed", "blocked", "failed"}
+
+
+def load_workflow():
+    """Load the manifest, normalising PyYAML's YAML-1.1 quirk: the bare key
+    `on` parses as boolean True under safe_load, while the authoritative
+    validator (zynax-ci, go-yaml v3 / YAML 1.2) keeps it the string "on"."""
+    with open(WORKFLOW_PATH) as f:
+        return _normalize_on(yaml.safe_load(f))
+
+
+def _normalize_on(obj):
+    if isinstance(obj, dict):
+        return {
+            ("on" if key is True else key): _normalize_on(value)
+            for key, value in obj.items()
+        }
+    if isinstance(obj, list):
+        return [_normalize_on(item) for item in obj]
+    return obj
+
+
+def load_planner():
+    with open(PLANNER_PATH) as f:
+        return yaml.safe_load(f)
+
+
+# ── minimal guard evaluator ──────────────────────────────────────────────────
+# Supports exactly the CEL subset used by the manifest guards:
+#   ctx.key == 'value' · ctx.key != 'value' · ctx.key in ['a', 'b'] · A || B
+
+
+def eval_guard(expr, ctx):
+    parts = [p.strip() for p in expr.split("||")]
+    return any(_eval_clause(p, ctx) for p in parts)
+
+
+def _eval_clause(clause, ctx):
+    m = re.fullmatch(r"ctx\.(\w+)\s*(==|!=)\s*'([^']*)'", clause)
+    if m:
+        key, op, value = m.groups()
+        actual = ctx.get(key, "")
+        return (actual == value) if op == "==" else (actual != value)
+    m = re.fullmatch(r"ctx\.(\w+)\s+in\s+\[([^\]]*)\]", clause)
+    if m:
+        key, items = m.groups()
+        values = [v.strip().strip("'\"") for v in items.split(",")]
+        return ctx.get(key, "") in values
+    raise AssertionError(f"guard clause not in the supported CEL subset: {clause!r}")
+
+
+# ── minimal state-machine walker (engine resolveTransition semantics) ───────
+
+
+def classify_title(title):
+    """Mirror of the read_issue contract: extract conventional-commit
+    type + scope from the issue title (mechanical parse — the routing
+    decision itself stays in the manifest)."""
+    m = re.match(r"^(\w+)(?:\(([^)]*)\))?:", title)
+    assert m, f"fixture title is not conventional-commit shaped: {title!r}"
+    return m.group(1), m.group(2) or ""
+
+
+def first_matching_transition(state, event, ctx):
+    """First transition whose event matches and whose guard passes —
+    engine-adapter resolveTransition semantics. An empty event (action-less
+    state sentinel) matches any declared transition event."""
+    for t in state.get("on", []):
+        if event and t["event"] != event:
+            continue
+        guard = t.get("guard")
+        if guard and not eval_guard(guard, ctx):
+            continue
+        return t
+    raise AssertionError(f"no transition matched event {event!r} with ctx {ctx}")
+
+
+def run_o4_leg(issue_title, planner_result):
+    """Walk intake → plan → route against a fixture issue and a stubbed
+    planner reply. Returns (final_state, ctx)."""
+    spec = load_workflow()["spec"]
+    states = spec["states"]
+    ctx = {}
+
+    # intake: read_issue output mappings populate the context.
+    commit_type, scope = classify_title(issue_title)
+    ctx["issue_title"] = issue_title
+    ctx["commit_type"] = commit_type
+    ctx["issue_scope"] = scope
+    current = spec["initial_state"]
+    t = first_matching_transition(states[current], "read_issue.completed", ctx)
+    current = t["goto"]
+
+    # plan: identify_next_issue output mappings populate the context.
+    assert current == "plan"
+    ctx["next_issue"] = str(planner_result["next_issue"])
+    ctx["blocked_by"] = ", ".join(str(n) for n in planner_result["blocked_by"])
+    ctx["ready_batch"] = ", ".join(str(n) for n in planner_result["ready_batch"])
+    ctx["plan_rationale"] = planner_result["rationale"]
+    t = first_matching_transition(states[current], "identify_next_issue.completed", ctx)
+    _apply_set(t, ctx)
+    current = t["goto"]
+
+    # route (when reached): action-less state — sentinel empty event.
+    if current == "route":
+        t = first_matching_transition(states[current], "", ctx)
+        _apply_set(t, ctx)
+        current = t["goto"]
+
+    assert states[current].get("type") == "terminal"
+    return current, ctx
+
+
+def _apply_set(transition, ctx):
+    for key, value in transition.get("set", {}).items():
+        assert key.startswith("context."), f"set key outside context: {key}"
+        if "{{" not in str(value):
+            ctx[key.removeprefix("context.")] = str(value)
+
+
+PLANNER_OK = {
+    "next_issue": 1099,
+    "blocked_by": [],
+    "ready_batch": [1099],
+    "rationale": "O4 is the only dependency-free Wave 4 story",
+}
+
+
+# ── Scenario: Manifest declares the O4 state machine ─────────────────────────
+
+
+@pytest.mark.skipif(not HAS_JSONSCHEMA, reason="jsonschema package required")
+def test_workflow_validates_against_schema():
+    """issue-delivery.yaml validates against workflow.schema.json."""
+    with open(SCHEMA_PATH) as f:
+        schema = json.load(f)
+    jsonschema.validate(load_workflow(), schema)
+
+
+def test_o4_state_machine_shape():
+    """initial_state intake; exactly the O4-leg states; correct terminals."""
+    spec = load_workflow()["spec"]
+    assert spec["initial_state"] == "intake"
+    assert set(spec["states"]) == O4_STATES
+    for name, state in spec["states"].items():
+        if name in TERMINAL_STATES:
+            assert state.get("type") == "terminal", f"{name} must be terminal"
+            assert not state.get("on"), f"terminal {name} must not transition"
+        else:
+            assert state.get("type", "normal") == "normal"
+            assert state.get("on"), f"{name} needs outbound transitions"
+
+
+# ── Scenario: Plan state calls the planner with its exact contract ──────────
+
+
+def test_plan_action_matches_planner_capability_contract():
+    """The plan action invokes identify_next_issue with the planner
+    manifest's exact input/output contract (canvas O4 / ADR-028)."""
+    plan_actions = load_workflow()["spec"]["states"]["plan"]["actions"]
+    assert len(plan_actions) == 1
+    action = plan_actions[0]
+    assert action["capability"] == "identify_next_issue"
+
+    planner_caps = {c["name"]: c for c in load_planner()["spec"]["capabilities"]}
+    cap = planner_caps["identify_next_issue"]
+
+    assert set(action["input"]) == set(cap["input_schema"]["required"])
+
+    mapped_outputs = {
+        re.search(r"\.result\.(\w+)", v).group(1) for v in action["output"].values()
+    }
+    assert mapped_outputs == set(cap["output_schema"]["required"])
+
+
+def test_routing_targets_are_registered_expert_agentdefs():
+    """Every expert the route table can select exists as an O2 AgentDef."""
+    route = load_workflow()["spec"]["states"]["route"]
+    experts = {t["set"]["context.expert"] for t in route["on"]}
+    available = {p.stem for p in EXPERTS_DIR.glob("*.yaml")}
+    assert experts <= available, f"unknown experts: {experts - available}"
+    # The fallback (last transition) must be unguarded → route never dead-ends.
+    assert "guard" not in route["on"][-1]
+    assert route["on"][-1]["set"]["context.expert"] == "planning-task-split"
+    # route is action-less: it must rely on the engine's sentinel-event pass.
+    assert "actions" not in route
+
+
+# ── Scenario: fixture issue → correct {next_issue, expert, blocked_by} ──────
+
+
+def test_fixture_issue_emits_o4_decision():
+    """Given a fixture issue, the workflow emits the correct
+    {next_issue, expert, blocked_by} decision (acceptance criterion 1)."""
+    final, ctx = run_o4_leg(
+        "feat(automation): issue-intake + planning Workflow", PLANNER_OK
+    )
+    assert final == "routed"
+    assert ctx["next_issue"] == "1099"
+    assert ctx["expert"] == "planning-task-split"
+    assert ctx["blocked_by"] == ""
+
+
+# ── Scenario Outline: routing table selects one expert per issue class ──────
+
+
+@pytest.mark.parametrize(
+    ("title", "expert"),
+    [
+        ("feat(protos): add memory service RPC", "api-contract"),
+        ("fix(task-broker): lease renewal race", "persistence-state"),
+        ("ci(actions): pin runner image digests", "ci-release"),
+        ("fix(security): rotate cosign signing key", "security-supply-chain"),
+        ("test(bdd): cover dispatch timeout path", "qa-bdd"),
+        ("docs(adr): record engine decision", "arch-adr"),
+        ("docs(readme): refresh quickstart", "docs-agents"),
+        ("chore(automation): tidy milestone state", "planning-task-split"),
+    ],
+)
+def test_routing_table_selects_expert(title, expert):
+    """Classify + route path picks exactly one expert per issue class."""
+    final, ctx = run_o4_leg(title, PLANNER_OK)
+    assert final == "routed"
+    assert ctx["expert"] == expert
+
+
+# ── Scenario: dependency-blocked plan ends in blocked ────────────────────────
+
+
+def test_blocked_plan_ends_in_blocked_state():
+    """next_issue == 0 routes to the blocked terminal with blocked_by set."""
+    final, ctx = run_o4_leg(
+        "feat(protos): add memory service RPC",
+        {
+            "next_issue": 0,
+            "blocked_by": [1097, 1098],
+            "ready_batch": [],
+            "rationale": "O3/O4 prerequisites still open",
+        },
+    )
+    assert final == "blocked"
+    assert ctx["blocked_by"] == "1097, 1098"
+    assert "expert" not in ctx

--- a/automation/workflows/issue-delivery.yaml
+++ b/automation/workflows/issue-delivery.yaml
@@ -1,0 +1,188 @@
+# SPDX-License-Identifier: Apache-2.0
+# automation/workflows/issue-delivery.yaml
+#
+# Issue-delivery engine — the self-hosting headline of EPIC #881 (Wave 4).
+# This manifest delivers the intake → plan → route leg (O4, #1099): read a
+# GitHub issue, classify its commit type + scope, call the planner's
+# identify_next_issue capability (the /m6-plan brain), and select the single
+# expert AgentDef that will implement the issue.
+#
+# Per ADR-028 all orchestration is kind: Workflow (state machine validated by
+# spec/schemas/workflow.schema.json); capability providers are kind: AgentDef.
+# The identify_next_issue action below matches the contract declared by
+# automation/workflows/experts/planner.yaml exactly. The read_issue capability
+# is declared contract-first (ADR-016); its runtime provider lands with the
+# context-slice binding in O5 (#1100) / the delivery leg in O6 (#1101).
+#
+# O6 (#1101) extends this workflow with the delivery leg:
+#   routed → inject → implement → verify → decide (durable decision-log +
+#   next-issue CloudEvent). Until then `routed` is the terminus that records
+#   the O4 decision {next_issue, expert, blocked_by} in the workflow context.
+#
+# Template/guard syntax (engine-adapter semantics):
+#   - action input/output values use '{{ .ctx.key }}' / '{{ .trigger.field }}'
+#     and output keys write workflow context paths ('context.key').
+#   - transition guards are CEL over the string-valued workflow context map
+#     ('ctx'); the engine evaluates transitions in order and fires the first
+#     match (interpreter.go resolveTransition) — first-match-wins, exactly the
+#     /m6-orchestrate routing-table semantics.
+#   - a state with no actions (route) yields the empty sentinel event, so its
+#     transitions are evaluated immediately; the declared event name is the
+#     contract label for the decision edge.
+#
+# Plane: platform (Wave 4)
+# Issue: #1099 (EPIC #881 — O4)
+
+kind: Workflow
+apiVersion: zynax.io/v1
+
+metadata:
+  name: issue-delivery
+  namespace: automation
+  labels:
+    plane: platform
+    epic: "881"
+  annotations:
+    description: "Self-hosted issue delivery: intake -> plan -> route (O4 leg); inject -> implement -> verify -> decide lands in O6 (#1101)"
+    issue: "1099"
+    adr: "ADR-028"
+
+spec:
+  initial_state: intake
+
+  # Manually triggered (the /m6-issue-generate analogue): the requester emits
+  # one CloudEvent carrying the issue number plus the planning snapshot
+  # (milestone, open_issues, in_progress, dependency_table). O6 replaces the
+  # snapshot fields with live reads on the delivery leg.
+  triggers:
+    - event: zynax.automation.issue_delivery.requested
+      filter:
+        repo: zynax-io/zynax
+
+  states:
+    # ── intake — read the GitHub issue and classify it ──────────────────────
+    # read_issue fetches the issue and mechanically extracts the conventional
+    # commit type and scope from its title (e.g. "feat(automation): …" →
+    # commit_type=feat, scope=automation). The routing *decision* stays in
+    # this manifest (route state) — the capability never picks an expert.
+    intake:
+      actions:
+        - capability: read_issue
+          timeout: 5m
+          input:
+            repo: "{{ .trigger.repo }}"
+            issue_number: "{{ .trigger.issue_number }}"
+          output:
+            context.issue_number: "{{ .result.number }}"
+            context.issue_title: "{{ .result.title }}"
+            context.issue_labels: "{{ .result.labels }}"
+            context.commit_type: "{{ .result.commit_type }}"
+            context.issue_scope: "{{ .result.scope }}"
+      on:
+        - event: read_issue.completed
+          goto: plan
+        - event: read_issue.failed
+          goto: failed
+          set:
+            context.failure_reason: "intake: read_issue failed"
+
+    # ── plan — call the planner (the /m6-plan brain) ────────────────────────
+    # Capability contract: automation/workflows/experts/planner.yaml
+    # identify_next_issue — input {milestone, open_issues, in_progress,
+    # dependency_table} → output {next_issue, blocked_by, ready_batch,
+    # rationale}. next_issue == 0 means nothing is ready (dependency-blocked).
+    plan:
+      actions:
+        - capability: identify_next_issue
+          timeout: 5m
+          input:
+            milestone: "{{ .trigger.milestone }}"
+            open_issues: "{{ .trigger.open_issues }}"
+            in_progress: "{{ .trigger.in_progress }}"
+            dependency_table: "{{ .trigger.dependency_table }}"
+          output:
+            context.next_issue: "{{ .result.next_issue }}"
+            context.blocked_by: "{{ .result.blocked_by }}"
+            context.ready_batch: "{{ .result.ready_batch }}"
+            context.plan_rationale: "{{ .result.rationale }}"
+      on:
+        - event: identify_next_issue.completed
+          goto: route
+          guard: "ctx.next_issue != '0'"
+        - event: identify_next_issue.completed
+          goto: blocked
+          guard: "ctx.next_issue == '0'"
+        - event: identify_next_issue.failed
+          goto: failed
+          set:
+            context.failure_reason: "plan: identify_next_issue failed"
+
+    # ── route — select the single expert AgentDef (first match wins) ────────
+    # The /m6-orchestrate STEP 5 routing table translated to the 9 platform
+    # expert AgentDefs under automation/workflows/experts/ (O2, #1097).
+    # Action-less state: transitions are evaluated immediately, in order.
+    route:
+      on:
+        # Proto / spec / AsyncAPI contracts → api-contract
+        - event: expert.selected
+          goto: routed
+          guard: "ctx.issue_scope in ['protos', 'proto', 'spec', 'asyncapi']"
+          set:
+            context.expert: "api-contract"
+        # Go platform services (Layer 1) → persistence-state
+        - event: expert.selected
+          goto: routed
+          guard: "ctx.issue_scope in ['api-gateway', 'workflow-compiler', 'engine-adapter', 'task-broker', 'agent-registry', 'event-bus', 'memory-service', 'services']"
+          set:
+            context.expert: "persistence-state"
+        # CI / Actions / images.yaml / release plumbing → ci-release
+        - event: expert.selected
+          goto: routed
+          guard: "ctx.commit_type == 'ci' || ctx.issue_scope in ['ci', 'actions', 'images', 'release']"
+          set:
+            context.expert: "ci-release"
+        # Security / supply-chain / dependency hygiene → security-supply-chain
+        - event: expert.selected
+          goto: routed
+          guard: "ctx.issue_scope in ['security', 'deps', 'supply-chain']"
+          set:
+            context.expert: "security-supply-chain"
+        # test: type or BDD/coverage scopes → qa-bdd
+        - event: expert.selected
+          goto: routed
+          guard: "ctx.commit_type == 'test' || ctx.issue_scope in ['tests', 'bdd', 'coverage']"
+          set:
+            context.expert: "qa-bdd"
+        # Architecture / ADR work → arch-adr
+        - event: expert.selected
+          goto: routed
+          guard: "ctx.issue_scope in ['adr', 'arch', 'architecture']"
+          set:
+            context.expert: "arch-adr"
+        # docs: type or documentation scopes → docs-agents
+        - event: expert.selected
+          goto: routed
+          guard: "ctx.commit_type == 'docs' || ctx.issue_scope in ['docs', 'agents-md', 'readme']"
+          set:
+            context.expert: "docs-agents"
+        # Fallback — planning / milestone / automation work → planning-task-split
+        - event: expert.selected
+          goto: routed
+          set:
+            context.expert: "planning-task-split"
+
+    # ── terminal states (O4 leg) ────────────────────────────────────────────
+    # routed: the O4 decision {next_issue, expert, blocked_by} is recorded in
+    # the workflow context. O6 (#1101) replaces this terminus with the
+    # inject → implement → verify → decide delivery leg.
+    routed:
+      type: terminal
+
+    # blocked: the planner found no dependency-free issue (next_issue == 0);
+    # context.blocked_by lists the blocking issues.
+    blocked:
+      type: terminal
+
+    # failed: intake or planning capability reported a failure.
+    failed:
+      type: terminal

--- a/docs/spdd/881-self-hosted-issue-delivery/canvas.md
+++ b/docs/spdd/881-self-hosted-issue-delivery/canvas.md
@@ -253,7 +253,14 @@ event-bus, (orchestrator) engine-adapter.
    `kind: Workflow`: `fan_out` (parallel dispatch of 9 `review` capabilities) → `aggregate`
    (weighted_consensus from `orchestrator/config.yaml`) → `act`/`escalate`. *Verify:* validates against
    `workflow.schema.json`; a BDD `.feature` covers the fan-out→aggregate→verdict path (ADR-016).
-4. **O4 — Issue-intake + planning Workflow (`feat`).** `issue-delivery.yaml` states `intake` → `plan`
+4. **O4 — Issue-intake + planning Workflow (`feat`).** ✅ Delivered (#1099 —
+   `automation/workflows/issue-delivery.yaml`, the intake→plan→route leg: `intake` reads + mechanically
+   classifies the issue, `plan` binds the planner's `identify_next_issue` contract 1:1, and the
+   routing table lives declaratively in the `route` state as first-match-wins guarded transitions;
+   `routed`/`blocked`/`failed` terminals record the `{next_issue, expert, blocked_by}` decision until
+   O6 adds the delivery leg. BDD feature + fixture-driven decision tests in `automation/tests/`;
+   `make validate-spec` now validates `automation/workflows/` against `workflow.schema.json`.)
+   `issue-delivery.yaml` states `intake` → `plan`
    (calls planner `identify_next_issue`) → `route`. Reads a GitHub issue, classifies type/expert,
    identifies the next issue. *Verify:* given a fixture issue, the workflow emits the correct
    `{next_issue, expert, blocked_by}` decision; BDD scenario for the classify+route path.

--- a/state/current-milestone.md
+++ b/state/current-milestone.md
@@ -58,7 +58,7 @@ As of 2026-06-11: **143 issues closed / 17 open** (CI-overhaul stories #1110–#
 **e2e-green execution path (#1086 — O1 #1087 ✅ / O2 #1088 ✅ merged via PR #1095; O3 #1089 ✅ satisfied by build-images gate PR #1132; O4 #1090 ✅ event-bus + memory-service enabled with required assertions — next: #1091 verification, #1092 promotion)**,
 Postgres off Bitnami (#1073 — O1 ADR-026 ✅, O2–O3 #1076 ✅, O4–O5 #1077 ✅, O6 #1078 ✅ verified; #1079 remaining),
 CI-E2E gate (#771 — #1070 ✅, #1071 remaining),
-DevAuto Wave 4 (#881 — canvas Aligned, stories #1096–#1104 created; O1 #1096 ✅ ADR-028; O2 #1097 ✅ 9 expert AgentDefs; O3 #1098 ✅ orchestrator Workflow manifest).
+DevAuto Wave 4 (#881 — canvas Aligned, stories #1096–#1104 created; O1 #1096 ✅ ADR-028; O2 #1097 ✅ 9 expert AgentDefs; O3 #1098 ✅ orchestrator Workflow manifest; O4 #1099 ✅ issue-delivery intake→plan→route Workflow).
 
 ---
 
@@ -302,7 +302,7 @@ Canvas: SPDD-exempt (docs:/chore:/ci: stories only, until Wave 4 #881 which is B
 | DevAuto.5 ci: Wave 1 orchestrator aggregation | [#878](https://github.com/zynax-io/zynax/issues/878) | ⬜ Ready |
 | DevAuto.6 ci: Wave 2 | [#879](https://github.com/zynax-io/zynax/issues/879) | ⬜ Pending |
 | DevAuto.7 ci: Wave 3 | [#880](https://github.com/zynax-io/zynax/issues/880) | ⬜ Pending |
-| DevAuto.8 feat: Wave 4 aspirational | [#881](https://github.com/zynax-io/zynax/issues/881) | 🔄 In progress — O1 [#1096](https://github.com/zynax-io/zynax/issues/1096) ✅ (ADR-028); O2 [#1097](https://github.com/zynax-io/zynax/issues/1097) ✅ (9 expert AgentDefs); O3 [#1098](https://github.com/zynax-io/zynax/issues/1098) ✅ (orchestrator Workflow); O4–O9 #1099–#1104 |
+| DevAuto.8 feat: Wave 4 aspirational | [#881](https://github.com/zynax-io/zynax/issues/881) | 🔄 In progress — O1 [#1096](https://github.com/zynax-io/zynax/issues/1096) ✅ (ADR-028); O2 [#1097](https://github.com/zynax-io/zynax/issues/1097) ✅ (9 expert AgentDefs); O3 [#1098](https://github.com/zynax-io/zynax/issues/1098) ✅ (orchestrator Workflow); O4 [#1099](https://github.com/zynax-io/zynax/issues/1099) ✅ (issue-delivery intake→plan→route); O5–O9 #1100–#1104 |
 | DevAuto.9 test: xfail gate | [#882](https://github.com/zynax-io/zynax/issues/882) | ⬜ Pending |
 | DevAuto.10 docs: AGENTS.md pointer + README | [#883](https://github.com/zynax-io/zynax/issues/883) | ⬜ Pending |
 


### PR DESCRIPTION
## Summary

Delivers **O4 of EPIC #881** (Wave 4 self-hosted issue-delivery, canvas `docs/spdd/881-self-hosted-issue-delivery/canvas.md`, Status: Aligned): the **intake → plan → route leg** of `automation/workflows/issue-delivery.yaml` as a `kind: Workflow` state machine per ADR-028 — the on-platform `/m6-plan` + read-issue path.

- **`intake`** dispatches `read_issue` (contract-first per ADR-016; runtime provider lands in O5 #1100 / O6 #1101), which mechanically extracts the conventional-commit type + scope from the issue title. The routing *decision* never lives in the capability.
- **`plan`** dispatches the planner's `identify_next_issue` capability with the exact contract from `automation/workflows/experts/planner.yaml`: input `{milestone, open_issues, in_progress, dependency_table}` → output `{next_issue, blocked_by, ready_batch, rationale}` mapped into the workflow context.
- **`route`** holds the `/m6-orchestrate` STEP 5 routing table **declaratively in the manifest** as first-match-wins CEL-guarded transitions (engine-adapter `resolveTransition` semantics; action-less state → transitions evaluated immediately) targeting the 9 platform expert AgentDefs from O2 (#1097), with an unguarded `planning-task-split` fallback so routing never dead-ends.
- **`routed` / `blocked` / `failed`** terminals record the `{next_issue, expert, blocked_by}` decision. O6 (#1101) replaces the `routed` terminus with the inject → implement → verify → decide delivery leg. The parallel O3 orchestrator manifest (#1098) is untouched.

## Canvas O4

Canvas O-step flipped to ✅ Delivered; `state/current-milestone.md` Wave 4 lines updated in the same PR.

## Acceptance criteria — evidence

- [x] **Given a fixture issue, emits correct `{next_issue, expert, blocked_by}` decision** — `automation/tests/test_issue_delivery.py::test_fixture_issue_emits_o4_decision` walks intake → plan → route against a fixture issue with engine `resolveTransition` semantics and asserts `next_issue=1099`, `expert=planning-task-split`, `blocked_by` empty; `test_blocked_plan_ends_in_blocked_state` covers the `next_issue == 0` → `blocked` path.
- [x] **BDD scenario for the classify + route path** — `automation/tests/features/issue_delivery.feature` (incl. a Scenario Outline covering all 8 routing classes), bound by `test_routing_table_selects_expert` (8 parametrized cases, all passing).
- [x] **Validates against `workflow.schema.json`** — `make validate-spec` now runs `zynax-ci validate workflows automation/workflows/` (Makefile line added): `OK automation/workflows/issue-delivery.yaml`. Also asserted offline in `test_workflow_validates_against_schema`.

Capability refs match the planner manifest exactly — `test_plan_action_matches_planner_capability_contract` asserts the action input keys equal the planner `input_schema.required` and the output mappings cover the planner `output_schema.required` 1:1; `test_routing_targets_are_registered_expert_agentdefs` asserts every routable expert exists under `automation/workflows/experts/`.

## Test plan

- `make validate-spec` — green (AsyncAPI + capabilities + workflows incl. `automation/workflows/` + agent-defs + policies).
- `python3 -m pytest automation/tests/` — **63 passed, 2 xfailed** (the two strict xfails in `test_platform_readiness.py` still xfail honestly: they require the O3 orchestrator manifest #1098 and a live platform, O8 #1103).
- PR size: code lines are the manifest + tests under `automation/` (size-gate excluded path); Makefile/docs/state also excluded.

Closes #1099

Assisted-by: Claude/claude-fable-5
