### PR TITLE
feat(workflow-compiler): compile + validate output/input bindings

### DIFF
--- a/services/workflow-compiler/internal/domain/graph.go
+++ b/services/workflow-compiler/internal/domain/graph.go
@@ -3,6 +3,7 @@ package domain
 import (
 	"context"
 	"fmt"
+	"strings"
 )
 
 // WorkflowGraph is the directed state machine built from a parsed Manifest.
@@ -83,6 +84,9 @@ func Build(_ context.Context, m *Manifest) (*WorkflowGraph, ParseErrors) {
 		}
 	}
 
+	// Every input binding reference must resolve to a declared upstream output.
+	errs = append(errs, validateInputBindings(m.States)...)
+
 	if len(errs) > 0 {
 		return nil, errs
 	}
@@ -93,6 +97,99 @@ func Build(_ context.Context, m *Manifest) (*WorkflowGraph, ParseErrors) {
 		InitialState: m.InitialState,
 		States:       m.States,
 	}, nil
+}
+
+// validateInputBindings checks that every action input binding reference of the
+// form "$.states.<state>.output.<key>" resolves to a state that exists and that
+// declares <key> in its output_bindings. Unresolved references yield a
+// COMPILATION_ERROR (ErrorCodeInvalidFieldValue) carrying the manifest line of
+// the consuming state. Returns all errors found — not just the first.
+func validateInputBindings(states map[string]*State) ParseErrors {
+	// Index declared outputs: stateID → set of output keys.
+	declared := make(map[string]map[string]struct{}, len(states))
+	for id, st := range states {
+		for _, a := range st.Actions {
+			for key := range a.OutputBindings {
+				if declared[id] == nil {
+					declared[id] = make(map[string]struct{})
+				}
+				declared[id][key] = struct{}{}
+			}
+		}
+	}
+
+	var errs ParseErrors
+	for id, st := range states {
+		for ai, a := range st.Actions {
+			for key, ref := range a.InputBindings {
+				if perr := resolveBinding(id, ai, key, ref, st.Line, declared); perr != nil {
+					errs = append(errs, *perr)
+				}
+			}
+		}
+	}
+	return errs
+}
+
+// resolveBinding parses a single "$.states.<state>.output.<key>" reference and
+// verifies the target state and output key are declared. Returns nil when the
+// reference resolves, or a ParseError describing why it does not.
+func resolveBinding(
+	consumer string,
+	actionIdx int,
+	inputKey, ref string,
+	line int,
+	declared map[string]map[string]struct{},
+) *ParseError {
+	srcState, srcKey, ok := parseBindingRef(ref)
+	if !ok {
+		return &ParseError{
+			Code:      ErrorCodeInvalidFieldValue,
+			Message:   fmt.Sprintf("state %q: actions[%d].input[%q] reference %q is malformed; expected \"$.states.<state>.output.<key>\"", consumer, actionIdx, inputKey, ref),
+			Line:      line,
+			StateName: consumer,
+		}
+	}
+	outputs, stateOK := declared[srcState]
+	if !stateOK {
+		return &ParseError{
+			Code:      ErrorCodeInvalidFieldValue,
+			Message:   fmt.Sprintf("state %q: actions[%d].input[%q] references output of unknown or output-less state %q", consumer, actionIdx, inputKey, srcState),
+			Line:      line,
+			StateName: consumer,
+		}
+	}
+	if _, keyOK := outputs[srcKey]; !keyOK {
+		return &ParseError{
+			Code:      ErrorCodeInvalidFieldValue,
+			Message:   fmt.Sprintf("state %q: actions[%d].input[%q] references undeclared output %q of state %q", consumer, actionIdx, inputKey, srcKey, srcState),
+			Line:      line,
+			StateName: consumer,
+		}
+	}
+	return nil
+}
+
+// parseBindingRef splits "$.states.<state>.output.<key>" into its state and
+// output key. <key> may itself contain dots (a nested path). Returns ok=false
+// for any other shape.
+func parseBindingRef(ref string) (state, key string, ok bool) {
+	const root = "$.states."
+	if !strings.HasPrefix(ref, root) {
+		return "", "", false
+	}
+	rest := ref[len(root):]
+	const mid = ".output."
+	idx := strings.Index(rest, mid)
+	if idx <= 0 {
+		return "", "", false
+	}
+	state = rest[:idx]
+	key = rest[idx+len(mid):]
+	if state == "" || key == "" {
+		return "", "", false
+	}
+	return state, key, true
 }
 
 // TransitionsFor returns all transitions from a state that match the given

--- a/services/workflow-compiler/internal/domain/graph_test.go
+++ b/services/workflow-compiler/internal/domain/graph_test.go
@@ -273,3 +273,81 @@ spec:
 		t.Errorf("unexpected transitions: %v", ts)
 	}
 }
