### PR TITLE
ci: promote e2e temporal leg to required check with paths shim

### DIFF
--- a/.github/workflows/e2e-smoke-skip.yml
+++ b/.github/workflows/e2e-smoke-skip.yml
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+# Required-check satisfier for the path-conditional e2e gate (#1092).
+#
+# "e2e smoke (temporal)" is a REQUIRED status check in the main-protection
+# ruleset, but e2e-smoke.yml only triggers when e2e-relevant paths change.
+# Without this shim, a docs-only PR would wait forever on the "Expected"
+# check. This workflow uses the COMPLEMENT of e2e-smoke.yml's `paths:`
+# (same list under `paths-ignore:`) and reports an instant success under
+# the exact same job name, so every PR gets exactly one "e2e smoke
+# (temporal)" check run:
+#   - e2e-relevant change  → real gate runs (kind cluster, full assertions)
+#   - anything else        → this shim runs (no-op success)
+# A PR touching both kinds of files matches `paths:` (real gate) and does
+# NOT match `paths-ignore:` (which only fires when ALL changed files are
+# ignored) — never both, never neither.
+#
+# KEEP THE PATH LISTS IN SYNC with .github/workflows/e2e-smoke.yml.
+#
+# The argo leg is intentionally NOT shimmed: it stays advisory until it
+# accumulates a stable green history (decision recorded on #1092,
+# 2026-06-12) — promote it by adding the same shim job + ruleset entry.
+
+name: e2e-smoke-skip
+
+on:
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - "helm/**"
+      - "services/**"
+      - "engine-adapter/**"
+      - "scripts/e2e/**"
+      - ".github/workflows/e2e-smoke.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  e2e-smoke-temporal:
+    name: "e2e smoke (temporal)"
+    runs-on: ubuntu-24.04
+    steps:
+      - name: No e2e-relevant paths changed
+        run: echo "No e2e-relevant paths in this PR — required check satisfied by shim (#1092)."

--- a/docs/contributing/engineering-manifesto.md
+++ b/docs/contributing/engineering-manifesto.md
@@ -300,7 +300,7 @@ file should fit on one screen.*
 |--------|--------|--------------------|
 | Deployment frequency | Multiple per day | Tag-triggered release, retag-not-rebuild promotion, no merge windows |
 | Lead time for changes | <1 day p50 | PR size limit, path-aware CI lanes, merge on green |
-| Change failure rate | <5% | Pre-merge image scan, BDD contract tests, e2e-smoke gate (⏳ advisory today — promotion to required tracked in #1092) |
+| Change failure rate | <5% | Pre-merge image scan, BDD contract tests, e2e-smoke gate (temporal leg required since #1092; argo leg advisory until stable) |
 | MTTR | <1 hour | Linear squash-merge history, `git bisect`, revert-as-PR |
 
 ## CNCF reference patterns

--- a/docs/spdd/1086-e2e-green/canvas.md
+++ b/docs/spdd/1086-e2e-green/canvas.md
@@ -130,6 +130,12 @@ EPIC #770 (harness) and #771 (CI-E2E gate).
    Issue #1091 closed.)
 6. **[O6]** Promote the gate from advisory to a stable/required check, covering Temporal + Argo
    (#1071) + failure paths. (Gap 5; depends O1, O2, O4, O5)
+   ✅ Delivered 2026-06-12 (#1092): "e2e smoke (temporal)" added to the main-protection
+   ruleset required checks, with the complementary-paths shim workflow
+   (.github/workflows/e2e-smoke-skip.yml) satisfying the check on PRs that touch no
+   e2e-relevant paths. The argo leg stays ADVISORY by recorded decision until it
+   accumulates a stable green history (first green: run 27423543856 after #1157) —
+   promote it later by adding the same shim job name + ruleset entry.
 
 ## N — Norms
 

--- a/state/current-milestone.md
+++ b/state/current-milestone.md
@@ -55,9 +55,9 @@ As of 2026-06-11: **143 issues closed / 17 open** (CI-overhaul stories #1110–#
 | DevAuto Wave 3 | #880 | post-merge completeness mesh |
 
 ### In progress / remaining
-**e2e-green execution path (#1086 — O1 #1087 ✅ / O2 #1088 ✅ merged via PR #1095; O3 #1089 ✅ satisfied by build-images gate PR #1132; O4 #1090 ✅ event-bus + memory-service enabled with required assertions; O5 #1091 ✅ runner sizing verified on full stack; bug #1149 ✅ fixed — JetStream subject overlap, completed/failed CloudEvent assertions now required — next: #1092 promotion (after #1071))**,
+**e2e-green execution path (#1086 — O1 #1087 ✅ / O2 #1088 ✅ merged via PR #1095; O3 #1089 ✅ satisfied by build-images gate PR #1132; O4 #1090 ✅ event-bus + memory-service enabled with required assertions; O5 #1091 ✅ runner sizing verified on full stack; bug #1149 ✅ fixed — JetStream subject overlap, completed/failed CloudEvent assertions now required — O6 #1092 ✅ temporal leg required + skip-shim; argo advisory until stable — EPIC #1086 complete)**,
 Postgres off Bitnami (#1073 — ✅ complete: O1 ADR-026, O2–O3 #1076, O4–O5 #1077, O6 #1078, O7–O8 #1079; canvas Implemented, EPIC ready to close),
-CI-E2E gate (#771 — #1070 ✅, #1071 ✅ merged via PR #1155: engine matrix temporal/argo in e2e-smoke; bug #1157 ✅ fixed — ArgoEngine submit now sends the WorkflowCreateRequest envelope, argo leg unblocked; next: #1092),
+CI-E2E gate (#771 — #1070 ✅, #1071 ✅ merged via PR #1155: engine matrix temporal/argo in e2e-smoke; bug #1157 ✅ fixed — ArgoEngine submit now sends the WorkflowCreateRequest envelope, argo leg unblocked; #1092 ✅ — EPIC #771 complete),
 DevAuto Wave 4 (#881 — canvas Aligned, stories #1096–#1104 created; O1 #1096 ✅ ADR-028; O2 #1097 ✅ 9 expert AgentDefs; O3 #1098 ✅ orchestrator Workflow manifest; O4 #1099 ✅ issue-delivery intake→plan→route Workflow).
 
 ---


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/e2e-smoke-skip.yml`, the complement of `e2e-smoke.yml`'s paths filter, reporting instant success under the exact job name `e2e smoke (temporal)` so the required check resolves on every PR.
- After merge the orchestrator adds that context to the main-protection ruleset (11th required check).
- Argo leg stays advisory by recorded decision until stable green history (first green run 27423543856 after #1157).
- Status surfaces flipped: canvas 1086 O6 done, manifesto DORA row, state file.

## Test plan

- [ ] actionlint green locally
- [ ] This PR itself (docs+workflow diff) must show the SHIM run satisfying `e2e smoke (temporal)` — this PR touches `.github/workflows/e2e-smoke-skip.yml` + docs + state, NOT in the real gate's paths list, so the shim must fire

Closes #1092

Assisted-by: Claude/claude-fable-5