### PR TITLE
refactor(engine-adapter): history long-poll replaces polling

### DIFF
--- a/services/engine-adapter/internal/domain/history.go
+++ b/services/engine-adapter/internal/domain/history.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package domain
+
+// HistoryEventType mirrors the ordinals of Temporal's history EventType enum so
+// the domain layer can classify execution-history events without importing the
+// Temporal SDK (the domain package has zero external imports — ADR-001).
+//
+// Ordinals are permanent and match temporal.api.enums.v1.EventType. Only the
+// subset the engine-adapter reasons about is named here; every other ordinal is
+// treated as a non-terminal, status-neutral progress event.
+type HistoryEventType int32
+
+// History event ordinals mirrored from temporal.api.enums.v1.EventType.
+const (
+	HistoryEventUnspecified          HistoryEventType = 0
+	HistoryEventWorkflowStarted      HistoryEventType = 1
+	HistoryEventWorkflowCompleted    HistoryEventType = 2
+	HistoryEventWorkflowFailed       HistoryEventType = 3
+	HistoryEventWorkflowTimedOut     HistoryEventType = 4
+	HistoryEventWorkflowCanceled     HistoryEventType = 21
+	HistoryEventWorkflowTerminated   HistoryEventType = 27
+	HistoryEventWorkflowContinuedNew HistoryEventType = 28
+)
+
+// HistoryEventStatus maps a history event type to the WorkflowStatus that the
+// run holds *after* the event is applied. Non-status-changing events (activity
+// scheduling, task completion, timers, …) report WorkflowStatusRunning so the
+// stream surfaces forward progress while the run is live.
+func HistoryEventStatus(t HistoryEventType) WorkflowStatus {
+	switch t {
+	case HistoryEventWorkflowStarted:
+		return WorkflowStatusRunning
+	case HistoryEventWorkflowCompleted:
+		return WorkflowStatusCompleted
+	case HistoryEventWorkflowFailed, HistoryEventWorkflowTimedOut:
+		return WorkflowStatusFailed
+	case HistoryEventWorkflowCanceled, HistoryEventWorkflowTerminated:
+		return WorkflowStatusCancelled
+	case HistoryEventWorkflowContinuedNew:
+		return WorkflowStatusCompleted
+	default:
+		return WorkflowStatusRunning
+	}
+}
+
+// IsTerminalHistoryEvent reports whether the event closes the execution. The
+// long-poll loop stops after emitting a terminal event so a finished run does
+// not leave a consumer blocked on an iterator that will never advance.
+func IsTerminalHistoryEvent(t HistoryEventType) bool {
+	switch t {
+	case HistoryEventWorkflowCompleted,
+		HistoryEventWorkflowFailed,
+		HistoryEventWorkflowTimedOut,
+		HistoryEventWorkflowCanceled,
+		HistoryEventWorkflowTerminated,
+		HistoryEventWorkflowContinuedNew:
+		return true
+	default:
+		return false
+	}
+}

