### PR TITLE
feat(task-broker): context-slice injection binding for expert dispatch

### DIFF
--- a/docs/spdd/881-self-hosted-issue-delivery/canvas.md
+++ b/docs/spdd/881-self-hosted-issue-delivery/canvas.md
@@ -264,7 +264,16 @@ event-bus, (orchestrator) engine-adapter.
    (calls planner `identify_next_issue`) → `route`. Reads a GitHub issue, classifies type/expert,
    identifies the next issue. *Verify:* given a fixture issue, the workflow emits the correct
    `{next_issue, expert, blocked_by}` decision; BDD scenario for the classify+route path.
-5. **O5 — Context-slice injection binding (`feat`).** The runtime binding that feeds one expert AgentDef
+5. **O5 — Context-slice injection binding (`feat`).** ✅ Delivered (#1100 — the binding lives in
+   task-broker's domain layer: an `expert`-keyed `review` dispatch is narrowed to exactly that expert
+   AgentDef and its registry-declared `{files[], max_tokens}` slice is bound into the capability
+   `input_payload` **before** the task row is persisted, replacing anything the caller supplied — so a
+   caller can never plant a foreign slice (strict isolation) and the bound payload is durable. Startup
+   recovery (`RecoverInFlight`) re-launches non-terminal tasks from the Postgres-backed repo (#626), so
+   a parallel fan-out survives a broker restart; task lifecycle CloudEvents
+   (`zynax.v1.task-broker.task.*`) are published best-effort to EventBus (#772) for durable fan-out
+   observation. Isolation + simulated-restart tests in `internal/domain/contextslice_test.go`.)
+   The runtime binding that feeds one expert AgentDef
    only its declared `context_slice` (bounded `max_tokens`, strict isolation) via capability dispatch
    (task-broker) over EventBus. *Verify:* an expert invocation receives only its slice files; isolation
    test proves no cross-expert context leakage.

--- a/services/task-broker/AGENTS.md
+++ b/services/task-broker/AGENTS.md
@@ -12,8 +12,11 @@ The Task Broker is the **work scheduler** of the mesh.
 - Accepts `DispatchTask` calls from `engine-adapter`; returns a broker-assigned `task_id` immediately (async execution).
 - Discovers eligible agents from `agent-registry` via gRPC (`AgentFinder` port).
 - Assigns tasks to agents using atomic round-robin selection.
+- **Context-slice injection binding (ADR-028, EPIC #881 O5):** a dispatch whose `input_payload` carries a top-level `"expert"` string is routed to exactly that agent (matched on `Name`/`AgentID`, never falls back), and the expert's registry-declared `context_slice` `{files[], max_tokens}` (the defaults in its capability `input_schema`) is bound into the payload before persistence — any caller-supplied `context_slice` is discarded (strict isolation).
 - Drives the task lifecycle state machine: `PENDING → DISPATCHED → COMPLETED | FAILED | CANCELLED`. Failed tasks with remaining retries transition to `RETRYING` before re-dispatching.
 - Executes capability invocations via `CapabilityExecutor` (HTTP-based agent call).
+- **Startup recovery:** `RecoverInFlight` re-launches all non-terminal tasks from the repository at boot, so an in-flight fan-out survives a broker restart (durable with the Postgres repo, #626).
+- **Lifecycle events (optional):** when `ZYNAX_BROKER_EVENTBUS_ADDR` is set, task transitions are published best-effort as CloudEvents on topics `zynax.v1.task-broker.task.<status>` (ADR-022).
 - Exposes `AcknowledgeTask` for agents to report outcomes; applies retry logic in the domain layer.
 - Exposes `ListTasks` for filtered, paginated queries (by workflow, status, or agent).
 
@@ -61,13 +64,16 @@ services/task-broker/
 │   │   └── handler.go               ← gRPC handler: DispatchTask, AcknowledgeTask, GetTask, ListTasks, CancelTask
 │   ├── domain/
 │   │   ├── model.go                 ← TaskStatus, Task, TaskError, AgentInfo, ListFilter, ListResult
-│   │   ├── ports.go                 ← TaskRepository, AgentFinder, CapabilityExecutor interfaces
-│   │   ├── service.go               ← TaskService: core dispatch, acknowledge, cancel, list logic
+│   │   ├── ports.go                 ← TaskRepository, AgentFinder, CapabilityExecutor, TaskEventPublisher interfaces
+│   │   ├── service.go               ← TaskService: core dispatch, acknowledge, cancel, list, startup recovery
+│   │   ├── contextslice.go          ← context-slice injection binding (ADR-028, EPIC #881 O5)
 │   │   ├── errors.go                ← ErrTaskNotFound, ErrNoEligibleAgent, ErrTaskTerminal, ErrInvalidArgument
-│   │   └── service_test.go
+│   │   ├── service_test.go
+│   │   └── contextslice_test.go     ← isolation + simulated-restart acceptance tests
 │   └── infrastructure/
 │       ├── memory_repo.go           ← in-memory TaskRepository (M5; Postgres in M6)
 │       ├── agent_executor.go        ← CapabilityExecutor: HTTP invocation of agent endpoints
+│       ├── event_publisher.go       ← TaskEventPublisher: best-effort CloudEvents to event-bus
 │       └── registry_client.go       ← AgentFinder: gRPC client for agent-registry
 ├── tests/
 │   └── features/task_broker.feature ← BDD contract scenarios
@@ -89,6 +95,7 @@ services/task-broker/
 |---------|---------|-------------|
 | `ZYNAX_BROKER_GRPC_PORT` | `50053` | gRPC listen port |
 | `ZYNAX_BROKER_REGISTRY_ADDR` | `localhost:50052` | agent-registry gRPC address |
+| `ZYNAX_BROKER_EVENTBUS_ADDR` | _(empty)_ | event-bus gRPC address; empty disables task lifecycle CloudEvents |
 | `ZYNAX_BROKER_LOG_LEVEL` | `info` | Log level: `debug`, `info`, `warn`, `error` |
 
 ---

--- a/services/task-broker/cmd/task-broker/main.go
+++ b/services/task-broker/cmd/task-broker/main.go
@@ -33,6 +33,7 @@ import (
 type config struct {
 	zynaxconfig.Base
 	RegistryAddr     string `envconfig:"REGISTRY_ADDR" default:"localhost:50052"`
+	EventBusAddr     string `envconfig:"EVENTBUS_ADDR"`
 	GRPCCallTimeoutS int    `envconfig:"GRPC_CALL_TIMEOUT_S" default:"30"`
 	TLSCert          string `envconfig:"TLS_CERT"`
 	TLSKey           string `envconfig:"TLS_KEY"`
@@ -80,21 +81,19 @@ func run(cfg config) error {
 	}
 	defer finderCleanup()
 
-	var repo domain.TaskRepository
-	if cfg.DBEnabled {
-		pgRepo, err := postgres.New(ctx, cfg.DBDSN)
-		if err != nil {
-			return fmt.Errorf("task-broker: postgres repository: %w", err)
-		}
-		defer pgRepo.Close()
-		repo = pgRepo
-		slog.Info("task-broker: using postgres repository")
-	} else {
-		repo = infrastructure.NewMemoryRepo()
-		slog.Info("task-broker: using in-memory repository")
+	repo, repoCleanup, err := newRepository(ctx, cfg)
+	if err != nil {
+		return err
 	}
+	defer repoCleanup()
 	executor := infrastructure.NewAgentExecutor(creds)
 	svc := domain.NewTaskService(repo, finder, executor)
+
+	publisherCleanup, err := attachEventPublisher(svc, cfg, callTimeout, creds)
+	if err != nil {
+		return err
+	}
+	defer publisherCleanup()
 
 	srv, healthSvc := newGRPCServer(creds, svc)
 
@@ -110,9 +109,55 @@ func run(cfg config) error {
 		}
 	}()
 
+	go recoverInFlight(ctx, svc)
+
 	<-ctx.Done()
 	gracefulShutdown(srv, healthSvc)
 	return nil
+}
+
+// newRepository selects the Postgres or in-memory TaskRepository per config.
+// The returned cleanup function must be deferred by the caller.
+func newRepository(ctx context.Context, cfg config) (domain.TaskRepository, func(), error) {
+	if !cfg.DBEnabled {
+		slog.Info("task-broker: using in-memory repository")
+		return infrastructure.NewMemoryRepo(), func() {}, nil
+	}
+	pgRepo, err := postgres.New(ctx, cfg.DBDSN)
+	if err != nil {
+		return nil, nil, fmt.Errorf("task-broker: postgres repository: %w", err)
+	}
+	slog.Info("task-broker: using postgres repository")
+	return pgRepo, func() { pgRepo.Close() }, nil
+}
+
+// attachEventPublisher wires the optional EventBus lifecycle publisher so
+// capability fan-outs are observable over the bus (EPIC #881 O5). An empty
+// address disables publication. The returned cleanup must be deferred.
+func attachEventPublisher(svc *domain.TaskService, cfg config, callTimeout time.Duration, creds credentials.TransportCredentials) (func(), error) {
+	if cfg.EventBusAddr == "" {
+		return func() {}, nil
+	}
+	publisher, cleanup, err := infrastructure.NewEventPublisher(cfg.EventBusAddr, callTimeout, creds)
+	if err != nil {
+		return nil, fmt.Errorf("task-broker: event publisher: %w", err)
+	}
+	svc.WithEventPublisher(publisher)
+	slog.Info("task-broker: publishing task events", "eventbus_addr", cfg.EventBusAddr)
+	return cleanup, nil
+}
+
+// recoverInFlight re-launches every non-terminal task left by a previous run
+// (EPIC #881 O5: a broker restart never loses an in-flight fan-out).
+func recoverInFlight(ctx context.Context, svc *domain.TaskService) {
+	n, err := svc.RecoverInFlight(ctx)
+	if err != nil {
+		slog.Warn("task recovery incomplete", "recovered", n, "err", err)
+		return
+	}
+	if n > 0 {
+		slog.Info("recovered in-flight tasks", "count", n)
+	}
 }
 
 // gracefulShutdown drains health (NOT_SERVING) before GracefulStop() so load

--- a/services/task-broker/internal/domain/contextslice.go
+++ b/services/task-broker/internal/domain/contextslice.go
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package domain
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// ContextSlice is the bounded {files[], max_tokens} context an expert
+// AgentDef declares for a capability (ADR-028, EPIC #881 O5): the expert
+// receives only its declared files, hard-capped at max_tokens.
+type ContextSlice struct {
+	Files     []string `json:"files"`
+	MaxTokens int      `json:"max_tokens"`
+}
+
+// expertTarget returns the top-level "expert" field of an input payload when
+// present and a non-empty string; anything else is not expert-targeted.
+func expertTarget(payload []byte) (string, bool) {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(payload, &fields); err != nil {
+		return "", false
+	}
+	raw, ok := fields["expert"]
+	if !ok {
+		return "", false
+	}
+	var expert string
+	if err := json.Unmarshal(raw, &expert); err != nil || expert == "" {
+		return "", false
+	}
+	return expert, true
+}
+
+// selectExpert returns the single agent whose Name (or AgentID) matches the
+// requested expert. Strict isolation (ADR-028): an expert-targeted dispatch
+// never falls back to a different provider of the same capability.
+func selectExpert(agents []AgentInfo, expert string) (AgentInfo, bool) {
+	for _, a := range agents {
+		if a.Name == expert || a.AgentID == expert {
+			return a, true
+		}
+	}
+	return AgentInfo{}, false
+}
+
+// declaredSlice extracts the context-slice declaration from a registered
+// capability input_schema (JSON Schema draft-07): the defaults of
+// properties.context_slice.properties.{files,max_tokens}. The registered
+// expert manifest is the single source of truth — slices are never inlined
+// into workflow manifests (ADR-028). Returns nil when none is declared.
+func declaredSlice(inputSchema []byte) (*ContextSlice, error) {
+	if len(inputSchema) == 0 {
+		return nil, nil
+	}
+	var schema struct {
+		Properties map[string]json.RawMessage `json:"properties"`
+	}
+	if err := json.Unmarshal(inputSchema, &schema); err != nil {
+		return nil, fmt.Errorf("parse input_schema: %w", err)
+	}
+	raw, ok := schema.Properties["context_slice"]
+	if !ok {
+		return nil, nil
+	}
+	var decl struct {
+		Properties struct {
+			Files struct {
+				Default []string `json:"default"`
+			} `json:"files"`
+			MaxTokens struct {
+				Default int `json:"default"`
+			} `json:"max_tokens"`
+		} `json:"properties"`
+	}
+	if err := json.Unmarshal(raw, &decl); err != nil {
+		return nil, fmt.Errorf("parse context_slice declaration: %w", err)
+	}
+	if decl.Properties.Files.Default == nil {
+		return nil, nil
+	}
+	return &ContextSlice{
+		Files:     decl.Properties.Files.Default,
+		MaxTokens: decl.Properties.MaxTokens.Default,
+	}, nil
+}
+
+// bindContextSlice rewrites payload so its context_slice field is exactly the
+// declared slice, or absent when the agent declares none. A caller-supplied
+// context_slice is always discarded: the registered manifest is the only
+// authority, so a caller can never plant another expert's slice into an
+// invocation — the strict-isolation enforcement point (ADR-028).
+func bindContextSlice(payload []byte, slice *ContextSlice) ([]byte, error) {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(payload, &fields); err != nil {
+		return nil, fmt.Errorf("parse input_payload: %w", err)
+	}
+	delete(fields, "context_slice")
+	if slice != nil {
+		raw, err := json.Marshal(slice)
+		if err != nil {
+			return nil, fmt.Errorf("marshal context_slice: %w", err)
+		}
+		fields["context_slice"] = raw
+	}
+	bound, err := json.Marshal(fields)
+	if err != nil {
+		return nil, fmt.Errorf("marshal input_payload: %w", err)
+	}
+	return bound, nil
+}
+
+// prepareExpertDispatch applies the context-slice injection binding (EPIC
+// #881 O5): an "expert"-keyed payload narrows the agent set to exactly that
+// expert and binds its declared slice into the payload, replacing anything
+// the caller supplied. Non-expert dispatches pass through untouched.
+func prepareExpertDispatch(payload []byte, agents []AgentInfo) ([]AgentInfo, []byte, error) {
+	expert, ok := expertTarget(payload)
+	if !ok {
+		return agents, payload, nil
+	}
+	agent, found := selectExpert(agents, expert)
+	if !found {
+		return nil, nil, fmt.Errorf("%w: no agent %q provides the requested capability", ErrNoEligibleAgent, expert)
+	}
+	slice, err := declaredSlice(agent.InputSchema)
+	if err != nil {
+		return nil, nil, fmt.Errorf("task-broker: expert %q: %w", expert, err)
+	}
+	bound, err := bindContextSlice(payload, slice)
+	if err != nil {
+		return nil, nil, fmt.Errorf("task-broker: expert %q: %w", expert, err)
+	}
+	return []AgentInfo{agent}, bound, nil
+}

--- a/services/task-broker/internal/domain/contextslice_test.go
+++ b/services/task-broker/internal/domain/contextslice_test.go
@@ -1,0 +1,399 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Context-slice injection binding tests (EPIC #881 O5, ADR-028). Acceptance:
+// (1) an expert invocation receives only its slice files (bounded max_tokens);
+// (2) isolation — no cross-expert context leakage, even via a smuggled slice;
+// (3) fan-out is durable across a simulated restart (repository-backed state).
+package domain_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/zynax-io/zynax/services/task-broker/internal/domain"
+)
+
+// recordingExecutor captures the exact input payload delivered to each agent.
+type recordingExecutor struct {
+	mu    sync.Mutex
+	calls map[string][]byte // agent ID -> input payload as executed
+}
+
+func newRecordingExecutor() *recordingExecutor {
+	return &recordingExecutor{calls: make(map[string][]byte)}
+}
+
+func (e *recordingExecutor) Execute(_ context.Context, agent domain.AgentInfo, task *domain.Task) ([]byte, *domain.TaskError, error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.calls[agent.AgentID] = append([]byte(nil), task.InputPayload...)
+	return []byte(`{"ok":true}`), nil, nil
+}
+
+func (e *recordingExecutor) payloadFor(t *testing.T, agentID string) map[string]json.RawMessage {
+	t.Helper()
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	raw, ok := e.calls[agentID]
+	if !ok {
+		t.Fatalf("agent %q was never invoked", agentID)
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		t.Fatalf("payload for %q is not a JSON object: %v", agentID, err)
+	}
+	return fields
+}
+
+// fakePublisher records every published task lifecycle event as "<id>:<status>".
+type fakePublisher struct {
+	mu     sync.Mutex
+	events []string
+}
+
+func (p *fakePublisher) PublishTaskEvent(_ context.Context, task *domain.Task) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.events = append(p.events, task.TaskID+":"+task.Status.String())
+}
+
+func (p *fakePublisher) snapshot() []string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return append([]string(nil), p.events...)
+}
+
+// expertSchema builds a registered capability input_schema declaring a context
+// slice — the shape the automation/workflows/experts/ AgentDefs register.
+func expertSchema(t *testing.T, files []string, maxTokens int) []byte {
+	t.Helper()
+	raw, err := json.Marshal(map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"trigger": map[string]any{"type": "string"},
+			"context_slice": map[string]any{
+				"type":     "object",
+				"required": []string{"files", "max_tokens"},
+				"properties": map[string]any{
+					"files":      map[string]any{"type": "array", "default": files},
+					"max_tokens": map[string]any{"type": "integer", "default": maxTokens},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal schema: %v", err)
+	}
+	return raw
+}
+
+var (
+	archSliceFiles = []string{"AGENTS.md", "docs/adr/INDEX.md", "docs/adr/*.md"}
+	qaSliceFiles   = []string{"protos/tests/**/*.feature", "coverage/**"}
+)
+
+// reviewExperts returns two expert agents both providing "review", each with
+// its own declared context slice — the isolation test pair.
+func reviewExperts(t *testing.T) map[string][]domain.AgentInfo {
+	t.Helper()
+	return map[string][]domain.AgentInfo{"review": {
+		{AgentID: "agent-arch", Name: "arch-adr", Endpoint: "localhost:9001",
+			InputSchema: expertSchema(t, archSliceFiles, 4000)},
+		{AgentID: "agent-qa", Name: "qa-bdd", Endpoint: "localhost:9002",
+			InputSchema: expertSchema(t, qaSliceFiles, 3000)},
+	}}
+}
+
+func reviewTask(payload string) *domain.Task {
+	return &domain.Task{WorkflowID: "wf-orch", CapabilityName: "review", InputPayload: []byte(payload)}
+}
+
+func sliceOf(t *testing.T, fields map[string]json.RawMessage) domain.ContextSlice {
+	t.Helper()
+	raw, ok := fields["context_slice"]
+	if !ok {
+		t.Fatalf("payload has no context_slice: %s", fields)
+	}
+	var slice domain.ContextSlice
+	if err := json.Unmarshal(raw, &slice); err != nil {
+		t.Fatalf("unmarshal context_slice: %v", err)
+	}
+	return slice
+}
+
+func assertFiles(t *testing.T, got, want []string) {
+	t.Helper()
+	if fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Fatalf("slice files = %v, want %v", got, want)
+	}
+}
+
+// ── AC1: expert invocation receives only its declared slice ───────────────
+
+func TestDispatchTask_BindsDeclaredContextSlice(t *testing.T) {
+	repo := newFakeRepo()
+	exec := newRecordingExecutor()
+	svc := domain.NewTaskService(repo, &fakeFinder{agents: reviewExperts(t)}, exec)
+
+	taskID, _, err := svc.DispatchTask(context.Background(),
+		reviewTask(`{"expert":"arch-adr","trigger":"pull_request"}`))
+	if err != nil {
+		t.Fatalf("DispatchTask: %v", err)
+	}
+	svc.WaitBackground()
+
+	payload := exec.payloadFor(t, "agent-arch")
+	slice := sliceOf(t, payload)
+	assertFiles(t, slice.Files, archSliceFiles)
+	if slice.MaxTokens != 4000 {
+		t.Errorf("max_tokens = %d, want 4000 (bounded by declaration)", slice.MaxTokens)
+	}
+	var trigger string
+	_ = json.Unmarshal(payload["trigger"], &trigger)
+	if trigger != "pull_request" {
+		t.Errorf("trigger = %q, want pull_request (non-slice fields untouched)", trigger)
+	}
+
+	// The bound payload is what was persisted: restart recovery re-dispatches
+	// the same slice (durability of the binding) — and targeting was strict.
+	stored, _ := repo.GetByID(context.Background(), taskID)
+	var storedFields map[string]json.RawMessage
+	_ = json.Unmarshal(stored.InputPayload, &storedFields)
+	assertFiles(t, sliceOf(t, storedFields).Files, archSliceFiles)
+	if stored.DispatchedTo != "agent-arch" {
+		t.Errorf("dispatched_to = %q, want agent-arch (strict expert targeting)", stored.DispatchedTo)
+	}
+}
+
+// ── AC2: strict isolation — no cross-expert context leakage ───────────────
+
+func TestDispatchTask_StrictIsolation_NoCrossExpertLeakage(t *testing.T) {
+	exec := newRecordingExecutor()
+	svc := domain.NewTaskService(newFakeRepo(), &fakeFinder{agents: reviewExperts(t)}, exec)
+
+	// A caller tries to smuggle qa-bdd's slice into the arch-adr invocation.
+	smuggled := fmt.Sprintf(`{"expert":"arch-adr","trigger":"pull_request","context_slice":{"files":[%q],"max_tokens":99999}}`,
+		qaSliceFiles[0])
+	if _, _, err := svc.DispatchTask(context.Background(), reviewTask(smuggled)); err != nil {
+		t.Fatalf("DispatchTask arch-adr: %v", err)
+	}
+	if _, _, err := svc.DispatchTask(context.Background(),
+		reviewTask(`{"expert":"qa-bdd","trigger":"pull_request"}`)); err != nil {
+		t.Fatalf("DispatchTask qa-bdd: %v", err)
+	}
+	svc.WaitBackground()
+
+	archPayload := exec.payloadFor(t, "agent-arch")
+	qaPayload := exec.payloadFor(t, "agent-qa")
+
+	// Each expert sees exactly its own declared slice (smuggled budget gone)…
+	assertFiles(t, sliceOf(t, archPayload).Files, archSliceFiles)
+	assertFiles(t, sliceOf(t, qaPayload).Files, qaSliceFiles)
+	if sliceOf(t, archPayload).MaxTokens != 4000 {
+		t.Errorf("smuggled max_tokens survived: %d", sliceOf(t, archPayload).MaxTokens)
+	}
+	// …and nothing of the other expert's slice appears anywhere in the
+	// payload (leak check over the raw bytes, both directions).
+	rawArch, _ := json.Marshal(archPayload)
+	rawQA, _ := json.Marshal(qaPayload)
+	for _, f := range qaSliceFiles {
+		if strings.Contains(string(rawArch), f) {
+			t.Errorf("arch-adr payload leaks qa-bdd slice file %q", f)
+		}
+	}
+	for _, f := range archSliceFiles {
+		if strings.Contains(string(rawQA), f) {
+			t.Errorf("qa-bdd payload leaks arch-adr slice file %q", f)
+		}
+	}
+}
+
+func TestDispatchTask_UnknownExpert_NeverFallsBack(t *testing.T) {
+	svc := domain.NewTaskService(newFakeRepo(), &fakeFinder{agents: reviewExperts(t)}, newRecordingExecutor())
+	_, _, err := svc.DispatchTask(context.Background(),
+		reviewTask(`{"expert":"security-supply-chain","trigger":"pull_request"}`))
+	if !errors.Is(err, domain.ErrNoEligibleAgent) {
+		t.Errorf("err = %v, want ErrNoEligibleAgent (strict targeting, no fallback)", err)
+	}
+}
+
+func TestDispatchTask_ExpertWithoutDeclaredSlice_StripsCallerSlice(t *testing.T) {
+	exec := newRecordingExecutor()
+	agents := map[string][]domain.AgentInfo{"review": {
+		{AgentID: "agent-plain", Name: "plain-expert", Endpoint: "localhost:9003",
+			InputSchema: []byte(`{"type":"object","properties":{"trigger":{"type":"string"}}}`)},
+	}}
+	svc := domain.NewTaskService(newFakeRepo(), &fakeFinder{agents: agents}, exec)
+
+	_, _, err := svc.DispatchTask(context.Background(),
+		reviewTask(`{"expert":"plain-expert","context_slice":{"files":["secret.md"],"max_tokens":1}}`))
+	if err != nil {
+		t.Fatalf("DispatchTask: %v", err)
+	}
+	svc.WaitBackground()
+	if _, ok := exec.payloadFor(t, "agent-plain")["context_slice"]; ok {
+		t.Error("undeclared context_slice passed through")
+	}
+}
+
+func TestDispatchTask_MalformedRegisteredSchema(t *testing.T) {
+	for name, schema := range map[string][]byte{
+		"invalid_json":     []byte(`{not json`),
+		"slice_not_object": []byte(`{"properties":{"context_slice":"not-an-object"}}`),
+	} {
+		t.Run(name, func(t *testing.T) {
+			agents := map[string][]domain.AgentInfo{"review": {
+				{AgentID: "agent-bad", Name: "bad-expert", Endpoint: "localhost:9004", InputSchema: schema},
+			}}
+			svc := domain.NewTaskService(newFakeRepo(), &fakeFinder{agents: agents}, newRecordingExecutor())
+			if _, _, err := svc.DispatchTask(context.Background(), reviewTask(`{"expert":"bad-expert"}`)); err == nil {
+				t.Fatal("expected error for malformed registered input_schema")
+			}
+		})
+	}
+}
+
+func TestDispatchTask_NonExpertPayloadUntouched(t *testing.T) {
+	// No (string) "expert" field => not expert-targeted: the payload passes
+	// through verbatim, even when it carries a context_slice.
+	for name, payload := range map[string]string{
+		"no_expert_field":   `{"text":"summarize me","context_slice":{"files":["a.md"],"max_tokens":10}}`,
+		"non_string_expert": `{"expert":42,"context_slice":{"files":["a.md"],"max_tokens":10}}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			exec := newRecordingExecutor()
+			svc := domain.NewTaskService(newFakeRepo(), &fakeFinder{agents: oneAgent()}, exec)
+			task := validTask()
+			task.InputPayload = []byte(payload)
+			if _, _, err := svc.DispatchTask(context.Background(), task); err != nil {
+				t.Fatalf("DispatchTask: %v", err)
+			}
+			svc.WaitBackground()
+			if _, ok := exec.payloadFor(t, "a1")["context_slice"]; !ok {
+				t.Error("non-targeted payload lost its context_slice field")
+			}
+		})
+	}
+}
+
+// ── AC3: fan-out durable across a simulated restart ───────────────────────
+
+func TestRecoverInFlight_SimulatedRestart(t *testing.T) {
+	repo := newFakeRepo()
+
+	// A previous broker instance dispatched a fan-out and crashed: the repo
+	// (Postgres-backed in production, #626) holds the bound non-terminal tasks.
+	boundArch := fmt.Sprintf(`{"expert":"arch-adr","context_slice":{"files":["%s"],"max_tokens":4000}}`,
+		strings.Join(archSliceFiles, `","`))
+	boundQA := fmt.Sprintf(`{"expert":"qa-bdd","context_slice":{"files":["%s"],"max_tokens":3000}}`,
+		strings.Join(qaSliceFiles, `","`))
+	seed := func(id, payload string, status domain.TaskStatus) {
+		storeTask(t, repo, &domain.Task{TaskID: id, WorkflowID: "wf", CapabilityName: "review",
+			InputPayload: []byte(payload), Status: status, MaxRetries: 2, RetryCount: 1})
+	}
+	seed("t-pending", boundArch, domain.TaskStatusPending)
+	seed("t-dispatched", boundQA, domain.TaskStatusDispatched)
+	seed("t-retrying", boundArch, domain.TaskStatusRetrying)
+	seed("t-done", `{}`, domain.TaskStatusCompleted)
+
+	// The "restarted" broker instance shares only the repository.
+	exec := newRecordingExecutor()
+	restarted := domain.NewTaskService(repo, &fakeFinder{agents: reviewExperts(t)}, exec)
+
+	n, err := restarted.RecoverInFlight(context.Background())
+	if err != nil {
+		t.Fatalf("RecoverInFlight: %v", err)
+	}
+	if n != 3 {
+		t.Fatalf("recovered = %d, want 3 (terminal tasks excluded)", n)
+	}
+	restarted.WaitBackground()
+
+	for _, id := range []string{"t-pending", "t-dispatched", "t-retrying"} {
+		task, _ := repo.GetByID(context.Background(), id)
+		if task.Status != domain.TaskStatusCompleted {
+			t.Errorf("%s: status = %s, want COMPLETED after recovery", id, task.Status)
+		}
+	}
+
+	// Strict targeting holds across the restart: the persisted bound slice
+	// reached the right expert, untouched.
+	assertFiles(t, sliceOf(t, exec.payloadFor(t, "agent-qa")).Files, qaSliceFiles)
+	archTask, _ := repo.GetByID(context.Background(), "t-pending")
+	if archTask.DispatchedTo != "agent-arch" {
+		t.Errorf("t-pending dispatched_to = %q, want agent-arch", archTask.DispatchedTo)
+	}
+}
+
+func TestRecoverInFlight_MissingExpertLeftForNextPass(t *testing.T) {
+	repo := newFakeRepo()
+	storeTask(t, repo, &domain.Task{TaskID: "t-orphan", WorkflowID: "wf", CapabilityName: "review",
+		InputPayload: []byte(`{"expert":"arch-adr"}`), Status: domain.TaskStatusPending})
+
+	svc := domain.NewTaskService(repo, &fakeFinder{agents: map[string][]domain.AgentInfo{}}, newRecordingExecutor())
+	n, err := svc.RecoverInFlight(context.Background())
+	if err != nil || n != 0 {
+		t.Fatalf("RecoverInFlight: n=%d err=%v, want 0 recovered", n, err)
+	}
+	task, _ := repo.GetByID(context.Background(), "t-orphan")
+	if task.Status != domain.TaskStatusPending {
+		t.Errorf("orphan task status = %s, want PENDING (never re-routed)", task.Status)
+	}
+}
+
+type listErrorRepo struct{ fakeRepo }
+
+func (r *listErrorRepo) List(_ context.Context, _ domain.ListFilter) (domain.ListResult, error) {
+	return domain.ListResult{}, fmt.Errorf("db unavailable")
+}
+
+func TestRecoverInFlight_RepositoryError(t *testing.T) {
+	svc := domain.NewTaskService(&listErrorRepo{fakeRepo: *newFakeRepo()}, &fakeFinder{}, &fakeExecutor{})
+	if n, err := svc.RecoverInFlight(context.Background()); err == nil || n != 0 {
+		t.Fatalf("RecoverInFlight: n=%d err=%v, want repository error surfaced", n, err)
+	}
+}
+
+// ── lifecycle events over the bus ──────────────────────────────────────────
+
+func TestDispatchTask_PublishesLifecycleEvents(t *testing.T) {
+	pub := &fakePublisher{}
+	svc := domain.NewTaskService(newFakeRepo(), &fakeFinder{agents: reviewExperts(t)}, newRecordingExecutor()).
+		WithEventPublisher(pub)
+
+	taskID, _, err := svc.DispatchTask(context.Background(), reviewTask(`{"expert":"qa-bdd"}`))
+	if err != nil {
+		t.Fatalf("DispatchTask: %v", err)
+	}
+	svc.WaitBackground()
+
+	want := fmt.Sprint([]string{taskID + ":DISPATCHED", taskID + ":COMPLETED"})
+	if got := fmt.Sprint(pub.snapshot()); got != want {
+		t.Errorf("events = %v, want %v", got, want)
+	}
+}
+
+func TestAckAndCancel_PublishEvents(t *testing.T) {
+	repo := newFakeRepo()
+	pub := &fakePublisher{}
+	svc := domain.NewTaskService(repo, &fakeFinder{}, &fakeExecutor{}).WithEventPublisher(pub)
+	storeTask(t, repo, dispatched("ack-ev"))
+	storeTask(t, repo, &domain.Task{TaskID: "c-ev", WorkflowID: "wf", CapabilityName: "cap",
+		InputPayload: []byte(`{}`), Status: domain.TaskStatusPending})
+
+	if _, err := svc.AcknowledgeTask(context.Background(), "ack-ev", domain.TaskStatusCompleted, []byte(`{"r":1}`), nil); err != nil {
+		t.Fatalf("AcknowledgeTask: %v", err)
+	}
+	if _, err := svc.CancelTask(context.Background(), "c-ev"); err != nil {
+		t.Fatalf("CancelTask: %v", err)
+	}
+	want := fmt.Sprint([]string{"ack-ev:COMPLETED", "c-ev:CANCELLED"})
+	if got := fmt.Sprint(pub.snapshot()); got != want {
+		t.Errorf("events = %v, want %v", got, want)
+	}
+}

--- a/services/task-broker/internal/domain/model.go
+++ b/services/task-broker/internal/domain/model.go
@@ -71,7 +71,12 @@ type TaskError struct {
 // AgentInfo carries the routing information needed to invoke an agent.
 type AgentInfo struct {
 	AgentID  string
+	Name     string
 	Endpoint string
+	// InputSchema is the registered JSON Schema (draft-07) of the requested
+	// capability. The dispatch-time context-slice injection binding (ADR-028,
+	// EPIC #881 O5) reads the declared {files[], max_tokens} defaults from it.
+	InputSchema []byte
 }
 
 // ListFilter specifies the criteria for a ListTasks call.

--- a/services/task-broker/internal/domain/ports.go
+++ b/services/task-broker/internal/domain/ports.go
@@ -22,3 +22,12 @@ type AgentFinder interface {
 type CapabilityExecutor interface {
 	Execute(ctx context.Context, agent AgentInfo, task *Task) (resultPayload []byte, taskErr *TaskError, err error)
 }
+
+// TaskEventPublisher publishes task lifecycle events to the event bus so a
+// parallel capability fan-out is observable and collectable over the bus
+// (ADR-022, EPIC #881 O5). Publication is best-effort: implementations must
+// not block task progress and must swallow (log) delivery errors — event-bus
+// unavailability never fails a task.
+type TaskEventPublisher interface {
+	PublishTaskEvent(ctx context.Context, task *Task)
+}

--- a/services/task-broker/internal/domain/service.go
+++ b/services/task-broker/internal/domain/service.go
@@ -20,6 +20,7 @@ type TaskService struct {
 	repo      TaskRepository
 	finder    AgentFinder
 	executor  CapabilityExecutor
+	publisher TaskEventPublisher
 	bg        sync.WaitGroup
 	nextAgent atomic.Uint64
 }
@@ -27,6 +28,14 @@ type TaskService struct {
 // NewTaskService constructs a TaskService with the given port implementations.
 func NewTaskService(repo TaskRepository, finder AgentFinder, executor CapabilityExecutor) *TaskService {
 	return &TaskService{repo: repo, finder: finder, executor: executor}
+}
+
+// WithEventPublisher attaches a best-effort lifecycle event publisher so the
+// capability fan-out is observable over the event bus (EPIC #881 O5). A nil
+// publisher disables publication. Returns s for chaining.
+func (s *TaskService) WithEventPublisher(p TaskEventPublisher) *TaskService {
+	s.publisher = p
+	return s
 }
 
 // DispatchTask validates the request, records the task as PENDING, and launches
@@ -49,6 +58,17 @@ func (s *TaskService) DispatchTask(ctx context.Context, task *Task) (taskID stri
 	if len(agents) == 0 {
 		return "", time.Time{}, fmt.Errorf("%w: no agent registered for capability %q", ErrNoEligibleAgent, task.CapabilityName)
 	}
+
+	// Context-slice injection binding (ADR-028, EPIC #881 O5): an
+	// expert-targeted payload is narrowed to exactly that expert and rewritten
+	// to carry only its declared slice. Binding happens before Save so the
+	// persisted payload — and therefore any restart recovery — carries the
+	// bound slice durably.
+	agents, boundPayload, err := prepareExpertDispatch(task.InputPayload, agents)
+	if err != nil {
+		return "", time.Time{}, err
+	}
+	task.InputPayload = boundPayload
 
 	task.TaskID = newTaskID()
 	task.Status = TaskStatusPending
@@ -96,6 +116,7 @@ func (s *TaskService) AcknowledgeTask(ctx context.Context, taskID string, newSta
 	if err := s.repo.Update(ctx, task); err != nil {
 		return 0, fmt.Errorf("task-broker: update: %w", err)
 	}
+	s.publishEvent(ctx, task)
 	return resulting, nil
 }
 
@@ -137,7 +158,83 @@ func (s *TaskService) CancelTask(ctx context.Context, taskID string) (time.Time,
 	if err := s.repo.Update(ctx, task); err != nil {
 		return time.Time{}, fmt.Errorf("task-broker: update: %w", err)
 	}
+	s.publishEvent(ctx, task)
 	return task.CompletedAt, nil
+}
+
+// recoveryPageSize is the repository page size used by startup recovery.
+const recoveryPageSize = 100
+
+// RecoverInFlight re-launches execution for every non-terminal task in the
+// repository, called once at startup so a broker restart never loses an
+// in-flight fan-out (EPIC #881 O5): task state — including the context slice
+// bound into input_payload at original dispatch time — is durable in the
+// repository (#626 Postgres-backed). Returns the number of tasks re-launched.
+func (s *TaskService) RecoverInFlight(ctx context.Context) (int, error) {
+	recovered := 0
+	for _, status := range []TaskStatus{TaskStatusPending, TaskStatusDispatched, TaskStatusRetrying} {
+		n, err := s.recoverByStatus(ctx, status)
+		recovered += n
+		if err != nil {
+			return recovered, err
+		}
+	}
+	return recovered, nil
+}
+
+func (s *TaskService) recoverByStatus(ctx context.Context, status TaskStatus) (int, error) {
+	recovered := 0
+	token := ""
+	for {
+		page, err := s.repo.List(ctx, ListFilter{Status: status, PageToken: token, PageSize: recoveryPageSize})
+		if err != nil {
+			return recovered, fmt.Errorf("task-broker: recover list %s tasks: %w", status, err)
+		}
+		for _, task := range page.Tasks {
+			if s.relaunch(ctx, task) {
+				recovered++
+			}
+		}
+		if page.NextPageToken == "" {
+			return recovered, nil
+		}
+		token = page.NextPageToken
+	}
+}
+
+// relaunch resolves the eligible agents for a recovered task and restarts its
+// async execution. The persisted payload already carries the slice bound at
+// original dispatch time — no re-binding; expert targeting is re-applied for
+// routing, and a task targeted at a now-missing expert is left untouched
+// (never re-routed) for a later recovery pass.
+func (s *TaskService) relaunch(ctx context.Context, task *Task) bool {
+	agents, err := s.finder.FindByCapability(ctx, task.CapabilityName)
+	if err != nil || len(agents) == 0 {
+		return false
+	}
+	if expert, ok := expertTarget(task.InputPayload); ok {
+		agent, found := selectExpert(agents, expert)
+		if !found {
+			return false
+		}
+		agents = []AgentInfo{agent}
+	}
+	s.bg.Add(1)
+	go func() {
+		defer s.bg.Done()
+		s.executeAsync(detach(ctx), task.TaskID, agents)
+	}()
+	return true
+}
+
+// publishEvent forwards a task snapshot to the lifecycle event publisher.
+// No-op when unset; best-effort by port contract, never affects task state.
+func (s *TaskService) publishEvent(ctx context.Context, task *Task) {
+	if s.publisher == nil {
+		return
+	}
+	snapshot := *task
+	s.publisher.PublishTaskEvent(ctx, &snapshot)
 }
 
 // WaitBackground blocks until all goroutines launched by DispatchTask have finished.
@@ -158,6 +255,7 @@ func (s *TaskService) executeAsync(ctx context.Context, taskID string, agents []
 	if err := s.repo.Update(ctx, task); err != nil {
 		return
 	}
+	s.publishEvent(ctx, task)
 
 	resultPayload, taskErr, execErr := s.executor.Execute(ctx, agent, task)
 
@@ -174,7 +272,9 @@ func (s *TaskService) executeAsync(ctx context.Context, taskID string, agents []
 	} else {
 		s.applyAcknowledgement(task, TaskStatusCompleted, resultPayload, nil)
 	}
-	_ = s.repo.Update(ctx, task)
+	if err := s.repo.Update(ctx, task); err == nil {
+		s.publishEvent(ctx, task)
+	}
 }
 
 func (s *TaskService) applyAcknowledgement(task *Task, newStatus TaskStatus, resultPayload []byte, taskErr *TaskError) TaskStatus {

--- a/services/task-broker/internal/infrastructure/event_publisher.go
+++ b/services/task-broker/internal/infrastructure/event_publisher.go
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package infrastructure
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/zynax-io/zynax/libs/zynaxobs"
+	zynaxv1 "github.com/zynax-io/zynax/protos/generated/go/zynax/v1"
+	"github.com/zynax-io/zynax/services/task-broker/internal/domain"
+)
+
+// EventBusClient is the minimal interface this package requires for publishing
+// task lifecycle events. It is satisfied by the generated
+// zynaxv1.EventBusServiceClient and can be replaced with a test stub.
+type EventBusClient interface {
+	Publish(ctx context.Context, in *zynaxv1.PublishRequest, opts ...grpc.CallOption) (*zynaxv1.PublishResponse, error)
+}
+
+// taskTopicPrefix is the task-broker entity prefix per the platform topic
+// taxonomy "zynax.<version>.<service>.<entity>.<event_type>" (root AGENTS.md).
+const taskTopicPrefix = "zynax.v1.task-broker.task."
+
+// EventPublisher implements domain.TaskEventPublisher over EventBusService.
+// Publication is best-effort by port contract: errors are logged and counted
+// (Prometheus) but never propagated, so event-bus unavailability never fails
+// a task (mirrors the engine-adapter lifecycle publisher).
+type EventPublisher struct {
+	client      EventBusClient
+	callTimeout time.Duration
+}
+
+// NewEventPublisher dials the event bus and returns a TaskEventPublisher.
+// callTimeout is the per-call Publish deadline; creds controls transport
+// security. The returned cleanup closes the connection (defer it).
+func NewEventPublisher(addr string, callTimeout time.Duration, creds credentials.TransportCredentials) (*EventPublisher, func(), error) {
+	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(creds))
+	if err != nil {
+		return nil, func() {}, fmt.Errorf("task-broker: event-bus dial: %w", err)
+	}
+	return &EventPublisher{
+		client:      zynaxv1.NewEventBusServiceClient(conn),
+		callTimeout: callTimeout,
+	}, func() { _ = conn.Close() }, nil
+}
+
+// PublishTaskEvent emits one CloudEvent for a task lifecycle transition.
+// Topic format: zynax.v1.task-broker.task.<status> (e.g. ".dispatched",
+// ".completed", ".failed") so a workflow fan-out is observable and
+// collectable over the durable bus (ADR-022, EPIC #881 O5).
+func (p *EventPublisher) PublishTaskEvent(ctx context.Context, task *domain.Task) {
+	eventType := taskTopicPrefix + strings.ToLower(task.Status.String())
+
+	id, err := newRequestID()
+	if err != nil {
+		p.warn(eventType, task, err)
+		return
+	}
+	data, err := json.Marshal(map[string]string{
+		"task_id":         task.TaskID,
+		"workflow_id":     task.WorkflowID,
+		"capability_name": task.CapabilityName,
+		"status":          task.Status.String(),
+		"dispatched_to":   task.DispatchedTo,
+	})
+	if err != nil {
+		p.warn(eventType, task, err)
+		return
+	}
+
+	callCtx, cancel := context.WithTimeout(ctx, p.callTimeout)
+	defer cancel()
+	_, err = p.client.Publish(callCtx, &zynaxv1.PublishRequest{
+		Event: &zynaxv1.CloudEvent{
+			Id:              id,
+			Source:          "/zynax/task-broker/" + task.WorkflowID,
+			Specversion:     "1.0",
+			Type:            eventType,
+			Datacontenttype: "application/json",
+			Subject:         task.TaskID,
+			Time:            timestamppb.New(time.Now()),
+			Data:            data,
+			WorkflowId:      task.WorkflowID,
+			CapabilityName:  task.CapabilityName,
+		},
+	})
+	if err != nil {
+		p.warn(eventType, task, err)
+	}
+}
+
+func (p *EventPublisher) warn(eventType string, task *domain.Task, err error) {
+	zynaxobs.EventPublishFailed(eventType)
+	slog.Warn("task event publish failed",
+		"event_type", eventType,
+		"task_id", task.TaskID,
+		"workflow_id", task.WorkflowID,
+		"err", err,
+	)
+}

--- a/services/task-broker/internal/infrastructure/event_publisher_test.go
+++ b/services/task-broker/internal/infrastructure/event_publisher_test.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package infrastructure
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+
+	zynaxv1 "github.com/zynax-io/zynax/protos/generated/go/zynax/v1"
+	"github.com/zynax-io/zynax/services/task-broker/internal/domain"
+)
+
+type capturingBusClient struct {
+	requests []*zynaxv1.PublishRequest
+	err      error
+}
+
+func (c *capturingBusClient) Publish(_ context.Context, in *zynaxv1.PublishRequest, _ ...grpc.CallOption) (*zynaxv1.PublishResponse, error) {
+	c.requests = append(c.requests, in)
+	return &zynaxv1.PublishResponse{EventId: "ev-1"}, c.err
+}
+
+func TestPublishTaskEvent(t *testing.T) {
+	task := &domain.Task{TaskID: "task-42", WorkflowID: "wf-orch", CapabilityName: "review",
+		Status: domain.TaskStatusDispatched, DispatchedTo: "agent-arch"}
+
+	bus := &capturingBusClient{}
+	p := &EventPublisher{client: bus, callTimeout: time.Second}
+	p.PublishTaskEvent(context.Background(), task)
+
+	if len(bus.requests) != 1 {
+		t.Fatalf("publish calls = %d, want 1", len(bus.requests))
+	}
+	ev := bus.requests[0].GetEvent()
+	if got, want := ev.GetType(), "zynax.v1.task-broker.task.dispatched"; got != want {
+		t.Errorf("type = %q, want %q", got, want)
+	}
+	if ev.GetSubject() != "task-42" || ev.GetWorkflowId() != "wf-orch" || ev.GetCapabilityName() != "review" {
+		t.Errorf("subject/workflow/capability = %q/%q/%q", ev.GetSubject(), ev.GetWorkflowId(), ev.GetCapabilityName())
+	}
+	if ev.GetId() == "" || ev.GetSpecversion() != "1.0" || len(ev.GetData()) == 0 {
+		t.Errorf("incomplete CloudEvent envelope: %+v", ev)
+	}
+
+	// Best-effort by port contract: a bus error must not panic or propagate.
+	failing := &EventPublisher{client: &capturingBusClient{err: fmt.Errorf("bus down")}, callTimeout: time.Second}
+	failing.PublishTaskEvent(context.Background(), task)
+}

--- a/services/task-broker/internal/infrastructure/registry_client.go
+++ b/services/task-broker/internal/infrastructure/registry_client.go
@@ -47,10 +47,21 @@ func (r *registryClient) FindByCapability(ctx context.Context, capabilityName st
 	}
 	agents := make([]domain.AgentInfo, len(resp.GetAgents()))
 	for i, a := range resp.GetAgents() {
-		agents[i] = domain.AgentInfo{
+		info := domain.AgentInfo{
 			AgentID:  a.GetAgentId(),
+			Name:     a.GetName(),
 			Endpoint: a.GetEndpoint(),
 		}
+		// Carry the registered input_schema of the requested capability so the
+		// domain layer can bind the declared context slice at dispatch time
+		// (ADR-028, EPIC #881 O5).
+		for _, c := range a.GetCapabilities() {
+			if c.GetName() == capabilityName {
+				info.InputSchema = c.GetInputSchema()
+				break
+			}
+		}
+		agents[i] = info
 	}
 	return agents, nil
 }

--- a/state/current-milestone.md
+++ b/state/current-milestone.md
@@ -58,7 +58,7 @@ As of 2026-06-11: **143 issues closed / 17 open** (CI-overhaul stories #1110–#
 **e2e-green execution path (#1086 — O1 #1087 ✅ / O2 #1088 ✅ merged via PR #1095; O3 #1089 ✅ satisfied by build-images gate PR #1132; O4 #1090 ✅ event-bus + memory-service enabled with required assertions; O5 #1091 ✅ runner sizing verified on full stack; bug #1149 ✅ fixed — JetStream subject overlap, completed/failed CloudEvent assertions now required — O6 #1092 ✅ temporal leg required + skip-shim; argo advisory until stable — EPIC #1086 complete)**,
 Postgres off Bitnami (#1073 — ✅ complete: O1 ADR-026, O2–O3 #1076, O4–O5 #1077, O6 #1078, O7–O8 #1079; canvas Implemented, EPIC ready to close),
 CI-E2E gate (#771 — #1070 ✅, #1071 ✅ merged via PR #1155: engine matrix temporal/argo in e2e-smoke; bug #1157 ✅ fixed — ArgoEngine submit now sends the WorkflowCreateRequest envelope, argo leg unblocked; #1092 ✅ — EPIC #771 complete),
-DevAuto Wave 4 (#881 — canvas Aligned, stories #1096–#1104 created; O1 #1096 ✅ ADR-028; O2 #1097 ✅ 9 expert AgentDefs; O3 #1098 ✅ orchestrator Workflow manifest; O4 #1099 ✅ issue-delivery intake→plan→route Workflow).
+DevAuto Wave 4 (#881 — canvas Aligned, stories #1096–#1104 created; O1 #1096 ✅ ADR-028; O2 #1097 ✅ 9 expert AgentDefs; O3 #1098 ✅ orchestrator Workflow manifest; O4 #1099 ✅ issue-delivery intake→plan→route Workflow; O5 #1100 ✅ context-slice injection binding in task-broker; next: O6 #1101 delivery leg).
 
 ---
 
@@ -302,7 +302,7 @@ Canvas: SPDD-exempt (docs:/chore:/ci: stories only, until Wave 4 #881 which is B
 | DevAuto.5 ci: Wave 1 orchestrator aggregation | [#878](https://github.com/zynax-io/zynax/issues/878) | ⬜ Ready |
 | DevAuto.6 ci: Wave 2 | [#879](https://github.com/zynax-io/zynax/issues/879) | ⬜ Pending |
 | DevAuto.7 ci: Wave 3 | [#880](https://github.com/zynax-io/zynax/issues/880) | ⬜ Pending |
-| DevAuto.8 feat: Wave 4 aspirational | [#881](https://github.com/zynax-io/zynax/issues/881) | 🔄 In progress — O1 [#1096](https://github.com/zynax-io/zynax/issues/1096) ✅ (ADR-028); O2 [#1097](https://github.com/zynax-io/zynax/issues/1097) ✅ (9 expert AgentDefs); O3 [#1098](https://github.com/zynax-io/zynax/issues/1098) ✅ (orchestrator Workflow); O4 [#1099](https://github.com/zynax-io/zynax/issues/1099) ✅ (issue-delivery intake→plan→route); O5–O9 #1100–#1104 |
+| DevAuto.8 feat: Wave 4 aspirational | [#881](https://github.com/zynax-io/zynax/issues/881) | 🔄 In progress — O1 [#1096](https://github.com/zynax-io/zynax/issues/1096) ✅ (ADR-028); O2 [#1097](https://github.com/zynax-io/zynax/issues/1097) ✅ (9 expert AgentDefs); O3 [#1098](https://github.com/zynax-io/zynax/issues/1098) ✅ (orchestrator Workflow); O4 [#1099](https://github.com/zynax-io/zynax/issues/1099) ✅ (issue-delivery intake→plan→route); O5 [#1100](https://github.com/zynax-io/zynax/issues/1100) ✅ (context-slice injection binding); O6–O9 #1101–#1104 |
 | DevAuto.9 test: xfail gate | [#882](https://github.com/zynax-io/zynax/issues/882) | ⬜ Pending |
 | DevAuto.10 docs: AGENTS.md pointer + README | [#883](https://github.com/zynax-io/zynax/issues/883) | ⬜ Pending |
 


### PR DESCRIPTION
## Summary

EPIC #881 O5 ([canvas](docs/spdd/881-self-hosted-issue-delivery/canvas.md), ADR-028):
the runtime binding that feeds one expert AgentDef **only** its declared
`context_slice` — the on-platform analogue of injecting one expert prompt
into a fresh subagent. Implemented in task-broker's domain layer, where
dispatch happens (per ADR-028 §Transport: "the slice is bound at dispatch
time into the capability input_payload, routed by the task broker over the
EventBus").

- **Binding:** a `review` dispatch whose payload carries `"expert": "<name>"`
  (exactly how `dev-advisory-orchestrator.yaml` keys its fan-out) is routed to
  exactly that agent and its registry-declared `{files[], max_tokens}` slice
  (the `context_slice` defaults in the registered capability `input_schema` —
  the expert manifests stay the single source of truth) is bound into
  `input_payload` **before persistence**, replacing anything the caller sent.
- **Strict isolation (ADR-028):** caller-supplied `context_slice` is always
  discarded; an unknown expert returns `ErrNoEligibleAgent` (never falls back
  to a different provider); non-expert dispatches pass through untouched
  (backward compatible).
- **Durable fan-out:** `RecoverInFlight` (called at startup) re-launches all
  PENDING/DISPATCHED/RETRYING tasks from the repository — on the Postgres repo
  (#626) an in-flight fan-out survives a broker restart, resuming from the
  persisted bound payload.
- **Over EventBus (#772):** task lifecycle CloudEvents on topics
  `zynax.v1.task-broker.task.<dispatched|completed|failed|cancelled>` are
  published best-effort when `ZYNAX_BROKER_EVENTBUS_ADDR` is set (engine-adapter
  publisher pattern; failures logged + counted, never fail a task).

No proto changes; the gRPC contract is untouched (`input_payload` is opaque
JSON). BDD spec for this behaviour was committed contract-first in O3 (#1098):
`automation/tests/features/dev_advisory_orchestrator.feature`, scenario
"Each expert receives only its own bounded context slice".

## Acceptance criteria (issue #1100)

- [x] **An expert invocation receives only its slice files (bounded by
  `max_tokens`)** — `TestDispatchTask_BindsDeclaredContextSlice`: the executed
  and persisted payloads carry exactly the declared files and budget.
- [x] **Isolation test proves no cross-expert context leakage** —
  `TestDispatchTask_StrictIsolation_NoCrossExpertLeakage`: a payload smuggling
  qa-bdd's slice into an arch-adr dispatch is rewritten; raw-byte leak check in
  both directions; smuggled token budget removed. Plus
  `TestDispatchTask_UnknownExpert_NeverFallsBack` and
  `TestDispatchTask_ExpertWithoutDeclaredSlice_StripsCallerSlice`.
- [x] **Fan-out is durable across a simulated restart (Postgres-backed
  state)** — `TestRecoverInFlight_SimulatedRestart`: a second TaskService
  sharing only the repository recovers 3 non-terminal tasks (terminal
  excluded) to COMPLETED with bound slices intact and strict targeting held;
  `TestRecoverInFlight_MissingExpertLeftForNextPass` proves a task is never
  re-routed. The repository port is the existing #626 Postgres-backed repo
  (List/status filters already integration-tested).

## Test plan

- `GOWORK=off go test ./... -race -timeout 60s` in `services/task-broker/` — PASS
- domain coverage **92.1%** (≥90% gate, ADR-016)
- BDD contract tests `protos/tests/task_broker_service/` — PASS
- `make lint` — PASS · `make validate-spec` — PASS
- `make security` — govulncheck 0 affected, bandit clean; pip-audit fails only
  on the known pre-existing pip 26.1.1 / PYSEC-2026-196 finding (unrelated)
- `python3 -m pytest automation/tests/` — 77 passed, 1 xfailed (the O8
  platform-readiness xfail, unchanged by design)

## Size

~894 countable lines (size/L, over the 400 soft limit): the acceptance
criteria mandate dedicated isolation + simulated-restart test suites
(`contextslice_test.go`, 399 lines) which dominate the diff; runtime code is
~250 lines across domain/infrastructure/wiring. Splitting tests from the
binding would break the canvas O5 "one reviewable PR" contract.

Assisted-by: Claude/claude-fable-5
