### PR TITLE
docs(spdd): repoint remaining canvas links to id folders

### DIFF
--- a/docs/milestones/M7-planning.md
+++ b/docs/milestones/M7-planning.md
@@ -92,10 +92,10 @@ Per ADR-019, every `feat:` issue is preceded by a **REASONS Canvas** (status `Al
 any implementation. This plan front-loads the SPDD artifacts:
 
 - **One canvas per EPIC** is committed with this plan under `docs/spdd/<letter>-<slug>/canvas.md`
-  (all 10: [W](../spdd/W-workflow-data-flow/canvas.md), [L](../spdd/L-log-streaming/canvas.md),
-  [O](../spdd/O-observability-otel-uptrace/canvas.md), [C](../spdd/1168-context-propagation/canvas.md),
-  [G](../spdd/G-git-mcp-shim/canvas.md), [X](../spdd/1170-expert-substrate/canvas.md),
-  [T](../spdd/1171-templates-real-workflows/canvas.md), [R](../spdd/R-test-rigor/canvas.md),
+  (all 10: [W](../spdd/1167-workflow-data-flow/canvas.md), [L](../spdd/468-log-streaming/canvas.md),
+  [O](../spdd/467-observability-otel-uptrace/canvas.md), [C](../spdd/1168-context-propagation/canvas.md),
+  [G](../spdd/1169-git-mcp-shim/canvas.md), [X](../spdd/1170-expert-substrate/canvas.md),
+  [T](../spdd/1171-templates-real-workflows/canvas.md), [R](../spdd/469-test-rigor/canvas.md),
   [Q](../spdd/1172-quality-supply-chain/canvas.md), [D](../spdd/1173-docs/canvas.md)). Each canvas's
   **O — Operations** section lists the EPIC's stories in `spdd-story` form (As-a / I-want / so-that,
   size, acceptance criteria, out-of-scope, dependencies) — ready to become one GitHub issue each.

--- a/docs/spdd/1167-workflow-data-flow/SECURITY-REVIEW.md
+++ b/docs/spdd/1167-workflow-data-flow/SECURITY-REVIEW.md
@@ -2,7 +2,7 @@
 
 # SPDD Security Review — EPIC W: Workflow Data-Flow (#1167)
 
-**Reviewed file:** `docs/spdd/W-workflow-data-flow/canvas.md`
+**Reviewed file:** `docs/spdd/1167-workflow-data-flow/canvas.md`
 **Companion ADR:** ADR-029 (Accepted)
 **Date:** 2026-06-16
 **Standard:** `.claude/commands/spdd-security-review.md` (5 checks) + EPIC-W feature-specific

--- a/docs/spdd/1169-git-mcp-shim/SECURITY-REVIEW.md
+++ b/docs/spdd/1169-git-mcp-shim/SECURITY-REVIEW.md
@@ -2,7 +2,7 @@
 
 # SPDD Security Review — EPIC G: Git MCP Shim (#1169)
 
-**Canvas:** `docs/spdd/G-git-mcp-shim/canvas.md` (Status: Draft)
+**Canvas:** `docs/spdd/1169-git-mcp-shim/canvas.md` (Status: Aligned)
 **Reviewer:** spdd-canvas expert · **Date:** 2026-06-16
 **Method:** `/spdd-security-review` (Tier-2 + injection) + domain threat-surface scan for a Git-over-MCP
 credential-handling EPIC.


### PR DESCRIPTION
Final reconciliation after the M7 canvas folder rename — points the last letter-path links (M7-planning link list W/L/O/G/R + two SECURITY-REVIEW self-references) at their `<id>-slug` folders. After this, no letter-prefixed canvas path remains in the repo.

Assisted-by: Claude/claude-opus-4-8