### PR TITLE
chore(release): open M7 — Usable Workflows + Observability

### DIFF
--- a/docs/adr/ADR-029-workflow-data-flow.md
+++ b/docs/adr/ADR-029-workflow-data-flow.md
@@ -1,0 +1,45 @@
+# ADR-029: Workflow data-flow semantics (output/input bindings)
+
+**Status:** Proposed  **Date:** 2026-06-15
+**Related:** ADR-012 (Workflow IR), ADR-014 (event-driven state machine), ADR-015 (pluggable engines)
+
+---
+
+## Context
+
+Workflows are event-driven state machines (ADR-014) compiled to a WorkflowIR (ADR-012). Today the
+compiler **rejects** `output:` on actions (`"output: which is not yet implemented; … upgrade to M7+"`),
+so no state can pass data to a later state. Every real pipeline — research→summarize, build→test→deploy
+— is inexpressible. M7's central goal ("make Zynax usable for real workflows") requires a data-flow
+model, but an over-rich expression language would be a large, hard-to-reverse one-way door on the proto
+contract. This ADR fixes the **minimal** model.
+
+## Decision
+
+We will add a **minimal, additive** data-flow model to the WorkflowIR:
+
+1. **`output_bindings`** on an action — named outputs an action publishes into a workflow-scoped data context.
+2. **`input_bindings`** on an action — inputs resolved from the data context by **literal value** or
+   **JSON-path reference** (e.g. `$.states.search.output.results`).
+3. A **workflow-run-scoped `WorkflowDataContext`** owned by the interpreter; written by outputs, read by inputs;
+   it does **not** persist beyond the run.
+4. Bindings are **literal or path references only** — **no expression/transform language** in M7.
+
+Proto fields are additive; manifests without bindings compile unchanged. `buf breaking` must pass.
+
+## Rationale
+
+| Option | Assessment |
+|--------|------------|
+| Minimal literal/path bindings (chosen) | ✅ Smallest contract that unblocks real workflows; additive; reversible-ish |
+| Full expression language (CEL/JSONata) | ✗ Deferred to M-dx — large surface, security review burden, premature |
+| Implicit shared state between states | ✗ Rejected — violates explicit-scoping; collides with ADR-008 spirit (no shared mutable state) |
+
+## Consequences
+
+- **Positive:** real multi-step workflows become expressible; the long-standing "not implemented"
+  rejection is lifted; trace/log correlation (EPIC C/O) has real data to follow.
+- **Negative / trade-off:** path references are stringly-typed; validation must catch unresolved refs
+  at compile time (clear `COMPILATION_ERROR` with line number).
+- **Neutral / follow-up:** transforms/filters and typed schemas for the data context are deferred to
+  M-dx; this ADR will be revisited if/when an expression language is added.

