### PR TITLE
chore(ci): reconcile docker-compose http-adapter digest pin post-merge of #1249

### DIFF
--- a/infra/docker-compose/docker-compose.services.yml
+++ b/infra/docker-compose/docker-compose.services.yml
@@ -43,7 +43,7 @@ services:
 
   http-adapter:
     profiles: [dev]
-    image: ghcr.io/zynax-io/zynax/http-adapter@sha256:b12750bf90c3617078ace8b90be54c137dc50a8d4b64916ed31dd11e9f2b27df
+    image: ghcr.io/zynax-io/zynax/http-adapter@sha256:d2d6e87a69b1602e2752041299ac715da784237992aa6b4639e31a7808c11b05
     build:
       context: ../..
       dockerfile: agents/adapters/http/Dockerfile


### PR DESCRIPTION
Post-merge digest reconciliation triggered by PR #1249 (issue #1176).

## What changed
- `infra/docker-compose/docker-compose.services.yml`: http-adapter pin
  `sha256:b12750bf...` -> `sha256:d2d6e87a...` (current GHCR `main`/`latest`).

## Why
`#1249` is proto-only (workflow_compiler proto + generated stubs + a `.feature`);
its Release `retag-on-merge` job ran and promoted no images. The compose
http-adapter pin had drifted from the digest already recorded in
`images/images.yaml` by the `#1250` retag's skip-ci digest-sync commit
(91f9f30). The release pipeline only auto-syncs `images/images.yaml`, never
docker-compose, so this pin needed a manual realign.

## Session image-state verification
- `#1247` (event-bus, 948e9107): CI failed on the merge SHA, so its Release run
  was skipped and event-bus was not promoted at that merge.
- `#1250` (59545ca) realigned go.sum across all 7 go-module services
  (incl. event-bus), which rebuilt their staging images and its successful
  retag-on-merge re-promoted all of them to `main-59545cac`/`main`/`latest`.
  event-bus `latest` = `sha256:f6bfb125...` matches `images.yaml` -- recovered.
- No open digest-bump / digest-drift issues to triage.

Assisted-by: Claude/claude-opus-4-8
