### PR TITLE
ci(infra): record e2e runner sizing verified on full stack

### DIFF
--- a/docs/spdd/1086-e2e-green/canvas.md
+++ b/docs/spdd/1086-e2e-green/canvas.md
@@ -117,8 +117,17 @@ EPIC #770 (harness) and #771 (CI-E2E gate).
    `E2E_REQUIRE_COMPLETED_EVENT=1` (default off, loud TODO) until #1149 lands; flip it as part
    of O6. Chart fixes folded in: memory-service env var `ZYNAX_MEMORY_REDIS_DSN` matched to the
    binary, engine-adapter gained `env.eventBusAddr`.)
-5. **[O5]** Right-size the `e2e smoke` runner / per-pod resource requests so the full stack fits
-   without eviction. (Gap 4; depends O2)
+5. **[O5]** ✅ Right-size the `e2e smoke` runner / per-pod resource requests so the full stack fits
+   without eviction. (Gap 4; depends O2. Verified 2026-06-12: the full 7-service stack
+   (api-gateway, workflow-compiler, engine-adapter, task-broker, agent-registry, event-bus,
+   memory-service) + NATS + Temporal (4 shards, web UI disabled) + Postgres + Redis ran the
+   e2e gate GREEN on `ubuntu-latest` (2 CPU / 7 GB) with trimmed resource requests delivered
+   by #1094 and #1090 (per-pod requests as low as 25m CPU / 32Mi mem; Temporal capped at
+   50m/96Mi req; Postgres at 100m/128Mi req). Evidence: PR #1148 run
+   https://github.com/zynax-io/zynax/actions/runs/27403151713 — all 7 deployments healthy,
+   zero Evicted/OOMKilled/Pending pods, happy-path + failure-path assertions passed; 3
+   consecutive green runs on PR #1150 (runs 27408137927, 27407858978, 27405246877).
+   Issue #1091 closed.)
 6. **[O6]** Promote the gate from advisory to a stable/required check, covering Temporal + Argo
    (#1071) + failure paths. (Gap 5; depends O1, O2, O4, O5)
 

--- a/state/current-milestone.md
+++ b/state/current-milestone.md
@@ -55,7 +55,7 @@ As of 2026-06-11: **143 issues closed / 17 open** (CI-overhaul stories #1110–#
 | DevAuto Wave 3 | #880 | post-merge completeness mesh |
 
 ### In progress / remaining
-**e2e-green execution path (#1086 — O1 #1087 ✅ / O2 #1088 ✅ merged via PR #1095; O3 #1089 ✅ satisfied by build-images gate PR #1132; O4 #1090 ✅ event-bus + memory-service enabled with required assertions — next: #1091 verification, #1092 promotion)**,
+**e2e-green execution path (#1086 — O1 #1087 ✅ / O2 #1088 ✅ merged via PR #1095; O3 #1089 ✅ satisfied by build-images gate PR #1132; O4 #1090 ✅ event-bus + memory-service enabled with required assertions; O5 #1091 ✅ runner sizing verified on full stack — next: #1092 promotion (after #1071/#1149))**,
 Postgres off Bitnami (#1073 — ✅ complete: O1 ADR-026, O2–O3 #1076, O4–O5 #1077, O6 #1078, O7–O8 #1079; canvas Implemented, EPIC ready to close),
 CI-E2E gate (#771 — #1070 ✅, #1071 remaining),
 DevAuto Wave 4 (#881 — canvas Aligned, stories #1096–#1104 created; O1 #1096 ✅ ADR-028; O2 #1097 ✅ 9 expert AgentDefs; O3 #1098 ✅ orchestrator Workflow manifest; O4 #1099 ✅ issue-delivery intake→plan→route Workflow).
@@ -74,10 +74,10 @@ up but fails at the happy-path assertion; this epic closes the execution-path ga
 | O2 | [#1088](https://github.com/zynax-io/zynax/issues/1088) minimal capability worker + reference workflow → succeeded | feat(infra) | M | ✅ merged (PR #1095) |
 | O3 | [#1089](https://github.com/zynax-io/zynax/issues/1089) event-bus + memory-service in pre-merge build-images matrix | ci(infra) | M | ✅ satisfied by PR #1132 (shift-left, ADR-027) — closed with evidence |
 | O4 | [#1090](https://github.com/zynax-io/zynax/issues/1090) enable event-bus + memory-service in e2e + assertions | test(infra) | M | ✅ merged — lifecycle CloudEvent + memory-Get required, no skip path; completed-event check gated on bug #1149 |
-| O5 | [#1091](https://github.com/zynax-io/zynax/issues/1091) right-size e2e-smoke runner / pod resources | ci(infra) | S | resources merged (PR #1094); verify on full gate run |
+| O5 | [#1091](https://github.com/zynax-io/zynax/issues/1091) right-size e2e-smoke runner / pod resources | ci(infra) | S | ✅ verified 2026-06-12 — full 7-service stack GREEN on ubuntu-latest (2 CPU/7 GB), zero Evicted/OOMKilled/Pending; 3 consecutive green runs (PRs #1148, #1150) |
 | O6 | [#1092](https://github.com/zynax-io/zynax/issues/1092) promote gate advisory → stable/required | ci | S | #1090 #1091 #1071 · flip `E2E_REQUIRE_COMPLETED_EVENT` once #1149 fixed |
 
-**Ready now for `/milestone-orchestrate`:** #1091 (O5 — verify right-sizing on the full 7-service gate). Then O6 (#1092, with #1071).
+**Ready now for `/milestone-orchestrate`:** #1092 (O6 — promote gate to required; depends #1071, flip `E2E_REQUIRE_COMPLETED_EVENT` once #1149 fixed).
 
 ## Recently Closed (last updated 2026-06-11)
 
@@ -317,7 +317,7 @@ Canvas: SPDD-exempt (docs:/chore:/ci: stories only, until Wave 4 #881 which is B
 - **#840** ci(infra): Python adapters in multi-arch release pipeline
 - **#841** ci(infra): audit and minimize image sizes
 
-**M6.E2E-Green chain (O1 #1087 / O2 #1088 / O3 #1089 / O4 #1090 all ✅):** #1091 (O5, verify on full 7-service gate) → #1092 (O6, needs #1087 #1088 #1090 #1091 #1071).
+**M6.E2E-Green chain (O1 #1087 / O2 #1088 / O3 #1089 / O4 #1090 / O5 #1091 all ✅):** #1092 (O6, needs #1071 + #1149 fix for `E2E_REQUIRE_COMPLETED_EVENT`).
 **M6.Postgres chain — ✅ complete:** #1076 ✅, #1077 ✅, #1078 ✅, #1079 ✅ (O1–O8 all delivered; canvas Implemented; EPIC #1073 ready to close).
 
 **M6.Argo continuation (after #795 merges):**


### PR DESCRIPTION
## Summary

- Marks canvas `docs/spdd/1086-e2e-green/canvas.md` O5 as ✅ with dated evidence
- Updates `state/current-milestone.md`: E2E-Green O5 #1091 done, next #1092 (after #1071/#1149)
- No code changes — this is a verify-and-close PR for issue #1091

## Evidence

**Runner:** `ubuntu-latest` (Ubuntu 24.04, 2 CPU / 7 GB)

**Resource requests in `scripts/e2e/values-e2e.yaml`** (trimmed by #1094 + #1090):
- 7 zynax services + event-bus + memory-service: 25m CPU / 32Mi mem per pod
- NATS container: 50m CPU / 64Mi mem (config reloader disabled)
- Temporal server roles (frontend/history/matching/worker): 50m CPU / 96Mi mem each (4 shards)
- Postgres primary: 100m CPU / 128Mi mem
- admintools: 25m CPU / 32Mi mem
- Temporal web UI: disabled (not needed for assertions)

**Green runs confirming zero Evicted/OOMKilled/Pending pods:**
- PR #1148 run https://github.com/zynax-io/zynax/actions/runs/27403151713 — all 7 service deployments healthy, happy-path + failure-path assertions passed
- PR #1150 — 3 consecutive green e2e-smoke runs: 27408137927, 27407858978, 27405246877 (satisfies "non-flaky across 3 consecutive runs" acceptance criterion)

All acceptance criteria from #1091 are met:
- [x] e2e-smoke completes bring-up + happy-path with zero Evicted/OOMKilled/Pending pods
- [x] Non-flaky across 3 consecutive runs

## Test plan

- [ ] CI passes (no code changes — only docs/state files, excluded from PR size gate)

Closes #1091

Assisted-by: Claude/claude-sonnet-4-6