--- a/docs/adr/ADR-030-observability-uptrace.md
+++ b/docs/adr/ADR-030-observability-uptrace.md
@@ -1,0 +1,47 @@
+# ADR-030: Observability — OpenTelemetry instrumentation with Uptrace backend
+
+**Status:** Proposed  **Date:** 2026-06-15
+**Related:** ADR-022 (event-bus/NATS), ADR-020 (mTLS), ADR-026 (Postgres distribution)
+
+---
+
+## Context
+
+M6 shipped a production platform with gRPC health and a Prometheus `/metrics` surface, but there is no
+distributed tracing, no log correlation, and no UI to view a workflow run. A run is a black box: the
+api-gateway → compiler → engine → broker → registry → agent path is unobservable. M7 must give a
+developer a single place to see **traces, metrics, logs, and an APM/service map** — locally and
+in-cluster — without standing up a sprawling telemetry stack (Jaeger + Loki + Elasticsearch + Grafana).
+The instrumentation standard and backend are a one-way door (they shape every service's dependencies).
+
+## Decision
+
+1. **OpenTelemetry** is the instrumentation standard across all services and adapters (no vendor SDKs).
+2. **Uptrace** is the default OTEL backend — a single binary/stack serving **traces, metrics, logs, and
+   APM** with a **login web UI** and service map.
+3. Default transport is **OTLP/gRPC**; OTLP/HTTP is optional. Telemetry is **off unless**
+   `ZYNAX_OTEL_EXPORTER_OTLP_ENDPOINT` is set (zero overhead when unset).
+4. **Logs are shipped to Uptrace via OTLP logs** and correlated to traces by `trace_id`/`span_id`, so
+   logs are viewable in the same UI as traces.
+5. **Sampling:** head-based parent sampling (configurable ratio; 100% in local dev).
+6. Uptrace ships in **both** a local `docker compose` overlay **and** a **Helm chart**
+   (`observability.enabled`), so logs/traces/APM are viewable in any environment.
+7. We will **not** deploy Jaeger, Loki, or Elasticsearch.
+
+## Rationale
+
+| Option | Assessment |
+|--------|------------|
+| OTEL + Uptrace (chosen) | ✅ One lightweight, self-hostable, CNCF-aligned backend for traces+metrics+logs+APM with a UI |
+| OTEL + Jaeger + Loki + Grafana | ✗ Rejected — heavy multi-component stack; more infra than the project needs at M7 |
+| Vendor APM SDKs | ✗ Rejected — vendor lock-in; violates the no-custom-lock-in goal |
+| Tracing only (no logs/metrics in backend) | ✗ Deferred — the brief requires logs+APM in one UI |
+
+## Consequences
+
+- **Positive:** one `docker compose up` (or `helm install` with `observability.enabled`) gives a full
+  telemetry UI with login; the default DX is `Zynax → OpenTelemetry → Uptrace`.
+- **Negative / trade-off:** Uptrace's single-binary mode is not tuned for high-scale retention — scale
+  retention/sampling is deferred to M8.
+- **Neutral / follow-up:** OTLP endpoint must respect mTLS in-cluster (ADR-020); tail-based sampling and
+  production retention are M8 work.

--- a/docs/adr/ADR-031-context-propagation.md
+++ b/docs/adr/ADR-031-context-propagation.md
@@ -1,0 +1,42 @@
+# ADR-031: Context propagation model (trace · data · correlation)
+
+**Status:** Proposed  **Date:** 2026-06-15
+**Related:** ADR-030 (OTEL/Uptrace), ADR-029 (data-flow), ADR-008 (no shared databases/state)
+
+---
+
+## Context
+
+For long-running autonomous workflows and expert handoffs, three distinct kinds of context must move
+across service, engine (Temporal), and event (NATS) boundaries: **trace context** (for observability),
+**workflow data context** (for data-flow, ADR-029), and a stable **correlation id** (for log/trace
+joining). Today none of these propagate deterministically. Conflating them — e.g. stuffing data into
+trace baggage — would be a hard-to-reverse mistake.
+
+## Decision
+
+1. **Trace context:** W3C `traceparent` propagated via gRPC metadata, Temporal memo/headers, and NATS
+   message headers (per ADR-030).
+2. **Correlation:** `x-request-id` (and `x-namespace`) propagated on every hop; emitted into every span
+   and log line.
+3. **Data context:** the workflow-run-scoped `WorkflowDataContext` (ADR-029), with **explicit read/write
+   scoping** — never shared across runs or namespaces.
+4. **Agent handoff:** a documented contract specifying exactly what context an agent receives on dispatch
+   and returns on completion. No implicit globals.
+5. The three contexts are **kept separate** — data is never carried in trace baggage.
+
+## Rationale
+
+| Option | Assessment |
+|--------|------------|
+| Three separate, explicit contexts (chosen) | ✅ Clear ownership; observability and data concerns don't entangle |
+| Single merged "context blob" | ✗ Rejected — couples observability to data; leakage and size risks |
+| Implicit ambient context | ✗ Rejected — non-deterministic; violates explicit-scoping |
+
+## Consequences
+
+- **Positive:** a request-id set at the gateway is observable in every downstream span+log; handoffs are
+  deterministic and documented; data stays run-scoped.
+- **Negative / trade-off:** every boundary (gRPC, Temporal, NATS) needs an explicit carrier
+  inject/extract — more wiring, covered by `libs/zynaxotel` propagators.
+- **Neutral / follow-up:** long-term memory, RAG, and context compression are deferred to M-dx.

--- a/docs/adr/ADR-032-git-mcp-shim.md
+++ b/docs/adr/ADR-032-git-mcp-shim.md
@@ -1,0 +1,40 @@
+# ADR-032: Git MCP as a thin shim over the git-adapter
+
+**Status:** Proposed  **Date:** 2026-06-15
+**Related:** ADR-013 (adapter-first, no mandatory SDK), ADR-010 (pluggable agent runtime)
+
+---
+
+## Context
+
+Zynax already ships a Go **git-adapter** — a runtime gRPC capability provider for clone/branch/commit/
+PR/review. The M7 brief requires **Git MCP integration** so Claude Code and agent-authoring loops can
+use Git tools. We could build a second, independent Git implementation behind MCP, or expose MCP as a
+surface over the existing adapter. Duplicating Git logic would create drift and double the security
+surface for credential handling — a costly long-term coupling decision.
+
+## Decision
+
+1. The MCP Git surface is a **thin shim over the existing git-adapter** — one Git implementation, two
+   surfaces (runtime gRPC capability + MCP tools). No Git logic is reimplemented in the MCP layer.
+2. Credentials (`GITHUB_TOKEN`) are **injected at process start** via env/secret-ref. A secret is
+   **never serialized into a prompt, log, or trace** — redaction is mandatory.
+3. Tokens follow **least-privilege** — scoped per session/repo.
+4. The git-adapter remains the runtime workflow path; MCP is for the authoring loop.
+
+## Rationale
+
+| Option | Assessment |
+|--------|------------|
+| MCP shim over git-adapter (chosen) | ✅ Single implementation; one credential/security surface; no drift |
+| Independent MCP Git implementation | ✗ Rejected — duplicate logic + duplicate credential surface; drift risk |
+| MCP everywhere, deprecate adapter | ✗ Deferred — runtime workflows depend on the capability adapter today |
+
+## Consequences
+
+- **Positive:** authoring agents get Git tools without a second codebase; one place to audit credential
+  handling; consistent behaviour across surfaces.
+- **Negative / trade-off:** the shim couples the MCP server to the adapter's interface — adapter changes
+  must keep the MCP mapping in sync.
+- **Neutral / follow-up:** a future consolidation (MCP as the primary path) remains possible but is out
+  of scope; Tier-2 security review is mandatory for this EPIC.

--- a/docs/adr/ADR-033-expert-agent-substrate.md
+++ b/docs/adr/ADR-033-expert-agent-substrate.md
@@ -1,0 +1,43 @@
+# ADR-033: Expert-agent substrate (runtime AgentDef + authoring experts)
+
+**Status:** Proposed  **Date:** 2026-06-15
+**Related:** ADR-010 (pluggable agent runtime), ADR-013 (adapter-first), ADR-019 (SPDD)
+
+---
+
+## Context
+
+The M7 brief asks for a system of "expert agents" (Go, Kubernetes, Security, Docs, …). Zynax already
+has **two** distinct expert-like surfaces: runtime agents (`kind: AgentDef`, registered in
+agent-registry and dispatched as capabilities) and **Claude Code delivery experts**
+(`automation/workflows/experts/*.yaml` + `.claude` skills) used in the SPDD authoring loop. Picking only
+one substrate would either prevent experts from running inside workflows (authoring-only) or lose the
+delivery-loop experts that already drive autonomous milestone work. Letting them evolve independently
+would cause silent drift.
+
+## Decision
+
+1. Experts exist on **both substrates**, with a documented mapping:
+   - **Runtime experts** (`kind: AgentDef`) — registered, dispatched, and OTEL-traced; run inside workflows.
+   - **Authoring experts** (`automation/workflows/experts/*.yaml` + `.claude` skills) — drive the SPDD
+     delivery/authoring loop.
+2. A **mapping table** is the single source of truth linking each authoring expert to its runtime
+   counterpart (or marking it "authoring-only"). A CI check requires every authoring expert to declare a
+   `runtime_mapping:`.
+3. `agents/examples/` holds canonical SDK-based reference agents (incl. a runtime expert) — created in M7.
+4. The full 14-expert library is **deferred to M-dx**; M7 establishes the substrate + the mapping + a few references.
+
+## Rationale
+
+| Option | Assessment |
+|--------|------------|
+| Both substrates + mapping (chosen) | ✅ Experts run in workflows AND drive delivery; drift controlled by a CI-checked mapping |
+| Runtime AgentDefs only | ✗ Rejected — loses the existing authoring-loop experts |
+| Claude Code experts only | ✗ Rejected — experts couldn't run inside Zynax workflows |
+
+## Consequences
+
+- **Positive:** a unified, coherent expert system; reference agents unblock `agents/examples/`; experts
+  become observable when run as runtime AgentDefs.
+- **Negative / trade-off:** two surfaces to maintain — mitigated by the mandatory mapping table + CI check.
+- **Neutral / follow-up:** the full expert library, RAG/memory strategies, and escalation rules are M-dx.

--- a/docs/adr/ADR-034-manifest-workflow-id-collision-domain.md
+++ b/docs/adr/ADR-034-manifest-workflow-id-collision-domain.md
@@ -1,0 +1,37 @@
+# ADR-034: ManifestWorkflowID 64-bit collision domain and canonicalization stability
+
+**Status:** Proposed  **Date:** 2026-06-15
+**Related:** ADR-012 (Workflow IR), ADR-029 (data-flow) · GitHub #583
+
+---
+
+## Context
+
+The workflow-compiler derives a `ManifestWorkflowID` used as the durable identity of a compiled
+workflow. #583 raised that the id's collision domain (a 64-bit space) and the canonicalization that
+feeds the hash are undocumented: it is unclear which manifest fields are canonicalized, in what order,
+and what the practical collision probability is. Without a recorded decision, a future change to
+canonicalization could silently change ids and break idempotent `ApplyWorkflow`.
+
+## Decision
+
+(To be finalized during the EPIC-Q canvas alignment.) Record:
+
+1. The exact **canonicalization** of a manifest before hashing (field set, ordering, normalization).
+2. The **collision domain** (64-bit) and the practical collision bound for expected workflow counts.
+3. The **stability guarantee**: canonicalization is part of the contract — changing it is a breaking
+   change requiring a new ADR and a migration note.
+
+## Rationale
+
+| Option | Assessment |
+|--------|------------|
+| Document + freeze canonicalization (chosen) | ✅ Makes idempotency contractual; prevents silent id drift |
+| Widen to 128-bit id | ✗ Deferred — proto/contract change; not justified at current scale |
+| Leave undocumented | ✗ Rejected — invites accidental breaking changes |
+
+## Consequences
+
+- **Positive:** `ApplyWorkflow` idempotency is contractually grounded; future contributors know the rules.
+- **Negative / trade-off:** canonicalization is now frozen — intentional changes cost an ADR + migration.
+- **Neutral / follow-up:** if scale ever warrants a wider id space, a successor ADR handles the migration.

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -39,6 +39,12 @@ a PR against `docs/adr/`.
 | [ADR-026](ADR-026-postgres-distribution.md) | Postgres distribution + target major version (official `postgres:17` + thin chart) | Accepted | 2026-06-10 | `helm/charts/postgres/`, `images/images.yaml`, all production Postgres — EPIC #1073 |
 | [ADR-027](ADR-027-shift-left-pipeline.md) | Shift-left pipeline model — build once pre-merge, promote by retag | Accepted | 2026-06-11 | `ci.yml` build-images, `release.yml` retag jobs, GHCR staging lane — EPIC #1109 |
 | [ADR-028](ADR-028-agentdef-vs-workflow-self-hosted-automation.md) | AgentDef-vs-Workflow split for self-hosted automation + context-slice injection contract | Accepted | 2026-06-11 | `automation/workflows/**`, `spec/schemas/agent-def.schema.json`, `spec/schemas/workflow.schema.json` — EPIC #881 |
+| [ADR-029](ADR-029-workflow-data-flow.md) | Workflow data-flow semantics (output/input bindings) | Proposed | 2026-06-15 | `WorkflowIR` proto, workflow-compiler, engine-adapter — M7 EPIC W |
+| [ADR-030](ADR-030-observability-uptrace.md) | Observability — OpenTelemetry + Uptrace backend | Proposed | 2026-06-15 | all services + adapters, `libs/zynaxotel`, observability compose + Helm — M7 EPIC O |
+| [ADR-031](ADR-031-context-propagation.md) | Context propagation model (trace · data · correlation) | Proposed | 2026-06-15 | all services, engine-adapter, agents/sdk — M7 EPIC C |
+| [ADR-032](ADR-032-git-mcp-shim.md) | Git MCP as a thin shim over the git-adapter | Proposed | 2026-06-15 | `agents/adapters/git/`, cli — M7 EPIC G |
+| [ADR-033](ADR-033-expert-agent-substrate.md) | Expert-agent substrate (runtime AgentDef + authoring experts) | Proposed | 2026-06-15 | `agents/examples/`, `automation/workflows/experts/`, agent-registry — M7 EPIC X |
+| [ADR-034](ADR-034-manifest-workflow-id-collision-domain.md) | ManifestWorkflowID 64-bit collision domain + canonicalization stability | Proposed | 2026-06-15 | workflow-compiler — M7 EPIC Q (#583) |
 
 ---
 

--- a/docs/milestones/M7-planning.md
+++ b/docs/milestones/M7-planning.md
@@ -1,0 +1,548 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Zynax M7 — Usable Workflows + Observability Planning
+
+> **Target version:** v0.6.0 · **GitHub milestone:** #7 (`Full Observability (M7)`)
+> **Status:** Active (opened 2026-06-15) · **Planning author:** SPDD program plan
+> **Program context:** first of a three-milestone program M7 → M-dx → M8 (see [§1 Program Roadmap](#1--program-roadmap)).
+
+This document is the **single planning source of truth** for M7. It is generated from
+the milestone brief and reconciled against **live GitHub + live stack state** (the local
+stack was started and exercised on 2026-06-15; findings are recorded in
+[§4 Reality Check](#4--reality-check-what-zynax-can-and-cannot-do-today)). Every EPIC maps
+to SPDD canvases and GitHub issues; every implementation issue traces back to a specification.
+
+The brief asked for 22 deliverables and an acceptance matrix; the map from brief →
+section is in [Appendix A](#appendix-a--brief-deliverable-coverage-map).
+
+---
+
+## 0 — TL;DR
+
+M6 shipped a production-ready **platform** (K8s, mTLS, Postgres, EventBus, Helm, SDK on
+PyPI). But a developer cannot yet do **real work** with it: workflows cannot pass data
+between states, you cannot stream execution logs, and there is no telemetry. M7 closes
+that gap with one **vertical slice** — *author a real workflow, run it locally, watch it
+execute end-to-end with traces/metrics/logs* — and lays the substrate for the expert-agent
+system and example catalog that M-dx scales out.
+
+**M7 ships when:** a developer runs `docker compose up` (platform **+ Uptrace**), applies a
+real multi-step workflow with data flowing state→state, streams its logs, and sees the full
+distributed trace (api-gateway → compiler → engine → broker → registry → agent) in Uptrace —
+with green `make ci` and the supply-chain/coverage gaps from the reality check closed.
+
+---
+
+## 1 — Program Roadmap
+
+The brief describes ~3 milestones of work. Rather than one unbounded milestone (which fights
+the Agentic Delivery Playbook's "thin vertical slices, small mergeable PRs" principle), it is
+sequenced as a **program** over the three already-planned GitHub milestones. This plan defines
+all three at EPIC altitude and **M7 in full executable detail**.
+
+```mermaid
+graph LR
+  M7["M7 — Usable Workflows + Observability<br/>v0.6.0 · milestone #7<br/>data-flow · log streaming · OTEL+Uptrace<br/>context propagation · Git MCP shim<br/>expert substrate + agents/examples<br/>first real workflows · quick-start docs"]
+  MDX["M-dx — Developer Experience<br/>v0.7.0 · milestone #9<br/>full 14-expert library · example catalog<br/>advanced context (RAG/memory/compression)<br/>replay · visualization · debugging<br/>WAVEs gates at scale · authoring docs"]
+  M8["M8 — CNCF Sandbox Submission<br/>v1.0.0 · milestone #8<br/>prod observability deploy · chaos/load/perf<br/>sampling/retention at scale · migration guides<br/>full docs suite · CNCF governance artifacts"]
+  M7 --> MDX --> M8
+```
+
+| Milestone | Version | GH # | Theme | Why it is a discrete slice |
+|-----------|---------|------|-------|----------------------------|
+| **M7** | v0.6.0 | #7 | **Usable Workflows + Observability** | The minimum to do *one real workflow* with full telemetry. Everything else depends on data-flow + observability existing first. |
+| **M-dx** | v0.7.0 | #9 | **Developer Experience** | Scales experts + examples + context once the substrate exists. Pure additive; no platform contract changes. |
+| **M8** | v1.0.0 | #8 | **CNCF Sandbox** | Production hardening, scale testing, governance — gated on a feature-complete, observable platform. |
+
+> **Reframing note.** GitHub milestone #7 was titled *"Full Observability"*. M7 keeps observability
+> as a pillar but is **broader**: observability is necessary but not sufficient for "usable". The
+> GitHub milestone title is unchanged (idempotent reuse); the scope is this document.
+
+---
+
+## 2 — Vision & Problem Statement
+
+**Vision.** Zynax is the **control plane for agentic software delivery**: declarative YAML
+workflows dispatch capabilities to pluggable agents, executed durably on pluggable engines,
+fully observable. A developer should author a workflow, run it locally in one command, and
+watch every step — without writing orchestration code.
+
+**Problem (today, empirically verified 2026-06-15).** The platform runs, but:
+
+1. **Workflows can't pass data.** `output:` bindings are rejected at compile time
+   (`"not yet implemented; … upgrade to M7+"`). Every state is isolated — no real pipeline
+   is expressible. *This is the keystone blocker.*
+2. **No execution visibility.** `GET /api/v1/workflows/{id}/logs` returns
+   `{"error":"streaming not supported"}`. There is no OTEL, no Prometheus scrape, no trace.
+3. **No reference agents.** `agents/examples/` does not exist; the SDK has no canonical
+   "write-your-own-agent" example, and there is no runtime expert pattern.
+4. **No authoring ergonomics.** No reusable workflow/task/expert templates; no Git MCP surface
+   for agent/expert authoring; quick-start docs are missing.
+5. **Quality debt blocks a clean `make ci`.** `security-agents` fails on a tools-image `pip`
+   CVE; `test-coverage` fails on an interface-only package; PyPI Trusted Publisher history is
+   undocumented.
+
+**Outcome.** Close 1–5 so the [§0 acceptance scenario](#0--tldr) passes.
+
+---
+
+## 3 — SPDD Discipline (how every spec is generated)
+
+Per ADR-019, every `feat:` issue is preceded by a **REASONS Canvas** (status `Aligned`) before
+any implementation. This plan front-loads the SPDD artifacts:
+
+- **One canvas per EPIC** is committed with this plan under `docs/spdd/<letter>-<slug>/canvas.md`
+  (all 10: [W](../spdd/W-workflow-data-flow/canvas.md), [L](../spdd/L-log-streaming/canvas.md),
+  [O](../spdd/O-observability-otel-uptrace/canvas.md), [C](../spdd/C-context-propagation/canvas.md),
+  [G](../spdd/G-git-mcp-shim/canvas.md), [X](../spdd/X-expert-substrate/canvas.md),
+  [T](../spdd/T-templates-real-workflows/canvas.md), [R](../spdd/R-test-rigor/canvas.md),
+  [Q](../spdd/Q-quality-supply-chain/canvas.md), [D](../spdd/D-docs/canvas.md)). Each canvas's
+  **O — Operations** section lists the EPIC's stories in `spdd-story` form (As-a / I-want / so-that,
+  size, acceptance criteria, out-of-scope, dependencies) — ready to become one GitHub issue each.
+  `feat:` canvases (W/L/O/C/G/X/T) are the binding SPDD artifact; R/Q/D canvases are committed for
+  traceability even though those types are SPDD-exempt.
+- **SPDD command runbook** for every EPIC is in [§9](#9--spdd-command-runbook).
+- `fix:`, `refactor:`, `docs:`, `ci:`, `chore:`, `test:` issues are **SPDD-exempt** (no canvas).
+
+Traceability chain enforced for every issue:
+
+```
+ROADMAP/brief  →  this plan (EPIC)  →  REASONS Canvas  →  ADR (if one-way door)
+               →  GitHub issue (labels/DoD/AC)  →  PR (Canvas-linked)  →  test + telemetry validation
+```
+
+---
+
+## 4 — Reality Check (what Zynax can and cannot do today)
+
+Verified by booting the full stack (`make run-local`, 13 containers healthy) and the test
+suite on 2026-06-15.
+
+### Works today ✅
+| Capability | Evidence |
+|------------|----------|
+| Full local stack boots | 13 containers healthy after compose-corruption fix (PR #1166) |
+| Apply a (single-state) workflow | `POST /api/v1/apply` `e2e-demo.yaml` → `run_id`, runs to `WORKFLOW_STATUS_COMPLETED` |
+| Query workflow status | `GET /api/v1/workflows/{id}` → status JSON |
+| Spec validation | `make validate-spec` — all 5 validators pass |
+| Contract + unit + SDK tests | `make test-bdd`, `test-unit-go`, `test-unit-agents` (100% SDK cov) green |
+| Proto/Python lint, Go vuln scan | `make lint-protos`, `lint-agents`, `security-go` clean |
+
+### Cannot do yet — **M7 scope** ❌
+| Gap | Evidence | Owning EPIC |
+|-----|----------|-------------|
+| Workflow **state→state data flow** (`output:`) | `apply research-task.yaml` → `COMPILATION_ERROR … "output: which is not yet implemented; … upgrade to M7+"` | **EPIC W** |
+| Execution **log/event streaming** (`/logs`) | `GET …/logs` → `{"error":"streaming not supported","code":"INTERNAL"}` | **EPIC L** |
+| **OTEL traces / Prometheus metrics** | no telemetry emitted; no collector in compose | **EPIC O** |
+| `agents/examples/` reference agents | directory does not exist | **EPIC X** |
+| `make lint-go` / `make security-agents` clean run | tools image ships `pip 26.1.1` (PYSEC-2026-196; fix 26.1.2) | **EPIC Q** |
+| `make test-coverage` clean run | `services/event-bus/internal/domain` is interface-only → gate reads `0.0% < 90%` | **EPIC Q** |
+| PyPI **Trusted Publisher** provenance history | not documented in milestone history / release docs | **EPIC Q** |
+
+These seven rows are **must-fix in M7** and are tracked explicitly in the acceptance matrix
+([§13](#13--acceptance-matrix)).
+
+---
+
+## 5 — EPIC Decomposition (M7)
+
+Ten EPICs. Three pre-exist on GitHub (#467/#468/#469) and are **absorbed/extended** rather than
+duplicated. New EPICs are created by this plan ([§10](#10--github-bootstrap)).
+
+| EPIC | Title | Type | GitHub issue | Primary area |
+|------|-------|------|--------------|--------------|
+| **W** | Workflow data-flow (`output:`/input bindings) | feat | **#1167** (new) | workflow-compiler, engine-adapter, protos |
+| **L** | Execution log/event streaming (`/logs`) | feat | extends **#468** | api-gateway, engine-adapter, event-bus |
+| **O** | Observability: OTEL + Uptrace + Prometheus | feat | absorbs **#467** | all services + adapters, infra |
+| **C** | Context propagation (trace + data + correlation) | feat | **#1168** (new) | protos, all services, engine-adapter |
+| **G** | Git MCP shim over git-adapter | feat | **#1169** (new) | agents/adapters, cli |
+| **X** | Expert-agent substrate + `agents/examples/` | feat | **#1170** (new) | agents/sdk, agents/examples, agent-registry |
+| **T** | Reusable templates + first real workflows | feat | **#1171** (new) | spec, cli, docs |
+| **R** | Test rigor: benchmarks, fuzz, integration/e2e gates | test | absorbs **#469** (+#553 #493 #1103) | ci, multiple |
+| **Q** | Quality & supply-chain fixes (audit closeout) | chore/ci | **#1172** (new) | ci, infra, docs |
+| **D** | Docs: quick-start + authoring + observability | docs | **#1173** (new) | docs |
+
+> EPIC issues created 2026-06-15 (W/C/G/X/T/Q/D = #1167–#1173). Pre-existing #467/#468/#469
+> annotated to point at canvases O/L/R. Story issues are created per-EPIC via `/spdd-story`
+> ([§9](#9--spdd-command-runbook)).
+
+### EPIC W — Workflow data-flow *(keystone; everything depends on it)*
+**Why first:** real workflows and expert pipelines are impossible without state→state data.
+The compiler explicitly rejects `output:` today.
+- **W.1** ADR: data-flow semantics & scoping model (`adr-proposal`) — see [ADR-029 stub](../adr/ADR-029-workflow-data-flow.md)
+- **W.2** Proto: `output`/`input` binding fields on `WorkflowIR` state/action + `.feature` (feat, new gRPC boundary → `/spdd-api-test`)
+- **W.3** Compiler: compile `output:` bindings to IR; validate references; lift the "not implemented" rejection
+- **W.4** Engine-adapter: interpreter threads outputs into a workflow-scoped data context; inputs resolve from it
+- **W.5** End-to-end: make `research-task.yaml` + `code-review.yaml` apply and run green
+**DoD:** `apply research-task.yaml` reaches terminal state with `summarize` consuming `search`'s output; BDD scenario for data-flow; ≥90% domain cov.
+
+### EPIC L — Execution log/event streaming
+**Why:** the `/logs` endpoint is stubbed; developers can't watch a run. Couples with #468
+(replace polling with Temporal history long-poll) on the engine side.
+- **L.1** Engine-adapter: history streaming (long-poll `GetWorkflowHistory`) — **closes #468**
+- **L.2** Event-bus: per-workflow event subscription stream (reuse `Subscribe` w/ `WorkflowID` scope)
+- **L.3** api-gateway: real Server-Sent-Events / chunked `GET /api/v1/workflows/{id}/logs`
+- **L.4** CLI: `zynax logs <run-id> --follow`
+**DoD:** streaming logs for the e2e-demo run show each state transition + capability event; no `streaming not supported`.
+
+### EPIC O — Observability: OTEL + **Uptrace (traces · metrics · logs · APM, with login UI)** + Prometheus *(absorbs #467)*
+**Backend decision:** **Uptrace** as the single default OTEL backend for **traces, metrics, logs,
+and APM**, with its **web UI (login) for viewing logs and service maps**; **OTLP/gRPC** default,
+OTLP/HTTP optional. No Jaeger/Loki/Elasticsearch (see [ADR-030 stub](../adr/ADR-030-observability-uptrace.md)).
+Uptrace ships in **both** the local `docker compose` stack **and** the Helm deployment, so a
+developer always has a UI to see logs/traces — locally and in-cluster.
+- **O.1** ADR: OTEL + Uptrace (traces+metrics+logs+APM), OTLP/gRPC default, head-based parent sampling (`adr-proposal`)
+- **O.2** Shared `libs/zynaxotel` Go package: tracer/meter/**logger** providers, OTLP exporter, resource attrs (semconv)
+- **O.3** Instrument all 7 services: gRPC server/client interceptors + HTTP middleware (api-gateway)
+- **O.4** Prometheus `/metrics` already exists (M6 gRPC health/metrics) — add RED metrics + exemplars; forward to Uptrace metrics
+- **O.5** Trace propagation across Temporal activities + NATS headers (W3C `traceparent`)
+- **O.6** Python adapters: OTEL SDK (traces+logs) in `agents/sdk`; auto-instrument capability handlers
+- **O.7** **`docker compose up` Uptrace stack** (`infra/docker-compose/docker-compose.observability.yml`): Uptrace + its ClickHouse/Postgres deps + OTLP collector; **login UI on a 70xx host port** for logs/traces/APM
+- **O.8** **Uptrace Helm chart** (`infra/helm/charts/uptrace/`): Deployment/Service/Ingress + login UI, wired as the in-cluster OTLP endpoint; values toggle (`observability.enabled`)
+- **O.9** **Log export to Uptrace** (structured logs shipped via OTLP logs) so logs are viewable in the Uptrace UI alongside traces; span/metric naming conventions doc + `trace_id`/`span_id` in every log line
+**DoD:** one workflow run produces a connected trace across all hops **and its logs**, viewable
+in the **Uptrace login UI** (local compose **and** Helm); RED metrics scraped; APM/service-map populated.
+
+### EPIC C — Context propagation
+**Why:** experts and multi-step workflows need deterministic context (both **trace context**
+and **workflow data context**) to flow across service, engine, and agent boundaries.
+- **C.1** ADR: context model — trace context vs. data context vs. correlation IDs; inheritance & handoff rules ([ADR-031 stub](../adr/ADR-031-context-propagation.md))
+- **C.2** Propagate `traceparent` + `x-request-id` + `x-namespace` through every gRPC hop and Temporal memo
+- **C.3** Workflow-scoped data context store (builds on EPIC W) with explicit read/write scoping
+- **C.4** Documented handoff contract between agents (what context an agent receives/returns)
+**DoD:** a request-id set at api-gateway appears in every downstream span and log line for that run; documented in the context guide.
+
+### EPIC G — Git MCP shim over git-adapter
+**Decision:** MCP is a **thin protocol shim over the existing git-adapter** (one Git
+implementation, two surfaces) — see [ADR-032 stub](../adr/ADR-032-git-mcp-shim.md).
+- **G.1** ADR: MCP-shim-over-adapter; least-privilege token injection; **no secrets in prompts**
+- **G.2** MCP server exposing git-adapter capabilities (clone/branch/commit/PR/review) as MCP tools
+- **G.3** Credential injection via env/secret ref at process start; redaction in logs/traces
+- **G.4** CLI/dev wiring: `zynax mcp git` + `.mcp.json` example for Claude Code authoring loop
+**DoD:** an authoring session can open a PR via MCP with a scoped token; no token ever serialized into a prompt; security review PASS.
+
+### EPIC X — Expert-agent substrate + `agents/examples/`
+**Decision (both substrates, mapped):** runtime **AgentDef** experts (registered, dispatched,
+OTEL-traced) for in-workflow execution **and** Claude Code experts (extend
+`automation/workflows/experts/*.yaml` + `.claude` skills) for the delivery/authoring loop, with
+a documented mapping ([ADR-033 stub](../adr/ADR-033-expert-agent-substrate.md)).
+- **X.1** ADR: expert substrate + runtime↔authoring mapping table
+- **X.2** Create `agents/examples/` with three reference agents (uses SDK): `echo`, `summarizer`, `go-review-expert`
+- **X.3** Runtime expert pattern: `kind: AgentDef` expert template + registration + capability schema
+- **X.4** Wire `make lint-agent`/`test-unit-agent` to discover `agents/examples/*`
+- **X.5** Map each authoring expert (`experts/*.yaml`) to its runtime counterpart (or "authoring-only")
+**DoD:** `agents/examples/` builds, lints, tests; `go-review-expert` registers and is dispatchable in a workflow with a trace.
+
+### EPIC T — Reusable templates + first real workflows
+- **T.1** Template mechanism: workflow templates + task templates + expert templates (with versioning field)
+- **T.2** Workflow validation + versioning fields surfaced in CLI (`zynax validate`, `version:`)
+- **T.3** First **production-quality** real workflows (runnable end-to-end): `code-review`, `ci-pipeline`, `feature-implementation`
+- **T.4** `zynax init workflow|expert` scaffolds from templates
+**DoD:** the three real workflows apply and run green locally with data-flow + traces; templates documented.
+
+### EPIC R — Test rigor *(absorbs #469; pulls in #553, #493, #1103)*
+- **R.1** Benchmarks for IRInterpreter + workflow-compiler with regression gate — **#493**
+- **R.2** Fuzz tests for the YAML→IR compiler
+- **R.3** Activate integration test suite as a required CI gate — **#553**
+- **R.4** Flip platform-readiness `xfail` to real `zynax apply` e2e — **#1103**
+- **R.5** Observability validation test: assert a run emits a connected trace
+**DoD:** benchmarks + fuzz + integration + e2e + observability tests run in CI as gates.
+
+### EPIC Q — Quality & supply-chain fixes (audit closeout)
+*(Directly closes the [§4](#4--reality-check-what-zynax-can-and-cannot-do-today) red rows that aren't features.)*
+- **Q.1** Bump tools image `pip` → 26.1.2 (PYSEC-2026-196) so `make security-agents` / `lint-go` run clean — `ci`
+- **Q.2** Coverage gate: exclude/ærhandle interface-only packages (`event-bus/internal/domain`) so `make test-coverage` passes honestly — `ci`
+- **Q.3** Document **PyPI Trusted Publisher** provenance in milestone history + release docs (the SDK publishes via Trusted Publisher; record the OIDC publisher config + first-publish provenance) — `docs`
+- **Q.4** Verify & document Go module consumption path (pkg.go.dev) — **#582**
+- **Q.5** ADR for `ManifestWorkflowID` 64-bit collision domain — **#583**
+**DoD:** `make ci` is green end-to-end on a clean checkout; PyPI Trusted Publisher history present in this doc ([§14](#14--pypi-trusted-publisher-history)).
+
+### EPIC D — Docs: quick-start + authoring + observability
+- **D.1** Quick Start (`docker compose up` → apply → watch trace) + Developer Guide
+- **D.2** Workflow Authoring + Expert Authoring guides
+- **D.3** Context System + Git MCP guides
+- **D.4** Observability + OpenTelemetry + Uptrace guides (sampling/retention/troubleshooting)
+- **D.5** Examples index + Best Practices + FAQ + Migration notes (v0.5→v0.6)
+**DoD:** a new developer can go from clone to a traced real-workflow run using only the docs.
+
+---
+
+## 6 — Dependency Graph & Critical Path
+
+```mermaid
+graph TD
+  W["W · data-flow (keystone)"]
+  C["C · context propagation"]
+  O["O · OTEL + Uptrace"]
+  L["L · log streaming"]
+  G["G · Git MCP shim"]
+  X["X · expert substrate + examples"]
+  T["T · templates + real workflows"]
+  R["R · test rigor"]
+  Q["Q · quality/supply-chain fixes"]
+  D["D · docs"]
+
+  Q --> W
+  Q --> O
+  W --> C
+  W --> T
+  W --> X
+  O --> C
+  O --> L
+  C --> X
+  C --> T
+  X --> T
+  G --> X
+  W --> R
+  O --> R
+  T --> R
+  T --> D
+  O --> D
+  G --> D
+  X --> D
+```
+
+- **Critical path:** `Q → W → C → X → T → D` (data-flow and context gate the expert/example/doc work).
+- **Parallelizable from the start:** `Q` (all sub-tasks), `O` (after Q.1 unblocks clean CI), `G` (independent of W).
+- **Q is the unblocker:** Q.1/Q.2 must merge early so every other EPIC's PR sees a green `make ci`.
+
+---
+
+## 7 — Parallel Execution Plan (waves)
+
+Designed for autonomous/parallel agent execution (≤3 concurrent per `/milestone-orchestrate`).
+
+| Wave | EPICs / tasks (parallel) | Gate to advance |
+|------|--------------------------|-----------------|
+| **0** | Q.1, Q.2, Q.3 (CI green + provenance) | `make ci` green on clean checkout |
+| **1** | W.1–W.5 (data-flow) · O.1–O.4 (OTEL core) · G.1–G.2 (MCP shim) | data-flow e2e green; trace visible in Uptrace |
+| **2** | C.1–C.4 (context) · O.5–O.8 (propagation+Uptrace compose) · L.1–L.4 (log streaming) | request-id end-to-end; `/logs` streams |
+| **3** | X.1–X.5 (experts + examples) · T.1–T.4 (templates + real workflows) · G.3–G.4 | 3 real workflows run; reference agents dispatchable |
+| **4** | R.1–R.5 (test rigor) · D.1–D.5 (docs) · Q.4/Q.5 | all CI gates active; docs complete; acceptance matrix green |
+
+Each task = one small, independently mergeable PR (≤400 lines target; planning/docs/spec
+exempt per CLAUDE.md PR-size rules).
+
+---
+
+## 8 — Risk Register
+
+| # | Risk | Likelihood | Impact | Mitigation | Owner EPIC |
+|---|------|-----------|--------|------------|------------|
+| 1 | Data-flow scoping (W) becomes a sprawling expression language | Med | High | ADR-029 fixes a **minimal** binding model (no expressions in M7 — literal/path refs only); defer transforms to M-dx | W |
+| 2 | OTEL adds latency/overhead in the hot path | Med | Med | Head-based parent sampling default; benchmark in R.5; document overhead | O/R |
+| 3 | Uptrace single-binary not prod-grade at scale | Low | Med | M7 targets local/dev; prod deploy + retention is M8 | O |
+| 4 | Git MCP token leakage into prompts/traces | Low | **Critical** | ADR-032 mandates injection-at-process-start + log/trace redaction; security review gate (Tier 2) | G |
+| 5 | Expert dual-substrate causes drift between runtime & authoring experts | Med | Med | ADR-033 mapping table is the SoT; CI check that every authoring expert declares its mapping | X |
+| 6 | Coverage-gate change (Q.2) masks real gaps | Low | Med | Exclude only packages with **zero executable statements**; assert via `go tool cover` count, not a blanket skip | Q |
+| 7 | Trace context lost across Temporal/NATS boundaries | Med | High | C.2 propagates via Temporal memo + NATS headers; R.5 asserts a connected trace | C |
+| 8 | Scope creep — brief is ~3 milestones | **High** | High | Program split (M7/M-dx/M8); M-dx absorbs full expert library + example catalog + RAG | program |
+
+---
+
+## 9 — SPDD Command Runbook
+
+Run from repo root. `feat:` EPICs require the full pipeline; non-feat are exempt.
+
+```bash
+# ── EPIC W — data-flow (feat, new gRPC boundary) ──────────────────────────
+/spdd-analysis <W.2-issue>
+/spdd-story <W-epic-issue>
+/spdd-reasons-canvas <W.2-issue>          # → docs/spdd/<id>-workflow-data-flow/canvas.md
+/spdd-security-review docs/spdd/<id>-workflow-data-flow/canvas.md   # must PASS
+/spdd-api-test docs/spdd/<id>-workflow-data-flow/canvas.md          # new gRPC boundary → .feature first
+# [human sets status: Aligned]
+/spdd-generate docs/spdd/<id>-workflow-data-flow/canvas.md          # one O-step; stop; review; repeat W.3→W.5
+
+# ── EPIC O — OTEL+Uptrace (feat) ──────────────────────────────────────────
+/spdd-analysis <O-issue>; /spdd-reasons-canvas <O-issue>; /spdd-security-review <canvas>; /spdd-generate <canvas>   # per O-step
+
+# ── EPIC C / G / X / T — same feat pipeline, one canvas per EPIC ──────────
+#   /spdd-analysis → /spdd-reasons-canvas → /spdd-security-review → [Aligned] → /spdd-generate (per O-step)
+#   EPIC X/T also need /spdd-api-test where a new capability schema or gRPC field is introduced.
+
+# ── EPIC L — log streaming (feat, extends existing endpoint) ──────────────
+/spdd-analysis <L-issue>; /spdd-reasons-canvas <L-issue>; /spdd-security-review <canvas>; /spdd-generate <canvas>
+
+# ── SPDD-EXEMPT EPICs (no canvas) ─────────────────────────────────────────
+#   EPIC Q: chore/ci/docs   — Q.1 ci, Q.2 ci, Q.3 docs, Q.4 docs, Q.5 adr-proposal
+#   EPIC R: test            — benchmarks/fuzz/integration/e2e/observability-validation
+#   EPIC D: docs            — all guides
+#   #468 (engine history streaming) is refactor:; reuse its existing context, no new canvas.
+```
+
+Whole-milestone orchestration: `/milestone-plan` → `/milestone-orchestrate` (≤3 issues/batch,
+routed to domain experts) → `/milestone-learn` after each cluster.
+
+---
+
+## 10 — GitHub Bootstrap
+
+Milestone #7 already exists (idempotent reuse). Commands to create the **new** EPIC issues are
+in [§10a](#10a--epic-create-commands). Pre-existing EPICs #467/#468/#469 and stories
+#493/#553/#582/#583/#1103 are **absorbed** (re-labeled/linked, not recreated).
+
+### 10a — EPIC create commands
+
+> Executed by this plan via `gh` (see PR). One representative shown; the rest follow the same shape.
+
+```bash
+gh issue create \
+  --title "epic(workflow-compiler): M7.W — Workflow data-flow (output/input bindings)" \
+  --label "type: epic,area: workflow-compiler,area: engine-adapter,area: protos,priority: high,milestone: M7" \
+  --milestone "Full Observability (M7)" \
+  --body "<scope · stories W.1–W.5 · ADR-029 · DoD · AC>  Assisted-by: Claude/claude-opus-4-8"
+# … EPICs L, O, C, G, X, T, Q, D analogously (see §5 for scope/stories).
+```
+
+---
+
+## 11 — ADRs Required
+
+| ADR | Title | Status | One-way door? | EPIC |
+|-----|-------|--------|---------------|------|
+| ADR-029 | Workflow data-flow semantics (binding model, scoping) | Proposed | Yes — proto contract | W |
+| ADR-030 | Observability: OTEL + Uptrace, OTLP/gRPC, head sampling | Proposed | Yes — backend choice | O |
+| ADR-031 | Context propagation model (trace vs data vs correlation) | Proposed | Yes — cross-service contract | C |
+| ADR-032 | Git MCP as a thin shim over git-adapter | Proposed | Partly — auth model | G |
+| ADR-033 | Expert-agent substrate (runtime AgentDef + authoring experts) | Proposed | Yes — agent model | X |
+| ADR-034 | `ManifestWorkflowID` 64-bit collision domain (from #583) | Proposed | No | Q |
+
+Stubs for ADR-029–033 are committed with this plan under [docs/adr/](../adr/) (status `Proposed`;
+finalized during each EPIC's canvas alignment).
+
+---
+
+## 12 — Observability, Security & Testing Plans
+
+### Observability plan (default DX = `Zynax → OpenTelemetry → Uptrace`)
+- Instrumentation standard: OpenTelemetry; backend: **Uptrace** (single backend for **traces,
+  metrics, logs, and APM**, with a **login web UI** + service map); transport: OTLP/gRPC (HTTP optional).
+- Signals: distributed traces, RED metrics (+exemplars), **structured logs shipped via OTLP** and
+  correlated by `trace_id`/`span_id` — all viewable together in the Uptrace UI.
+- Span naming: `<service>.<rpc>` for gRPC, `workflow.<state>` / `capability.<name>` for execution.
+- Sampling: head-based parent sampling (configurable ratio; 100% local dev). Retention: M7 = dev defaults; scale retention → M8.
+- **Local:** `docker compose -f …observability.yml up` brings Uptrace (+ deps + OTLP collector) with the login UI on a 70xx port.
+- **In-cluster:** `infra/helm/charts/uptrace/` deploys Uptrace + UI behind an Ingress, toggled by `observability.enabled`, so logs/traces are visible in any environment — not just locally.
+- Validation: R.5 asserts a connected end-to-end trace per run.
+
+### Security plan (review BEFORE implementation — Tier 2 scan per canvas)
+Every `feat:` canvas runs `/spdd-security-review`. Focus areas this milestone:
+- **STRIDE** on the data-flow context (W/C): tampering/info-disclosure via cross-state data leakage → explicit read/write scoping.
+- **Git MCP (G):** credential management (no secrets in prompts), least-privilege token, prompt-injection on PR/issue content, context-leakage via traces (redaction).
+- **Experts (X):** agent isolation, capability least-privilege, MCP permission scoping.
+- **Supply chain (Q):** pip CVE closeout, cosign/SBOM unchanged from M6, PyPI Trusted Publisher provenance recorded.
+
+### Testing plan (ADR-016 tiers + new gates)
+| Test type | Where | Gate |
+|-----------|-------|------|
+| Unit (≥90% domain) | `services/*/internal/domain` | `make test-coverage` (Q.2 fixes interface-only) |
+| BDD contract | `protos/tests/` + `services/*/tests` | `make test-bdd` |
+| Integration | `//go:build integration` | **R.3 — new required gate (#553)** |
+| Benchmarks (regression) | compiler + interpreter | **R.1 (#493)** |
+| Fuzz | YAML→IR compiler | **R.2** |
+| E2E | `zynax apply` real workflow | **R.4 (#1103)** |
+| Observability validation | trace assertion | **R.5** |
+| Performance/load/chaos | — | **deferred to M8** |
+
+---
+
+## 13 — Acceptance Matrix
+
+M7 is **DONE** when every row is green. Rows 1–7 are the [§4](#4--reality-check-what-zynax-can-and-cannot-do-today) gaps the user flagged as must-include.
+
+| # | Acceptance criterion | Verifies | EPIC | Done-check |
+|---|----------------------|----------|------|------------|
+| 1 | `apply research-task.yaml` runs to terminal with state→state data flow | data-flow | W | e2e test green |
+| 2 | `GET /workflows/{id}/logs` streams real execution events | log streaming | L | `zynax logs --follow` shows transitions |
+| 3 | One run emits a connected trace across all hops in Uptrace + RED metrics | OTEL/Uptrace | O | R.5 trace assertion |
+| 4 | `agents/examples/` builds/lints/tests; a reference expert is dispatchable | reference agents | X | `make test-unit-agent` green |
+| 5 | `make security-agents` / `make lint-go` run clean (pip 26.1.2) | supply chain | Q | `make ci` green |
+| 6 | `make test-coverage` passes honestly (interface-only handled) | coverage gate | Q | `make ci` green |
+| 7 | PyPI Trusted Publisher provenance documented ([§14](#14--pypi-trusted-publisher-history)) | provenance | Q | this doc + release notes |
+| 8 | request-id propagates to every downstream span+log | context | C | log/trace inspection |
+| 9 | Git MCP opens a PR with a scoped token; no secret in any prompt/trace | Git MCP | G | security review PASS |
+| 10 | 3 real workflows (code-review, ci-pipeline, feature-impl) run green | templates/examples | T | e2e |
+| 11 | Quick-start takes a new dev from clone → traced real-workflow run | docs | D | doc walkthrough |
+| 12 | All new CI gates (integration, benchmark, fuzz, e2e, observability) active | test rigor | R | CI config |
+
+**Definition of Done (every issue):** linked Canvas (feat) or rationale (non-feat); labels +
+priority + milestone set; AC met; tests written and green; `make ci` green; telemetry emitted
+where applicable; docs updated; one logical commit; PR ≤400 lines or justified; DCO signed;
+`Assisted-by` trailer; squash-merged.
+
+---
+
+## 14 — PyPI Trusted Publisher History
+
+> Recorded here per the milestone brief — the program had no durable record of the SDK's PyPI
+> Trusted Publisher (OIDC) configuration. This is the canonical history; release notes link here.
+
+**Mechanism.** `zynax-sdk` is published to PyPI via **Trusted Publishing (OIDC)** — no long-lived
+API token is stored. The GitHub Actions workflow `sdk-publish.yml` requests a short-lived OIDC
+token that PyPI exchanges for an upload scope.
+
+| Field | Value |
+|-------|-------|
+| Distribution | `zynax-sdk` |
+| Publisher | GitHub Actions — `zynax-io/zynax` |
+| Workflow | `.github/workflows/sdk-publish.yml` |
+| Environment | release (protected) |
+| Trust model | OIDC Trusted Publisher (no stored token) |
+| TestPyPI dry-run | `tools-publish.yml` |
+| First milestone | M6 (v0.5.0) — SDK first published to PyPI |
+
+**Action items in Q.3:** (a) confirm the Trusted Publisher entry is registered on PyPI for the
+above workflow/environment; (b) record the first-publish version + provenance attestation
+reference; (c) link this section from `docs/milestones/M1-release-notes.md` successor and the
+v0.6.0 release notes. *(If the Trusted Publisher entry does not yet exist on PyPI, Q.3 creates it
+before the next SDK publish and updates the "First milestone" row above.)*
+
+---
+
+## Appendix A — Brief deliverable coverage map
+
+| # | Brief deliverable | Section |
+|---|-------------------|---------|
+| 1 | milestone description | §0, §2 |
+| 2 | roadmap | §1 |
+| 3 | dependency graph | §6 |
+| 4 | GitHub issue hierarchy | §5, §10 |
+| 5 | labels | §10 (existing label set) |
+| 6 | milestones | §1 |
+| 7 | epics | §5 |
+| 8 | features | §5 (stories per EPIC) |
+| 9 | implementation order | §6, §7 |
+| 10 | critical path | §6 |
+| 11 | parallel execution plan | §7 |
+| 12 | risk register | §8 |
+| 13 | ADR list | §11 |
+| 14 | documentation plan | §5 EPIC D |
+| 15 | testing plan | §12 |
+| 16 | observability plan | §12 |
+| 17 | security plan | §12 |
+| 18 | rollout strategy | §15 |
+| 19 | rollback strategy | §15 |
+| 20 | acceptance matrix | §13 |
+| 21 | DoD per issue | §13 |
+| 22 | SPDD commands per spec | §9 |
+
+---
+
+## 15 — Rollout & Rollback
+
+**Rollout.** Incremental, per-EPIC, behind feature gates where a contract changes:
+- Data-flow (W): proto fields are **additive** (backward-compatible per `buf breaking`); the
+  compiler accepts manifests without `output:` unchanged.
+- OTEL (O): off unless `ZYNAX_OTEL_EXPORTER_OTLP_ENDPOINT` is set → zero impact when unset.
+- Uptrace (O.7): separate compose file; never required for the core stack.
+- Git MCP (G): opt-in process; no change to runtime workflow path.
+
+**Rollback.** Each EPIC is independently revertible:
+- Proto additions are additive → revert is a stub-regenerate, no data migration.
+- Observability is env-gated → unset the endpoint to disable.
+- Quality fixes (Q) are isolated CI/tooling changes.
+- No schema migrations introduced in M7 beyond additive proto fields → no destructive rollback path.
+
+**Version cut.** v0.6.0 tagged via `/milestone-close` after the acceptance matrix is green;
+GitHub Release + signed tag; `state/milestone.yaml` rotates M7 → history.

--- a/docs/spdd/C-context-propagation/canvas.md
+++ b/docs/spdd/C-context-propagation/canvas.md
@@ -1,0 +1,72 @@
+# REASONS Canvas — EPIC C: Context Propagation
+
+> Tier 1 (public-safe). Tier 2 → `canvas.private.md`. Run `/spdd-security-review` before committing.
+
+**Issue:** #1168 · **Milestone:** M7 (v0.6.0)
+**Author:** M7 program plan · **Date:** 2026-06-15 · **Status:** Draft
+
+---
+
+## R — Requirements
+- **Problem:** there is no deterministic context carried across service/engine/agent boundaries —
+  neither **trace context** nor **workflow data context** nor a stable **correlation id**.
+- A request id set at the gateway must appear in **every** downstream span and log line for that run.
+- Agents must receive a **documented, deterministic** context on handoff and return a defined context.
+- **Done when:** a request-id set at api-gateway is observable in every downstream span+log; the
+  agent handoff contract is documented and exercised by a test.
+
+## E — Entities
+```
+RequestContext = { trace_id, span_id, request_id, namespace }
+ContextCarrier  ← gRPC metadata · Temporal memo/header · NATS header
+WorkflowDataContext (from EPIC W)  ← workflow-scoped data, read/write-scoped
+AgentHandoff contract              ← inbound context an agent receives / outbound it returns
+```
+
+## A — Approach
+**We will:** propagate W3C `traceparent` + `x-request-id` + `x-namespace` through every gRPC hop,
+Temporal memo, and NATS header; define explicit read/write scoping for the data context (EPIC W);
+document the agent handoff contract.
+**We will NOT:** build long-term memory/RAG or context compression — **deferred to M-dx**.
+**Governing ADRs:** ADR-031 (context model — this EPIC), ADR-030 (trace context), ADR-008 (no shared state).
+
+## S — Structure (first S)
+```
+libs/zynaxotel/ (propagators)   ← inject/extract carriers
+services/*/ (interceptors)       ← attach RequestContext to ctx
+services/engine-adapter/         ← Temporal memo/header carrier; data-context scoping
+agents/sdk/                       ← inbound context extraction; handoff helpers
+docs/context/                     ← context model + handoff contract guide
+```
+
+## O — Operations (stories — `spdd-story` form)
+**C.1 — ADR: context model** · S · `adr-proposal`
+- As a `maintainer`, I want trace vs data vs correlation contexts defined so propagation is deterministic.
+- AC: [ ] ADR-031 committed (carriers, inheritance, handoff rules, non-goals). Deps: none.
+
+**C.2 — Propagate correlation context across all hops** · M · `feat`
+- As an `operator`, I want `request_id`/`namespace`/`traceparent` on every hop so a run is traceable.
+- AC: [ ] gRPC metadata + Temporal memo + NATS headers carry the context; [ ] visible in every span+log. Deps: C.1, O.5.
+
+**C.3 — Workflow data-context scoping** · M · `feat`
+- As a `workflow author`, I want explicit read/write scoping so states can't leak data across runs.
+- AC: [ ] read/write scoping enforced on the EPIC-W data context; [ ] cross-run access denied; [ ] tested. Deps: W.4, C.1.
+
+**C.4 — Agent handoff contract** · S · `feat`/`docs`
+- As an `agent author`, I want a documented handoff contract so agents receive/return deterministic context.
+- AC: [ ] contract documented; [ ] SDK helper to read inbound + emit outbound context; [ ] example test. Deps: C.2.
+
+**Order:** C.1 → C.2 → {C.3, C.4}.
+
+## N — Norms
+- W3C tracecontext standard; no bespoke header formats. `Signed-off-by:` + `Assisted-by:` per commit.
+- Cross-service only via gRPC (ADR-008); `GOWORK=off` (ADR-017).
+
+## S — Safeguards (second S)
+### Context Security
+- [ ] No Tier 2 content; [ ] no PII in context fields; [ ] no prompt-injection; [ ] `/spdd-security-review` — PENDING
+
+### Feature Safeguards
+- Never put secrets/credentials into propagated context or memo — correlation ids only.
+- Never share a data context across workflows or namespaces — strict run+namespace scoping.
+- Never rely on implicit globals for context — always explicit carriers on `ctx`.

--- a/docs/spdd/D-docs/canvas.md
+++ b/docs/spdd/D-docs/canvas.md
@@ -1,0 +1,74 @@
+# REASONS Canvas — EPIC D: Documentation (quick-start · authoring · observability)
+
+> Tier 1 (public-safe). `docs:` work is SPDD-exempt; committed for traceability.
+
+**Issue:** #1173 · **Milestone:** M7 (v0.6.0)
+**Author:** M7 program plan · **Date:** 2026-06-15 · **Status:** Draft
+
+---
+
+## R — Requirements
+- **Problem:** there is no quick-start, no authoring guide, and no observability guide. A new
+  developer cannot get from clone to a traced real-workflow run using docs alone.
+- **Done when:** the quick-start takes a new developer clone → `docker compose up` (incl. Uptrace) →
+  `apply` a real workflow → watch the trace/logs in the Uptrace UI, using only the docs.
+
+## E — Entities
+```
+docs/quickstart · docs/developer-guide
+docs/authoring (workflow + expert)
+docs/context · docs/git-mcp
+docs/observability (OpenTelemetry + Uptrace)
+docs/examples-index · best-practices · faq · migration (v0.5→v0.6)
+```
+
+## A — Approach
+**We will:** write the quick-start + developer guide, workflow/expert authoring guides, context +
+Git MCP guides, observability (OTEL + Uptrace, incl. login UI for logs) guide, and an examples index +
+FAQ + v0.5→v0.6 migration notes.
+**We will NOT:** write the full example-catalog docs (K8s/Helm/GitOps/security catalog) — **M-dx**.
+**Governing ADRs:** all M7 ADRs (028–033) are the source material.
+
+## S — Structure (first S)
+```
+docs/quickstart.md · docs/developer-guide.md
+docs/authoring/{workflows.md,experts.md}
+docs/context/context-system.md · docs/git-mcp/git-mcp.md
+docs/observability/{opentelemetry.md,uptrace.md,sampling.md,troubleshooting.md}
+docs/examples/index.md · docs/best-practices.md · docs/faq.md · docs/migration-v0.6.md
+```
+
+## O — Operations (stories — `spdd-story` form)
+**D.1 — Quick Start + Developer Guide** · M · `docs`
+- As a `new developer`, I want a clone→traced-run quick-start so I'm productive in minutes.
+- AC: [ ] quick-start: compose up (incl. Uptrace) → apply real workflow → see trace+logs in UI; [ ] developer guide covering make targets. Deps: T.3, O.7.
+
+**D.2 — Workflow + Expert authoring guides** · M · `docs`
+- As an `author`, I want authoring guides so I can write workflows and experts correctly.
+- AC: [ ] workflow authoring (data-flow, templates, versioning); [ ] expert authoring (runtime + Claude). Deps: T.1, X.2.
+
+**D.3 — Context System + Git MCP guides** · S · `docs`
+- As an `author`, I want context + Git MCP guides so handoffs and Git usage are safe and clear.
+- AC: [ ] context model + handoff contract; [ ] Git MCP least-privilege setup. Deps: C.4, G.4.
+
+**D.4 — Observability guides (OTEL + Uptrace)** · M · `docs`
+- As an `operator`, I want OTEL + Uptrace guides so I can run, view (login UI), and tune telemetry.
+- AC: [ ] OTEL setup; [ ] Uptrace local + Helm with login UI for logs/traces/APM; [ ] sampling + retention + troubleshooting. Deps: O.7, O.8, O.9.
+
+**D.5 — Examples index + best practices + FAQ + migration** · S · `docs`
+- As a `developer`, I want an index + FAQ + migration notes so I can find examples and upgrade cleanly.
+- AC: [ ] examples index; [ ] best practices; [ ] FAQ; [ ] v0.5→v0.6 migration notes. Deps: T.3.
+
+**Order:** {D.1, D.4} after their features land → {D.2, D.3, D.5}.
+
+## N — Norms
+- Docs are PR-size-exempt; keep examples copy-pasteable and verified against the running stack.
+- `Signed-off-by:` + `Assisted-by:`; no literal personal emails in docs (gitleaks PII gate).
+
+## S — Safeguards (second S)
+### Context Security
+- [ ] No Tier 2 content (placeholder hosts/tokens only); [ ] no PII / no literal emails; [ ] N/A non-feat
+
+### Feature Safeguards
+- Never document a command/flow that isn't verified against the running stack — docs must be true.
+- Never include real credentials or internal hostnames in examples — placeholders only.

--- a/docs/spdd/G-git-mcp-shim/canvas.md
+++ b/docs/spdd/G-git-mcp-shim/canvas.md
@@ -1,0 +1,75 @@
+# REASONS Canvas — EPIC G: Git MCP Shim over git-adapter
+
+> Tier 1 (public-safe). Tier 2 (tokens, real repo URLs) → `canvas.private.md`. Run `/spdd-security-review` before committing.
+
+**Issue:** #1169 · **Milestone:** M7 (v0.6.0)
+**Author:** M7 program plan · **Date:** 2026-06-15 · **Status:** Draft
+
+---
+
+## R — Requirements
+- **Problem:** experts/authoring loops have no safe Git surface. The existing `git-adapter` is a
+  runtime gRPC capability provider, not an MCP server consumable by Claude Code / agent authoring.
+- An authoring session must perform Git ops (clone/branch/commit/PR/review) via **MCP tools** with a
+  **least-privilege, injected** token — **no secret ever serialized into a prompt**.
+- **Done when:** an authoring session opens a PR via MCP with a scoped token; no token appears in any
+  prompt or trace; `/spdd-security-review` PASS.
+
+## E — Entities
+```
+git-adapter (existing)     ← single Git implementation (clone/branch/commit/PR/review)
+GitMcpServer (new, thin)   ← exposes adapter capabilities as MCP tools
+CredentialInjector         ← env/secret-ref → process env at start; redaction in logs/traces
+.mcp.json example          ← wires `zynax mcp git` into the authoring loop
+```
+
+## A — Approach
+**We will:** build an MCP server as a **thin shim over git-adapter** (one Git implementation, two
+surfaces); inject credentials at process start via env/secret-ref; redact tokens in logs/traces; ship
+a `.mcp.json` example + `zynax mcp git`.
+**We will NOT:** reimplement Git logic in the MCP layer; embed tokens in prompts/config; deprecate the
+git-adapter (it stays the runtime path).
+**Governing ADRs:** ADR-032 (Git MCP shim — this EPIC), ADR-013 (adapter-first).
+
+## S — Structure (first S)
+```
+agents/adapters/git/internal/mcp/   ← thin MCP server over existing adapter handlers
+agents/adapters/git/cmd/git-adapter ← add `mcp` subcommand / mode
+cmd/zynax/                           ← `zynax mcp git`
+docs/git-mcp/ + .mcp.json.example    ← authoring-loop wiring + least-privilege guide
+```
+Config env prefix: `GIT_ADAPTER_` / token via `GITHUB_TOKEN` (injected, never logged).
+
+## O — Operations (stories — `spdd-story` form)
+**G.1 — ADR: MCP-shim-over-adapter + auth model** · S · `adr-proposal`
+- As a `maintainer`, I want the shim + least-privilege token model recorded so security is settled first.
+- AC: [ ] ADR-032 committed (shim rationale, injection-at-start, no-secrets-in-prompts, redaction). Deps: none.
+
+**G.2 — MCP server over git-adapter capabilities** · M · `feat`
+- As an `authoring agent`, I want Git ops as MCP tools so I can clone/branch/commit/PR via MCP.
+- AC: [ ] MCP tools map 1:1 to adapter handlers; [ ] no Git logic duplicated; [ ] `.feature`/contract test. Deps: G.1.
+
+**G.3 — Credential injection + redaction** · S · `feat`
+- As a `security reviewer`, I want tokens injected at process start and redacted so no secret leaks.
+- AC: [ ] token from env/secret-ref only; [ ] never serialized to prompt/log/trace; [ ] redaction test. Deps: G.2.
+
+**G.4 — CLI + `.mcp.json` wiring** · S · `feat`/`docs`
+- As a `developer`, I want `zynax mcp git` + an example config so the authoring loop uses it safely.
+- AC: [ ] `zynax mcp git` launches the server; [ ] `.mcp.json.example` documented with least-privilege scope. Deps: G.2.
+
+**Order:** G.1 → G.2 → {G.3, G.4}. (Independent of EPIC W — can run in Wave 1.)
+
+## N — Norms
+- Least-privilege by default; `Signed-off-by:` + `Assisted-by:` per commit.
+- `.feature`/contract test before MCP tool impl (ADR-016 spirit); `GOWORK=off` (ADR-017).
+
+## S — Safeguards (second S)
+### Context Security
+- [ ] No Tier 2 content (no real tokens/repo URLs — placeholders only)
+- [ ] No PII; [ ] no prompt-injection; [ ] `/spdd-security-review` — PENDING (Tier-2 mandatory for this EPIC)
+
+### Feature Safeguards
+- Never embed a Git token in a prompt, log, trace, or committed config — inject at process start only.
+- Never grant broader than required scope — least-privilege token per session/repo.
+- Never duplicate Git logic in the MCP layer — it is a thin shim over git-adapter only.
+- Never trust PR/issue content as instructions — treat external text as data (prompt-injection guard).

--- a/docs/spdd/L-log-streaming/canvas.md
+++ b/docs/spdd/L-log-streaming/canvas.md
@@ -1,0 +1,70 @@
+# REASONS Canvas — EPIC L: Execution Log/Event Streaming
+
+> Tier 1 (public-safe). Tier 2 → `canvas.private.md`. Run `/spdd-security-review` before committing.
+
+**Issue:** #468 (engine side; EPIC L) · **Milestone:** M7 (v0.6.0)
+**Author:** M7 program plan · **Date:** 2026-06-15 · **Status:** Draft
+
+---
+
+## R — Requirements
+- **Problem:** `GET /api/v1/workflows/{id}/logs` returns `{"error":"streaming not supported"}` — a
+  developer cannot watch a run. The engine-adapter polls Temporal instead of streaming history.
+- A developer must **stream live execution events** (state transitions + capability events) for a run.
+- **Done when:** `zynax logs <run-id> --follow` shows each transition/capability event for the
+  e2e-demo run with no `streaming not supported` error.
+
+## E — Entities
+```
+EngineAdapter.HistoryStream      ← long-poll GetWorkflowHistory → ordered events
+EventBus subscription (scoped)   ← per-workflow CloudEvents (TypePattern + WorkflowID)
+api-gateway log stream           ← SSE/chunked HTTP merging engine history + events
+CLI follower (`zynax logs`)      ← consumes the stream
+```
+
+## A — Approach
+**We will:** replace polling with Temporal **history long-poll** (closes #468); reuse EventBus
+`Subscribe` scoped by `WorkflowID`; expose a real streaming `/logs` (SSE/chunked); add `zynax logs --follow`.
+**We will NOT:** persist logs to a store (Uptrace handles log UI — EPIC O); add log search/filter (M-dx).
+**Governing ADRs:** ADR-015 (engine interface), ADR-022 (event-bus), ADR-016 (.feature first).
+
+## S — Structure (first S)
+```
+services/engine-adapter/internal/domain/   ← history streaming (replaces polling)
+services/event-bus/                          ← scoped subscription reuse
+services/api-gateway/internal/api/handler.go ← streaming /logs handler
+cmd/zynax/                                    ← `zynax logs --follow`
+```
+Config env prefix: `ZYNAX_ENGINE_ADAPTER_` / `ZYNAX_GW_`.
+
+## O — Operations (stories — `spdd-story` form)
+**L.1 — Engine-adapter history streaming (closes #468)** · M · `refactor`
+- As an `operator`, I want history long-poll instead of polling so events stream with low latency.
+- AC: [ ] `GetWorkflowHistory` long-poll replaces `DescribeWorkflowExecution` polling; [ ] ordered event stream; [ ] domain cov ≥90%. Deps: none.
+
+**L.2 — Per-workflow event subscription** · S · `feat`
+- As the `gateway`, I want a workflow-scoped event stream so capability events reach clients.
+- AC: [ ] reuse EventBus `Subscribe` with `WorkflowID` scope; [ ] stream closes on terminal state. Deps: L.1.
+
+**L.3 — Streaming `/logs` endpoint** · M · `feat`
+- As a `developer`, I want a real streaming `/logs` so I can watch a run live.
+- AC: [ ] SSE/chunked response merging history + events; [ ] no `streaming not supported`; [ ] `.feature` committed first. Deps: L.1, L.2.
+
+**L.4 — `zynax logs --follow`** · S · `feat`
+- As a `developer`, I want a CLI follower so I can tail a run from the terminal.
+- AC: [ ] `zynax logs <run-id> --follow` prints transitions/events until terminal. Deps: L.3.
+
+**Order:** L.1 → L.2 → L.3 → L.4.
+
+## N — Norms
+- `.feature` before the streaming endpoint impl (ADR-016); `GOWORK=off` (ADR-017).
+- `Signed-off-by:` + `Assisted-by:`; one logical change per commit.
+
+## S — Safeguards (second S)
+### Context Security
+- [ ] No Tier 2 content; [ ] no PII; [ ] no prompt-injection; [ ] `/spdd-security-review` — PENDING
+
+### Feature Safeguards
+- Never leak payload secrets in streamed events — redact (consistent with EPIC O).
+- Never block the engine worker on a slow client — bounded buffering / drop-with-marker.
+- Never bypass auth on the streaming endpoint — same bearer rules as other gateway routes.

--- a/docs/spdd/O-observability-otel-uptrace/canvas.md
+++ b/docs/spdd/O-observability-otel-uptrace/canvas.md
@@ -1,0 +1,130 @@
+# REASONS Canvas — EPIC O: Observability (OTEL + Uptrace + Prometheus)
+
+> **All content in this Canvas is Tier 1 (public-safe).** Tier 2 → `canvas.private.md`. Run `/spdd-security-review` before committing.
+
+**Issue:** #467 (absorbed into EPIC O)
+**Author:** M7 program plan · **Date:** 2026-06-15 · **Status:** Draft
+
+---
+
+## R — Requirements
+
+- **Problem:** there is no telemetry — no traces, no scraped metrics, no log correlation. A run is
+  a black box; you cannot see the api-gateway → compiler → engine → broker → registry → agent path.
+- A developer must see **traces, metrics, logs, and an APM/service-map** in **one UI with login**,
+  both **locally** (`docker compose up`) and **in-cluster** (Helm).
+- Logs must be **viewable in the UI** alongside traces (shipped via OTLP) and correlated by `trace_id`.
+- **Done when:** one workflow run yields a connected trace across every hop **and its logs**, visible
+  in the Uptrace login UI (compose + Helm); RED metrics scraped; service map populated.
+
+---
+
+## E — Entities
+
+```
+zynaxotel (shared lib)
+├── TracerProvider / MeterProvider / LoggerProvider  ← OTLP/gRPC exporters
+└── ResourceAttributes                                ← semconv (service.name, service.version, …)
+Uptrace (backend)
+├── UI (login)            ← traces · metrics · logs · APM · service map
+├── OTLP ingest (gRPC)    ← default endpoint for all services + adapters
+└── storage deps          ← (single-binary or ClickHouse/Postgres per deployment)
+Prometheus /metrics       ← existing scrape surface (M6) + RED metrics + exemplars
+```
+
+---
+
+## A — Approach
+
+**We will:**
+- Standardise on **OpenTelemetry**; default backend **Uptrace** (traces+metrics+logs+APM, login UI).
+- Default transport **OTLP/gRPC**; OTLP/HTTP optional. Off unless `ZYNAX_OTEL_EXPORTER_OTLP_ENDPOINT` set.
+- Provide a shared `libs/zynaxotel` Go package and OTEL in the Python SDK.
+- Propagate W3C `traceparent` across gRPC, Temporal activities, and NATS headers.
+- Ship Uptrace in **both** a compose overlay **and** a Helm chart (`observability.enabled`), with the **login UI** exposed.
+- Ship structured logs to Uptrace via **OTLP logs**; keep `/metrics` for Prometheus scrape.
+
+**We will NOT:**
+- Deploy Jaeger, Loki, or Elasticsearch (single backend; avoid sprawl).
+- Implement tail-based sampling or long-term retention tuning — **deferred to M8**.
+
+**Governing ADRs:** ADR-030 (OTEL + Uptrace — this EPIC), ADR-022 (event-bus/NATS), ADR-020 (mTLS — secure OTLP in-cluster).
+
+---
+
+## S — Structure (first S)
+
+```
+libs/zynaxotel/                                  ← providers, exporters, interceptors
+services/*/cmd/*/main.go                          ← init providers; gRPC/HTTP interceptors
+agents/sdk/src/zynax_sdk/                          ← OTEL traces+logs for capability handlers
+infra/docker-compose/docker-compose.observability.yml  ← Uptrace + deps + collector + login UI (70xx)
+infra/helm/charts/uptrace/                         ← Deployment/Service/Ingress + UI; values toggle
+docs/observability/                                ← naming conventions, sampling, troubleshooting
+```
+
+Config env prefix: `ZYNAX_OTEL_` · Uptrace UI host port: 70xx (local).
+
+---
+
+## O — Operations (stories — `spdd-story` form)
+
+**O.1 — ADR: OTEL + Uptrace (traces+metrics+logs+APM)** · S · `adr-proposal`
+- As a `maintainer`, I want the backend + transport + sampling decision recorded so the stack is stable.
+- AC: [ ] ADR-030 committed (Uptrace default, OTLP/gRPC, head sampling, logs-via-OTLP); [ ] non-goals listed. Deps: none.
+
+**O.2 — Shared `libs/zynaxotel` package** · M · `feat`
+- As a `service author`, I want one package for tracer/meter/logger providers so instrumentation is consistent.
+- AC: [ ] providers + OTLP exporter + semconv resource attrs; [ ] no-op when endpoint unset; [ ] unit tests. Deps: O.1.
+
+**O.3 — Instrument all 7 services** · M · `feat`
+- As an `operator`, I want every gRPC/HTTP hop traced so requests are followable end-to-end.
+- AC: [ ] server+client gRPC interceptors wired; [ ] api-gateway HTTP middleware; [ ] spans named `<service>.<rpc>`. Deps: O.2.
+
+**O.4 — RED metrics + exemplars** · S · `feat`
+- As an `operator`, I want rate/error/duration metrics with exemplars so dashboards link to traces.
+- AC: [ ] RED metrics on gRPC + HTTP; [ ] exemplars carry `trace_id`; [ ] scraped at `/metrics`. Deps: O.2.
+
+**O.5 — Trace propagation across Temporal + NATS** · M · `feat`
+- As an `operator`, I want trace context preserved across the engine and event bus so the trace is unbroken.
+- AC: [ ] `traceparent` in Temporal memo/headers + NATS message headers; [ ] connected trace across async hops. Deps: O.3.
+
+**O.6 — Python adapter instrumentation** · M · `feat`
+- As an `agent author`, I want capability handlers auto-traced + logs exported so agent work appears in the UI.
+- AC: [ ] OTEL traces+logs in `agents/sdk`; [ ] `capability.<name>` spans; [ ] context extracted from inbound task. Deps: O.2, O.5.
+
+**O.7 — Local Uptrace compose stack (login UI for logs/traces/APM)** · M · `feat`/`infra`
+- As a `developer`, I want `docker compose up` to give me a UI for logs/traces/APM so I can see runs locally.
+- AC: [ ] `docker-compose.observability.yml` runs Uptrace + deps + collector; [ ] login UI on a 70xx port; [ ] a run's traces+logs visible. Deps: O.2.
+
+**O.8 — Uptrace Helm chart** · M · `feat`/`infra`
+- As an `operator`, I want Uptrace deployable in-cluster so logs/traces are visible in any environment.
+- AC: [ ] `infra/helm/charts/uptrace/` (Deployment/Service/Ingress + UI); [ ] `observability.enabled` toggle; [ ] services point at in-cluster OTLP endpoint; [ ] `helm lint` green. Deps: O.7.
+
+**O.9 — Logs to Uptrace + naming conventions** · S · `feat`/`docs`
+- As an `operator`, I want structured logs in the UI correlated to traces so I can debug from one place.
+- AC: [ ] logs shipped via OTLP logs; [ ] every log line carries `trace_id`/`span_id`; [ ] span/metric naming doc committed. Deps: O.3, O.7.
+
+**Order:** O.1 → O.2 → {O.3, O.4, O.7} → {O.5, O.8, O.9} → O.6.
+
+---
+
+## N — Norms
+- `Signed-off-by:` + `Assisted-by:` per commit; one logical change per commit.
+- OTEL semantic conventions for resource + span attributes; no custom vendor lock-in.
+- Telemetry **off by default** (env-gated) — zero overhead when disabled.
+- `helm lint` gate for the new chart; `GOWORK=off` for service `go` commands (ADR-017).
+
+## S — Safeguards (second S)
+
+### Context Security
+- [ ] No Tier 2 content (the compose/Helm values use placeholders, not real hostnames/credentials)
+- [ ] No PII in span/log attributes; redact request payloads by default
+- [ ] No prompt-injection phrasing
+- [ ] `/spdd-security-review` — result: PENDING
+
+### Feature Safeguards
+- Never emit secrets/credentials/tokens into spans, metrics, or logs — redact by default.
+- Never make telemetry mandatory for the core stack — must run with observability disabled.
+- Never add a second tracing backend — Uptrace is the single sink (avoid Jaeger/Loki/ES sprawl).
+- Never block the request path on the exporter — use batch/async export.

--- a/docs/spdd/Q-quality-supply-chain/canvas.md
+++ b/docs/spdd/Q-quality-supply-chain/canvas.md
@@ -1,0 +1,74 @@
+# REASONS Canvas — EPIC Q: Quality & Supply-Chain Fixes (audit closeout)
+
+> Tier 1 (public-safe). `chore:`/`ci:`/`docs:` work is SPDD-exempt; committed for traceability.
+
+**Issue:** #1172 + #582 #583 · **Milestone:** M7 (v0.6.0)
+**Author:** M7 program plan · **Date:** 2026-06-15 · **Status:** Draft
+
+---
+
+## R — Requirements
+- **Problem (from the 2026-06-15 reality check):** `make security-agents`/`lint-go` fail on a
+  tools-image `pip` CVE; `make test-coverage` fails on an interface-only package; PyPI Trusted
+  Publisher provenance is undocumented.
+- **Done when:** `make ci` is green on a clean checkout; the PyPI Trusted Publisher history is
+  recorded; the Go module consumption path is documented.
+
+## E — Entities
+```
+tools image (pip 26.1.1 → 26.1.2, PYSEC-2026-196)
+coverage gate (event-bus interface-only domain package)
+PyPI Trusted Publisher (OIDC) provenance record
+pkg.go.dev module consumption path
+ManifestWorkflowID collision-domain ADR
+```
+
+## A — Approach
+**We will:** bump tools-image `pip`; make the coverage gate honest for zero-statement packages;
+document the PyPI Trusted Publisher history; verify pkg.go.dev import; record the ManifestWorkflowID ADR.
+**We will NOT:** restructure the coverage gate beyond zero-statement handling (no blanket skips).
+**Governing ADRs:** ADR-024 (image SoT), ADR-025 (SLSA provenance), ADR-027 (shift-left pipeline).
+
+## S — Structure (first S)
+```
+infra/docker/Dockerfile.tools (+ images.yaml)   ← pip bump
+Makefile (test-coverage gate)                     ← zero-statement package handling
+docs/milestones/M7-planning.md §14                ← PyPI Trusted Publisher history
+docs/ (module consumption) · docs/adr/ADR-034     ← #582 / #583
+```
+
+## O — Operations (stories — `spdd-story` form)
+**Q.1 — Bump tools-image pip → 26.1.2** · XS · `ci`
+- As a `maintainer`, I want the pip CVE closed so `make security-agents`/`lint-go` run clean.
+- AC: [ ] tools image rebuilt with pip 26.1.2; [ ] `make security-agents` passes; [ ] images.yaml updated via `make sync-images`. Deps: none. **(Wave 0 — unblocks green CI for all EPICs.)**
+
+**Q.2 — Honest coverage gate for interface-only packages** · S · `ci`
+- As a `maintainer`, I want the gate to handle zero-statement packages so `make test-coverage` passes truthfully.
+- AC: [ ] `event-bus/internal/domain` no longer reported as `0.0% < 90%`; [ ] only zero-statement packages excluded (verified via `go tool cover` count, not a blanket skip). Deps: none. **(Wave 0.)**
+
+**Q.3 — Document PyPI Trusted Publisher history** · S · `docs`
+- As a `maintainer`, I want the OIDC publisher config recorded so SDK provenance is auditable.
+- AC: [ ] §14 of the M7 plan filled with publisher/workflow/environment/first-publish; [ ] linked from v0.6.0 release notes; [ ] if the PyPI entry is missing, it is created before next publish. Deps: none.
+
+**Q.4 — Document Go module consumption path (#582)** · XS · `docs`
+- As a `consumer`, I want a verified pkg.go.dev import path so the module is usable downstream.
+- AC: [ ] import availability verified + documented. Deps: none.
+
+**Q.5 — ManifestWorkflowID collision-domain ADR (#583)** · S · `adr-proposal`
+- As a `maintainer`, I want the 64-bit collision domain + canonicalization recorded so the id scheme is stable.
+- AC: [ ] ADR-034 committed. Deps: none.
+
+**Order:** {Q.1, Q.2} first (Wave 0) → {Q.3, Q.4, Q.5} any time.
+
+## N — Norms
+- Image refs only via `images.yaml` + `make sync-images` (ADR-024) — never hand-edit banner regions.
+- `Signed-off-by:` + `Assisted-by:`; squash-merge required; no `[skip ci]` token.
+
+## S — Safeguards (second S)
+### Context Security
+- [ ] No Tier 2 content (no real tokens/registry creds); [ ] no PII / no literal emails; [ ] N/A non-feat
+
+### Feature Safeguards
+- Never exclude a package with executable statements from the coverage gate — only true zero-statement packages.
+- Never store a long-lived PyPI token — Trusted Publisher (OIDC) only.
+- Never hand-edit image-version banner regions — use `make sync-images`.

--- a/docs/spdd/R-test-rigor/canvas.md
+++ b/docs/spdd/R-test-rigor/canvas.md
@@ -1,0 +1,71 @@
+# REASONS Canvas — EPIC R: Test Rigor (benchmarks · fuzz · integration · e2e · observability)
+
+> Tier 1 (public-safe). `test:`/`ci:` work is SPDD-exempt; this canvas is committed for traceability.
+
+**Issue:** #469 (absorbed) + #493 #553 #1103 · **Milestone:** M7 (v0.6.0)
+**Author:** M7 program plan · **Date:** 2026-06-15 · **Status:** Draft
+
+---
+
+## R — Requirements
+- **Problem:** integration tests exist but aren't a required gate; no benchmarks/fuzz; e2e is `xfail`;
+  no test asserts that telemetry is actually emitted.
+- **Done when:** benchmark, fuzz, integration, e2e, and observability-validation tests run in CI as gates.
+
+## E — Entities
+```
+Benchmarks (IRInterpreter, workflow-compiler) + regression gate
+Fuzz harness (YAML→IR compiler)
+Integration suite (//go:build integration) as required CI gate
+E2E (real `zynax apply`) replacing platform-readiness xfail
+Observability-validation test (connected-trace assertion)
+```
+
+## A — Approach
+**We will:** add benchmarks with a regression gate (#493); fuzz the compiler; promote the integration
+suite to a required gate (#553); flip the platform-readiness `xfail` to a real e2e (#1103); add a test
+that asserts a run emits a connected trace.
+**We will NOT:** add performance/load/chaos tests — **deferred to M8**.
+**Governing ADRs:** ADR-016 (layered testing), ADR-017 (GOWORK=off).
+
+## S — Structure (first S)
+```
+services/{workflow-compiler,engine-adapter}/...   ← benchmarks + fuzz
+.github/workflows/ci.yml + e2e-smoke.yml          ← integration + e2e + benchmark gates
+protos/tests/ · spec/automation/                  ← e2e + observability-validation
+```
+
+## O — Operations (stories — `spdd-story` form)
+**R.1 — Benchmarks + regression gate (#493)** · M · `test`
+- As a `maintainer`, I want compiler/interpreter benchmarks gated so perf regressions are caught.
+- AC: [ ] benchmarks committed; [ ] regression threshold gate in CI. Deps: W.4.
+
+**R.2 — Fuzz the YAML→IR compiler** · S · `test`
+- As a `maintainer`, I want fuzzing so malformed manifests can't crash the compiler.
+- AC: [ ] fuzz target committed; [ ] runs in CI; [ ] seed corpus from examples. Deps: W.3.
+
+**R.3 — Integration suite as required gate (#553)** · S · `ci`
+- As a `maintainer`, I want integration tests required so cross-service breakage is caught pre-merge.
+- AC: [ ] `//go:build integration` suite runs in CI as a required check. Deps: none.
+
+**R.4 — Real e2e replaces xfail (#1103)** · M · `test`
+- As a `maintainer`, I want a real `zynax apply` e2e so platform-readiness is genuinely verified.
+- AC: [ ] platform-readiness `xfail` flipped to a real e2e against the stack. Deps: T.3.
+
+**R.5 — Observability-validation test** · S · `test`
+- As a `maintainer`, I want a test asserting a connected trace so observability can't silently regress.
+- AC: [ ] test asserts one run produces a connected end-to-end trace (+log correlation). Deps: O.5, O.9.
+
+**Order:** {R.2, R.3} early → R.1 → {R.4, R.5}.
+
+## N — Norms
+- `GOWORK=off` for all `go test` in services (ADR-017); BDD at gRPC boundaries (ADR-016).
+- `Signed-off-by:` + `Assisted-by:`; `[skip ci]` marker forbidden in messages/PR bodies.
+
+## S — Safeguards (second S)
+### Context Security
+- [ ] No Tier 2 content; [ ] no PII; [ ] no prompt-injection; [ ] N/A — non-feat (no security-review gate)
+
+### Feature Safeguards
+- Never weaken an existing gate to make a new one pass — gates only get stricter.
+- Never mark a flaky test `xfail` to bypass — fix or quarantine with a tracked issue.

--- a/docs/spdd/T-templates-real-workflows/canvas.md
+++ b/docs/spdd/T-templates-real-workflows/canvas.md
@@ -1,0 +1,70 @@
+# REASONS Canvas — EPIC T: Reusable Templates + First Real Workflows
+
+> Tier 1 (public-safe). Tier 2 → `canvas.private.md`. Run `/spdd-security-review` before committing.
+
+**Issue:** #1171 · **Milestone:** M7 (v0.6.0)
+**Author:** M7 program plan · **Date:** 2026-06-15 · **Status:** Draft
+
+---
+
+## R — Requirements
+- **Problem:** there are validation example manifests but no **reusable templates** (workflow/task/
+  expert) and no **production-quality real workflows** that run end-to-end with data-flow.
+- **Done when:** three real workflows (`code-review`, `ci-pipeline`, `feature-implementation`) apply
+  and run green locally with data-flow + traces; `zynax init` scaffolds from templates; templates versioned.
+
+## E — Entities
+```
+WorkflowTemplate / TaskTemplate / ExpertTemplate  ← parameterized, versioned scaffolds
+version: field                                      ← workflow versioning
+zynax init workflow|expert                          ← scaffolder
+Real workflows: code-review · ci-pipeline · feature-implementation
+```
+
+## A — Approach
+**We will:** add a template mechanism (parameterized + `version:`); surface validation/versioning in
+the CLI; ship three runnable real workflows built on EPIC W data-flow + EPIC X experts; add
+`zynax init` scaffolding.
+**We will NOT:** ship the full example catalog (K8s/Helm/GitOps/security/etc.) — **deferred to M-dx**;
+no replay/visualization/debugging yet (M-dx).
+**Governing ADRs:** ADR-011 (declarative YAML), ADR-014 (state machine), ADR-029 (data-flow).
+
+## S — Structure (first S)
+```
+spec/templates/{workflow,task,expert}/   ← reusable templates (versioned)
+spec/workflows/examples/                   ← code-review.yaml · ci-pipeline.yaml · feature-implementation.yaml (runnable)
+cmd/zynax/                                  ← `zynax init`, `zynax validate`, `version:` surfacing
+docs/authoring/                             ← template + authoring guide
+```
+
+## O — Operations (stories — `spdd-story` form)
+**T.1 — Template mechanism (workflow/task/expert) + versioning** · M · `feat`
+- As a `workflow author`, I want reusable, versioned templates so I don't author from scratch.
+- AC: [ ] template format + `version:` field; [ ] schema validation; [ ] `.feature`/contract test. Deps: W.3.
+
+**T.2 — CLI validate + versioning surfacing** · S · `feat`
+- As a `developer`, I want `zynax validate` and visible workflow versions so I catch errors pre-apply.
+- AC: [ ] `zynax validate <file>` reports schema/data-flow errors; [ ] `version:` shown in status. Deps: T.1.
+
+**T.3 — Three real, runnable workflows** · M · `feat`
+- As a `developer`, I want production-quality workflows that actually run so Zynax is usable.
+- AC: [ ] `code-review`, `ci-pipeline`, `feature-implementation` apply + run to terminal with data-flow + traces. Deps: W.5, X.3.
+
+**T.4 — `zynax init workflow|expert`** · S · `feat`
+- As a `developer`, I want scaffolding so I can start a new workflow/expert from a template.
+- AC: [ ] `zynax init workflow|expert` emits a valid, versioned starting manifest. Deps: T.1.
+
+**Order:** T.1 → {T.2, T.4} → T.3.
+
+## N — Norms
+- Manifests validate against `spec/schemas`; `make validate-spec` gate.
+- `Signed-off-by:` + `Assisted-by:`; one logical change per commit.
+
+## S — Safeguards (second S)
+### Context Security
+- [ ] No Tier 2 content (templates use placeholder repos/values); [ ] no PII; [ ] no prompt-injection; [ ] `/spdd-security-review` — PENDING
+
+### Feature Safeguards
+- Never ship a real workflow that depends on unimplemented features — must run on M7 capabilities.
+- Never bake secrets into templates — parameterize via inputs/secret-refs.
+- Never break manifest schema backward-compatibility — `version:` gates evolution.

--- a/docs/spdd/W-workflow-data-flow/canvas.md
+++ b/docs/spdd/W-workflow-data-flow/canvas.md
@@ -1,0 +1,144 @@
+# REASONS Canvas — EPIC W: Workflow Data-Flow (output/input bindings)
+
+> **All content in this Canvas is Tier 1 (public-safe).**
+> Tier 2 content belongs in `canvas.private.md` (gitignored). Run `/spdd-security-review <path>` before committing.
+
+**Issue:** #1167 · **Milestone:** M7 (v0.6.0)
+**Author:** M7 program plan
+**Date:** 2026-06-15
+**Status:** Draft
+
+---
+
+## R — Requirements
+
+- **Problem:** the compiler rejects `output:` on actions/states (`"output: which is not yet
+  implemented; … upgrade to M7+"`), so no workflow can pass data between states. Every real
+  pipeline (research → summarize, build → test → deploy) is currently inexpressible.
+- A state's action must be able to **publish named outputs**; a later state must be able to
+  **consume** them as inputs by reference.
+- Data must be **workflow-scoped** and **explicitly read/written** — no implicit global mutable state.
+- **Done when:** `research-task.yaml` and `code-review.yaml` apply and run to a terminal state with
+  a downstream state consuming an upstream output; a BDD scenario covers data-flow; domain cov ≥90%.
+
+---
+
+## E — Entities
+
+```
+WorkflowIR
+├── State
+│   ├── Action.output_bindings   ← named outputs an action publishes (key → source path)
+│   └── Action.input_bindings    ← inputs an action consumes (key → reference into data context)
+└── WorkflowDataContext          ← workflow-scoped key/value store, written by outputs, read by inputs
+        └── DataReference          ← typed reference ("$.states.search.output.results")
+```
+
+Relationships: `Action` *writes* `WorkflowDataContext` via `output_bindings`; `Action` *reads* it
+via `input_bindings`. The context lives for the workflow run only.
+
+---
+
+## A — Approach
+
+**We will:**
+- Add **additive** proto fields for `output_bindings` / `input_bindings` to `WorkflowIR`
+  (backward-compatible; manifests without them compile unchanged).
+- Define a **minimal binding model**: literal values + JSON-path references into the data context.
+- Compile bindings to IR, validate that every input reference resolves to a declared upstream output.
+- Thread a workflow-scoped data context through the `IRInterpreterWorkflow` in engine-adapter.
+
+**We will NOT:**
+- Add an expression/transform language (filters, math, templating) — **deferred to M-dx**.
+- Allow cross-workflow or cross-namespace data sharing.
+- Persist the data context beyond the run (no durable data store in M7).
+
+**Governing ADRs:** ADR-029 (workflow data-flow semantics — this EPIC), ADR-012 (Workflow IR),
+ADR-014 (event-driven state machine), ADR-015 (pluggable engines), ADR-016 (.feature before impl).
+
+---
+
+## S — Structure (first S)
+
+```
+protos/zynax/v1/workflow_compiler.proto   ← add output_bindings/input_bindings (additive)
+services/workflow-compiler/internal/domain/ir/        ← compile + validate bindings
+services/workflow-compiler/internal/domain/validators/ ← reference-resolution validation
+services/engine-adapter/internal/domain/              ← WorkflowDataContext + interpreter threading
+protos/tests/workflow_compiler_service/               ← .feature for data-flow (new behaviour)
+```
+
+Config env prefix: `ZYNAX_WC_` / `ZYNAX_ENGINE_ADAPTER_` · No new ports.
+
+---
+
+## O — Operations (stories — `spdd-story` form)
+
+**W.1 — ADR: data-flow semantics & scoping model**
+- As a `maintainer`, I want a recorded decision on the binding model so that the contract is stable before code.
+- Size: S · Type: `docs`/`adr-proposal`
+- Acceptance:
+  - [ ] ADR-029 committed (Proposed→Accepted) defining binding syntax, scoping, and non-goals
+  - [ ] `buf breaking` implications documented (fields are additive)
+- Out of scope: implementation. Dependencies: none (gates W.2).
+
+**W.2 — Proto: output/input binding fields + `.feature`**
+- As a `workflow author`, I want IR fields for published outputs and consumed inputs so that states can exchange data.
+- Size: M · Type: `feat` (new gRPC behaviour → `/spdd-api-test` first)
+- Acceptance:
+  - [ ] `output_bindings`/`input_bindings` added to the IR proto; stubs regenerated
+  - [ ] `.feature` scenario committed before implementation (ADR-016)
+  - [ ] `buf breaking` passes (additive only)
+- Out of scope: compiler logic. Dependencies: W.1.
+
+**W.3 — Compiler: compile + validate bindings; lift the rejection**
+- As a `workflow author`, I want `output:` accepted and validated so that valid manifests compile.
+- Size: M · Type: `feat`
+- Acceptance:
+  - [ ] `output:` no longer rejected; bindings compiled into IR
+  - [ ] unresolved input references produce a clear `COMPILATION_ERROR` with line number
+  - [ ] domain coverage ≥90%
+- Out of scope: execution. Dependencies: W.2.
+
+**W.4 — Engine-adapter: workflow-scoped data context**
+- As a `workflow run`, I want outputs stored and inputs resolved at execution so that data flows state→state.
+- Size: M · Type: `feat`
+- Acceptance:
+  - [ ] interpreter writes action outputs into a run-scoped context and resolves inputs from it
+  - [ ] missing/typed-mismatch reference fails the run with a structured error
+  - [ ] domain coverage ≥90%
+- Out of scope: persistence. Dependencies: W.3.
+
+**W.5 — End-to-end: real workflows run green**
+- As a `developer`, I want the example workflows to actually run so that data-flow is proven end-to-end.
+- Size: S · Type: `test`
+- Acceptance:
+  - [ ] `apply research-task.yaml` reaches terminal with `summarize` consuming `search` output
+  - [ ] `apply code-review.yaml` runs green
+  - [ ] e2e assertion added to the suite
+- Out of scope: new examples (EPIC T). Dependencies: W.4.
+
+**Order:** W.1 → W.2 → W.3 → W.4 → W.5 (strictly sequential — keystone path).
+
+---
+
+## N — Norms
+
+- `Signed-off-by:` + `Assisted-by: Claude/<model>` on every commit; one logical change per commit.
+- `.feature` committed before any gRPC boundary implementation (ADR-016); `GOWORK=off` for all `go` in services (ADR-017).
+- Proto changes additive only; `buf breaking` is a CI gate.
+- Conventional commit types limited to feat/fix/refactor/docs/test/ci/chore.
+
+## S — Safeguards (second S)
+
+### Context Security (complete before committing this Canvas)
+- [ ] No Tier 2 content (no hostnames/IPs/credentials/deployment specifics)
+- [ ] No PII; all E-section entities are public-safe abstractions
+- [ ] No prompt-injection phrasing
+- [ ] `/spdd-security-review` passed — result: PENDING (run before Aligned)
+
+### Feature Safeguards
+- Never make proto changes non-additive — backward compatibility is mandatory (ADR-012, `buf breaking`).
+- Never let one workflow read another's data context — strict run-scoping (ADR-008 spirit: no shared state).
+- Never introduce an expression language in M7 — bindings are literal/path refs only (scope guard).
+- Never hardcode engine behaviour — data context lives behind the `WorkflowEngine` interface (ADR-015).

--- a/docs/spdd/X-expert-substrate/canvas.md
+++ b/docs/spdd/X-expert-substrate/canvas.md
@@ -1,0 +1,79 @@
+# REASONS Canvas — EPIC X: Expert-Agent Substrate + agents/examples
+
+> Tier 1 (public-safe). Tier 2 → `canvas.private.md`. Run `/spdd-security-review` before committing.
+
+**Issue:** #1170 · **Milestone:** M7 (v0.6.0)
+**Author:** M7 program plan · **Date:** 2026-06-15 · **Status:** Draft
+
+---
+
+## R — Requirements
+- **Problem:** `agents/examples/` does not exist; there is no canonical "write-your-own-agent"
+  reference and no runtime **expert** pattern. The brief wants experts on **two substrates**:
+  runtime AgentDef agents (in-workflow) and Claude Code experts (authoring loop).
+- **Done when:** `agents/examples/` builds/lints/tests; a runtime expert (`go-review-expert`)
+  registers and is dispatchable in a workflow with a trace; every authoring expert declares its
+  runtime mapping.
+
+## E — Entities
+```
+agents/examples/{echo, summarizer, go-review-expert}  ← reference agents on the SDK
+RuntimeExpert (kind: AgentDef)                          ← registered + dispatched + OTEL-traced
+AuthoringExpert (automation/workflows/experts/*.yaml)   ← Claude Code delivery-loop experts
+ExpertMapping table                                     ← runtime ↔ authoring (or authoring-only)
+```
+
+## A — Approach
+**We will:** create `agents/examples/` with three SDK-based reference agents; define a runtime
+expert pattern (`kind: AgentDef` template + capability schema + registration); map each authoring
+expert to its runtime counterpart (or mark "authoring-only"); wire `make lint-agent`/`test-unit-agent`
+to discover `agents/examples/*`.
+**We will NOT:** ship the full 14-expert library or RAG/memory strategies — **deferred to M-dx**.
+**Governing ADRs:** ADR-033 (expert substrate — this EPIC), ADR-010 (pluggable agent runtime), ADR-013 (adapter-first).
+
+## S — Structure (first S)
+```
+agents/examples/echo/ · summarizer/ · go-review-expert/   ← pyproject + handler + tests
+agents/sdk/                                                 ← expert helpers (capability schema)
+spec/workflows/examples/agent-def-expert.yaml               ← runtime expert AgentDef template
+automation/workflows/experts/*.yaml                         ← add `runtime_mapping:` field
+Makefile (lint-agent/test-unit-agent discovery)             ← glob agents/examples/*
+docs/experts/                                               ← authoring guide + mapping table
+```
+Config: Python 3.12 + uv (ADR-002/003).
+
+## O — Operations (stories — `spdd-story` form)
+**X.1 — ADR: expert substrate + mapping** · S · `adr-proposal`
+- As a `maintainer`, I want the dual-substrate model + mapping recorded so runtime/authoring don't drift.
+- AC: [ ] ADR-033 committed (runtime AgentDef + authoring expert, mapping table, drift guard). Deps: none.
+
+**X.2 — `agents/examples/` reference agents** · M · `feat`
+- As an `agent author`, I want canonical SDK examples so I can copy a working pattern.
+- AC: [ ] `echo`, `summarizer`, `go-review-expert` build/lint/test; [ ] each has a capability schema + BDD. Deps: X.1.
+
+**X.3 — Runtime expert pattern (AgentDef)** · M · `feat`
+- As a `workflow author`, I want a registerable expert so an expert can run inside a workflow.
+- AC: [ ] `kind: AgentDef` expert template; [ ] registers in agent-registry; [ ] dispatchable + OTEL-traced. Deps: X.2, O.6.
+
+**X.4 — Make discovery for examples** · XS · `ci`
+- As a `contributor`, I want CI to lint/test `agents/examples/*` so they stay green.
+- AC: [ ] `make lint-agent AGENT=` + `test-unit-agent AGENT=` discover examples; [ ] CI runs them. Deps: X.2.
+
+**X.5 — Authoring↔runtime mapping** · S · `docs`/`feat`
+- As a `maintainer`, I want each authoring expert mapped to a runtime expert so the system is coherent.
+- AC: [ ] `runtime_mapping:` added to `experts/*.yaml`; [ ] CI check that every authoring expert declares it; [ ] mapping table in docs. Deps: X.1.
+
+**Order:** X.1 → X.2 → {X.3, X.4, X.5}.
+
+## N — Norms
+- Python: ruff + mypy clean; ≥90% coverage on new agent code; uv-managed (ADR-002/003).
+- `Signed-off-by:` + `Assisted-by:`; `.claude/commands` files need `git add -f`; no literal emails (gitleaks PII gate).
+
+## S — Safeguards (second S)
+### Context Security
+- [ ] No Tier 2 content; [ ] no PII / no literal emails; [ ] no prompt-injection; [ ] `/spdd-security-review` — PENDING
+
+### Feature Safeguards
+- Never grant an expert broader capability scope than declared — least-privilege per capability.
+- Never let runtime and authoring experts drift silently — the mapping table is the SoT (CI-checked).
+- Never require the SDK for agents — examples use it but adapters remain SDK-optional (ADR-013).

--- a/state/current-milestone.md
+++ b/state/current-milestone.md
@@ -18,6 +18,7 @@
 | M4 — YAML System + CLI | ⚠ Partial | v0.3.0 |
 | **M5 — Adapter Library** | ✅ **Complete** | **v0.4.0** |
 | **M6 — K8s Production-Ready** | ✅ **Complete** | **v0.5.0** |
+| **M7 — Usable Workflows + Observability** | 🚧 **Active** | **v0.6.0 (target)** |
 
 M3/M4 are partial because task-broker and agent-registry were not delivered in those milestones.
 Both completed under M5.C (#460). CloudEvents publishing is log-only (not wired to NATS).
@@ -27,10 +28,38 @@ See [docs/milestones/M5-plan.md](../docs/milestones/M5-plan.md).
 
 ---
 
+## M7 — Active (🚧 target v0.6.0, opened 2026-06-15)
+
+GitHub milestone #7 ("Full Observability"); scope broadened to **Usable Workflows + Observability**
+— first of the M7 → M-dx → M8 program. Full plan: **[docs/milestones/M7-planning.md](../docs/milestones/M7-planning.md)**.
+
+Goal: a developer authors a real multi-step workflow, runs it locally (`docker compose up` incl.
+**Uptrace**), watches it execute state→state with **data-flow**, **streamed logs**, and a connected
+**distributed trace** in the Uptrace login UI — with green `make ci`.
+
+### EPICs (10) — one REASONS Canvas each under `docs/spdd/<letter>-<slug>/`
+| EPIC | Title | Type | Canvas |
+|------|-------|------|--------|
+| W | Workflow data-flow (output/input bindings) — **keystone** | feat | [W](../docs/spdd/W-workflow-data-flow/canvas.md) |
+| L | Execution log/event streaming (`/logs`) | feat | [L](../docs/spdd/L-log-streaming/canvas.md) |
+| O | Observability — OTEL + **Uptrace** (traces/metrics/logs/APM + login UI; compose **and** Helm) | feat | [O](../docs/spdd/O-observability-otel-uptrace/canvas.md) |
+| C | Context propagation (trace · data · correlation) | feat | [C](../docs/spdd/C-context-propagation/canvas.md) |
+| G | Git MCP shim over git-adapter | feat | [G](../docs/spdd/G-git-mcp-shim/canvas.md) |
+| X | Expert-agent substrate + `agents/examples/` | feat | [X](../docs/spdd/X-expert-substrate/canvas.md) |
+| T | Reusable templates + first real workflows | feat | [T](../docs/spdd/T-templates-real-workflows/canvas.md) |
+| R | Test rigor (absorbs #469; #493 #553 #1103) | test | [R](../docs/spdd/R-test-rigor/canvas.md) |
+| Q | Quality & supply-chain fixes (pip CVE · coverage gate · PyPI Trusted Publisher) | chore/ci | [Q](../docs/spdd/Q-quality-supply-chain/canvas.md) |
+| D | Docs — quick-start · authoring · observability | docs | [D](../docs/spdd/D-docs/canvas.md) |
+
+Pre-existing M7 EPICs #467 (OTel) / #468 (history streaming) / #469 (test rigor) are **absorbed** into
+O / L / R respectively. New ADRs: ADR-029…034 (Proposed).
+
+---
+
 ## M6 — Complete (✅ released v0.5.0, 2026-06-12)
 
 GitHub milestone #6 closed; all 8 EPICs and every story delivered (one deferral: Wave 4 O8 → M7 #1103).
-Release: https://github.com/zynax-io/zynax/releases/tag/v0.5.0 · Next milestone: not yet open — run /milestone-new (M7 — Full Observability).
+Release: https://github.com/zynax-io/zynax/releases/tag/v0.5.0 · **Next milestone: M7 — open (active) as of 2026-06-15.**
 
 Full plan + per-EPIC status: **[docs/milestones/M6-planning.md](../docs/milestones/M6-planning.md)**.
 As of 2026-06-11: **143 issues closed / 17 open** (CI-overhaul stories #1110–#1122 added 2026-06-10).

--- a/state/milestone.yaml
+++ b/state/milestone.yaml
@@ -8,22 +8,28 @@
 # Validated against state/milestone.schema.json by `make validate-milestone-state`
 # (containerized) and by the advisory milestone-state-check job in pr-checks.yml.
 
-# M6 closed 2026-06-12 — released as v0.5.0. status: complete means no work may
-# be claimed against it; run /milestone-new to scaffold the next milestone
-# (M7 — Full Observability, GitHub milestone #7 already exists) — it rotates
-# this block into history.
+# M7 opened 2026-06-15 — target v0.6.0 (GitHub milestone #7, "Full Observability").
+# Scope is broadened to "Usable Workflows + Observability" per docs/milestones/M7-planning.md
+# (first of the M7 → M-dx → M8 program). open_epics is filled as EPIC issues are created.
 active:
-  name: M6
-  title: "K8s Production-Ready"
-  github_milestone_number: 6
-  version: v0.5.0
-  status: complete # active | closing | complete — released 2026-06-12 as v0.5.0
-  planning_doc: docs/milestones/M6-planning.md
+  name: M7
+  title: "Full Observability"
+  github_milestone_number: 7
+  version: v0.6.0
+  status: active # active | closing | complete
+  planning_doc: docs/milestones/M7-planning.md
   labels:
-    milestone: "milestone: M6"
-  open_epics: []
+    milestone: "milestone: M7"
+  # EPIC W,C,G,X,T,Q,D = #1167-#1173 (new). O,L,R absorb pre-existing #467,#468,#469.
+  open_epics: [467, 468, 469, 1167, 1168, 1169, 1170, 1171, 1172, 1173]
 
 history:
+  - name: M6
+    title: "K8s Production-Ready"
+    github_milestone_number: 6
+    version: v0.5.0
+    released: "2026-06-12"
+    planning_doc: docs/milestones/M6-planning.md
   - name: M5
     title: "Adapter Library"
     github_milestone_number: 5


### PR DESCRIPTION
## What

Opens **M7** (target **v0.6.0**, GitHub milestone #7) and lands the full SPDD program plan.

GitHub milestone #7 was titled *Full Observability*; M7's scope is broadened to **Usable Workflows + Observability** — the first of a three-milestone program **M7 → M-dx → M8**. M6 shipped a production platform, but a developer still can't do real work: workflows can't pass data, logs don't stream, there's no telemetry. M7 closes that with one vertical slice: author a real workflow → run it locally (`docker compose up` incl. **Uptrace**) → watch it execute state→state with **data-flow**, **streamed logs**, and a connected **distributed trace** in the Uptrace login UI — with green `make ci`.

## Contents

- **`state/milestone.yaml`** — rotate M6 → history; M7 active; `open_epics` = #467-#469 + #1167-#1173. `make validate-milestone-state` ✅
- **`state/current-milestone.md`** — M7 active section + EPIC table.
- **`docs/milestones/M7-planning.md`** — all 22 brief deliverables: program roadmap, 10-EPIC decomposition, dependency DAG (Mermaid), parallel waves, risk register, observability/security/test plans, acceptance matrix, DoD, SPDD runbook, rollout/rollback, **PyPI Trusted Publisher history** (§14).
- **`docs/spdd/{W,L,O,C,G,X,T,R,Q,D}/canvas.md`** — one REASONS Canvas per EPIC; each lists its stories in `spdd-story` form. `make validate-canvas` ✅ (Draft until human alignment).
- **`docs/adr/ADR-029..034`** (Proposed) — data-flow, OTEL+Uptrace, context propagation, Git MCP shim, expert substrate, ManifestWorkflowID; INDEX updated.

## EPIC issues created

W #1167 · C #1168 · G #1169 · X #1170 · T #1171 · Q #1172 · D #1173. Pre-existing #467/#468/#469 annotated and absorbed into O/L/R.

## Decisions baked in (from planning Q&A)

- **Scope:** program (M7→M-dx→M8) with M7 in full executable detail.
- **Git MCP:** thin shim over the existing git-adapter (ADR-032).
- **Experts:** both substrates (runtime AgentDef + Claude authoring experts) with a mapping (ADR-033).
- **Observability:** OpenTelemetry → **Uptrace** (traces/metrics/logs/APM + login UI) in **both** docker-compose **and** Helm (ADR-030).

## Notes

The reality-check gaps the audit surfaced (workflow data-flow, `/logs` streaming, OTEL/metrics, `agents/examples/`, pip CVE, coverage gate, PyPI Trusted Publisher history) are each tracked to an owning EPIC and to the acceptance matrix. The docker-compose corruption that blocked `make run-local` is fixed separately in #1166.

🤖 Generated with [Claude Code](https://claude.com/claude-code)