### PR TITLE
fix(infra): select arm64 toolchain binaries via TARGETARCH

### DIFF
--- a/infra/docker/Dockerfile.ci-runner
+++ b/infra/docker/Dockerfile.ci-runner
@@ -51,6 +51,11 @@ ARG ALPINE_DIGEST=sha256:48b0309ca019d89d40f670aa1bc06e426dc0931948452e8491e3d65
 # ── Stage 1: builder — has curl; downloads / builds all binaries ─────────────
 FROM golang:${GO_VERSION}-alpine@${GO_ALPINE_DIGEST} AS builder
 
+# TARGETARCH is auto-populated by buildx (amd64 | arm64). `go install` compiles
+# natively for it; only the curl'd buf release below must select the matching
+# arch asset, or the arm64 image embeds an amd64 buf.
+ARG TARGETARCH
+
 RUN apk add --no-cache git curl ca-certificates
 
 # golangci-lint — compiled from source so it embeds Go 1.26.4 stdlib
@@ -81,8 +86,13 @@ RUN go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
 # buf — proto linter and codegen orchestrator (no go install; complex plugin deps)
 # renovate: datasource=github-releases depName=bufbuild/buf
 ARG BUF_VERSION=1.69.0
-RUN curl -fsSL \
-      "https://github.com/bufbuild/buf/releases/download/v${BUF_VERSION}/buf-Linux-x86_64" \
+RUN case "${TARGETARCH}" in \
+      amd64) BUF_ARCH=x86_64 ;; \
+      arm64) BUF_ARCH=aarch64 ;; \
+      *) echo "unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac && \
+    curl -fsSL \
+      "https://github.com/bufbuild/buf/releases/download/v${BUF_VERSION}/buf-Linux-${BUF_ARCH}" \
       -o /usr/local/bin/buf \
     && chmod +x /usr/local/bin/buf
 

--- a/infra/docker/Dockerfile.tools
+++ b/infra/docker/Dockerfile.tools
@@ -56,6 +56,12 @@ ARG PYTHON_ALPINE_DIGEST=sha256:003970a263347645cd23d4f90929ad16ba7ce7d808ee4674
 # ── Stage 1: Go binaries ────────────────────────────────────────────────────
 FROM golang:${GO_VERSION}-alpine@${GO_ALPINE_DIGEST} AS go-tools
 
+# TARGETARCH is auto-populated by buildx (amd64 | arm64). `go install` already
+# compiles natively for it; the curl'd release binaries below must select the
+# matching arch asset (each project names arches differently) — otherwise the
+# arm64 image silently embeds amd64 binaries.
+ARG TARGETARCH
+
 RUN apk add --no-cache git curl
 
 # golangci-lint — compiled from source; avoids install.sh checksum variance
@@ -88,23 +94,33 @@ RUN go install -tags 'postgres' github.com/golang-migrate/migrate/v4/cmd/migrate
 # renovate: datasource=github-releases depName=grpc-ecosystem/grpc-health-probe
 RUN GRPC_HEALTH_PROBE_VERSION=v0.4.26 && \
     curl -fsSL \
-      "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64" \
+      "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-${TARGETARCH}" \
       -o /usr/local/bin/grpc_health_probe \
     && chmod +x /usr/local/bin/grpc_health_probe
 
 # buf — proto linter and codegen orchestrator
 # renovate: datasource=github-releases depName=bufbuild/buf
 ARG BUF_VERSION=1.69.0
-RUN curl -fsSL \
-      "https://github.com/bufbuild/buf/releases/download/v${BUF_VERSION}/buf-Linux-x86_64" \
+RUN case "${TARGETARCH}" in \
+      amd64) BUF_ARCH=x86_64 ;; \
+      arm64) BUF_ARCH=aarch64 ;; \
+      *) echo "unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac && \
+    curl -fsSL \
+      "https://github.com/bufbuild/buf/releases/download/v${BUF_VERSION}/buf-Linux-${BUF_ARCH}" \
       -o /usr/local/bin/buf \
     && chmod +x /usr/local/bin/buf
 
 # gitleaks — secret scanner; version must match .pre-commit-config.yaml rev:
 # renovate: datasource=github-releases depName=gitleaks/gitleaks
 RUN GITLEAKS_VERSION=v8.21.2 && \
+    case "${TARGETARCH}" in \
+      amd64) GITLEAKS_ARCH=x64 ;; \
+      arm64) GITLEAKS_ARCH=arm64 ;; \
+      *) echo "unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac && \
     curl -fsSL \
-      "https://github.com/gitleaks/gitleaks/releases/download/${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION#v}_linux_x64.tar.gz" \
+      "https://github.com/gitleaks/gitleaks/releases/download/${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION#v}_linux_${GITLEAKS_ARCH}.tar.gz" \
       -o /tmp/gitleaks.tar.gz \
     && tar -xzf /tmp/gitleaks.tar.gz -C /usr/local/bin gitleaks \
     && rm /tmp/gitleaks.tar.gz
@@ -113,7 +129,7 @@ RUN GITLEAKS_VERSION=v8.21.2 && \
 # renovate: datasource=github-releases depName=anchore/syft
 RUN SYFT_VERSION=v1.44.0 && \
     curl -fsSL \
-      "https://github.com/anchore/syft/releases/download/${SYFT_VERSION}/syft_${SYFT_VERSION#v}_linux_amd64.tar.gz" \
+      "https://github.com/anchore/syft/releases/download/${SYFT_VERSION}/syft_${SYFT_VERSION#v}_linux_${TARGETARCH}.tar.gz" \
       -o /tmp/syft.tar.gz \
     && tar -xzf /tmp/syft.tar.gz -C /usr/local/bin syft \
     && rm /tmp/syft.tar.gz


### PR DESCRIPTION
## What

Parameterizes the curl'd toolchain-binary downloads in `Dockerfile.tools` (go-tools stage) and `Dockerfile.ci-runner` (builder stage) by `TARGETARCH`, so the arm64 images get native arm64 binaries instead of amd64 ones.

## Why

#1232 made the arm64 `tools-image` build succeed, but four binaries were fetched from hardcoded amd64 URLs (`buf`, `gitleaks`, `syft`, `grpc-health-probe`). The build doesn't exec them, so it passed — but the resulting arm64 image embedded amd64 binaries that fail on arm64 hardware, defeating the native multi-arch pipeline (#839). Pre-existing latent defect, now relevant since arm64 builds again.

## Fix

Consume buildx's auto-provided `ARG TARGETARCH` and select the correct asset (names verified against each project's release):

| Tool | amd64 asset | arm64 asset | Strategy |
|------|-------------|-------------|----------|
| grpc-health-probe | `linux-amd64` | `linux-arm64` | `linux-${TARGETARCH}` |
| syft | `linux_amd64` | `linux_arm64` | `linux_${TARGETARCH}` |
| buf | `Linux-x86_64` | `Linux-aarch64` | case map |
| gitleaks | `linux_x64` | `linux_arm64` | case map |

Unsupported `TARGETARCH` fails fast. `go install` tools (golangci-lint, govulncheck, godog, mockery, migrate, actionlint, protoc-gen-*) already compile natively — unchanged.

## Verification

- All arm64 asset names confirmed present via each project's GitHub releases API.
- No hardcoded `amd64`/`x86_64`/`x64` remains in any curl URL.
- Definitive proof is the post-merge native `tools-image` run (both arch legs); this PR triggers it.

Closes #1234

Assisted-by: Claude/claude-opus-4-8
