### PR TITLE
docs(ai-learnings): append session learnings — 2026-06-16

### DIFF
--- a/docs/ai-learnings/ci-release.md
+++ b/docs/ai-learnings/ci-release.md
@@ -525,3 +525,21 @@ Post-merge verification of an engine-adapter change. Outcome: SKIP — image pub
 - Rule: After a post-merge multi-arch tools/ci-runner image build, verify the `latest` tag moved (not just that a new version row exists) — a single-arch matrix leg failure strands an `<arch>-<sha>` tag while `latest` stays on the old image. For an `apk add` exit-255 arm64-QEMU failure, remediate with `gh run rerun <id> --failed` (transient), not a Dockerfile change.
   Category: domain
   Reason: Prevents declaring a CVE-bump "live" when the consumed `:latest` image still carries the vulnerable toolchain.
+
+## Session — 2026-06-16 (post-merge PR #1237, issue #1180)
+domain: ci-release · post-merge verification of refactor(engine-adapter)
+
+### Effective patterns
+- Reading release.yml header comments first revealed the ADR-027 retag-only model: images build once pre-merge in ci.yml `build-images` staging lane, release.yml promotes via `workflow_run` after CI completes. Prevents a false ERROR when no "Release" run is tied directly to the merge-SHA push.
+- Query GHCR versions filtered by `tags | test("^main")` to skip the `.sig` cosign artifact that occupies `.[0]` and would be mistaken for the image digest.
+
+### Edge cases discovered
+- The release workflow's github-actions bot commits the digest sync to `images/images.yaml` (`chore(images): sync digests … [skip ci]`, DCO-signed) as a recorded ADR-027 exception — by the time the verifier inspects main, pins are already current; no manual digest PR is warranted. Contrary to the generic guide note, service-image digests (engine-adapter etc.) DO live in images.yaml in this repo via that bot.
+- engine-adapter is not digest-pinned in docker-compose.services.yml (only http-adapter is); the primary docker-compose.yml uses a floating `:main` tag. The Phase-4a sed loop is a no-op for it.
+
+### Failed approaches
+- Looked for a workflow literally named "Release" tied to the merge-SHA push; it only materializes after CI completes via `workflow_run`. Wait for CI green first, then re-query `event=workflow_run`.
+
+### Proposed expert prompt update
+- Rule: This repo follows ADR-027 retag-only: release.yml fires via `workflow_run` AFTER the CI run on main completes (not on the push). Wait for CI green, then query `actions/runs?event=workflow_run` for the Release run. Its github-actions bot auto-commits digest sync to images/images.yaml as `chore(images): sync digests … [skip ci]` — verify pins are current there before assuming a manual digest PR is needed; service-image digests legitimately live in images.yaml via that bot.
+  Category: domain

--- a/docs/ai-learnings/go-services.md
+++ b/docs/ai-learnings/go-services.md
@@ -433,3 +433,22 @@ decision is workflow-compiler/protos domain knowledge.
 - ADR stub + INDEX row may already exist at Proposed → "flesh out + flip status" in place,
   never duplicate. Docs-only PRs correctly skip Go/proto build+lint+test; only the universal
   gates (DCO, gitleaks, conventional-commit, layer-boundary, proto-compat, security) run.
+
+## Session — 2026-06-16 (issue #1180)
+domain: go-services · refactor(engine-adapter): replace polling with Temporal history long-poll · PR #1237
+
+### Effective patterns
+- Mirror SDK enum ordinals into a pure domain type (`HistoryEventType int32`): keeps the domain import-free (ADR-001) while letting the long-poll mapping be unit-tested to 100% without the Temporal SDK.
+- Empty-branch atomic claim then `git branch -m` to add the slug after the claim push wins: deterministic key avoids slug races; rename is local and free.
+- `client.HistoryEventIterator` stubs cleanly via a slice-backed `HasNext()/Next()` fake; modeling the trailing-error case (HasNext true once after drain) covers the NotFound/cancel paths.
+
+### Edge cases discovered
+- Removing the poll-interval field left `time` unused in the test file only (build caught it); gofmt also needed a manual run on the new const block or pre-commit would fail.
+- PR landed behind main; resolved with `git rebase --signoff origin/main` + `--force-with-lease` (never update-branch — DCO/signature safe), which re-triggered CI before a CLEAN merge.
+
+### Failed approaches
+- `gh pr checks --watch --fail-fast`: `--fail-fast` is not a valid flag in this gh version; drop it and just `--watch`.
+
+### Proposed expert prompt update
+- Rule: After deleting a struct field that a test configured (e.g. a poll interval), grep the `_test.go` for now-unused imports (`time`) and run `gofmt -w` on any new file with an aligned const block before committing — pre-commit gofmt will otherwise reject the commit.
+  Category: domain

--- a/docs/ai-learnings/spdd-canvas.md
+++ b/docs/ai-learnings/spdd-canvas.md
@@ -97,3 +97,21 @@
 - Rule: When `gh pr merge` returns BLOCKED but all REQUIRED checks pass and state is UNSTABLE (slow non-required gates pending), use `--auto`; if the gate has already FAILED and is non-required, use `--admin`. If BEHIND and `gh pr update-branch` is unavailable, rebase + `push --force-with-lease`.
   Category: structural-workaround
   Reason: Permanent for this gh build + branch-protection config.
+
+## Session — 2026-06-16 (issues #1193, #1201)
+domain: spdd-canvas · two ADR-proposal stories (ADR-031 context propagation; ADR-033 expert substrate)
+
+### Effective patterns
+- Verify-before-write for ADR stories: glob `docs/adr/ADR-<N>*` and grep the number in INDEX.md before authoring. #1193's ADR-031 already existed complete on main (PR #1174) → closed as already-satisfied, no duplicate. #1201's ADR-033 existed as a stub → audited against ACs and filled the missing mapping table + drift-guard (PR #1236).
+- Tracing the introducing commit (`git log -1 -- <file>`) gives a traceable close reason when a deliverable is pre-seeded by the milestone-open commit.
+- Deterministic branch-ref claim (`docs/<N>`, no slug) pushed empty first = clean atomic claim; the GitHub `status: in-progress` label is NOT the lock, the branch ref is.
+
+### Edge cases discovered
+- Milestone-open commits pre-seed ADR files/stubs. Two outcomes: (a) file already meets every AC → close issue, no PR (#1193); (b) file exists but misses an AC clause (concrete mapping table) → enhance the body only, leave INDEX row untouched if already present (#1201).
+
+### Failed approaches
+- none.
+
+### Proposed expert prompt update
+- Rule: For ADR-proposal / docs issues, before claiming a branch or writing, glob `docs/adr/ADR-<N>*` AND grep the number in INDEX.md. If the file exists, diff its content against each acceptance-criterion clause: close as completed (with file+commit reference) if every AC is met; otherwise enhance only the gaps. Never create a second numbered ADR or a no-op PR.
+  Category: domain


### PR DESCRIPTION
Appending learnings from /milestone-orchestrate batch: issues #1180, #1193, #1201 (+ post-merge PR #1237).

- **go-services** (#1180): SDK-free domain enum mirroring, atomic empty-branch claim, history-iterator test stubs.
- **spdd-canvas** (#1193, #1201): verify-before-write for ADR stories — close-as-satisfied vs stub-audit-and-fill.
- **ci-release** (PR #1237): ADR-027 retag-only post-merge model; release bot auto-syncs images.yaml digests.

Assisted-by: Claude/claude-opus-4-8