+
+// dataFlowManifest returns a two-state manifest where "summarize" consumes the
+// declared "results" output of "search". The badRef override, when non-empty,
+// replaces the consuming input reference to exercise validation failures.
+func dataFlowManifest(badRef string) []byte {
+	ref := "$.states.search.output.results"
+	if badRef != "" {
+		ref = badRef
+	}
+	return []byte(`
+kind: Workflow
+apiVersion: zynax.io/v1
+metadata:
+  name: data-flow-wf
+spec:
+  initial_state: search
+  states:
+    search:
+      actions:
+        - capability: web_search
+          output:
+            results: results
+      on:
+        - event: search.done
+          goto: summarize
+    summarize:
+      type: terminal
+      actions:
+        - capability: summarize
+          input:
+            doc: "` + ref + `"
+`)
+}
+
+func TestBuild_InputBindingResolves(t *testing.T) {
+	m, parseErrs := ParseManifest(context.Background(), dataFlowManifest(""))
+	if len(parseErrs) != 0 {
+		t.Fatalf("parse failed: %v", parseErrs)
+	}
+	if _, errs := Build(context.Background(), m); len(errs) != 0 {
+		t.Fatalf("expected resolvable binding to compile, got: %v", errs)
+	}
+}
+
+func TestBuild_InputBindingValidationFailures(t *testing.T) {
+	tests := []struct {
+		name string
+		ref  string
+	}{
+		{"undeclared output key", "$.states.search.output.missing"},
+		{"unknown source state", "$.states.nope.output.results"},
+		{"malformed reference", "$.states.search.results"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m, parseErrs := ParseManifest(context.Background(), dataFlowManifest(tt.ref))
+			if len(parseErrs) != 0 {
+				t.Fatalf("parse failed: %v", parseErrs)
+			}
+			_, errs := Build(context.Background(), m)
+			if len(errs) == 0 {
+				t.Fatalf("expected a COMPILATION_ERROR for %q", tt.ref)
+			}
+			found := false
+			for _, e := range errs {
+				if e.Code == ErrorCodeInvalidFieldValue && e.StateName == "summarize" {
+					found = true
+					if e.Line <= 0 {
+						t.Errorf("expected a line number on the error, got %d", e.Line)
+					}
+				}
+			}
+			if !found {
+				t.Errorf("expected ErrorCodeInvalidFieldValue on 'summarize', got: %v", errs)
+			}
+		})
+	}
+}

--- a/services/workflow-compiler/internal/domain/ir/ir.go
+++ b/services/workflow-compiler/internal/domain/ir/ir.go
@@ -102,9 +102,24 @@ func convertActions(stateID string, actions []domain.Action) ([]*zynaxv1.ActionI
 			Timeout:           pbDur,
 			InputTemplateJson: inputJSON,
 			Async:             a.Async,
+			OutputBindings:    copyBindings(a.OutputBindings),
+			InputBindings:     copyBindings(a.InputBindings),
 		})
 	}
 	return out, nil
+}
+
+// copyBindings returns a defensive copy of a binding map, or nil when empty, so
+// that the IR does not alias the domain Action's maps.
+func copyBindings(m map[string]string) map[string]string {
+	if len(m) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
 }
 
 func marshalInputTemplate(input map[string]interface{}) (string, error) {

--- a/services/workflow-compiler/internal/domain/ir/ir_test.go
+++ b/services/workflow-compiler/internal/domain/ir/ir_test.go
@@ -259,6 +259,38 @@ func TestToIR_ActionFields(t *testing.T) {
 	}
 }
 
