### PR TITLE
ci: exempt zero-statement packages from domain coverage gate

### DIFF
--- a/.github/workflows/_test-go.yml
+++ b/.github/workflows/_test-go.yml
@@ -138,7 +138,15 @@ jobs:
               if [ -f domain-coverage.out ]; then
                 pct=$(GOWORK=off go tool cover -func=domain-coverage.out 2>/dev/null \
                       | grep "^total:" | awk '{print $3}' | tr -d '%') || true
-                [ -n "$pct" ] && echo "service|${svc}|internal/domain|${pct}" >> /tmp/coverage-results.txt
+                funcs=$(GOWORK=off go tool cover -func=domain-coverage.out 2>/dev/null \
+                        | grep -vc "^total:") || true
+                # Skip recording zero-statement (interface-only) packages so the PR
+                # coverage report does not show a misleading 0.0%.
+                if [ "$funcs" = "0" ]; then
+                  echo "── coverage: services/${svc} [no coverable statements — exempt]"
+                elif [ -n "$pct" ]; then
+                  echo "service|${svc}|internal/domain|${pct}" >> /tmp/coverage-results.txt
+                fi
               fi
               cd ../..
             fi
@@ -153,8 +161,15 @@ jobs:
               cd "services/${svc}"
               total=$(GOWORK=off go tool cover -func=domain-coverage.out 2>/dev/null \
                       | grep "^total:" | awk '{print $3}' | tr -d '%')
+              funcs=$(GOWORK=off go tool cover -func=domain-coverage.out 2>/dev/null \
+                      | grep -vc "^total:")
               cd ../..
               [ -z "$total" ] && echo "  ⚠ no coverage for services/${svc} — skipping" && continue
+              # Zero-statement packages (interface-only domains) report a false 0.0%.
+              # Detect via go tool cover func-row count, not a hardcoded skip list.
+              if [ "$funcs" = "0" ]; then
+                echo "  ➖ services/${svc}: no coverable statements — exempt from gate"; continue
+              fi
               echo "── domain coverage: services/${svc}  ${total}%"
               if awk "BEGIN{exit !(${total} < ${COVERAGE_DOMAIN_GATE:-90})}"; then
                 echo "  ❌ ${total}% < ${COVERAGE_DOMAIN_GATE:-90}% for services/${svc}"; failed=true

--- a/Makefile
+++ b/Makefile
@@ -184,6 +184,8 @@ test-coverage: ensure-tools ## Domain coverage gate — ≥90% on internal/domai
 			$(TOOLS_RUN) sh -c "cd services/$$svc && GOWORK=off go test -tags=\"\" ./internal/domain/... -coverprofile=domain-coverage.out -covermode=atomic -count=1 2>/dev/null"; \
 			total=$$($(TOOLS_RUN) sh -c "cd services/$$svc && GOWORK=off go tool cover -func=domain-coverage.out | grep '^total:' | awk '{print \$$3}' | tr -d '%'" 2>/dev/null); \
 			if [ -z "$$total" ]; then echo "  ⚠  services/$$svc: no domain coverage data"; continue; fi; \
+			funcs=$$($(TOOLS_RUN) sh -c "cd services/$$svc && GOWORK=off go tool cover -func=domain-coverage.out | grep -vc '^total:'" 2>/dev/null); \
+			if [ "$$funcs" = "0" ]; then printf "  %-35s %s\n" "services/$$svc" "no coverable statements — exempt"; continue; fi; \
 			printf "  %-35s %s%%\n" "services/$$svc" "$$total"; \
 			if awk "BEGIN{exit !($$total < 90)}"; then \
 				echo "  ❌ $$total%% < 90%% — coverage gate failed for services/$$svc"; \


### PR DESCRIPTION
## What

Make the Go domain coverage gate honest about interface-only packages.
`services/event-bus/internal/domain` is interface/type-only (zero coverable
statements), so `go tool cover` prints `total: 0.0%`. The naive `< 90`
threshold flagged this as `0.0% < 90%` and failed `make test-coverage`
even though there is nothing to cover.

## How

Data-driven detection of zero-statement packages via the `go tool cover -func`
function-row count: a package with no coverable statements produces **zero**
non-`total:` rows, whereas any real package produces one row per function. We
exempt only those packages — no hardcoded skip list.

Applied in three places for parity:
- `Makefile` `test-coverage` target (the failing path)
- `.github/workflows/_test-go.yml` domain coverage gate step
- the same workflow's coverage-measurement step, so the PR coverage report
  no longer records a misleading 0.0% for exempt packages

## Verification

`make test-coverage` locally:
- before: `event-bus  ❌ 0.0% < 90%` → gate fails
- after:  `services/event-bus  no coverable statements — exempt` → gate passes
- all real domains still gated (agent-registry 94.0%, task-broker 92.1%, …)

Confirmed `event-bus/internal/domain` is genuinely zero-statement
(`coverage: [no statements]`, func-row count = 0) vs a real package
(task-broker: 27 func rows).

Closes #1213
