### PR TITLE
fix(infra): repair corrupt merge artifact in docker-compose.yml

### DIFF
--- a/infra/docker-compose/docker-compose.yml
+++ b/infra/docker-compose/docker-compose.yml
@@ -274,27 +274,8 @@ services:
       workflow-compiler:
         condition: service_healthy
       event-bus:
-    image: ghcr.io/zynax-io/zynax/event-bus:main
-    build:
-      context: ../..
-      dockerfile: infra/docker/Dockerfile.service
-      args:
-        SVC: event-bus
-    environment:
-      ZYNAX_EVENTBUS_GRPC_PORT: "50056"
-      ZYNAX_EVENTBUS_LOG_LEVEL: info
-      ZYNAX_EVENTBUS_NATS_URL: "nats://nats:4222"
-    depends_on:
-      nats:
         condition: service_healthy
-    healthcheck:
-      test: ["CMD", "/healthcheck", "tcp://localhost:50056"]
-      interval: 10s
-      timeout: 5s
-      retries: 10
-      start_period: 15s
-
-  engine-adapter:
+      engine-adapter:
         condition: service_healthy
       agent-registry:
         condition: service_healthy


### PR DESCRIPTION
## What

The local-stack compose file (`infra/docker-compose/docker-compose.yml`) contained a corrupt merge artifact: the `api-gateway` block had the entire `event-bus` service definition embedded inside its `depends_on`, followed by an orphaned `engine-adapter:` fragment that held only the tail of `api-gateway`'s `depends_on` + healthcheck.

## Impact

`docker compose config` failed to parse the file, so `make run-local` / `make dev-up` were broken — the whole local development stack could not start.

## Fix

Reconstructed `api-gateway`'s `depends_on` (workflow-compiler, event-bus, engine-adapter, agent-registry — all `service_healthy`) and its `/readyz` healthcheck from the surrounding context and the duplicated fragments. The legitimate `event-bus` and `engine-adapter` service blocks already existed earlier in the file and were untouched.

## Verification

- `docker compose -f infra/docker-compose/docker-compose.yml config` — parses clean
- `make run-local` — full 13-container stack reaches healthy; `POST /api/v1/apply` with `e2e-demo.yaml` runs to `WORKFLOW_STATUS_COMPLETED`

🤖 Generated with [Claude Code](https://claude.com/claude-code)