### PR TITLE
feat(event-bus): close workflow-scoped stream on terminal

### DIFF
--- a/services/event-bus/internal/domain/bus.go
+++ b/services/event-bus/internal/domain/bus.go
@@ -13,7 +13,9 @@ type EventBus interface {
 
 	// Subscribe opens a channel that delivers CloudEvents matching req.TypePattern
 	// and optional req.WorkflowID scope. The channel is closed when Unsubscribe
-	// is called for req.SubscriberID or when ctx is cancelled.
+	// is called for req.SubscriberID, when ctx is cancelled, or — for a
+	// workflow-scoped subscription (req.WorkflowID set) — after delivering a
+	// terminal workflow lifecycle event (see IsTerminalEventType).
 	Subscribe(ctx context.Context, req SubscribeRequest) (<-chan CloudEvent, error)
 
 	// Unsubscribe closes the active subscription for subscriberID.

--- a/services/event-bus/internal/domain/event.go
+++ b/services/event-bus/internal/domain/event.go
@@ -4,7 +4,10 @@
 // This package has zero imports from api or infrastructure — it is the innermost layer.
 package domain
 
-import "time"
+import (
+	"strings"
+	"time"
+)
 
 // CloudEvent is the domain representation of a CNCF CloudEvents v1.0 envelope.
 // Field names mirror the CloudEvents specification attribute names exactly.
@@ -50,4 +53,32 @@ type SubscribeRequest struct {
 	TypePattern string
 	// WorkflowID is an optional scope filter; empty means "all workflows".
 	WorkflowID string
+}
+
+// terminalWorkflowVerbs are the workflow lifecycle event-type verbs that mark a
+// run as finished. They mirror the engine-adapter lifecycle events
+// ("zynax.workflow.completed"/"failed", see engine-adapter interpreter) plus the
+// other Temporal terminal outcomes a run may end in. A workflow-scoped
+// subscriber receives the terminal event and then the stream closes.
+var terminalWorkflowVerbs = []string{
+	"workflow.completed",
+	"workflow.failed",
+	"workflow.terminated",
+	"workflow.canceled",
+	"workflow.timed_out",
+}
+
+// IsTerminalEventType reports whether eventType denotes a terminal workflow
+// lifecycle event — i.e. a run reaching a finished state. Matching is by
+// dot-segment suffix so it is independent of the taxonomy prefix
+// ("zynax.v1.engine-adapter.workflow.completed" and a bare
+// "zynax.workflow.completed" both match). It backs the "stream closes on
+// terminal state" guarantee for workflow-scoped subscriptions.
+func IsTerminalEventType(eventType string) bool {
+	for _, verb := range terminalWorkflowVerbs {
+		if eventType == verb || strings.HasSuffix(eventType, "."+verb) {
+			return true
+		}
+	}
+	return false
 }

--- a/services/event-bus/internal/domain/event_test.go
+++ b/services/event-bus/internal/domain/event_test.go
@@ -115,6 +115,34 @@ func TestSubscribeRequest_ZeroValue(t *testing.T) {
 	}
 }
 
+func TestIsTerminalEventType(t *testing.T) {
+	cases := []struct {
+		name      string
+		eventType string
+		want      bool
+	}{
+		{"completed full taxonomy", "zynax.v1.engine-adapter.workflow.completed", true},
+		{"failed full taxonomy", "zynax.v1.engine-adapter.workflow.failed", true},
+		{"terminated", "zynax.v1.engine-adapter.workflow.terminated", true},
+		{"canceled", "zynax.v1.engine-adapter.workflow.canceled", true},
+		{"timed_out", "zynax.v1.engine-adapter.workflow.timed_out", true},
+		{"bare completed verb", "workflow.completed", true},
+		{"engine lifecycle completed", "zynax.workflow.completed", true},
+		{"engine lifecycle failed", "zynax.workflow.failed", true},
+		{"non-terminal state transition", "zynax.v1.engine-adapter.workflow.state.entered", false},
+		{"capability event", "zynax.v1.task-broker.task.completed", false},
+		{"empty", "", false},
+		{"suffix-only false positive guard", "myworkflow.completed", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := domain.IsTerminalEventType(tc.eventType); got != tc.want {
+				t.Errorf("IsTerminalEventType(%q) = %v, want %v", tc.eventType, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestErrors_Sentinel(t *testing.T) {
 	if domain.ErrTopicNotFound == nil {
 		t.Error("ErrTopicNotFound must not be nil")

--- a/services/event-bus/internal/infrastructure/nats.go
+++ b/services/event-bus/internal/infrastructure/nats.go
@@ -408,6 +408,15 @@ func dispatchMsg(ctx context.Context, msg *nats.Msg, req domain.SubscribeRequest
 	case ch <- event:
 		_ = msg.Ack()
 	}
+
+	// A workflow-scoped subscription is a per-run follower: once that run
+	// reaches a terminal lifecycle event no further events are coming, so
+	// deliver the terminal event (above) and then close the stream. Wildcard
+	// subscriptions (no WorkflowID scope) span many runs and must not close on
+	// one run's terminal event.
+	if req.WorkflowID != "" && domain.IsTerminalEventType(event.Type) {
+		return true
+	}
 	return false
 }
 


### PR DESCRIPTION
## What

Implements EPIC L (#468) canvas O-step **L.2 — Per-workflow event subscription** (`docs/spdd/468-log-streaming/canvas.md`, Status: Aligned).

A workflow-scoped EventBus subscription now closes automatically once the run reaches a terminal lifecycle event, so a per-run follower is not left hanging after the workflow finishes.

## How

- **Reuse, no new RPC.** `WorkflowID` scoping was already wired end-to-end (`domain.SubscribeRequest.WorkflowID` → handler `req.GetWorkflowId()` → NATS `dispatchMsg` filter). AC #1 is satisfied by reuse.
- New pure-domain helper `domain.IsTerminalEventType` recognizes terminal workflow lifecycle event types by dot-segment suffix (`workflow.completed` / `failed` / `terminated` / `canceled` / `timed_out`). Matches both the full taxonomy (`zynax.v1.engine-adapter.workflow.completed`) and the bare engine-adapter lifecycle verbs (`zynax.workflow.completed`).
- NATS `Subscribe` dispatch: after delivering a matching event on a **workflow-scoped** subscription, if the event is terminal it closes the channel. Wildcard subscriptions (no `WorkflowID`) span many runs and are unaffected.

## Acceptance criteria

- [x] reuse EventBus `Subscribe` with `WorkflowID` scope (no new RPC)
- [x] stream closes on terminal state

Out of scope (per canvas): HTTP `/logs` surface is L.3 (#1182).

## Evidence

```
GOWORK=off go build ./...                       # exit 0
GOWORK=off go test ./... -race -timeout 120s    # all ok (api, domain, infrastructure)
domain coverage                                 # 100.0% of statements
make lint-go-svc SVC=event-bus                  # 0 issues
```

Closes #1181

🤖 Assisted-by: Claude/claude-opus-4-8
