### PR TITLE
docs(ai-learnings): append M7 batch session learnings — 2026-06-16

### DIFF
--- a/docs/ai-learnings/ci-release.md
+++ b/docs/ai-learnings/ci-release.md
@@ -543,3 +543,29 @@ domain: ci-release · post-merge verification of refactor(engine-adapter)
 ### Proposed expert prompt update
 - Rule: This repo follows ADR-027 retag-only: release.yml fires via `workflow_run` AFTER the CI run on main completes (not on the push). Wait for CI green, then query `actions/runs?event=workflow_run` for the Release run. Its github-actions bot auto-commits digest sync to images/images.yaml as `chore(images): sync digests … [skip ci]` — verify pins are current there before assuming a manual digest PR is needed; service-image digests legitimately live in images.yaml via that bot.
   Category: domain
+
+## Session — 2026-06-16 (post-merge PRs #1248 #1247 #1249, issues #1185 #1181 #1176)
+domain: ci-release / post-mrg · M7 batch post-merge verification (3 verifiers; digest PR #1251)
+
+### Effective patterns
+- `gh run view <release_run_id> --json jobs` is the ONLY reliable promotion proof: a "Release" run existing — even with conclusion `success` — does NOT mean images were rebuilt. #1249's Release run was success but its retag promoted 0 images (proto-only); #1250's run is what actually re-promoted event-bus.
+- Cross-reference each PR's changed files against the retag-on-merge model (promotes only `staging/pr-<that-PR-head>`) to reason about which services were truly rebuilt — this explained how event-bus recovered: #1250 touched `event-bus/go.sum` → CI rebuilt its staging image → #1250's retag re-promoted it, so the skipped #1247 retag left no permanent gap.
+- `gh pr view --json files` first immediately classifies a libs-only / proto-only change and short-circuits matrix mapping.
+
+### Edge cases discovered
+- The release pipeline auto-syncs `images/images.yaml` ONLY, never `infra/docker-compose/docker-compose.services.yml` — compose pins drift silently and reconciling them is the verifier's real job when images.yaml is already current (here http-adapter `b12750bf`→`d2d6e87a`).
+- A "Release" run triggers even on a libs-only / non-service merge but runs only the retag/promote job with all service-build matrix jobs `skipped`. A FAILED CI on main skips the ENTIRE Release run — that is why #1247's event-bus retag was skipped while main was transiently red from the #1248 go.sum drift.
+- `ci.yml build-images` matrix runs only on `pull_request`/`workflow_dispatch`, never on push — the on-merge path is retag-only, never a fresh build.
+- A required check that is path-gated to `skipped` is treated as satisfied by the ruleset; a required check that simply never reports keeps the PR BLOCKED forever — distinguish the two before assuming a stuck PR.
+
+### Failed approaches
+- Literal `[skip ci]` in a digest PR's commit message AND body silently suppressed the PR's CI (only CodeQL ran), leaving auto-merge BLOCKED with "no required checks reported". Fix: amend the commit + edit the body to use "skip-ci marker" phrasing, force-push to re-trigger CI.
+- `gh api -f body=@file` does NOT read the file (`@` only works with `-F`) — it set the body literally to `@/path`; use `gh api -F body=@file`.
+- `gh run view <jobID> --log-failed` returns HTTP 404 — pass the RUN id, not a job id, and let `--log-failed` find the failing job.
+
+### Proposed expert prompt update
+- Rule: Verify post-merge promotion via `gh run view <release_run_id> --json jobs` and confirm the "Retag staging → main" job conclusion is `success` (not `skipped`); a Release run merely existing/succeeding is not proof. A failed CI on main skips the entire Release. The guide's matrix-service list is stale (event-bus IS in the matrix) — use the per-PR changed-file → staging-image mapping instead.
+  Category: domain
+- Rule: NEVER put the literal `[skip ci]`/`[ci skip]` token in a digest PR's commit message OR body, even when quoting the bot's skip-ci digest-sync commit — write "skip-ci marker". The token in a PR body silently skips the PR's CI and leaves auto-merge BLOCKED with "no required checks reported".
+  Category: structural-workaround
+  Reason: Recurring, hard-to-diagnose, and unique to this verifier role which routinely references the bot's skip-ci digest-sync commits.

--- a/docs/ai-learnings/go-services.md
+++ b/docs/ai-learnings/go-services.md
@@ -452,3 +452,31 @@ domain: go-services · refactor(engine-adapter): replace polling with Temporal h
 ### Proposed expert prompt update
 - Rule: After deleting a struct field that a test configured (e.g. a poll interval), grep the `_test.go` for now-unused imports (`time`) and run `gofmt -w` on any new file with an aligned const block before committing — pre-commit gofmt will otherwise reject the commit.
   Category: domain
+
+## Session — 2026-06-16 (issues #1185 #1181 #1176 + post-#1248 deps-realign)
+domain: go-services · M7 batch — O.2 OTEL providers (#1185 PR #1248), L.2 event stream (#1181 PR #1247), W.2 keystone proto fields (#1176 PR #1249), plus the `chore(deps)` recovery PR #1250.
+
+### Effective patterns
+- verify-before-create (O.2 #1185): the planned `libs/zynaxotel` already existed as `libs/zynaxobs`; reading the live tree and extending it (new `providers.go`) beat green-fielding a duplicate — live tree wins over canvas naming.
+- Official OTEL noop packages (`trace/noop`, `metric/noop`, `log/noop`) for the unset-endpoint path: callers need no telemetry on/off branching and tests can assert the exact no-op types.
+- `.feature`-before-impl with godog non-strict (W.2 #1176): append data-flow scenarios to the existing feature file; godog reports their unimplemented steps as `undefined` (not failed), so the suite stays green while the spec lands first per ADR-016. Step impls follow with the compiler logic (W.3).
+- ActionIR bindings modeled as `map<string,string>` (proto fields 5/6): matched ADR-029's stringly-typed literal/JSON-path model, purely additive, kept `buf breaking` green with zero new imports.
+- Find shared-lib consumers via `grep -rl "libs/<x>" --include=go.mod` before assuming the blast radius (deps-realign): a lib's go.mod change invalidates EVERY module with a local `replace` directive — here all 7 consumers, not just the one CI named.
+
+### Edge cases discovered
+- A libs-only PR's CI does NOT rebuild consuming services, so new transitive deps added to a shared lib (OTEL OTLP exporters in #1248) reach `main` with stale consumer `go.sum` and break `main` post-merge (agent-registry/event-bus/memory-service + 4 more failed `test-integration`/`lint-go`/`security`). Recovered with `go mod tidy` across all 7 `libs/zynaxobs` consumers in one `chore(deps)` PR.
+- Touching `protos/generated/go/` flips every Go service to `*_CHANGED=true` in the CI `changes` filter, so lint-go/security/test-go/Build+scan run against ALL consumers even for a pure proto-additive change — this is how the latent repo-wide go.sum drift was surfaced by the keystone proto PR.
+- `go mod tidy` did NOT auto-bump OTEL core in this repo: every consumer pins via `replace`→`libs/zynaxobs`, whose go.mod fixes otel core v1.43.0 / log v0.19.0, so tidy resolved to the pinned versions. The auto-bump fear (O.2) did not materialize at the consumer level — but verify across all go.mod files; the `check deps` alignment gate validates go/envconfig/grpc/protobuf/yaml.v3, not OTEL directly (OTEL only matters because a bump can cascade into grpc/protobuf).
+- pre-commit ruff reformats committed `_pb2.py`; re-stage the hook-modified file and re-commit. `make generate-protos` also bumped protoc-gen-python 7.35.0→7.35.1 touching ~17 unrelated stubs — `git checkout --` all but the genuinely-changed package to keep the PR minimal.
+- A behind-base branch makes lint-go report "no go files to analyze" and security report "go mod tidy needed" — a stale-base artifact; fix with `git rebase --signoff origin/main`.
+
+### Failed approaches
+- Running `go mod tidy` on individual gated services inside the proto-only PR (W.2) to fix lint-go/security: it cascaded into NEW failures because the drift was repo-wide and the shared-lib go.sum was equally stale. Correct move: do NOT tidy inside the feature PR; route the reconciliation to a dedicated `chore(deps)` PR.
+- golangci-lint with an absolute module path / `...` pattern errors ("does not contain main module"); in a no-cd sandbox write a 2-line helper script that `cd`s into the module then lints, and `bash` it.
+
+### Proposed expert prompt update
+- Rule: When a shared `libs/*` module gains a dependency, EVERY module with `replace .../libs/<x> => ../../libs/<x>` must be re-tidied. Find them all with `grep -rl "libs/<x>" --include=go.mod`. A libs-only PR's CI never rebuilds consumers, so this drift reaches main silently; CI may name only one failing module but the fix is repo-wide.
+  Category: domain
+- Rule: A PR that touches `protos/generated/go/` flips every Go service to changed in the CI `changes` filter. If lint-go/security/test-go fail with "go mod tidy needed", FIRST check whether main itself is drifted (build a service the PR does NOT touch); if so the drift is pre-existing/out-of-scope for the proto PR — document it and route to a `chore(deps)` PR rather than tidying inside the feature PR (which cascades into shared-lib go.sum/Docker-build failures).
+  Category: structural-workaround
+  Reason: Recurs for any additive-proto or shared-lib PR; tidying inside the feature PR makes it worse and violates scope, while the correct diagnosis (build an untouched module) is non-obvious.


### PR DESCRIPTION
Appends session learnings from the 2026-06-16 `/milestone-orchestrate` batch.

**Batch:** #1185 (O.2 OTEL providers, PR #1248), #1181 (L.2 event stream, PR #1247),
#1176 (W.2 keystone proto fields, PR #1249), plus the `chore(deps)` recovery PR #1250
and post-merge verification of all three (digest reconcile PR #1251).

**go-services** — shared `libs/*` dependency additions invalidate every
`replace`-directive consumer's `go.sum`; a libs-only PR's CI never rebuilds those
consumers, so the drift reaches main silently. `protos/generated/` changes flip all
services to changed in the CI `changes` filter. Repo-wide go.sum drift belongs in a
dedicated `chore(deps)` PR, never tidied inside a feature PR.

**ci-release** — `gh run view <id> --json jobs` is the only reliable promotion proof;
the release pipeline auto-syncs `images.yaml` but not the docker-compose digest pins;
a literal skip-ci token in a PR body silently blocks auto-merge.

Docs-only; no code paths affected.

Assisted-by: Claude/claude-opus-4-8
