### PR TITLE
ci(infra): bump tools-image pip to 26.1.2 for PYSEC-2026-196

### DIFF
--- a/infra/docker/Dockerfile.tools
+++ b/infra/docker/Dockerfile.tools
@@ -124,6 +124,13 @@ FROM python:${PYTHON_VERSION}-alpine@${PYTHON_ALPINE_DIGEST} AS tools
 # Minimal Alpine system deps only — no build toolchain in the final image
 RUN apk add --no-cache git curl ca-certificates libstdc++ libgcc
 
+# ── pip — upgraded to close PYSEC-2026-196 ────────────────────────────────────
+# The python:3.14-alpine base ships an older pip that pip-audit flags as
+# PYSEC-2026-196. Pin the interpreter's bundled pip to the patched release so
+# `make security-agents` runs clean. Update this version when a newer CVE lands.
+# renovate: datasource=pypi depName=pip
+RUN python -m pip install --no-cache-dir --upgrade "pip==26.1.2"
+
 # ── Copy all Go binaries from go-tools stage ──────────────────────────────
 COPY --from=go-tools /usr/local/go              /usr/local/go
 COPY --from=go-tools /go/bin/golangci-lint            /usr/local/bin/


### PR DESCRIPTION
## What

Bump the bundled pip in the tools image to `26.1.2` to close
**PYSEC-2026-196**, so `make security-agents` (bandit + pip-audit) runs
clean.

## Why

The `python:3.14-alpine` base image ships an older pip that `pip-audit`
flags as PYSEC-2026-196. The story (#1212, Q.1 Wave 0) unblocks green CI
for all EPICs. Fix: add an explicit `pip install --upgrade pip==26.1.2`
in the final stage of `infra/docker/Dockerfile.tools`.

## images.yaml note

`make sync-images` is a no-op: the tools image is **not tracked by
digest** in `images/images.yaml` (no consumer references a tools
digest), so there is nothing to sync locally. The published tools-image
digest updates **post-merge** via `tools-image.yml` when the image
rebuilds with the new pin.

## Acceptance criteria

- [x] tools image pip pinned to 26.1.2
- [x] `make sync-images` run (no-op — tools image not digest-tracked)
- [ ] `make security-agents` passes — requires the rebuilt tools image,
      which is published post-merge by `tools-image.yml`; verified by the
      post-merge gate.

Closes #1212

Assisted-by: Claude/claude-opus-4-8
