### PR TITLE
docs(spdd): link M7 EPIC stories to their GitHub issue IDs

### DIFF
--- a/docs/spdd/C-context-propagation/canvas.md
+++ b/docs/spdd/C-context-propagation/canvas.md
@@ -40,6 +40,8 @@ docs/context/                     ← context model + handoff contract guide
 ```
 
 ## O — Operations (stories — `spdd-story` form)
+
+**GitHub issues:** C.1 #1193 · C.2 #1194 · C.3 #1195 · C.4 #1196 (epic #1168)
 **C.1 — ADR: context model** · S · `adr-proposal`
 - As a `maintainer`, I want trace vs data vs correlation contexts defined so propagation is deterministic.
 - AC: [ ] ADR-031 committed (carriers, inheritance, handoff rules, non-goals). Deps: none.

--- a/docs/spdd/D-docs/canvas.md
+++ b/docs/spdd/D-docs/canvas.md
@@ -39,6 +39,8 @@ docs/examples/index.md · docs/best-practices.md · docs/faq.md · docs/migratio
 ```
 
 ## O — Operations (stories — `spdd-story` form)
+
+**GitHub issues:** D.1 #1217 · D.2 #1218 · D.3 #1219 · D.4 #1220 · D.5 #1221 (epic #1173)
 **D.1 — Quick Start + Developer Guide** · M · `docs`
 - As a `new developer`, I want a clone→traced-run quick-start so I'm productive in minutes.
 - AC: [ ] quick-start: compose up (incl. Uptrace) → apply real workflow → see trace+logs in UI; [ ] developer guide covering make targets. Deps: T.3, O.7.

--- a/docs/spdd/G-git-mcp-shim/canvas.md
+++ b/docs/spdd/G-git-mcp-shim/canvas.md
@@ -41,6 +41,8 @@ docs/git-mcp/ + .mcp.json.example    ← authoring-loop wiring + least-privilege
 Config env prefix: `GIT_ADAPTER_` / token via `GITHUB_TOKEN` (injected, never logged).
 
 ## O — Operations (stories — `spdd-story` form)
+
+**GitHub issues:** G.1 #1197 · G.2 #1198 · G.3 #1199 · G.4 #1200 (epic #1169)
 **G.1 — ADR: MCP-shim-over-adapter + auth model** · S · `adr-proposal`
 - As a `maintainer`, I want the shim + least-privilege token model recorded so security is settled first.
 - AC: [ ] ADR-032 committed (shim rationale, injection-at-start, no-secrets-in-prompts, redaction). Deps: none.

--- a/docs/spdd/L-log-streaming/canvas.md
+++ b/docs/spdd/L-log-streaming/canvas.md
@@ -38,6 +38,8 @@ cmd/zynax/                                    ← `zynax logs --follow`
 Config env prefix: `ZYNAX_ENGINE_ADAPTER_` / `ZYNAX_GW_`.
 
 ## O — Operations (stories — `spdd-story` form)
