### PR TITLE
docs(spdd): mark EPICs #1086 and #771 canvases Implemented

### DIFF
--- a/docs/spdd/1086-e2e-green/canvas.md
+++ b/docs/spdd/1086-e2e-green/canvas.md
@@ -7,7 +7,7 @@
 **Issue:** #1086
 **Author:** Oscar Gómez Manresa
 **Date:** 2026-06-10
-**Status:** Aligned
+**Status:** Implemented
 
 ---
 

--- a/docs/spdd/771-ci-e2e/canvas.md
+++ b/docs/spdd/771-ci-e2e/canvas.md
@@ -7,7 +7,7 @@
 **Issue:** #771
 **Author:** Oscar Gómez Manresa
 **Date:** 2026-06-10
-**Status:** Aligned
+**Status:** Implemented
 
 **Child issues:** #1070 (H.1) · #1071 (H.2)
 


### PR DESCRIPTION
## Summary

- Flips `docs/spdd/1086-e2e-green/canvas.md` and `docs/spdd/771-ci-e2e/canvas.md` from `Status: Aligned` to `Status: Implemented`.
- Both EPICs are fully delivered and their GitHub issues have been closed as completed.
- EPIC #1086: all 6 O-steps landed (O3 #1089, O4 #1090, O5 #1091, O6 #1092, bugs #1149/#1157).
- EPIC #771: both H-steps landed (#1070, #1071 PR #1155).

Assisted-by: Claude/claude-fable-5