+func TestToIR_ActionBindings(t *testing.T) {
+	g := &domain.WorkflowGraph{
+		Name:         "t",
+		Namespace:    "default",
+		InitialState: "s",
+		States: map[string]*domain.State{
+			"s": {
+				ID:   "s",
+				Type: domain.StateTypeNormal,
+				Actions: []domain.Action{
+					{
+						Capability:     "summarize",
+						OutputBindings: map[string]string{"summary": "results"},
+						InputBindings:  map[string]string{"doc": "$.states.search.output.results"},
+					},
+				},
+			},
+		},
+	}
+	wfIR, err := ir.ToIR(context.Background(), g, "id", "v1", time.Time{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	a := wfIR.States[0].Actions[0]
+	if a.OutputBindings["summary"] != "results" {
+		t.Errorf("OutputBindings[summary] = %q, want %q", a.OutputBindings["summary"], "results")
+	}
+	if a.InputBindings["doc"] != "$.states.search.output.results" {
+		t.Errorf("InputBindings[doc] = %q, want reference", a.InputBindings["doc"])
+	}
+}
+
 // Terminal state has no transitions ────────────────────────────────────────────
 
 func TestToIR_TerminalStateHasNoTransitions(t *testing.T) {

--- a/services/workflow-compiler/internal/domain/manifest.go
+++ b/services/workflow-compiler/internal/domain/manifest.go
@@ -27,13 +27,20 @@ const (
 // Action is a single capability invocation within a state. It holds no proto
 // types — the api layer maps Action to ActionIR when building WorkflowIR.
 //
-// Note: output mapping is not yet implemented (tracked for M7+). The parser
-// rejects any action that sets output: with ErrorCodeInvalidFieldValue.
+// OutputBindings declares the named outputs this action publishes into the
+// workflow-scoped data context (ADR-029): context key → source path within the
+// action's result payload. InputBindings declares the inputs this action
+// consumes: context key → a JSON-path reference rooted at
+// "$.states.<state>.output.<key>". Literal (non-reference) inputs remain in
+// Input. Both binding maps are nil when the action declares none — additive and
+// backward-compatible (M7 EPIC W, issue #1177).
 type Action struct {
-	Capability string
-	Timeout    time.Duration // zero means no timeout
-	Input      map[string]interface{}
-	Async      bool
+	Capability     string
+	Timeout        time.Duration // zero means no timeout
+	Input          map[string]interface{}
+	OutputBindings map[string]string
+	InputBindings  map[string]string
+	Async          bool
 }
 
 // Transition is an outbound edge in the workflow state machine.
@@ -252,20 +259,16 @@ func convertState( //nolint:funlen // validates type + actions + transitions in 
 				})
 			}
 		}
-		if len(ya.Output) > 0 {
-			errs = append(errs, ParseError{
-				Code:      ErrorCodeInvalidFieldValue,
-				Message:   fmt.Sprintf("state %q: action %q uses output: which is not yet implemented; remove it or upgrade to M7+", name, ya.Capability),
-				Line:      line,
-				StateName: name,
-			})
-			continue
-		}
+		outputs, outErrs := convertOutputBindings(name, i, ya.Output, line)
+		errs = append(errs, outErrs...)
+		literals, inputs := splitInputBindings(ya.Input)
 		st.Actions = append(st.Actions, Action{
-			Capability: ya.Capability,
-			Timeout:    d,
-			Input:      ya.Input,
-			Async:      ya.Async,
+			Capability:     ya.Capability,
+			Timeout:        d,
+			Input:          literals,
+			OutputBindings: outputs,
+			InputBindings:  inputs,
+			Async:          ya.Async,
 		})
 	}
 
@@ -300,6 +303,71 @@ func convertState( //nolint:funlen // validates type + actions + transitions in 
 		return nil, errs
 	}
 	return st, nil
+}
+
+// inputBindingPrefix is the JSON-path root that marks a string input value as a
+// reference into the workflow data context rather than a literal. The full form
+// is "$.states.<state>.output.<key>" (ADR-029, M7 EPIC W). There is no
+// expression/transform language in M7 — a value resolves verbatim or is a
+// compile-time error.
+const inputBindingPrefix = "$.states."
+
+// convertOutputBindings flattens a YAML output: mapping into a string→string
+// map of context key → source path. Non-string source paths are a compile-time
+// error: M7 has no transform language, so each binding value must be a literal
+// path string (ADR-029).
+func convertOutputBindings(
+	state string,
+	actionIdx int,
+	raw map[string]interface{},
+	line int,
+) (map[string]string, ParseErrors) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	var errs ParseErrors
+	out := make(map[string]string, len(raw))
+	for key, val := range raw {
+		s, ok := val.(string)
+		if !ok {
+			errs = append(errs, ParseError{
+				Code:      ErrorCodeInvalidFieldValue,
+				Message:   fmt.Sprintf("state %q: actions[%d].output[%q] must be a string source path, got %T", state, actionIdx, key, val),
+				Line:      line,
+				StateName: state,
+			})
+			continue
+		}
+		out[key] = s
+	}
+	if len(out) == 0 {
+		return nil, errs
+	}
+	return out, errs
+}
+
+// splitInputBindings partitions a YAML input: mapping into literal inputs (which
+// stay in the input template, preserving their original types) and binding
+// references (string values rooted at inputBindingPrefix). Either returned map
+// is nil when it would be empty.
+func splitInputBindings(raw map[string]interface{}) (literals map[string]interface{}, bindings map[string]string) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	for key, val := range raw {
+		if s, ok := val.(string); ok && strings.HasPrefix(s, inputBindingPrefix) {
+			if bindings == nil {
+				bindings = make(map[string]string)
+			}
+			bindings[key] = s
+			continue
+		}
+		if literals == nil {
+			literals = make(map[string]interface{})
+		}
+		literals[key] = val
+	}
+	return literals, bindings
 }
 
 // extractStateLines walks the yaml.Node tree to find the source line of each