+
+**GitHub issues:** L.1 #1180 · L.2 #1181 · L.3 #1182 · L.4 #1183 (epic #468)
 **L.1 — Engine-adapter history streaming (closes #468)** · M · `refactor`
 - As an `operator`, I want history long-poll instead of polling so events stream with low latency.
 - AC: [ ] `GetWorkflowHistory` long-poll replaces `DescribeWorkflowExecution` polling; [ ] ordered event stream; [ ] domain cov ≥90%. Deps: none.

--- a/docs/spdd/O-observability-otel-uptrace/canvas.md
+++ b/docs/spdd/O-observability-otel-uptrace/canvas.md
@@ -69,6 +69,8 @@ Config env prefix: `ZYNAX_OTEL_` · Uptrace UI host port: 70xx (local).
 
 ## O — Operations (stories — `spdd-story` form)
 
+**GitHub issues:** O.1 #1184 · O.2 #1185 · O.3 #1186 · O.4 #1187 · O.5 #1188 · O.6 #1189 · O.7 #1190 · O.8 #1191 · O.9 #1192 (epic #467)
+
 **O.1 — ADR: OTEL + Uptrace (traces+metrics+logs+APM)** · S · `adr-proposal`
 - As a `maintainer`, I want the backend + transport + sampling decision recorded so the stack is stable.
 - AC: [ ] ADR-030 committed (Uptrace default, OTLP/gRPC, head sampling, logs-via-OTLP); [ ] non-goals listed. Deps: none.

--- a/docs/spdd/Q-quality-supply-chain/canvas.md
+++ b/docs/spdd/Q-quality-supply-chain/canvas.md
@@ -38,6 +38,8 @@ docs/ (module consumption) · docs/adr/ADR-034     ← #582 / #583
 ```
 
 ## O — Operations (stories — `spdd-story` form)
+
+**GitHub issues:** Q.1 #1212 · Q.2 #1213 · Q.3 #1214 · Q.4 #1215 · Q.5 #1216 (epic #1172)
 **Q.1 — Bump tools-image pip → 26.1.2** · XS · `ci`
 - As a `maintainer`, I want the pip CVE closed so `make security-agents`/`lint-go` run clean.
 - AC: [ ] tools image rebuilt with pip 26.1.2; [ ] `make security-agents` passes; [ ] images.yaml updated via `make sync-images`. Deps: none. **(Wave 0 — unblocks green CI for all EPICs.)**

--- a/docs/spdd/R-test-rigor/canvas.md
+++ b/docs/spdd/R-test-rigor/canvas.md
@@ -36,6 +36,8 @@ protos/tests/ · spec/automation/                  ← e2e + observability-valid
 ```
 
 ## O — Operations (stories — `spdd-story` form)
+
+**GitHub issues:** R.1 #493 · R.2 #1210 · R.3 #553 · R.4 #1103 · R.5 #1211 (epic #469)
 **R.1 — Benchmarks + regression gate (#493)** · M · `test`
 - As a `maintainer`, I want compiler/interpreter benchmarks gated so perf regressions are caught.
 - AC: [ ] benchmarks committed; [ ] regression threshold gate in CI. Deps: W.4.

--- a/docs/spdd/T-templates-real-workflows/canvas.md
+++ b/docs/spdd/T-templates-real-workflows/canvas.md
@@ -38,6 +38,8 @@ docs/authoring/                             ← template + authoring guide
 ```
 
 ## O — Operations (stories — `spdd-story` form)
+
+**GitHub issues:** T.1 #1206 · T.2 #1207 · T.3 #1208 · T.4 #1209 (epic #1171)
 **T.1 — Template mechanism (workflow/task/expert) + versioning** · M · `feat`
 - As a `workflow author`, I want reusable, versioned templates so I don't author from scratch.
 - AC: [ ] template format + `version:` field; [ ] schema validation; [ ] `.feature`/contract test. Deps: W.3.

--- a/docs/spdd/W-workflow-data-flow/canvas.md
+++ b/docs/spdd/W-workflow-data-flow/canvas.md
@@ -74,6 +74,8 @@ Config env prefix: `ZYNAX_WC_` / `ZYNAX_ENGINE_ADAPTER_` · No new ports.
 
 ## O — Operations (stories — `spdd-story` form)
 
+**GitHub issues:** W.1 #1175 · W.2 #1176 · W.3 #1177 · W.4 #1178 · W.5 #1179 (epic #1167)
+
 **W.1 — ADR: data-flow semantics & scoping model**
 - As a `maintainer`, I want a recorded decision on the binding model so that the contract is stable before code.
 - Size: S · Type: `docs`/`adr-proposal`

--- a/docs/spdd/X-expert-substrate/canvas.md
+++ b/docs/spdd/X-expert-substrate/canvas.md
@@ -43,6 +43,8 @@ docs/experts/                                               ← authoring guide 
 Config: Python 3.12 + uv (ADR-002/003).
 
 ## O — Operations (stories — `spdd-story` form)
+
+**GitHub issues:** X.1 #1201 · X.2 #1202 · X.3 #1203 · X.4 #1204 · X.5 #1205 (epic #1170)
 **X.1 — ADR: expert substrate + mapping** · S · `adr-proposal`
 - As a `maintainer`, I want the dual-substrate model + mapping recorded so runtime/authoring don't drift.
 - AC: [ ] ADR-033 committed (runtime AgentDef + authoring expert, mapping table, drift guard). Deps: none.


### PR DESCRIPTION
## What

Follow-up to #1174 (M7 opened). After creating the **50 M7 story issues** and linking each to its parent EPIC, this PR records the **Story → GitHub issue** mapping inside every EPIC canvas's `O — Operations` section, so the canvases and the issue tracker stay in sync.

## Story issues created (one per canvas O-step, spdd-story format)

| EPIC | Parent | Stories |
|------|--------|---------|
| W data-flow | #1167 | #1175–#1179 |
| L log streaming | #468 | #1180–#1183 |
| O OTEL+Uptrace | #467 | #1184–#1192 |
| C context | #1168 | #1193–#1196 |
| G Git MCP | #1169 | #1197–#1200 |
| X experts | #1170 | #1201–#1205 |
| T templates | #1171 | #1206–#1209 |
| R test rigor | #469 | #1210, #1211 (+ existing #493/#553/#1103) |
| Q quality | #1172 | #1212–#1216 |
| D docs | #1173 | #1217–#1221 |

Each story issue carries its full spdd-story body (As-a / I-want / so-that, acceptance criteria, out-of-scope, size, dependencies), is labelled `spdd: canvas-step` + area + type + `milestone: M7`, and references its parent epic in the title (`(#epic, step N)`) and body. Each epic has a tracked story **checklist** comment linking its stories both ways.

`make validate-canvas` ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)