### PR TITLE
fix(event-bus): derive JetStream streams at fixed entity depth (#1149)

### DIFF
--- a/helm/charts/nats/values.yaml
+++ b/helm/charts/nats/values.yaml
@@ -4,24 +4,26 @@
 # Overrides for the community nats/nats chart are nested under the `nats:` key.
 
 # JetStream stream configuration — applied via ConfigMap to document the
-# required streams for Zynax event-bus (EventBusService, ADR-022).
-# Actual stream creation is performed by event-bus on startup (EPIC I).
+# streams Zynax event-bus derives (EventBusService, ADR-022).
+# Actual stream creation is performed on demand by event-bus at publish/
+# subscribe time: one stream per entity prefix — the first 4 segments of the
+# topic taxonomy "zynax.v1.<service>.<entity>.<event_type>", upper-snake-cased
+# (StreamName in services/event-bus/internal/infrastructure/nats.go, #1149).
 jetstream:
-  # Stream definitions are documented here for operator awareness.
-  # event-bus creates these streams on startup using the NATS Go SDK.
+  # Stream definitions are documented here for operator awareness only.
   streams:
-    - name: ZYNAX_WORKFLOW_EVENTS
-      subjects: ["zynax.workflow.>"]
+    - name: ZYNAX_V1_ENGINE_ADAPTER_WORKFLOW
+      subjects: ["zynax.v1.engine-adapter.workflow.>"]
       retention: limits
       maxAge: 7d
       storage: file
-    - name: ZYNAX_TASK_EVENTS
-      subjects: ["zynax.task.>"]
+    - name: ZYNAX_V1_TASK_BROKER_TASK
+      subjects: ["zynax.v1.task-broker.task.>"]
       retention: limits
       maxAge: 7d
       storage: file
-    - name: ZYNAX_AGENT_EVENTS
-      subjects: ["zynax.agent.>"]
+    - name: ZYNAX_V1_AGENT_REGISTRY_AGENT
+      subjects: ["zynax.v1.agent-registry.agent.>"]
       retention: limits
       maxAge: 7d
       storage: file

--- a/scripts/e2e/README.md
+++ b/scripts/e2e/README.md
@@ -67,8 +67,10 @@ scripts/e2e/cluster-down.sh
    test's failure condition);
 2. the failure is a capability dispatch timeout, bounded by
    `ZYNAX_CAPABILITY_TIMEOUT`;
-3. the `zynax.workflow.failed` CloudEvent is consumed off the
-   `ZYNAX_WORKFLOW` NATS JetStream stream.
+3. the workflow.failed CloudEvent (subject
+   `zynax.v1.engine-adapter.workflow.failed`) is consumed off the
+   `ZYNAX_V1_ENGINE_ADAPTER_WORKFLOW` NATS JetStream stream (required since
+   the #1149 fix).
 
 The workflow fixture is generated at runtime (and removed on exit) rather than
 committed under `spec/workflows/examples/`, to avoid publishing an intentionally

--- a/scripts/e2e/e2e-failure.sh
+++ b/scripts/e2e/e2e-failure.sh
@@ -7,12 +7,14 @@
 # UNREACHABLE capability, then:
 #   1. polls the workflow status and asserts it reaches a terminal "failed" state,
 #   2. asserts the capability dispatch timed out within ZYNAX_CAPABILITY_TIMEOUT,
-#   3. asserts the "zynax.workflow.failed" CloudEvent arrived on NATS JetStream.
+#   3. asserts the workflow.failed CloudEvent (subject
+#      "zynax.v1.engine-adapter.workflow.failed") arrived on NATS JetStream —
+#      REQUIRED since the #1149 fix, no skip path.
 #
 # This is the failure-path sibling of e2e-happy.sh (#810): same cluster, same
 # api-gateway submission flow, same JetStream assertion approach — only the
 # expected terminal outcome is inverted (failed, not succeeded) and the asserted
-# CloudEvent is "zynax.workflow.failed".
+# CloudEvent is the terminal workflow.failed event.
 #
 # The workflow fixture is generated at runtime (see make_failure_workflow below)
 # rather than committed under spec/workflows/examples/, because it intentionally
@@ -196,14 +198,10 @@ fi
 
 # Verify event-bus exists — the workflow.failed CloudEvent assertion needs it.
 # The deployment name is pinned via fullnameOverride in values-e2e.yaml (#1090).
-# Hardening the failed-event assertion to the strict happy-path level is part
-# of the gate-promotion step (canvas 1086 O6).
-if ! kubectl -n "${NAMESPACE}" get deployment \
-    "zynax-event-bus" >/dev/null 2>&1; then
-  warn "event-bus deployment not found — NATS JetStream assertion will be skipped"
-  SKIP_NATS=1
-fi
-SKIP_NATS="${SKIP_NATS:-0}"
+# REQUIRED since the #1149 fix made the terminal failed event reliably
+# deliverable — the assertion has no skip path (same strictness as e2e-happy.sh).
+kubectl -n "${NAMESPACE}" get deployment "zynax-event-bus" >/dev/null 2>&1 \
+  || fail "event-bus deployment not found — required for the workflow.failed CloudEvent assertion (values-e2e.yaml enables it; run cluster-up.sh)"
 
 log "preflight passed (capability timeout = ${ZYNAX_CAPABILITY_TIMEOUT})."
 
@@ -311,73 +309,72 @@ fi
 log "step 3: capability timeout budget = ${ZYNAX_CAPABILITY_TIMEOUT}; observed failure after ~${FAIL_ELAPSED}s."
 
 # ── 4. Assert the workflow.failed CloudEvent off NATS JetStream ────────────────────
+#
+# REQUIRED since the #1149 fix — no skip path (same strictness as e2e-happy.sh
+# step 3b). PublishLifecycleEventActivity maps the interpreter event type onto
+# the topic taxonomy "zynax.v1.engine-adapter.workflow.failed", and event-bus
+# derives one stream per entity prefix (first 4 subject segments, upper-snake-
+# cased — StreamName in services/event-bus/internal/infrastructure/nats.go),
+# so the failed event shares the ZYNAX_V1_ENGINE_ADAPTER_WORKFLOW stream with
+# the rest of the lifecycle family. We assert with the `nats` CLI inside the
+# nats-box pod (deployed by the NATS subchart) so the host needs no NATS tooling.
 
-if [[ "${SKIP_NATS}" -eq 1 ]]; then
-  warn "step 4: SKIPPED — event-bus not available."
-else
-  log "step 4: asserting CloudEvent 'zynax.workflow.failed' off NATS JetStream…"
+log "step 4: asserting CloudEvent off NATS JetStream (subject 'zynax.v1.engine-adapter.workflow.failed')…"
 
-  # NATS lives inside the cluster. We use kubectl exec into the NATS pod to
-  # avoid depending on the `nats` CLI tool on the host. The JetStream stream
-  # name derives from the event type by convention (see nats.go):
-  #   "zynax.workflow.failed" → drop last segment → "zynax.workflow"
-  #   stream name = "ZYNAX_WORKFLOW"
-  # The happy-path "completed" and failure-path "failed" events share the same
-  # stream; we assert the stream carries at least one message.
-  STREAM_NAME="ZYNAX_WORKFLOW"
-  NATS_SVC="${RELEASE_NAME}-zynax-nats"
-  NATS_POD=$(kubectl -n "${NAMESPACE}" get pod \
-    -l "app.kubernetes.io/name=nats" \
-    -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
+EVENTS_STREAM="ZYNAX_V1_ENGINE_ADAPTER_WORKFLOW"
+FAILED_SUBJECT="zynax.v1.engine-adapter.workflow.failed"
+NATS_ASSERT_TIMEOUT="${NATS_ASSERT_TIMEOUT:-60}"
 
-  if [[ -z "${NATS_POD}" ]]; then
-    warn "step 4: could not locate NATS pod — attempting port-forward to service instead"
-    port_forward "svc/${NATS_SVC}" 4222 4222
-    if command -v nats >/dev/null 2>&1; then
-      STREAM_INFO=$(nats stream info "${STREAM_NAME}" \
-        --server nats://127.0.0.1:4222 2>&1) || true
-      log "NATS stream info: ${STREAM_INFO}"
-      MSGS=$(printf '%s' "${STREAM_INFO}" | grep -i "messages:" | grep -oE '[0-9]+' | head -1 || echo "0")
-      [[ "${MSGS}" -gt 0 ]] || fail "step 4: NATS stream '${STREAM_NAME}' has 0 messages — workflow.failed CloudEvent not delivered"
-      pass "step 4: NATS stream '${STREAM_NAME}' has ${MSGS} message(s)."
-    else
-      warn "step 4: 'nats' CLI not found; connectivity confirmed but message count not verified."
-      pass "step 4: NATS connectivity verified (port-forward to 4222 succeeded)."
-    fi
-  else
-    log "  NATS pod: ${NATS_POD}"
-    STREAM_CMD="nats stream info ${STREAM_NAME} --server nats://localhost:4222 2>&1 || true"
-    STREAM_INFO=$(kubectl -n "${NAMESPACE}" exec "${NATS_POD}" -- \
-      sh -c "${STREAM_CMD}" 2>/dev/null || true)
-    log "  stream info: ${STREAM_INFO}"
+NATS_BOX_POD=$(kubectl -n "${NAMESPACE}" get pod \
+  -l "app.kubernetes.io/component=nats-box" \
+  -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
+[[ -n "${NATS_BOX_POD}" ]] \
+  || fail "step 4: nats-box pod not found (label app.kubernetes.io/component=nats-box) — the NATS subchart must be enabled with natsBox for this assertion"
+log "  nats-box pod: ${NATS_BOX_POD}"
 
-    if printf '%s' "${STREAM_INFO}" | grep -qi "not found\|unknown\|error\|command not found"; then
-      # Fallback: check via the NATS HTTP monitoring endpoint (port 8222).
-      MONITORING=$(kubectl -n "${NAMESPACE}" exec "${NATS_POD}" -- \
-        sh -c "wget -qO- http://localhost:8222/jsz?streams=1 2>/dev/null || curl -s http://localhost:8222/jsz?streams=1 2>/dev/null || echo '{}'" 2>/dev/null || echo "{}")
-      log "  NATS monitoring jsz: ${MONITORING}"
-      if printf '%s' "${MONITORING}" | grep -q "${STREAM_NAME}"; then
-        pass "step 4: NATS JetStream stream '${STREAM_NAME}' found via monitoring endpoint."
-      else
-        warn "step 4: could not confirm CloudEvent delivery — nats CLI not in pod and jsz stream not found."
-        warn "        The workflow reached '${FINAL_STATUS}'; event-bus publish is best-effort."
-      fi
-    else
-      MSGS=$(printf '%s' "${STREAM_INFO}" | grep -i "messages:" | grep -oE '[0-9]+' | head -1 || echo "0")
-      if [[ -n "${MSGS}" && "${MSGS}" -gt 0 ]]; then
-        pass "step 4: NATS stream '${STREAM_NAME}' has ${MSGS} message(s) — workflow.failed CloudEvent delivered."
-      else
-        warn "step 4: NATS stream '${STREAM_NAME}' message count is 0 or unknown (may be placeholder image)."
-        pass "step 4: NATS JetStream stream assertion completed (placeholder image acceptable)."
-      fi
-    fi
+# nats_exec <args…> — run the nats CLI inside the nats-box pod.
+nats_exec() {
+  kubectl -n "${NAMESPACE}" exec "${NATS_BOX_POD}" -- nats "$@"
+}
+
+# nats_diagnostics — dump JetStream + publisher state on assertion failure so
+# the CI log carries the evidence (the cluster is torn down right after).
+nats_diagnostics() {
+  warn "── step 4 diagnostics ──"
+  warn "JetStream streams:"
+  nats_exec stream ls 2>&1 | sed 's/^/    /' >&2 || true
+  warn "event-bus log tail:"
+  kubectl -n "${NAMESPACE}" logs deployment/zynax-event-bus --tail=40 2>&1 | sed 's/^/    /' >&2 || true
+  warn "engine-adapter log tail:"
+  kubectl -n "${NAMESPACE}" logs deployment/zynax-engine-adapter --tail=40 2>&1 | sed 's/^/    /' >&2 || true
+}
+
+# The workflow already reached terminal failure in step 2, so the failed event
+# must land within the assertion timeout — no skip path.
+NATS_ELAPSED=0
+LAST_FAILED_EVENT=""
+while [[ ${NATS_ELAPSED} -lt ${NATS_ASSERT_TIMEOUT} ]]; do
+  LAST_FAILED_EVENT=$(nats_exec stream get "${EVENTS_STREAM}" \
+    --last-for "${FAILED_SUBJECT}" 2>/dev/null) || LAST_FAILED_EVENT=""
+  if printf '%s' "${LAST_FAILED_EVENT}" | grep -q "workflow.failed"; then
+    break
   fi
-fi
+  log "  [${NATS_ELAPSED}s] no message on subject '${FAILED_SUBJECT}' yet — retrying…"
+  sleep 5
+  NATS_ELAPSED=$((NATS_ELAPSED + 5))
+done
+printf '%s' "${LAST_FAILED_EVENT}" | grep -q "workflow.failed" || {
+  nats_diagnostics
+  fail "step 4: workflow.failed CloudEvent not on JetStream after ${NATS_ASSERT_TIMEOUT}s (subject='${FAILED_SUBJECT}', stream='${EVENTS_STREAM}') — #1149 regression"
+}
+log "  last failed event: ${LAST_FAILED_EVENT}"
+pass "step 4: workflow.failed CloudEvent delivered to JetStream (stream=${EVENTS_STREAM}, subject=${FAILED_SUBJECT})."
 
 # ── summary ──────────────────────────────────────────────────────────────────────
 
 printf '\n\033[1;32m[e2e-failure] ALL ASSERTIONS PASSED\033[0m\n'
 printf '  workflow:  run_id=%s  status=%s  (expected failure)\n' "${RUN_ID}" "${FINAL_STATUS}"
 printf '  timeout:   budget=%s  observed=~%ss\n' "${ZYNAX_CAPABILITY_TIMEOUT}" "${FAIL_ELAPSED}"
-printf '  event-bus: stream=ZYNAX_WORKFLOW  event=zynax.workflow.failed  skip=%s\n' "${SKIP_NATS}"
+printf '  event-bus: stream=%s  subject=%s  failed-event=delivered (required, #1149)\n' \
+  "${EVENTS_STREAM}" "${FAILED_SUBJECT}"
 printf '\n'

--- a/scripts/e2e/e2e-happy.sh
+++ b/scripts/e2e/e2e-happy.sh
@@ -8,9 +8,9 @@
 # CloudEvents arrived on NATS JetStream, and verifies that the memory-service
 # KV plane works by writing a sentinel key and reading it back. The CloudEvent
 # + memory assertions are REQUIRED (#1090, canvas 1086 O4) — there is no skip
-# path. Exception: the terminal workflow.completed event is enforced only with
-# E2E_REQUIRE_COMPLETED_EVENT=1 until bug #1149 (JetStream stream subject
-# overlap makes it undeliverable) is fixed — see step 3b.
+# path. This includes the terminal workflow.completed CloudEvent (step 3b),
+# required since the #1149 fix (JetStream stream subject overlap previously
+# made it undeliverable).
 #
 # Requires a running kind cluster created by cluster-up.sh (G.1 / #809).
 # Compatible with both ci/docker and local developer environments.
@@ -28,8 +28,6 @@
 #   POLL_INTERVAL      seconds between status polls       (default: 5)
 #   WORKFLOW_FILE      path to the workflow YAML          (default: spec/workflows/examples/e2e-demo.yaml)
 #   NATS_ASSERT_TIMEOUT          max seconds to wait for the JetStream events (default: 60)
-#   E2E_REQUIRE_COMPLETED_EVENT  1 = hard-fail when workflow.completed is not
-#                                on JetStream (default: 0 until #1149 is fixed)
 #
 # Exit codes:
 #   0  all assertions passed
@@ -234,32 +232,28 @@ pass "step 2: workflow reached terminal success state '${FINAL_STATUS}' (run_id=
 # REQUIRED since #1090 (canvas 1086 O4) — no skip path. The engine-adapter
 # publishes lifecycle CloudEvents through EventBusService, which lands them on
 # NATS JetStream. PublishLifecycleEventActivity (services/engine-adapter/
-# internal/infrastructure/activities.go) builds the subject as
-#   "zynax.v1.engine-adapter.workflow." + <event type from interpreter.go>
-# and event-bus derives the stream by dropping the last subject segment and
-# upper-snake-casing the rest (StreamName in services/event-bus/internal/
-# infrastructure/nats.go). We assert with the `nats` CLI inside the nats-box
-# pod (deployed by the NATS subchart) so the host needs no NATS tooling.
+# internal/infrastructure/activities.go) maps the interpreter event type onto
+# the topic taxonomy "zynax.v1.engine-adapter.workflow.<verb>" (#1149), and
+# event-bus derives one stream per entity prefix (first 4 subject segments,
+# upper-snake-cased — StreamName in services/event-bus/internal/infrastructure/
+# nats.go), so the whole lifecycle family shares the single stream
+# ZYNAX_V1_ENGINE_ADAPTER_WORKFLOW. We assert with the `nats` CLI inside the
+# nats-box pod (deployed by the NATS subchart) so the host needs no NATS tooling.
 #
-# Two checks:
-#   3a (REQUIRED): the state-lifecycle CloudEvents (zynax.workflow.state.entered/
-#       exited) for this run are on JetStream — proves the full engine-adapter →
-#       event-bus → NATS pipeline delivers CloudEvents end-to-end.
-#   3b: the terminal zynax.workflow.completed CloudEvent. BLOCKED by #1149:
-#       the state stream's subject filter overlaps the completed stream's, so
-#       JetStream rejects the completed stream (err 10065) and the event is
-#       undeliverable today. Enforced only when E2E_REQUIRE_COMPLETED_EVENT=1.
-#       TODO(#1149): flip the default to required once the stream-derivation
-#       overlap is fixed — do NOT remove this assertion.
+# Two checks, both REQUIRED:
+#   3a: the state-lifecycle CloudEvents (….workflow.state.entered/exited) for
+#       this run are on JetStream — proves the full engine-adapter → event-bus
+#       → NATS pipeline delivers CloudEvents end-to-end.
+#   3b: the terminal ….workflow.completed CloudEvent is on JetStream — the
+#       #1149 regression guard (the old per-depth stream derivation made the
+#       completed/failed family undeliverable: NATS err 10065).
 
 log "step 3: asserting lifecycle CloudEvents off NATS JetStream…"
 
-STATE_SUBJECT_PREFIX="zynax.v1.engine-adapter.workflow.zynax.workflow.state"
-STATE_STREAM="ZYNAX_V1_ENGINE_ADAPTER_WORKFLOW_ZYNAX_WORKFLOW_STATE"
-COMPLETED_SUBJECT="zynax.v1.engine-adapter.workflow.zynax.workflow.completed"
-COMPLETED_STREAM="ZYNAX_V1_ENGINE_ADAPTER_WORKFLOW_ZYNAX_WORKFLOW"
+EVENTS_STREAM="ZYNAX_V1_ENGINE_ADAPTER_WORKFLOW"
+STATE_SUBJECT_PREFIX="zynax.v1.engine-adapter.workflow.state"
+COMPLETED_SUBJECT="zynax.v1.engine-adapter.workflow.completed"
 NATS_ASSERT_TIMEOUT="${NATS_ASSERT_TIMEOUT:-60}"
-E2E_REQUIRE_COMPLETED_EVENT="${E2E_REQUIRE_COMPLETED_EVENT:-0}"
 
 NATS_BOX_POD=$(kubectl -n "${NAMESPACE}" get pod \
   -l "app.kubernetes.io/component=nats-box" \
@@ -289,60 +283,60 @@ nats_diagnostics() {
 NATS_ELAPSED=0
 STATE_MSGS="0"
 while [[ ${NATS_ELAPSED} -lt ${NATS_ASSERT_TIMEOUT} ]]; do
-  STATE_MSGS=$(nats_exec stream info "${STATE_STREAM}" --json 2>/dev/null \
+  STATE_MSGS=$(nats_exec stream info "${EVENTS_STREAM}" --json 2>/dev/null \
     | jq -r '.state.messages // 0' 2>/dev/null || echo "0")
   [[ "${STATE_MSGS}" =~ ^[0-9]+$ ]] || STATE_MSGS=0
   if [[ "${STATE_MSGS}" -gt 0 ]]; then
     break
   fi
-  log "  [${NATS_ELAPSED}s] stream '${STATE_STREAM}' not ready yet (messages=${STATE_MSGS}) — retrying…"
+  log "  [${NATS_ELAPSED}s] stream '${EVENTS_STREAM}' not ready yet (messages=${STATE_MSGS}) — retrying…"
   sleep 5
   NATS_ELAPSED=$((NATS_ELAPSED + 5))
 done
 if [[ "${STATE_MSGS}" -eq 0 ]]; then
   nats_diagnostics
-  fail "step 3a: NATS JetStream stream '${STATE_STREAM}' has no messages after ${NATS_ASSERT_TIMEOUT}s — lifecycle CloudEvents are not reaching JetStream"
+  fail "step 3a: NATS JetStream stream '${EVENTS_STREAM}' has no messages after ${NATS_ASSERT_TIMEOUT}s — lifecycle CloudEvents are not reaching JetStream"
 fi
-log "  stream '${STATE_STREAM}' has ${STATE_MSGS} message(s)."
+log "  stream '${EVENTS_STREAM}' has ${STATE_MSGS} message(s)."
 
-LAST_STATE_EVENT=$(nats_exec stream get "${STATE_STREAM}" \
+LAST_STATE_EVENT=$(nats_exec stream get "${EVENTS_STREAM}" \
   --last-for "${STATE_SUBJECT_PREFIX}.entered" 2>&1) || {
     nats_diagnostics
-    fail "step 3a: no message on subject '${STATE_SUBJECT_PREFIX}.entered' in stream '${STATE_STREAM}': ${LAST_STATE_EVENT}"
+    fail "step 3a: no message on subject '${STATE_SUBJECT_PREFIX}.entered' in stream '${EVENTS_STREAM}': ${LAST_STATE_EVENT}"
   }
 log "  last state.entered event: ${LAST_STATE_EVENT}"
-printf '%s' "${LAST_STATE_EVENT}" | grep -q "zynax.workflow.state.entered" || {
+printf '%s' "${LAST_STATE_EVENT}" | grep -q "workflow.state.entered" || {
   nats_diagnostics
-  fail "step 3a: message on '${STATE_SUBJECT_PREFIX}.entered' does not carry the zynax.workflow.state.entered CloudEvent type. Payload: ${LAST_STATE_EVENT}"
+  fail "step 3a: message on '${STATE_SUBJECT_PREFIX}.entered' does not carry the workflow.state.entered CloudEvent type. Payload: ${LAST_STATE_EVENT}"
 }
 if printf '%s' "${LAST_STATE_EVENT}" | grep -q "${RUN_ID}"; then
-  pass "step 3a: lifecycle CloudEvents delivered to JetStream (stream=${STATE_STREAM}, workflow_id matches run_id=${RUN_ID})."
+  pass "step 3a: lifecycle CloudEvents delivered to JetStream (stream=${EVENTS_STREAM}, workflow_id matches run_id=${RUN_ID})."
 else
   warn "  state.entered payload does not reference run_id=${RUN_ID} (workflow id mapping may differ)."
-  pass "step 3a: lifecycle CloudEvents delivered to JetStream (stream=${STATE_STREAM}, ${STATE_MSGS} message(s))."
+  pass "step 3a: lifecycle CloudEvents delivered to JetStream (stream=${EVENTS_STREAM}, ${STATE_MSGS} message(s))."
 fi
 
-# 3b — terminal completed CloudEvent (gated on #1149, see header comment).
-COMPLETED_MSGS=$(nats_exec stream info "${COMPLETED_STREAM}" --json 2>/dev/null \
-  | jq -r '.state.messages // 0' 2>/dev/null || echo "0")
-[[ "${COMPLETED_MSGS}" =~ ^[0-9]+$ ]] || COMPLETED_MSGS=0
-if [[ "${COMPLETED_MSGS}" -gt 0 ]]; then
-  LAST_EVENT=$(nats_exec stream get "${COMPLETED_STREAM}" \
-    --last-for "${COMPLETED_SUBJECT}" 2>&1) || true
-  log "  last completed event: ${LAST_EVENT}"
-  if printf '%s' "${LAST_EVENT}" | grep -q "zynax.workflow.completed"; then
-    pass "step 3b: workflow.completed CloudEvent delivered to JetStream (stream=${COMPLETED_STREAM})."
-  elif [[ "${E2E_REQUIRE_COMPLETED_EVENT}" -eq 1 ]]; then
-    nats_diagnostics
-    fail "step 3b: stream '${COMPLETED_STREAM}' has messages but none carry zynax.workflow.completed"
+# 3b — REQUIRED: terminal completed CloudEvent (#1149 regression guard).
+# The workflow already reached terminal success in step 2, so the completed
+# event must land within the assertion timeout — no skip path.
+NATS_ELAPSED=0
+LAST_EVENT=""
+while [[ ${NATS_ELAPSED} -lt ${NATS_ASSERT_TIMEOUT} ]]; do
+  LAST_EVENT=$(nats_exec stream get "${EVENTS_STREAM}" \
+    --last-for "${COMPLETED_SUBJECT}" 2>/dev/null) || LAST_EVENT=""
+  if printf '%s' "${LAST_EVENT}" | grep -q "workflow.completed"; then
+    break
   fi
-elif [[ "${E2E_REQUIRE_COMPLETED_EVENT}" -eq 1 ]]; then
+  log "  [${NATS_ELAPSED}s] no message on subject '${COMPLETED_SUBJECT}' yet — retrying…"
+  sleep 5
+  NATS_ELAPSED=$((NATS_ELAPSED + 5))
+done
+printf '%s' "${LAST_EVENT}" | grep -q "workflow.completed" || {
   nats_diagnostics
-  fail "step 3b: workflow.completed CloudEvent not on JetStream (stream='${COMPLETED_STREAM}' empty or missing)"
-else
-  warn "step 3b: workflow.completed CloudEvent NOT on JetStream — known bug #1149 (stream subject overlap)."
-  warn "         Enforce with E2E_REQUIRE_COMPLETED_EVENT=1 once #1149 is fixed."
-fi
+  fail "step 3b: workflow.completed CloudEvent not on JetStream after ${NATS_ASSERT_TIMEOUT}s (subject='${COMPLETED_SUBJECT}', stream='${EVENTS_STREAM}') — #1149 regression"
+}
+log "  last completed event: ${LAST_EVENT}"
+pass "step 3b: workflow.completed CloudEvent delivered to JetStream (stream=${EVENTS_STREAM}, subject=${COMPLETED_SUBJECT})."
 
 # ── 4. Assert memory-service KV roundtrip ────────────────────────────────────────
 #
@@ -388,7 +382,7 @@ fi
 
 printf '\n\033[1;32m[e2e-happy] ALL ASSERTIONS PASSED\033[0m\n'
 printf '  workflow:  run_id=%s  status=%s\n' "${RUN_ID}" "${FINAL_STATUS}"
-printf '  event-bus: state-stream=%s messages=%s  completed-stream=%s messages=%s (enforced=%s, #1149)\n' \
-  "${STATE_STREAM}" "${STATE_MSGS}" "${COMPLETED_STREAM}" "${COMPLETED_MSGS}" "${E2E_REQUIRE_COMPLETED_EVENT}"
+printf '  event-bus: stream=%s messages=%s  completed-event=delivered (required, #1149)\n' \
+  "${EVENTS_STREAM}" "${STATE_MSGS}"
 printf '  memory:    workflow_id=%s  key=%s roundtrip=ok\n' "${MEMORY_WF_ID}" "${MEMORY_KEY}"
 printf '\n'

--- a/services/engine-adapter/internal/infrastructure/activities.go
+++ b/services/engine-adapter/internal/infrastructure/activities.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -32,14 +33,33 @@ type ActivityWorker struct {
 	EventBus EventBusPublisher
 }
 
+// lifecycleTopicPrefix is the engine-adapter entity prefix per the platform
+// topic taxonomy "zynax.<version>.<service>.<entity>.<event_type>" (root AGENTS.md).
+const lifecycleTopicPrefix = "zynax.v1.engine-adapter.workflow."
+
+// lifecycleTopic maps the interpreter's canonical lifecycle event type onto
+// the platform topic taxonomy by replacing the interpreter's "zynax.workflow."
+// family prefix with the engine-adapter entity prefix:
+//
+//	"zynax.workflow.state.entered" → "zynax.v1.engine-adapter.workflow.state.entered"
+//	"zynax.workflow.completed"     → "zynax.v1.engine-adapter.workflow.completed"
+//
+// Before #1149 the interpreter event type was appended verbatim, double-prefixing
+// the topic (e.g. "zynax.v1.engine-adapter.workflow.zynax.workflow.completed")
+// and deriving overlapping JetStream streams on the event-bus side, which made
+// the terminal completed/failed events undeliverable (NATS err 10065).
+func lifecycleTopic(eventType string) string {
+	return lifecycleTopicPrefix + strings.TrimPrefix(eventType, "zynax.workflow.")
+}
+
 // PublishLifecycleEventActivity is registered with the Temporal worker and called
 // by IRInterpreterWorkflow to emit workflow lifecycle events to EventBusService.
 // Publication is best-effort: errors are logged but not returned so that event-bus
 // unavailability never interrupts the workflow state machine.
 //
-// Topic format: zynax.v1.engine-adapter.workflow.<event_type>
+// Topic format: zynax.v1.engine-adapter.workflow.<event_type> (see lifecycleTopic).
 func (a *ActivityWorker) PublishLifecycleEventActivity(ctx context.Context, eventType, workflowID, stateID string) error {
-	topic := fmt.Sprintf("zynax.v1.engine-adapter.workflow.%s", eventType)
+	topic := lifecycleTopic(eventType)
 
 	req := &zynaxv1.PublishRequest{
 		Event: &zynaxv1.CloudEvent{

--- a/services/engine-adapter/internal/infrastructure/activities_test.go
+++ b/services/engine-adapter/internal/infrastructure/activities_test.go
@@ -100,6 +100,40 @@ func TestPublishLifecycleEventActivity_AllEventTypes(t *testing.T) {
 	}
 }
 
+// TestPublishLifecycleEventActivity_InterpreterEventTypes_NoDoublePrefix is
+// the regression test for #1149: the interpreter emits canonical lifecycle
+// event types ("zynax.workflow.…"), and the activity must map them onto the
+// topic taxonomy instead of appending them verbatim (which double-prefixed the
+// topic to "zynax.v1.engine-adapter.workflow.zynax.workflow.…" and derived
+// overlapping JetStream streams on the event-bus side).
+func TestPublishLifecycleEventActivity_InterpreterEventTypes_NoDoublePrefix(t *testing.T) {
+	cases := map[string]string{
+		"zynax.workflow.state.entered": "zynax.v1.engine-adapter.workflow.state.entered",
+		"zynax.workflow.state.exited":  "zynax.v1.engine-adapter.workflow.state.exited",
+		"zynax.workflow.completed":     "zynax.v1.engine-adapter.workflow.completed",
+		"zynax.workflow.failed":        "zynax.v1.engine-adapter.workflow.failed",
+	}
+	for eventType, wantTopic := range cases {
+		t.Run(eventType, func(t *testing.T) {
+			stub := &stubEventBusPublisher{}
+			w := newTestActivityWorker(stub)
+			if err := w.PublishLifecycleEventActivity(context.Background(), eventType, "wf-1149", "s1"); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(stub.reqs) != 1 {
+				t.Fatalf("expected 1 Publish call, got %d", len(stub.reqs))
+			}
+			got := stub.reqs[0].Event.GetType()
+			if got != wantTopic {
+				t.Errorf("topic = %q; want %q", got, wantTopic)
+			}
+			if strings.Contains(got, "workflow.zynax.workflow") {
+				t.Errorf("topic %q is double-prefixed (#1149 regression)", got)
+			}
+		})
+	}
+}
+
 func TestPublishLifecycleEventActivity_EventBusError_BestEffort(t *testing.T) {
 	// Event bus errors must not be propagated — activity is best-effort.
 	stub := &stubEventBusPublisher{publishErr: errors.New("connection refused")}

--- a/services/event-bus/internal/infrastructure/nats.go
+++ b/services/event-bus/internal/infrastructure/nats.go
@@ -58,49 +58,80 @@ type cloudEventEnvelope struct {
 	Data            []byte `json:"data,omitempty"`
 }
 
+// streamSubjectDepth is the number of leading subject segments that identify
+// the entity owning a JetStream stream, per the platform topic taxonomy
+// "zynax.<version>.<service>.<entity>.<event_type>" (root AGENTS.md): the
+// entity prefix is always the first four segments, while the event_type verb
+// may itself contain dots (e.g. "state.entered").
+//
+// Deriving every stream at the same fixed depth makes subject filters either
+// identical (same stream) or pairwise disjoint by construction. The previous
+// "drop the last segment" rule derived overlapping filters for event types of
+// different depth within the same prefix tree (e.g. "….workflow.state.entered"
+// vs "….workflow.completed"), and NATS rejected the second stream with
+// "subjects overlap with an existing stream" (err 10065), silently making
+// whole event families undeliverable — see #1149.
+const streamSubjectDepth = 4
+
+// streamPrefix returns the leading subject segments (at most
+// streamSubjectDepth) that identify the stream owning eventType. Event types
+// shorter than the taxonomy depth are used verbatim.
+func streamPrefix(eventType string) string {
+	parts := strings.Split(eventType, ".")
+	if len(parts) > streamSubjectDepth {
+		return strings.Join(parts[:streamSubjectDepth], ".")
+	}
+	return eventType
+}
+
 // StreamName derives a JetStream stream name from a dot-separated event type.
-// The stream covers the full event type as subject filter using ">" wildcard.
 // Examples:
 //
-//	"zynax.v1.engine-adapter.workflow.completed" → "ZYNAX_V1_ENGINE_ADAPTER_WORKFLOW"
-//	"zynax.v1.agent-registry.agent.registered"  → "ZYNAX_V1_AGENT_REGISTRY_AGENT"
+//	"zynax.v1.engine-adapter.workflow.completed"     → "ZYNAX_V1_ENGINE_ADAPTER_WORKFLOW"
+//	"zynax.v1.engine-adapter.workflow.state.entered" → "ZYNAX_V1_ENGINE_ADAPTER_WORKFLOW"
+//	"zynax.v1.agent-registry.agent.registered"       → "ZYNAX_V1_AGENT_REGISTRY_AGENT"
 //
 // Dashes are replaced with underscores; dots become underscores; all uppercase.
-// The last segment (the verb) is dropped so all events of the same entity
-// share a single stream.
+// All events under the same entity prefix (first streamSubjectDepth segments)
+// share a single stream regardless of how many segments the verb has.
 func StreamName(eventType string) string {
-	parts := strings.Split(eventType, ".")
-	// Use all but the last segment (verb) for the stream name.
-	prefix := parts
-	if len(parts) > 1 {
-		prefix = parts[:len(parts)-1]
-	}
-	name := strings.Join(prefix, "_")
+	name := strings.ReplaceAll(streamPrefix(eventType), ".", "_")
 	name = strings.ReplaceAll(name, "-", "_")
 	return strings.ToUpper(name)
 }
 
-// SubjectFilter returns the NATS subject filter for a stream created from eventType.
-// All events whose type starts with the entity prefix are captured.
+// SubjectFilter returns the widest NATS subject filter for the stream that
+// owns eventType: "<entity-prefix>.>" for taxonomy-depth event types, or the
+// literal event type when it has fewer segments than the taxonomy depth
+// (literal subjects can never overlap a fixed-depth wildcard filter).
 func SubjectFilter(eventType string) string {
-	parts := strings.Split(eventType, ".")
-	// Drop the last segment (verb) and replace with ">" wildcard.
-	if len(parts) > 1 {
-		prefix := strings.Join(parts[:len(parts)-1], ".")
+	prefix := streamPrefix(eventType)
+	if prefix != eventType {
 		return prefix + ".>"
 	}
-	return eventType + ".>"
+	return eventType
+}
+
+// streamSubjects returns the full subject set for the stream owning eventType.
+// Taxonomy-depth streams carry both the literal entity prefix and its ".>"
+// wildcard so a (degenerate) event type that IS the entity prefix still lands
+// on the same stream instead of requiring an overlapping second stream.
+func streamSubjects(eventType string) []string {
+	prefix := streamPrefix(eventType)
+	if prefix != eventType {
+		return []string{prefix, prefix + ".>"}
+	}
+	return []string{eventType}
 }
 
 // ensureStream creates the JetStream stream if it does not already exist.
 // If the stream already exists with the same config, this is a no-op (idempotent).
 func (b *NATSEventBus) ensureStream(eventType string) error {
 	name := StreamName(eventType)
-	filter := SubjectFilter(eventType)
 
 	cfg := &nats.StreamConfig{
 		Name:      name,
-		Subjects:  []string{filter},
+		Subjects:  streamSubjects(eventType),
 		Retention: nats.LimitsPolicy,
 		Storage:   nats.FileStorage,
 		Replicas:  1,
@@ -265,23 +296,25 @@ func dlqStreamName(sourceStreamName string) string {
 	return "DLQ_" + sourceStreamName
 }
 
-// dlqSubjectFilter returns the NATS subject filter for the dead-letter queue stream.
-// Example: "zynax.v1.engine-adapter.workflow.completed" → "zynax.dlq.zynax.v1.engine-adapter.workflow.>"
-func dlqSubjectFilter(eventType string) string {
-	parts := strings.Split(eventType, ".")
-	if len(parts) > 1 {
-		prefix := strings.Join(parts[:len(parts)-1], ".")
-		return "zynax.dlq." + prefix + ".>"
-	}
-	return "zynax.dlq." + eventType + ".>"
+// dlqDeliverSubject returns the concrete NATS subject that carries messages
+// which exhausted their delivery retries for the stream owning eventType.
+// It is an exact subject (no wildcard) so DLQ stream filters are pairwise
+// disjoint by construction — the same #1149 overlap class applied to the
+// "zynax.dlq." namespace. The "zynax.dlq." prefix is reserved: event types
+// must not be published under it.
+// Example: "zynax.v1.engine-adapter.workflow.completed" →
+// "zynax.dlq.zynax.v1.engine-adapter.workflow.dead"
+func dlqDeliverSubject(eventType string) string {
+	return "zynax.dlq." + streamPrefix(eventType) + ".dead"
 }
 
 // ensureDLQStream creates the dead-letter queue JetStream stream for a source
 // stream if it does not already exist. The DLQ stream uses WorkQueuePolicy
-// (each message consumed once) and captures subjects under "zynax.dlq.<topic>".
+// (each message consumed once) and captures the exact "zynax.dlq.<prefix>.dead"
+// deliver subject for the source stream.
 func (b *NATSEventBus) ensureDLQStream(sourceStreamName, eventType string) error {
 	dlqName := dlqStreamName(sourceStreamName)
-	dlqSubj := dlqSubjectFilter(eventType)
+	dlqSubj := dlqDeliverSubject(eventType)
 
 	cfg := &nats.StreamConfig{
 		Name:         dlqName,
@@ -402,7 +435,7 @@ func (b *NATSEventBus) Subscribe(ctx context.Context, req domain.SubscribeReques
 	}
 
 	// Build the DLQ deliver subject for exhausted messages.
-	dlqSubj := strings.TrimSuffix(dlqSubjectFilter(streamSubject), ".>") + ".dead"
+	dlqSubj := dlqDeliverSubject(streamSubject)
 
 	sub, err := b.openSubscription(
 		streamName,

--- a/services/event-bus/internal/infrastructure/nats_publish_test.go
+++ b/services/event-bus/internal/infrastructure/nats_publish_test.go
@@ -3,6 +3,7 @@
 package infrastructure_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/zynax-io/zynax/services/event-bus/internal/infrastructure"
@@ -29,9 +30,15 @@ func TestStreamName(t *testing.T) {
 			eventType: "single",
 			want:      "SINGLE",
 		},
+		// Event types at or below the taxonomy depth are used verbatim.
 		{
 			eventType: "zynax.v1.workflow.completed",
-			want:      "ZYNAX_V1_WORKFLOW",
+			want:      "ZYNAX_V1_WORKFLOW_COMPLETED",
+		},
+		// Multi-segment verbs share the entity stream (#1149 regression).
+		{
+			eventType: "zynax.v1.engine-adapter.workflow.state.entered",
+			want:      "ZYNAX_V1_ENGINE_ADAPTER_WORKFLOW",
 		},
 	}
 
@@ -57,8 +64,18 @@ func TestSubjectFilter(t *testing.T) {
 			want:      "zynax.v1.agent-registry.agent.>",
 		},
 		{
+			eventType: "zynax.v1.engine-adapter.workflow.state.entered",
+			want:      "zynax.v1.engine-adapter.workflow.>",
+		},
+		// At or below the taxonomy depth the literal type is the filter —
+		// literal subjects can never overlap a fixed-depth wildcard filter.
+		{
+			eventType: "zynax.v1.workflow.completed",
+			want:      "zynax.v1.workflow.completed",
+		},
+		{
 			eventType: "single",
-			want:      "single.>",
+			want:      "single",
 		},
 	}
 
@@ -66,6 +83,93 @@ func TestSubjectFilter(t *testing.T) {
 		got := infrastructure.SubjectFilter(tc.eventType)
 		if got != tc.want {
 			t.Errorf("SubjectFilter(%q): got %q, want %q", tc.eventType, got, tc.want)
+		}
+	}
+}
+
+// subjectsOverlap reports whether two NATS subject filters can match a common
+// subject. Token semantics: "*" matches exactly one token, ">" matches one or
+// more remaining tokens.
+func subjectsOverlap(a, b string) bool {
+	at := strings.Split(a, ".")
+	bt := strings.Split(b, ".")
+	for i := 0; i < len(at) && i < len(bt); i++ {
+		if at[i] == ">" || bt[i] == ">" {
+			return true
+		}
+		if at[i] == "*" || bt[i] == "*" || at[i] == bt[i] {
+			continue
+		}
+		return false
+	}
+	return len(at) == len(bt)
+}
+
+// TestStreamDerivation_NoOverlap_AcrossEventTypeSet is the regression test for
+// #1149: deriving streams for the full platform event-type set (including the
+// engine-adapter workflow lifecycle family, whose verbs have different segment
+// counts, and the historical double-prefixed forms) must yield subject filters
+// that are either identical (same stream) or pairwise disjoint. The previous
+// "drop the last segment" derivation produced a filter for "….workflow.completed"
+// that was a superset of the "….workflow.state.>" filter, and NATS rejected the
+// second stream with "subjects overlap with an existing stream" (err 10065),
+// silently making workflow.completed/failed undeliverable platform-wide.
+func TestStreamDerivation_NoOverlap_AcrossEventTypeSet(t *testing.T) {
+	eventTypes := []string{
+		// Engine-adapter workflow lifecycle family (interpreter event types
+		// mapped onto the topic taxonomy by lifecycleTopic in engine-adapter).
+		"zynax.v1.engine-adapter.workflow.state.entered",
+		"zynax.v1.engine-adapter.workflow.state.exited",
+		"zynax.v1.engine-adapter.workflow.completed",
+		"zynax.v1.engine-adapter.workflow.failed",
+		// Historical double-prefixed forms (pre-#1149 engine-adapter topics):
+		// even malformed deep types must not derive overlapping streams.
+		"zynax.v1.engine-adapter.workflow.zynax.workflow.state.entered",
+		"zynax.v1.engine-adapter.workflow.zynax.workflow.completed",
+		// Other entity families per the taxonomy.
+		"zynax.v1.agent-registry.agent.registered",
+		"zynax.v1.task-broker.task.submitted",
+		// Below taxonomy depth.
+		"zynax.v1.workflow.completed",
+		"single",
+	}
+
+	for i, a := range eventTypes {
+		for _, b := range eventTypes[i+1:] {
+			nameA, nameB := infrastructure.StreamName(a), infrastructure.StreamName(b)
+			filterA, filterB := infrastructure.SubjectFilter(a), infrastructure.SubjectFilter(b)
+			if nameA == nameB {
+				if filterA != filterB {
+					t.Errorf("same stream %q for %q and %q but different filters %q vs %q",
+						nameA, a, b, filterA, filterB)
+				}
+				continue
+			}
+			if subjectsOverlap(filterA, filterB) {
+				t.Errorf("streams %q (%q) and %q (%q) have overlapping subject filters %q vs %q — JetStream would reject the second stream (err 10065)",
+					nameA, a, nameB, b, filterA, filterB)
+			}
+		}
+	}
+}
+
+// TestStreamDerivation_LifecycleFamilySharesOneStream pins the #1149 fix shape:
+// every workflow lifecycle event type — regardless of verb segment count —
+// lands on the single ZYNAX_V1_ENGINE_ADAPTER_WORKFLOW entity stream.
+func TestStreamDerivation_LifecycleFamilySharesOneStream(t *testing.T) {
+	const wantStream = "ZYNAX_V1_ENGINE_ADAPTER_WORKFLOW"
+	const wantFilter = "zynax.v1.engine-adapter.workflow.>"
+	for _, et := range []string{
+		"zynax.v1.engine-adapter.workflow.state.entered",
+		"zynax.v1.engine-adapter.workflow.state.exited",
+		"zynax.v1.engine-adapter.workflow.completed",
+		"zynax.v1.engine-adapter.workflow.failed",
+	} {
+		if got := infrastructure.StreamName(et); got != wantStream {
+			t.Errorf("StreamName(%q) = %q, want %q", et, got, wantStream)
+		}
+		if got := infrastructure.SubjectFilter(et); got != wantFilter {
+			t.Errorf("SubjectFilter(%q) = %q, want %q", et, got, wantFilter)
 		}
 	}
 }

--- a/state/current-milestone.md
+++ b/state/current-milestone.md
@@ -55,7 +55,7 @@ As of 2026-06-11: **143 issues closed / 17 open** (CI-overhaul stories #1110–#
 | DevAuto Wave 3 | #880 | post-merge completeness mesh |
 
 ### In progress / remaining
-**e2e-green execution path (#1086 — O1 #1087 ✅ / O2 #1088 ✅ merged via PR #1095; O3 #1089 ✅ satisfied by build-images gate PR #1132; O4 #1090 ✅ event-bus + memory-service enabled with required assertions; O5 #1091 ✅ runner sizing verified on full stack — next: #1092 promotion (after #1071/#1149))**,
+**e2e-green execution path (#1086 — O1 #1087 ✅ / O2 #1088 ✅ merged via PR #1095; O3 #1089 ✅ satisfied by build-images gate PR #1132; O4 #1090 ✅ event-bus + memory-service enabled with required assertions; O5 #1091 ✅ runner sizing verified on full stack; bug #1149 ✅ fixed — JetStream subject overlap, completed/failed CloudEvent assertions now required — next: #1092 promotion (after #1071))**,
 Postgres off Bitnami (#1073 — ✅ complete: O1 ADR-026, O2–O3 #1076, O4–O5 #1077, O6 #1078, O7–O8 #1079; canvas Implemented, EPIC ready to close),
 CI-E2E gate (#771 — #1070 ✅, #1071 remaining),
 DevAuto Wave 4 (#881 — canvas Aligned, stories #1096–#1104 created; O1 #1096 ✅ ADR-028; O2 #1097 ✅ 9 expert AgentDefs; O3 #1098 ✅ orchestrator Workflow manifest; O4 #1099 ✅ issue-delivery intake→plan→route Workflow).
@@ -73,11 +73,11 @@ up but fails at the happy-path assertion; this epic closes the execution-path ga
 | O1 | [#1087](https://github.com/zynax-io/zynax/issues/1087) expose api-gateway on host (NodePort 30080) | feat(infra) | S | ✅ merged (PR #1095) |
 | O2 | [#1088](https://github.com/zynax-io/zynax/issues/1088) minimal capability worker + reference workflow → succeeded | feat(infra) | M | ✅ merged (PR #1095) |
 | O3 | [#1089](https://github.com/zynax-io/zynax/issues/1089) event-bus + memory-service in pre-merge build-images matrix | ci(infra) | M | ✅ satisfied by PR #1132 (shift-left, ADR-027) — closed with evidence |
-| O4 | [#1090](https://github.com/zynax-io/zynax/issues/1090) enable event-bus + memory-service in e2e + assertions | test(infra) | M | ✅ merged — lifecycle CloudEvent + memory-Get required, no skip path; completed-event check gated on bug #1149 |
+| O4 | [#1090](https://github.com/zynax-io/zynax/issues/1090) enable event-bus + memory-service in e2e + assertions | test(infra) | M | ✅ merged — lifecycle CloudEvent + memory-Get required, no skip path; completed-event check now also required (#1149 fixed) |
 | O5 | [#1091](https://github.com/zynax-io/zynax/issues/1091) right-size e2e-smoke runner / pod resources | ci(infra) | S | ✅ verified 2026-06-12 — full 7-service stack GREEN on ubuntu-latest (2 CPU/7 GB), zero Evicted/OOMKilled/Pending; 3 consecutive green runs (PRs #1148, #1150) |
-| O6 | [#1092](https://github.com/zynax-io/zynax/issues/1092) promote gate advisory → stable/required | ci | S | #1090 #1091 #1071 · flip `E2E_REQUIRE_COMPLETED_EVENT` once #1149 fixed |
+| O6 | [#1092](https://github.com/zynax-io/zynax/issues/1092) promote gate advisory → stable/required | ci | S | #1090 #1091 #1071 · unblocked: #1149 fixed (JetStream subject overlap; completed/failed event assertions now required in e2e scripts) |
 
-**Ready now for `/milestone-orchestrate`:** #1092 (O6 — promote gate to required; depends #1071, flip `E2E_REQUIRE_COMPLETED_EVENT` once #1149 fixed).
+**Ready now for `/milestone-orchestrate`:** #1092 (O6 — promote gate to required; depends #1071. #1149 fixed: completed/failed CloudEvent assertions already required in the e2e scripts).
 
 ## Recently Closed (last updated 2026-06-11)
 


### PR DESCRIPTION
## Summary

**Root cause:** event-bus derived JetStream streams by dropping the *last* segment of each event type. Event types of different depth inside one prefix tree therefore produced overlapping subject filters — `…engine-adapter.workflow.zynax.workflow.state.entered` created a stream filtering `….zynax.workflow.state.>`, and the later `….zynax.workflow.completed` needed a stream filtering `….zynax.workflow.>`, a superset. NATS rejected the second stream (err 10065, "subjects overlap with an existing stream"), and because the engine-adapter publish path is best-effort, `workflow.completed` / `workflow.failed` CloudEvents silently vanished platform-wide. A second contributing bug: `PublishLifecycleEventActivity` appended the interpreter's full event type (`zynax.workflow.*`) to the entity prefix, double-prefixing every topic.

**Fix (root cause, per ADR-022 / topic taxonomy `zynax.v1.<service>.<entity>.<event_type>`):**

- `services/event-bus/internal/infrastructure/nats.go` — streams are now derived at a fixed entity depth (first 4 taxonomy segments). All filters are identical (same stream) or pairwise disjoint **by construction**, so err 10065 cannot occur. The whole workflow lifecycle family shares the single `ZYNAX_V1_ENGINE_ADAPTER_WORKFLOW` stream (subjects `zynax.v1.engine-adapter.workflow.>`); event types at/below taxonomy depth get literal-subject streams (literals can never overlap a fixed-depth wildcard). DLQ streams now use the exact `zynax.dlq.<prefix>.dead` deliver subject — same overlap class eliminated in the DLQ namespace.
- `services/engine-adapter/internal/infrastructure/activities.go` — `lifecycleTopic` maps interpreter event types onto the taxonomy (`zynax.workflow.state.entered` → `zynax.v1.engine-adapter.workflow.state.entered`) instead of appending them verbatim.
- `helm/charts/nats/values.yaml` — operator-awareness stream docs updated to the real derived streams.

## Acceptance criteria / evidence

- [x] `workflow.completed` and `workflow.failed` CloudEvents deliverable — **e2e-smoke gate on this PR runs `e2e-happy.sh` with the completed-event assertion REQUIRED** (the `E2E_REQUIRE_COMPLETED_EVENT` escape and `TODO(#1149)` are removed in this PR; step 3b hard-fails if the event is missing). The gate deploys this PR's staging images (services/ touched → staging lane).
- [x] `e2e-failure.sh` `workflow.failed` check hardened from soft/skippable to the same strict nats-box assertion (correct stream/subject; it previously probed a stream name that never existed).
- [x] Regression unit tests: `TestStreamDerivation_NoOverlap_AcrossEventTypeSet` (full event-type set incl. the historical double-prefixed forms → filters identical or disjoint), `TestStreamDerivation_LifecycleFamilySharesOneStream`, `TestPublishLifecycleEventActivity_InterpreterEventTypes_NoDoublePrefix`.
- [x] No band-aid: 10065 is not swallowed anywhere; the derivation makes it structurally impossible.

## Test plan

- `GOWORK=off go test ./... -race` in `services/event-bus` and `services/engine-adapter` — pass.
- `GOWORK=off go test ./event_bus_service/... ./engine_adapter_service/...` in `protos/tests` — pass (BDD contract unaffected; gRPC surface unchanged).
- `make lint` — pass. `make security` — govulncheck/bandit pass; pip-audit flags `pip 26.1.1` (PYSEC-2026-196) in the SDK tooling venv, pre-existing on clean `main` (reproduced), unrelated to this change.
- e2e-smoke gate on this PR = end-to-end proof (happy path requires the completed event; failure path requires the failed event).

Note for any non-ephemeral cluster carrying pre-fix streams: legacy `ZYNAX_V1_ENGINE_ADAPTER_WORKFLOW_ZYNAX_WORKFLOW*` streams must be deleted once (their filters overlap the new entity stream). e2e clusters are created fresh per run, so the gate is unaffected.

Closes #1149

Assisted-by: Claude/claude-fable-5
