### PR TITLE
chore(release): close M6 — v0.5.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,7 +114,7 @@ Full guide: `docs/patterns/spdd-guide.md` · Template: `docs/spdd/CANVAS_TEMPLAT
 | **M3** (Partial) | Temporal-backed `EngineAdapterService` — `WorkflowEngine` interface, `IRInterpreterWorkflow`, `DispatchCapabilityActivity`, `TemporalEngine`, gRPC wiring | Other engine adapters, K8s deployment · task-broker delivered later in M5.C |
 | **M4** (Partial) | api-gateway REST layer, `zynax` CLI, `kind: AgentDef` routing, Docker Compose runner, GitOps watch | Observability, production hardening · agent-registry delivered later in M5.C |
 | **M5** (Complete, v0.4.0) | M5.A docs alignment, M5.B engine fixes, M5.C capability dispatch (task-broker, agent-registry), M5.D security baseline, M5.E DX polish, all 5 adapters, e2e-demo | Persistence, K8s deployment, event-bus (all delivered in M6) |
-| **M6** (Active) | K8s production-readiness: mTLS, supply-chain hardening, Postgres-backed repos, Helm charts, EventBus over NATS, images.yaml SoT, memory-service, ArgoEngine, multi-namespace, policy/rate-limit, SDK on PyPI, e2e harness, multi-arch builds, gRPC health, Prometheus /metrics | M7 observability (OTel), M8 CNCF submission |
+| **M6** (Complete, v0.5.0) | K8s production-readiness: mTLS, supply-chain hardening, Postgres-backed repos, Helm charts, EventBus over NATS, images.yaml SoT, memory-service, ArgoEngine, multi-namespace, policy/rate-limit, SDK on PyPI, e2e harness, multi-arch builds, gRPC health, Prometheus /metrics | M7 observability (OTel), M8 CNCF submission |
 
 ## AI Anti-Patterns
 

--- a/README.md
+++ b/README.md
@@ -374,7 +374,7 @@ make test        # full suite (unit + BDD + coverage gate)
 
 ## Milestone Status
 
-Active milestone: **M6 — K8s Production-Ready** 🚧 — live status in
+Latest release: **v0.5.0 — K8s Production-Ready (M6 ✅)** · next milestone not yet open — live status in
 [state/current-milestone.md](state/current-milestone.md) · milestone goals and sequence in
 [ROADMAP.md](ROADMAP.md).
 

--- a/state/current-milestone.md
+++ b/state/current-milestone.md
@@ -17,7 +17,7 @@
 | M3 — Temporal Execution | ⚠ Partial | v0.2.0 |
 | M4 — YAML System + CLI | ⚠ Partial | v0.3.0 |
 | **M5 — Adapter Library** | ✅ **Complete** | **v0.4.0** |
-| **M6 — K8s Production-Ready** | 🚧 **Active** | — |
+| **M6 — K8s Production-Ready** | ✅ **Complete** | **v0.5.0** |
 
 M3/M4 are partial because task-broker and agent-registry were not delivered in those milestones.
 Both completed under M5.C (#460). CloudEvents publishing is log-only (not wired to NATS).
@@ -27,7 +27,10 @@ See [docs/milestones/M5-plan.md](../docs/milestones/M5-plan.md).
 
 ---
 
-## M6 — Progress (🚧 Active)
+## M6 — Complete (✅ released v0.5.0, 2026-06-12)
+
+GitHub milestone #6 closed; all 8 EPICs and every story delivered (one deferral: Wave 4 O8 → M7 #1103).
+Release: https://github.com/zynax-io/zynax/releases/tag/v0.5.0 · Next milestone: not yet open — run /milestone-new (M7 — Full Observability).
 
 Full plan + per-EPIC status: **[docs/milestones/M6-planning.md](../docs/milestones/M6-planning.md)**.
 As of 2026-06-11: **143 issues closed / 17 open** (CI-overhaul stories #1110–#1122 added 2026-06-10).
@@ -116,7 +119,7 @@ up but fails at the happy-path assertion; this epic closes the execution-path ga
 
 ---
 
-## M6 — Active Work
+## M6 — Final Work Log (historical)
 
 ### M6.A Health Probe Semantics (#463) — ✅ COMPLETE
 

--- a/state/milestone.yaml
+++ b/state/milestone.yaml
@@ -8,19 +8,20 @@
 # Validated against state/milestone.schema.json by `make validate-milestone-state`
 # (containerized) and by the advisory milestone-state-check job in pr-checks.yml.
 
+# M6 closed 2026-06-12 — released as v0.5.0. status: complete means no work may
+# be claimed against it; run /milestone-new to scaffold the next milestone
+# (M7 — Full Observability, GitHub milestone #7 already exists) — it rotates
+# this block into history.
 active:
   name: M6
   title: "K8s Production-Ready"
   github_milestone_number: 6
   version: v0.5.0
-  status: active # active | closing | complete
+  status: complete # active | closing | complete — released 2026-06-12 as v0.5.0
   planning_doc: docs/milestones/M6-planning.md
   labels:
     milestone: "milestone: M6"
-  # Static hint only — commands re-query the live list at runtime when GH_TOKEN
-  # is available (gh issue list --milestone <title> --label "type: epic"
-  # --state open) and fall back to this list offline.
-  open_epics: [771, 873, 881, 1073, 1086, 1107, 1108, 1109]
+  open_epics: []
 
 history:
   - name: M5


### PR DESCRIPTION
Rotates the milestone state after the v0.5.0 release: `state/milestone.yaml` active block → `status: complete` (history rotation happens in /milestone-new), README/CLAUDE.md/current-milestone.md headers flipped to Complete.

Release: https://github.com/zynax-io/zynax/releases/tag/v0.5.0 (25 assets, 14 images promoted+signed) · GitHub milestone #6 closed · all 8 EPICs delivered · one recorded deferral: Wave 4 O8 → M7 #1103.

`make validate-milestone-state` — green locally.

Assisted-by: Claude/claude-fable-5