### PR TITLE
docs(ai-learnings): append session learnings — 2026-06-16

### DIFF
--- a/docs/ai-learnings/go-services.md
+++ b/docs/ai-learnings/go-services.md
@@ -419,3 +419,17 @@ but the `gh issue list --state open` query may lag due to GitHub API eventual co
 - Rule: When adding gRPC health wiring, source the named serving key from the generated `<Svc>Service_ServiceDesc.ServiceName`, never a hardcoded string; and factor the SERVING/NOT_SERVING + GracefulStop sequence into a small `cmd/` helper — inline calls frequently trip golangci-lint `funlen` (40-stmt limit) on `run`/`main`.
   Category: domain
   Reason: Permanent project constraints (generated ServiceName is the SoT; funlen=40 enforced in CI); recurred across all 6 services.
+
+## Session — 2026-06-16 (issue #1175)
+ADR-proposal docs story (ADR-029 workflow data-flow). Routed to go-svc because the
+decision is workflow-compiler/protos domain knowledge.
+
+### Effective patterns
+- For an ADR story, mirror a recent *Accepted* ADR's house format (SPDX header + metadata
+  table) rather than the lighter stub style — keeps the register consistent.
+- Multiline commit/PR bodies via a file + `-F`/`--body-file` (sandbox denies `-m` newlines).
+
+### Edge cases discovered
+- ADR stub + INDEX row may already exist at Proposed → "flesh out + flip status" in place,
+  never duplicate. Docs-only PRs correctly skip Go/proto build+lint+test; only the universal
+  gates (DCO, gitleaks, conventional-commit, layer-boundary, proto-compat, security) run.

--- a/docs/ai-learnings/infra-helm.md
+++ b/docs/ai-learnings/infra-helm.md
@@ -110,3 +110,13 @@ Completed EPIC G (#770) e2e harness: G.4 `e2e-failure.sh` (#812) and G.5 `helm-u
 - Rule: "When committing with `-s` and the message also carries an `Assisted-by` trailer, place `Assisted-by` BEFORE a single `Signed-off-by` (or omit the manual sign-off entirely and let `-s` add it). A non-adjacent existing sign-off makes `-s` append a duplicate."
   Category: structural-workaround
   Reason: DCO passes either way, but duplicate trailers are reviewer noise and avoidable with deterministic ordering.
+
+## Session — 2026-06-16 (issue #1184)
+ADR-proposal docs story (ADR-030 OTEL + Uptrace). Docs-only — no helm lint/validate gates.
+
+### Effective patterns
+- Pre-existing Proposed stub already held the correct decision content; task reduced to
+  reformat to house format (mirror ADR-027) + flip both file status and INDEX row to Accepted.
+
+### Edge cases discovered
+- Keep ADR file status and the INDEX register row in sync — both must move Proposed→Accepted.

--- a/docs/ai-learnings/python-adapters.md
+++ b/docs/ai-learnings/python-adapters.md
@@ -91,3 +91,15 @@
 - Rule: Before running `git commit` in a project with Docker-based lint tooling, check if `.ruff_cache` (or equivalent cache dirs) are owned by root. If so, prepend `RUFF_CACHE_DIR=/tmp/ruff-cache-<issue>` to the commit command to avoid pre-commit hook permission failures.
   Category: structural-workaround
   Reason: The tools Docker image creates root-owned cache dirs that block host pre-commit hooks — affects all Python-touching PRs in this repo.
+
+## Session — 2026-06-16 (issue #1197)
+ADR-proposal docs story with a security dimension (ADR-032 Git MCP shim + auth model).
+
+### Effective patterns
+- Deterministic-key claim first (bare `docs/<N>`, no slug) before writing — a lost race costs
+  nothing; confirm the empty-branch push has no non-fast-forward rejection before investing.
+- Describe the auth/token model abstractly (no literal secrets/emails) to clear the gitleaks gate.
+
+### Edge cases discovered
+- Docs-only diff makes the whole Go/Python build matrix report `skipping` — correct behaviour,
+  not a failure; only universal gates (DCO, gitleaks, CodeQL, dep-review, layer-boundary) run.


### PR DESCRIPTION
Appending learnings from orchestrator batch: issues #1175 #1184 #1197 (Wave 1 EPIC-kickoff ADRs W/O/G).

Shared, reusable insight across all three docs stories:
- ADR stubs pre-exist at status Proposed → flesh out + flip status in place (file + INDEX row); never duplicate.
- Docs-only PRs correctly skip the Go/Python/proto build+lint+test matrices; only universal gates run (DCO, gitleaks, conventional-commit, layer-boundary, CodeQL, dep-review).

Assisted-by: Claude/claude-opus-4-8