--- a/services/engine-adapter/internal/domain/history_test.go
+++ b/services/engine-adapter/internal/domain/history_test.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package domain
+
+import "testing"
+
+func TestHistoryEventStatus(t *testing.T) {
+	cases := []struct {
+		name string
+		in   HistoryEventType
+		want WorkflowStatus
+	}{
+		{"started maps to running", HistoryEventWorkflowStarted, WorkflowStatusRunning},
+		{"completed", HistoryEventWorkflowCompleted, WorkflowStatusCompleted},
+		{"failed", HistoryEventWorkflowFailed, WorkflowStatusFailed},
+		{"timed_out maps to failed", HistoryEventWorkflowTimedOut, WorkflowStatusFailed},
+		{"canceled maps to cancelled", HistoryEventWorkflowCanceled, WorkflowStatusCancelled},
+		{"terminated maps to cancelled", HistoryEventWorkflowTerminated, WorkflowStatusCancelled},
+		{"continued-as-new maps to completed", HistoryEventWorkflowContinuedNew, WorkflowStatusCompleted},
+		{"unspecified is a running progress event", HistoryEventUnspecified, WorkflowStatusRunning},
+		{"unknown progress event maps to running", HistoryEventType(99), WorkflowStatusRunning},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := HistoryEventStatus(tc.in); got != tc.want {
+				t.Errorf("HistoryEventStatus(%v) = %v; want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsTerminalHistoryEvent(t *testing.T) {
+	cases := []struct {
+		name string
+		in   HistoryEventType
+		want bool
+	}{
+		{"completed is terminal", HistoryEventWorkflowCompleted, true},
+		{"failed is terminal", HistoryEventWorkflowFailed, true},
+		{"timed_out is terminal", HistoryEventWorkflowTimedOut, true},
+		{"canceled is terminal", HistoryEventWorkflowCanceled, true},
+		{"terminated is terminal", HistoryEventWorkflowTerminated, true},
+		{"continued-as-new is terminal", HistoryEventWorkflowContinuedNew, true},
+		{"started is not terminal", HistoryEventWorkflowStarted, false},
+		{"unspecified is not terminal", HistoryEventUnspecified, false},
+		{"unknown progress event is not terminal", HistoryEventType(42), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsTerminalHistoryEvent(tc.in); got != tc.want {
+				t.Errorf("IsTerminalHistoryEvent(%v) = %v; want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/services/engine-adapter/internal/domain/model.go
+++ b/services/engine-adapter/internal/domain/model.go
@@ -46,8 +46,13 @@ type WorkflowRun struct {
 
 // WorkflowEvent is emitted when the workflow transitions state or reaches
 // a terminal condition. Streamed by Watch and published to the event bus.
+//
+// EventID carries the engine's monotonically increasing history event ID. It
+// gives consumers a total order over the stream even when timestamps collide,
+// satisfying the ordered-event-stream contract for history long-poll (#468).
 type WorkflowEvent struct {
 	RunID     string
+	EventID   int64
 	EventType string
 	FromState string
 	ToState   string

--- a/services/engine-adapter/internal/infrastructure/temporal.go
+++ b/services/engine-adapter/internal/infrastructure/temporal.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	enumspb "go.temporal.io/api/enums/v1"
+	historypb "go.temporal.io/api/history/v1"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/sdk/client"
@@ -23,7 +24,6 @@ import (
 const (
 	irInterpreterWorkflowName = "IRInterpreterWorkflow"
 	temporalEngineName        = "temporal"
-	defaultWatchPollInterval  = 2 * time.Second
 )
 
 // temporalClient is a narrow interface over client.Client covering only the
@@ -33,15 +33,15 @@ type temporalClient interface {
 	SignalWorkflow(ctx context.Context, workflowID, runID, signalName string, arg interface{}) error
 	CancelWorkflow(ctx context.Context, workflowID, runID string) error
 	DescribeWorkflowExecution(ctx context.Context, workflowID, runID string) (*workflowservice.DescribeWorkflowExecutionResponse, error)
+	GetWorkflowHistory(ctx context.Context, workflowID, runID string, isLongPoll bool, filterType enumspb.HistoryEventFilterType) client.HistoryEventIterator
 }
 
 // TemporalEngine implements domain.WorkflowEngine backed by the Temporal Go SDK.
 // Selected when ZYNAX_ENGINE_ADAPTER_ACTIVE_ENGINE=temporal (ADR-015).
 type TemporalEngine struct {
-	client       temporalClient
-	taskQueue    string
-	namespace    string
-	pollInterval time.Duration
+	client    temporalClient
+	taskQueue string
+	namespace string
 }
 
 // NewTemporalEngine constructs a TemporalEngine wrapping the given Temporal client.
@@ -53,10 +53,9 @@ func NewTemporalEngine(c client.Client, taskQueue, namespace string) *TemporalEn
 // can inject a stub without implementing the full client.Client.
 func newTemporalEngine(c temporalClient, taskQueue, namespace string) *TemporalEngine {
 	return &TemporalEngine{
-		client:       c,
-		taskQueue:    taskQueue,
-		namespace:    namespace,
-		pollInterval: defaultWatchPollInterval,
+		client:    c,
+		taskQueue: taskQueue,
+		namespace: namespace,
 	}
 }
 
@@ -118,26 +117,54 @@ func (e *TemporalEngine) GetStatus(ctx context.Context, runID string) (*domain.W
 	return describeToWorkflowRun(resp, runID, e.namespace), nil
 }
 
-// Watch polls DescribeWorkflowExecution and calls send for each status update
-// until the workflow reaches a terminal state or ctx is cancelled.
+// Watch long-polls the Temporal execution history and calls send for each
+// history event in order until the workflow reaches a terminal state or ctx is
+// cancelled. Long-poll replaces the previous DescribeWorkflowExecution polling
+// loop: the iterator blocks server-side until new events are available, so
+// transitions and capability events stream with low latency rather than at a
+// fixed poll cadence (#468, EPIC L step L.1).
 func (e *TemporalEngine) Watch(ctx context.Context, runID string, send func(*domain.WorkflowEvent) error) error {
-	for {
-		run, err := e.GetStatus(ctx, runID)
+	iter := e.client.GetWorkflowHistory(
+		ctx, runID, "", true, enumspb.HISTORY_EVENT_FILTER_TYPE_ALL_EVENT,
+	)
+	for iter.HasNext() {
+		hev, err := iter.Next()
 		if err != nil {
-			return err
+			var nf *serviceerror.NotFound
+			if errors.As(err, &nf) {
+				return domain.ErrExecutionNotFound
+			}
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return fmt.Errorf("engine-adapter: %w", ctxErr)
+			}
+			return fmt.Errorf("engine-adapter: workflow history %q: %w", runID, err)
 		}
-		ev := &domain.WorkflowEvent{RunID: runID, Status: run.Status, Timestamp: time.Now()}
+		ev := historyEventToWorkflowEvent(hev, runID)
 		if err := send(ev); err != nil {
 			return fmt.Errorf("engine-adapter: send event: %w", err)
 		}
-		if run.Status.IsTerminal() {
+		if domain.IsTerminalHistoryEvent(domain.HistoryEventType(hev.GetEventType())) {
 			return nil
 		}
-		select {
-		case <-ctx.Done():
-			return fmt.Errorf("engine-adapter: %w", ctx.Err())
-		case <-time.After(e.pollInterval):
-		}
+	}
+	return nil
+}
+
+// historyEventToWorkflowEvent maps a Temporal history event onto the ordered
+// domain WorkflowEvent. EventID preserves the engine's total order and the
+// event type drives the status the run holds after the event is applied.
+func historyEventToWorkflowEvent(hev *historypb.HistoryEvent, runID string) *domain.WorkflowEvent {
+	hetype := domain.HistoryEventType(hev.GetEventType())
+	ts := time.Time{}
+	if t := hev.GetEventTime(); t != nil {
+		ts = t.AsTime()
+	}
+	return &domain.WorkflowEvent{
+		RunID:     runID,
+		EventID:   hev.GetEventId(),
+		EventType: hev.GetEventType().String(),
+		Status:    domain.HistoryEventStatus(hetype),
+		Timestamp: ts,
 	}
 }
 

--- a/services/engine-adapter/internal/infrastructure/temporal_test.go
+++ b/services/engine-adapter/internal/infrastructure/temporal_test.go
@@ -9,9 +9,9 @@ import (
 	"context"
 	"errors"
 	"testing"
-	"time"
 
 	enumspb "go.temporal.io/api/enums/v1"
+	historypb "go.temporal.io/api/history/v1"
 	"go.temporal.io/api/serviceerror"
 	workflowpb "go.temporal.io/api/workflow/v1"
 	"go.temporal.io/api/workflowservice/v1"
@@ -30,6 +30,40 @@ type stubTemporalClient struct {
 	descResps   []*workflowservice.DescribeWorkflowExecutionResponse
 	descErr     error
 	descCallIdx int
+	historyEvts []*historypb.HistoryEvent
+	historyErr  error
+}
+
+// stubHistoryIterator implements client.HistoryEventIterator over a fixed slice,
+// optionally returning historyErr once all events are drained.
+type stubHistoryIterator struct {
+	evts []*historypb.HistoryEvent
+	idx  int
+	err  error
+}
+
+func (it *stubHistoryIterator) HasNext() bool {
+	return it.idx < len(it.evts) || (it.err != nil && it.idx == len(it.evts))
+}
+
+func (it *stubHistoryIterator) Next() (*historypb.HistoryEvent, error) {
+	if it.idx < len(it.evts) {
+		ev := it.evts[it.idx]
+		it.idx++
+		return ev, nil
+	}
+	it.idx++
+	return nil, it.err
+}
+
+func (s *stubTemporalClient) GetWorkflowHistory(
+	_ context.Context, _, _ string, _ bool, _ enumspb.HistoryEventFilterType,
+) client.HistoryEventIterator {
+	return &stubHistoryIterator{evts: s.historyEvts, err: s.historyErr}
+}
+
+func historyEvent(id int64, t enumspb.EventType) *historypb.HistoryEvent {
+	return &historypb.HistoryEvent{EventId: id, EventType: t}
 }
 
 func (s *stubTemporalClient) ExecuteWorkflow(
@@ -85,9 +119,7 @@ func descResp(status enumspb.WorkflowExecutionStatus) *workflowservice.DescribeW
 }
 
 func newTestEngine(c *stubTemporalClient) *TemporalEngine {
-	e := newTemporalEngine(c, "default", "default")
-	e.pollInterval = time.Millisecond
-	return e
+	return newTemporalEngine(c, "default", "default")
 }
 
 func TestTemporalEngine_Submit_Success(t *testing.T) {
@@ -189,37 +221,69 @@ func TestTemporalEngine_GetStatus_AllMappings(t *testing.T) {
 	}
 }
 
-func TestTemporalEngine_Watch_TerminatesOnCompleted(t *testing.T) {
+func TestTemporalEngine_Watch_StreamsOrderedHistory(t *testing.T) {
 	stub := &stubTemporalClient{
-		descResps: []*workflowservice.DescribeWorkflowExecutionResponse{
-			descResp(enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING),
-			descResp(enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED),
+		historyEvts: []*historypb.HistoryEvent{
+			historyEvent(1, enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED),
+			historyEvent(2, enumspb.EVENT_TYPE_ACTIVITY_TASK_SCHEDULED),
+			historyEvent(3, enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED),
+			// This trailing event must never be delivered: Watch returns after
+			// the terminal COMPLETED event above.
+			historyEvent(4, enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED),
 		},
 	}
+	var ids []int64
 	var received []domain.WorkflowStatus
 	err := newTestEngine(stub).Watch(context.Background(), "wf-1", func(ev *domain.WorkflowEvent) error {
+		ids = append(ids, ev.EventID)
 		received = append(received, ev.Status)
 		return nil
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(received) < 2 {
-		t.Fatalf("expected ≥2 events, got %d", len(received))
+	if len(received) != 3 {
+		t.Fatalf("expected 3 events (stop on terminal), got %d", len(received))
+	}
+	wantIDs := []int64{1, 2, 3}
+	for i, want := range wantIDs {
+		if ids[i] != want {
+			t.Errorf("event %d EventID = %d; want %d (order not preserved)", i, ids[i], want)
+		}
 	}
 	if received[len(received)-1] != domain.WorkflowStatusCompleted {
 		t.Errorf("last status = %v; want Completed", received[len(received)-1])
 	}
 }
 
-func TestTemporalEngine_Watch_ContextCancelled(t *testing.T) {
+func TestTemporalEngine_Watch_SendError(t *testing.T) {
 	stub := &stubTemporalClient{
-		descResps: []*workflowservice.DescribeWorkflowExecutionResponse{
-			descResp(enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING),
+		historyEvts: []*historypb.HistoryEvent{
+			historyEvent(1, enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED),
 		},
 	}
+	sendErr := errors.New("client gone")
+	err := newTestEngine(stub).Watch(context.Background(), "wf-1", func(_ *domain.WorkflowEvent) error {
+		return sendErr
+	})
+	if err == nil || !containsStr(err.Error(), "client gone") {
+		t.Errorf("expected wrapped send error, got: %v", err)
+	}
+}
+
+func TestTemporalEngine_Watch_NotFound(t *testing.T) {
+	stub := &stubTemporalClient{historyErr: &serviceerror.NotFound{Message: "workflow not found"}}
+	err := newTestEngine(stub).Watch(context.Background(), "wf-missing", func(_ *domain.WorkflowEvent) error {
+		return nil
+	})
+	if !errors.Is(err, domain.ErrExecutionNotFound) {
+		t.Errorf("expected ErrExecutionNotFound, got: %v", err)
+	}
+}
+
+func TestTemporalEngine_Watch_ContextCancelled(t *testing.T) {
+	stub := &stubTemporalClient{historyErr: errors.New("long-poll interrupted")}
 	engine := newTestEngine(stub)
-	engine.pollInterval = time.Hour // long interval so ctx cancellation fires first
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()


### PR DESCRIPTION
## What

Replace the `DescribeWorkflowExecution` polling loop in `TemporalEngine.Watch`
with a `GetWorkflowHistory` long-poll iterator, exposing an ordered execution
event stream (EPIC L step L.1, closes #468 engine side).

## Why

The old loop re-described the workflow on a fixed 2s cadence and only surfaced
coarse status. Long-poll blocks server-side until new history events arrive, so
state transitions and capability events stream with low latency. Each event now
carries an explicit `EventID` giving consumers a total order even when
timestamps collide.

## Changes

- `internal/infrastructure/temporal.go` — `Watch` long-polls `GetWorkflowHistory`
  (filter ALL_EVENT, isLongPoll=true), maps each `HistoryEvent` to a domain
  event, stops after the terminal event; removed the poll-interval field and
  `DescribeWorkflowExecution`-based watch loop. `GetStatus` still uses Describe.
- `internal/domain/history.go` — pure, SDK-free mappers `HistoryEventStatus` /
  `IsTerminalHistoryEvent` over mirrored Temporal event-type ordinals (domain
  keeps zero external imports — ADR-001).
- `internal/domain/model.go` — `WorkflowEvent` gains `EventID int64`.
- Tests updated: history-iterator stub; ordered-stream, send-error, not-found
  and context-cancel Watch cases; domain table tests for the new mappers.

## Scope

Engine/domain layer only. Gateway streaming surface is out of scope (L.3).

## Evidence

```
GOWORK=off go build ./...        # exit 0
GOWORK=off go test ./... -race   # all pass
go test ./internal/domain/... -cover  # 91.2% (history mappers 100%)
make lint-go                     # 0 issues
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
