### PR TITLE
docs(workflow-compiler): ADR-029 workflow data-flow semantics

### DIFF
--- a/docs/adr/ADR-029-workflow-data-flow.md
+++ b/docs/adr/ADR-029-workflow-data-flow.md
@@ -1,45 +1,124 @@
-# ADR-029: Workflow data-flow semantics (output/input bindings)
+<!-- SPDX-License-Identifier: Apache-2.0 -->
 
-**Status:** Proposed  **Date:** 2026-06-15
-**Related:** ADR-012 (Workflow IR), ADR-014 (event-driven state machine), ADR-015 (pluggable engines)
+# ADR-029 — Workflow Data-Flow Semantics (output/input bindings)
+
+| Field | Value |
+|-------|-------|
+| **Status** | Accepted |
+| **Date** | 2026-06-16 |
+| **Deciders** | Oscar Gómez Manresa |
+| **Scope** | `WorkflowIR` proto (`protos/zynax/v1/workflow_compiler.proto`), `services/workflow-compiler/`, `services/engine-adapter/` — M7 EPIC W (#1167) |
+| **Related** | ADR-012 (Workflow IR), ADR-014 (event-driven state machine), ADR-015 (pluggable engines), ADR-008 (no shared databases / no shared mutable state) |
 
 ---
 
 ## Context
 
-Workflows are event-driven state machines (ADR-014) compiled to a WorkflowIR (ADR-012). Today the
-compiler **rejects** `output:` on actions (`"output: which is not yet implemented; … upgrade to M7+"`),
-so no state can pass data to a later state. Every real pipeline — research→summarize, build→test→deploy
-— is inexpressible. M7's central goal ("make Zynax usable for real workflows") requires a data-flow
-model, but an over-rich expression language would be a large, hard-to-reverse one-way door on the proto
-contract. This ADR fixes the **minimal** model.
+Workflows are event-driven state machines (ADR-014) compiled to an engine-agnostic
+WorkflowIR (ADR-012). Today the compiler **rejects** `output:` on actions —
+`"output: which is not yet implemented; … upgrade to M7+"` — so no state can pass
+data to a later state. Every real pipeline (research → summarize, build → test →
+deploy) is therefore inexpressible.
+
+M7's central goal is to make Zynax usable for real workflows, which requires a
+data-flow model. The risk is over-reach: an expression/transform language baked
+into the proto contract would be a large, security-sensitive, hard-to-reverse
+one-way door. Because this decision shapes the proto contract that EPIC W steps
+W.2–W.5 build on, it must be fixed **before** any implementation lands (this
+story gates W.2). This ADR records the **minimal** binding model so the contract
+is stable first.
 
 ## Decision
 
-We will add a **minimal, additive** data-flow model to the WorkflowIR:
+We adopt a **minimal, additive** data-flow model on the WorkflowIR.
 
-1. **`output_bindings`** on an action — named outputs an action publishes into a workflow-scoped data context.
-2. **`input_bindings`** on an action — inputs resolved from the data context by **literal value** or
-   **JSON-path reference** (e.g. `$.states.search.output.results`).
-3. A **workflow-run-scoped `WorkflowDataContext`** owned by the interpreter; written by outputs, read by inputs;
-   it does **not** persist beyond the run.
-4. Bindings are **literal or path references only** — **no expression/transform language** in M7.
+### 1. Binding syntax — literal values and JSON-path references only
 
-Proto fields are additive; manifests without bindings compile unchanged. `buf breaking` must pass.
+An action declares two binding maps:
+
+- **`output_bindings`** — named outputs an action *publishes* into the
+  workflow-scoped data context. Each entry maps a context key to a source path
+  within the action's result (e.g. `results` ← the action output payload).
+- **`input_bindings`** — inputs an action *consumes*. Each entry resolves to a
+  value by exactly one of two forms:
+  - a **literal** value (string/number/bool), or
+  - a **JSON-path reference** into the data context, written as a dotted path
+    rooted at `$.states.<state>.output.<key>` —
+    e.g. `$.states.search.output.results`.
+
+There is **no expression, transform, filter, templating, or arithmetic
+syntax** in M7. A reference either resolves to a stored value verbatim or it is
+a compile-time error. This is the entire surface.
+
+### 2. Scoping model — one run-scoped data context, explicitly read/written
+
+- A single **`WorkflowDataContext`** exists per workflow **run**. It is a
+  key/value store owned by the interpreter (`IRInterpreterWorkflow` in
+  engine-adapter, behind the `WorkflowEngine` interface per ADR-015).
+- The context is **written only** by `output_bindings` and **read only** by
+  `input_bindings` — there is no implicit/global mutable state and no ambient
+  read of one state's locals by another.
+- The context is **strictly run-scoped**: it does not leak across workflow runs,
+  workflows, or namespaces, and it does **not persist beyond the run** (no
+  durable data store in M7). This keeps the model aligned with ADR-008's "no
+  shared mutable state" spirit.
+- **Compile-time validation:** every `input_bindings` JSON-path reference must
+  resolve to a key declared by an upstream state's `output_bindings`. An
+  unresolved reference is a `COMPILATION_ERROR` carrying the manifest line
+  number — failure is loud and early, not at run time.
+
+### 3. Non-goals (explicit scope guard for M7)
+
+- **No expression / transform language** (CEL, JSONata, math, string templating,
+  filters) — deferred to a later milestone (M-dx).
+- **No cross-workflow or cross-namespace data sharing.**
+- **No persistence** of the data context beyond a single run.
+- **No typed schema** for context values in M7 — references are stringly-typed
+  paths; a typed data-context schema is future work.
+
+### 4. `buf breaking` implications — additive only
+
+The new IR fields (`output_bindings`, `input_bindings`, and the data-context
+representation) are added as **new fields with new field numbers** on existing
+messages. They are purely **additive**:
+
+- Manifests without bindings compile unchanged (the maps are simply empty).
+- No existing field is renamed, renumbered, retyped, or removed.
+- Therefore `buf breaking` (a CI gate per ADR-012) stays **green**; the proto
+  contract remains backward-compatible. W.2 must keep the change additive — any
+  non-additive edit is blocked.
 
 ## Rationale
 
 | Option | Assessment |
 |--------|------------|
-| Minimal literal/path bindings (chosen) | ✅ Smallest contract that unblocks real workflows; additive; reversible-ish |
-| Full expression language (CEL/JSONata) | ✗ Deferred to M-dx — large surface, security review burden, premature |
-| Implicit shared state between states | ✗ Rejected — violates explicit-scoping; collides with ADR-008 spirit (no shared mutable state) |
+| **A — Minimal literal + JSON-path bindings (chosen)** | ✅ Smallest contract that unblocks real multi-step workflows; purely additive to the proto, so `buf breaking` stays green; references validated at compile time; reversible-enough — an expression language can be layered on later as a strict superset. |
+| **B — Full expression language (CEL / JSONata) now** | ✗ Rejected for M7 — large API and security-review surface, premature before real usage data; can be added later without breaking A. Deferred to M-dx. |
+| **C — Implicit shared state between states** | ✗ Rejected — violates explicit read/write scoping and collides with ADR-008's no-shared-mutable-state spirit; makes data-flow untraceable for EPIC C/O correlation. |
 
 ## Consequences
 
-- **Positive:** real multi-step workflows become expressible; the long-standing "not implemented"
-  rejection is lifted; trace/log correlation (EPIC C/O) has real data to follow.
-- **Negative / trade-off:** path references are stringly-typed; validation must catch unresolved refs
-  at compile time (clear `COMPILATION_ERROR` with line number).
-- **Neutral / follow-up:** transforms/filters and typed schemas for the data context are deferred to
-  M-dx; this ADR will be revisited if/when an expression language is added.
+### Positive
+
+- Real multi-step workflows (research → summarize, build → test → deploy) become
+  expressible; the long-standing `output:` rejection is lifted in W.3.
+- The proto change is additive, so no consumer breaks and `buf breaking` passes.
+- Trace/log correlation (EPIC C/O) gains concrete data to follow through a run.
+- The minimal surface keeps the security-review and validation burden small.
+
+### Negative / trade-offs
+
+- JSON-path references are **stringly-typed**; correctness depends on compile-time
+  reference-resolution validation rather than the type system.
+- Without transforms, some shaping that an expression language would do inline
+  must instead be done inside an agent/capability or deferred to M-dx.
+
+### Neutral / follow-up required
+
+| Action | Tracking |
+|--------|---------|
+| Add `output_bindings`/`input_bindings` IR fields + `.feature` (additive; `buf breaking` green) | EPIC W step W.2 (#1176) |
+| Compile + validate bindings; lift the `output:` rejection | EPIC W step W.3 (#1177) |
+| Thread run-scoped `WorkflowDataContext` through the interpreter | EPIC W step W.4 (#1178) |
+| Prove real workflows run end-to-end | EPIC W step W.5 (#1179) |
+| Revisit if/when an expression/transform language is added | M-dx (future) |

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -39,7 +39,7 @@ a PR against `docs/adr/`.
 | [ADR-026](ADR-026-postgres-distribution.md) | Postgres distribution + target major version (official `postgres:17` + thin chart) | Accepted | 2026-06-10 | `helm/charts/postgres/`, `images/images.yaml`, all production Postgres — EPIC #1073 |
 | [ADR-027](ADR-027-shift-left-pipeline.md) | Shift-left pipeline model — build once pre-merge, promote by retag | Accepted | 2026-06-11 | `ci.yml` build-images, `release.yml` retag jobs, GHCR staging lane — EPIC #1109 |
 | [ADR-028](ADR-028-agentdef-vs-workflow-self-hosted-automation.md) | AgentDef-vs-Workflow split for self-hosted automation + context-slice injection contract | Accepted | 2026-06-11 | `automation/workflows/**`, `spec/schemas/agent-def.schema.json`, `spec/schemas/workflow.schema.json` — EPIC #881 |
-| [ADR-029](ADR-029-workflow-data-flow.md) | Workflow data-flow semantics (output/input bindings) | Proposed | 2026-06-15 | `WorkflowIR` proto, workflow-compiler, engine-adapter — M7 EPIC W |
+| [ADR-029](ADR-029-workflow-data-flow.md) | Workflow data-flow semantics (output/input bindings) | Accepted | 2026-06-16 | `WorkflowIR` proto, workflow-compiler, engine-adapter — M7 EPIC W |
 | [ADR-030](ADR-030-observability-uptrace.md) | Observability — OpenTelemetry + Uptrace backend | Proposed | 2026-06-15 | all services + adapters, `libs/zynaxotel`, observability compose + Helm — M7 EPIC O |
 | [ADR-031](ADR-031-context-propagation.md) | Context propagation model (trace · data · correlation) | Proposed | 2026-06-15 | all services, engine-adapter, agents/sdk — M7 EPIC C |
 | [ADR-032](ADR-032-git-mcp-shim.md) | Git MCP as a thin shim over the git-adapter | Proposed | 2026-06-15 | `agents/adapters/git/`, cli — M7 EPIC G |


### PR DESCRIPTION
## What

Fleshes out **ADR-029 — Workflow data-flow semantics (output/input bindings)** to
status **Accepted** and updates the ADR register row to match.

This is **EPIC W step W.1** (`docs/spdd/W-workflow-data-flow/canvas.md`) — a
recorded decision on the binding model so the proto contract is stable before any
implementation. It **gates W.2**.

## Decision recorded

- **Minimal binding model:** literal values + JSON-path references only
  (`$.states.<state>.output.<key>`) — **no expression/transform language in M7**
  (deferred to M-dx).
- **Scoping:** a single run-scoped `WorkflowDataContext`, written only by
  `output_bindings`, read only by `input_bindings`; no implicit/global state, no
  cross-run/workflow/namespace sharing, no persistence beyond the run.
- **Compile-time validation:** unresolved input references → `COMPILATION_ERROR`
  with line number.
- **Non-goals** explicitly enumerated as an M7 scope guard.

## `buf breaking` implications

Documented: the new IR fields (`output_bindings`/`input_bindings` + data context)
are added as **new fields with new field numbers** on existing messages — purely
**additive**. Manifests without bindings compile unchanged; nothing is renamed,
renumbered, retyped, or removed, so `buf breaking` (a CI gate per ADR-012) stays
green. W.2 must keep the change additive.

## Acceptance criteria

- [x] ADR-029 committed (Proposed → Accepted) defining binding syntax, scoping, and non-goals
- [x] `buf breaking` implications documented (fields are additive)

## Scope

Docs only. Implementation is W.2+ (out of scope here).

Closes #1175

🤖 Generated with [Claude Code](https://claude.com/claude-code)