--- a/services/workflow-compiler/internal/domain/manifest_test.go
+++ b/services/workflow-compiler/internal/domain/manifest_test.go
@@ -319,7 +319,7 @@ spec:
 	}
 }
 
-func TestParseManifest_ActionOutputRejected(t *testing.T) {
+func TestParseManifest_ActionOutputAccepted(t *testing.T) {
 	data := []byte(`
 kind: Workflow
 apiVersion: zynax.io/v1
@@ -333,27 +333,76 @@ spec:
       actions:
         - capability: summarize
           output:
-            ctx.result: "{{ .result.text }}"
+            result: results
+`)
+	m, errs := ParseManifest(context.Background(), data)
+	if len(errs) != 0 {
+		t.Fatalf("expected output: to be accepted, got errors: %v", errs)
+	}
+	got := m.States["s"].Actions[0].OutputBindings
+	if got["result"] != "results" {
+		t.Errorf("OutputBindings[result] = %q, want %q", got["result"], "results")
+	}
+}
+
+func TestParseManifest_InputBindingSplit(t *testing.T) {
+	data := []byte(`
+kind: Workflow
+apiVersion: zynax.io/v1
+metadata:
+  name: wf
+spec:
+  initial_state: s
+  states:
+    s:
+      type: terminal
+      actions:
+        - capability: summarize
+          input:
+            doc: "$.states.search.output.results"
+            limit: 5
+`)
+	m, errs := ParseManifest(context.Background(), data)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	a := m.States["s"].Actions[0]
+	if a.InputBindings["doc"] != "$.states.search.output.results" {
+		t.Errorf("InputBindings[doc] = %q, want reference", a.InputBindings["doc"])
+	}
+	if _, ok := a.InputBindings["limit"]; ok {
+		t.Error("literal input 'limit' must not be treated as a binding")
+	}
+	if a.Input["limit"] != 5 {
+		t.Errorf("literal input 'limit' = %v, want 5", a.Input["limit"])
+	}
+	if _, ok := a.Input["doc"]; ok {
+		t.Error("binding reference 'doc' must be removed from the input template")
+	}
+}
+
+func TestParseManifest_OutputNonStringRejected(t *testing.T) {
+	data := []byte(`
+kind: Workflow
+apiVersion: zynax.io/v1
+metadata:
+  name: wf
+spec:
+  initial_state: s
+  states:
+    s:
+      type: terminal
+      actions:
+        - capability: summarize
+          output:
+            result: 42
 `)
 	_, errs := ParseManifest(context.Background(), data)
 	if len(errs) == 0 {
-		t.Fatal("expected error when output: is used on an action")
+		t.Fatal("expected error for non-string output source path")
 	}
-	found := false
-	for _, e := range errs {
-		if e.Code == ErrorCodeInvalidFieldValue {
-			found = true
-		}
-	}
-	if !found {
-		t.Errorf("expected ErrorCodeInvalidFieldValue for output: usage, got %v", errs)
-	}
-	// Verify the error message is descriptive enough to guide the user.
-	if len(errs) > 0 {
-		msg := errs[0].Message
-		if msg == "" {
-			t.Error("expected non-empty error message for output: usage")
-		}
+	if errs[0].Code != ErrorCodeInvalidFieldValue {
+		t.Errorf("code = %v, want ErrorCodeInvalidFieldValue", errs[0].Code)
 	}
 }
 


### PR DESCRIPTION
## What

Implements EPIC W step **W.3** (issue #1177): the workflow-compiler now accepts and validates `output:` / input bindings instead of rejecting them.

- Lift the `output:` rejection in `manifest.go` (was: "not yet implemented; upgrade to M7+").
- Compile `output:` mappings into `Action.OutputBindings` (context key → source path).
- Split `input:` values: JSON-path references rooted at `$.states.<state>.output.<key>` go to `Action.InputBindings`; literals stay in the input template (types preserved).
- Populate the existing IR fields `ActionIR.output_bindings` / `ActionIR.input_bindings` delivered by W.2 (PR #1249) — no new proto fields.
- Validate every input binding reference resolves to a declared upstream output; unresolved/malformed references raise a `COMPILATION_ERROR` (`ErrorCodeInvalidFieldValue`) carrying the consuming state's manifest line number.

## Out of scope

Execution / data-context threading (W.4 #1178). This PR is `output:` acceptance + compile-time validation only.

## Evidence

- `GOWORK=off go test ./... -race -timeout 60s` — all packages pass.
- Domain coverage: `internal/domain` 97.0%, `internal/domain/ir` 92.7%, `internal/domain/validators` 95.9% (all ≥90%).
- `make lint` — proto + Go + adapters + Python all green.

## Canvas

`docs/spdd/1167-workflow-data-flow/canvas.md` (Status: Aligned), section O step W.3.

Closes #1177
