### PR TITLE
fix(infra): pin tools-image base digests to multi-arch indexes

### DIFF
--- a/images/images.yaml
+++ b/images/images.yaml
@@ -36,6 +36,19 @@ images:
       - infra/docker/Dockerfile.service
       - infra/docker/Dockerfile.tools
 
+  # Alpine base for the ci-runner final stage. digest MUST be the multi-arch
+  # INDEX digest of the tag (not a single-platform manifest) — the tools-image
+  # builds compile natively on ubuntu-24.04-arm with no QEMU (#839), so a
+  # single-arch pin makes the arm64 `apk add` fail with exit 255. Managing it
+  # here means `make check-images` governs the pin and the drift gate catches
+  # a future single-arch mispin.
+  - name: alpine
+    ref: alpine
+    tag: "3.21"
+    digest: sha256:48b0309ca019d89d40f670aa1bc06e426dc0931948452e8491e3d65087abc07d
+    consumers:
+      - infra/docker/Dockerfile.ci-runner
+
   - name: distroless-static
     ref: gcr.io/distroless/static
     tag: nonroot
@@ -57,6 +70,17 @@ images:
     consumers:
       - agents/adapters/langgraph/Dockerfile
       - agents/adapters/llm/Dockerfile
+
+  # Python base for the developer tools image (distinct from python-alpine,
+  # which is 3.12 for the adapters). digest MUST be the multi-arch INDEX digest
+  # of the tag — a single-platform pin breaks the native arm64 tools-image
+  # build (see the `alpine` entry above for the failure mode).
+  - name: python-tools-alpine
+    ref: python
+    tag: "3.14-alpine"
+    digest: sha256:003970a263347645cd23d4f90929ad16ba7ce7d808ee4674ffcc93cb21cc289f
+    consumers:
+      - infra/docker/Dockerfile.tools
 
   # Postgres base image for the thin project-owned chart (ADR-026). The chart
   # renders `<ref>:<tag>@<digest>`; the digest is the multi-arch index digest

--- a/infra/docker/Dockerfile.ci-runner
+++ b/infra/docker/Dockerfile.ci-runner
@@ -42,7 +42,11 @@ ARG GO_ALPINE_DIGEST=sha256:f23e8b227fb4493eabe03bede4d5a32d04092da71962f1fb79b5
 # END zynax-ci:images:golang-alpine
 # renovate: datasource=docker depName=alpine versioning=docker
 ARG ALPINE_VERSION=3.21
-ARG ALPINE_DIGEST=sha256:f27cad9117495d32d067133afff942cb2dc745dfe9163e949f6bfe8a6a245339
+# Managed by images/images.yaml (alpine). MUST be the multi-arch INDEX digest —
+# a single-platform pin breaks the native arm64 ci-runner build (#1232).
+# BEGIN zynax-ci:images:alpine
+ARG ALPINE_DIGEST=sha256:48b0309ca019d89d40f670aa1bc06e426dc0931948452e8491e3d65087abc07d
+# END zynax-ci:images:alpine
 
 # ── Stage 1: builder — has curl; downloads / builds all binaries ─────────────
 FROM golang:${GO_VERSION}-alpine@${GO_ALPINE_DIGEST} AS builder

--- a/infra/docker/Dockerfile.tools
+++ b/infra/docker/Dockerfile.tools
@@ -47,7 +47,11 @@ ARG GO_ALPINE_DIGEST=sha256:f23e8b227fb4493eabe03bede4d5a32d04092da71962f1fb79b5
 # END zynax-ci:images:golang-alpine
 # renovate: datasource=docker depName=python versioning=docker
 ARG PYTHON_VERSION=3.14
-ARG PYTHON_ALPINE_DIGEST=sha256:1aba322febb2d47185eb4db4934a1d7ce942cf3a469be8908dbce95aa513419b
+# Managed by images/images.yaml (python-tools-alpine). MUST be the multi-arch
+# INDEX digest — a single-platform pin breaks the native arm64 build (#1232).
+# BEGIN zynax-ci:images:python-tools-alpine
+ARG PYTHON_ALPINE_DIGEST=sha256:003970a263347645cd23d4f90929ad16ba7ce7d808ee4674ffcc93cb21cc289f
+# END zynax-ci:images:python-tools-alpine
 
 # ── Stage 1: Go binaries ────────────────────────────────────────────────────
 FROM golang:${GO_VERSION}-alpine@${GO_ALPINE_DIGEST} AS go-tools


### PR DESCRIPTION
## What

Re-pins the two base-image digests that broke the `tools-image` arm64 build, and brings them under `images/images.yaml` banner management.

## Root cause

`tools-image`'s arm64 leg (`runs-on: ubuntu-24.04-arm`, native, **no QEMU** by design — #839) has failed on every run since 2026-06-08. Two base-image ARGs were pinned to **single-platform amd64 manifests** instead of multi-arch **index** digests, so buildx pulls an amd64 base on the arm64 runner and the first `RUN apk add` dies instantly with `exit code: 255` (cannot exec an amd64 shell on arm64):

| File | ARG | Was (amd64 manifest) | Now (multi-arch index) |
|------|-----|----------------------|------------------------|
| `Dockerfile.tools` | `PYTHON_ALPINE_DIGEST` (`python:3.14-alpine`) | `sha256:1aba322…` | `sha256:003970a…` |
| `Dockerfile.ci-runner` | `ALPINE_DIGEST` (`alpine:3.21`) | `sha256:f27cad9…` | `sha256:48b0309…` |

Both were plain `ARG`s — **not** banner-managed by `images.yaml`, so the digest-drift gate never caught the mispin. The amd64 leg passed because the digest matched its arch.

## Fix

- Re-pin both to the multi-arch **index** digest of their tag (both verified to contain `linux/arm64/v8`).
- Add `images.yaml` entries `python-tools-alpine` and `alpine` with banner regions in the two Dockerfiles, so `make check-images` governs the pins and a future single-arch mispin fails the drift gate.
- `make sync-images` is a no-op and `make check-images` passes — confirms the hand-stamped digests match the SoT.

## Verification

- `make check-images` ✅ aligned
- Both new digests confirmed `application/vnd.oci.image.index.v1+json` with `linux/amd64` + `linux/arm64/v8` manifests.
- Post-merge: the `tools-image` workflow re-runs on this Dockerfile change; the arm64 leg should build green and republish `tools:latest` + `ci-runner:latest` as multi-arch — finally making #1212's pip-26.1.2 fix live.

## Known follow-up (out of scope)

The go-tools stage downloads some toolchain binaries via hardcoded `amd64`/`x86_64` URLs (buf, gitleaks, syft, grpc-health-probe), so the arm64 image embeds amd64 binaries. Pre-existing (all prior "successful" arm64 builds had it); to be tracked separately.

Closes #1232

Assisted-by: Claude/claude-opus-4-8
