### PR TITLE
feat(adapters): MCP shim over git-adapter capabilities

### DIFF
--- a/agents/adapters/git/AGENTS.md
+++ b/agents/adapters/git/AGENTS.md
@@ -41,6 +41,16 @@ YAML file at the path given by `ADAPTER_CONFIG`. Key fields:
 
 Default: **50060** (set via `endpoint` in config YAML).
 
+## MCP shim surface (ADR-032)
+
+`git-adapter mcp` runs a thin Model Context Protocol stdio server over the **same**
+capability handlers (one Git implementation, two surfaces — ADR-032). It binds no
+port and needs no registry. MCP tools map 1:1 onto the capabilities above; the
+exposed tool set is an explicit allow-list built from `capabilities[].name` — no
+Git logic is reimplemented in `internal/mcp/`. The owner/repo target stays pinned
+in config, so no caller-supplied owner/repo/remote reaches a Git call (SSRF guard).
+Credential injection + redaction are delivered by G.3 (#1199), not this layer.
+
 ## Testing
 
 ```bash

--- a/agents/adapters/git/cmd/git-adapter/main.go
+++ b/agents/adapters/git/cmd/git-adapter/main.go
@@ -7,6 +7,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"io"
 	"log/slog"
 	"net"
 	"os"
@@ -15,6 +16,7 @@ import (
 
 	"github.com/zynax-io/zynax/agents/adapters/git/internal/adapter"
 	"github.com/zynax-io/zynax/agents/adapters/git/internal/config"
+	"github.com/zynax-io/zynax/agents/adapters/git/internal/mcp"
 	"github.com/zynax-io/zynax/agents/adapters/git/internal/registry"
 	zynaxv1 "github.com/zynax-io/zynax/protos/generated/go/zynax/v1"
 	"google.golang.org/grpc"
@@ -47,6 +49,13 @@ func run() error {
 		return fmt.Errorf("resolve token: %w", err)
 	}
 
+	// `git-adapter mcp` runs the thin MCP stdio shim over the same handlers
+	// instead of the runtime gRPC server (ADR-032 — one implementation, two
+	// surfaces). It needs no registry and binds no port.
+	if len(os.Args) > 1 && os.Args[1] == "mcp" {
+		return serveMCP(cfg, token, os.Stdin, os.Stdout)
+	}
+
 	regClient, cleanup, err := dialRegistry(cfg.RegistryEndpoint)
 	if err != nil {
 		return err
@@ -57,6 +66,21 @@ func run() error {
 	defer stop()
 
 	return serve(ctx, cfg, token, regClient)
+}
+
+// serveMCP runs the MCP stdio shim. The exposed tool set is an explicit
+// allow-list built from the configured capability names — not "every handler".
+func serveMCP(cfg *config.AdapterConfig, token string, in io.Reader, out io.Writer) error {
+	srv := adapter.NewAgentServer(cfg, token)
+	tools := make([]string, 0, len(cfg.Capabilities))
+	for _, c := range cfg.Capabilities {
+		tools = append(tools, c.Name)
+	}
+	slog.Info("git-adapter mcp serving over stdio", "tools", tools) //nolint:gosec
+	if err := mcp.NewServer(srv, tools).Serve(context.Background(), in, out); err != nil {
+		return fmt.Errorf("mcp serve: %w", err)
+	}
+	return nil
 }
 
 func dialRegistry(endpoint string) (zynaxv1.AgentRegistryServiceClient, func(), error) {

--- a/agents/adapters/git/cmd/git-adapter/mcp_main_test.go
+++ b/agents/adapters/git/cmd/git-adapter/mcp_main_test.go
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Whitebox coverage for the `git-adapter mcp` stdio path (#1198, G.2).
+package main
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/zynax-io/zynax/agents/adapters/git/internal/config"
+)
+
+// TestServeMCP_ClosedTransportReturnsNil covers serveMCP: it builds the tool
+// allow-list from the configured capabilities and serves until the transport
+// closes. An empty reader closes immediately, so the stdio loop returns nil.
+func TestServeMCP_ClosedTransportReturnsNil(t *testing.T) {
+	cfg := &config.AdapterConfig{
+		Capabilities: []config.GitCapabilityConfig{{Name: "open_pr"}, {Name: "get_diff"}},
+	}
+	if err := serveMCP(cfg, "token", strings.NewReader(""), io.Discard); err != nil {
+		t.Fatalf("serveMCP over a closed transport should return nil, got %v", err)
+	}
+}

--- a/agents/adapters/git/internal/mcp/coverage_test.go
+++ b/agents/adapters/git/internal/mcp/coverage_test.go
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp_test
+
+// Coverage tests for the thin MCP shim (#1198, G.2): the gRPC ServerStream sink
+// stubs, the JSON-RPC framing/error branches, and the allow-list dedup and
+// tools/list schema edge cases. All exercised through the public Serve/NewServer
+// surface — no Git logic lives in this layer, so none is asserted here.
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/zynax-io/zynax/agents/adapters/git/internal/mcp"
+	zynaxv1 "github.com/zynax-io/zynax/protos/generated/go/zynax/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// streamProbeCaps drives every AgentService_ExecuteCapabilityServer method the
+// shim's eventSink implements, proving the stream stubs are safe no-ops before
+// the terminal event is collapsed into the MCP tool result.
+type streamProbeCaps struct{}
+
+func (streamProbeCaps) ExecuteCapability(req *zynaxv1.ExecuteCapabilityRequest, stream zynaxv1.AgentService_ExecuteCapabilityServer) error {
+	_ = stream.Context()
+	_ = stream.SetHeader(nil)
+	_ = stream.SendHeader(nil)
+	stream.SetTrailer(nil)
+	_ = stream.SendMsg(nil)
+	_ = stream.RecvMsg(nil)
+	return stream.Send(&zynaxv1.TaskEvent{ //nolint:wrapcheck // test stub mirrors handler send semantics
+		TaskId:    req.TaskId,
+		EventType: zynaxv1.TaskEventType_TASK_EVENT_TYPE_COMPLETED,
+		Payload:   []byte(`{"ok":true}`),
+	})
+}
+
+func (streamProbeCaps) GetCapabilitySchema(_ context.Context, req *zynaxv1.GetCapabilitySchemaRequest) (*zynaxv1.GetCapabilitySchemaResponse, error) {
+	return &zynaxv1.GetCapabilitySchemaResponse{
+		CapabilityName:  req.CapabilityName,
+		InputSchemaJson: `{"type":"object"}`,
+	}, nil
+}
+
+func TestToolsCall_StreamStubsAreNoOps(t *testing.T) {
+	t.Parallel()
+	// No "arguments" key ⇒ also covers the empty-args ⇒ "{}" default branch.
+	srv := mcp.NewServer(streamProbeCaps{}, []string{"clone"})
+	resp := roundtrip(t, srv, `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"clone"}}`)
+	result := resp["result"].(map[string]interface{})
+	if result["isError"].(bool) {
+		t.Fatalf("expected success after exercising stream stubs, got %v", result)
+	}
+}
+
+func TestDispatch_ParseError(t *testing.T) {
+	t.Parallel()
+	srv, _ := newFakeServer()
+	resp := roundtrip(t, srv, `{not json`)
+	errObj, ok := resp["error"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected JSON-RPC parse error, got %v", resp)
+	}
+	if errObj["code"].(float64) != -32700 {
+		t.Errorf("expected parse error code -32700, got %v", errObj["code"])
+	}
+}
+
+func TestDispatch_WrongJSONRPCVersion(t *testing.T) {
+	t.Parallel()
+	srv, _ := newFakeServer()
+	resp := roundtrip(t, srv, `{"jsonrpc":"1.0","id":1,"method":"initialize"}`)
+	if _, ok := resp["error"]; !ok {
+		t.Fatalf("expected invalid-request error for bad jsonrpc version, got %v", resp)
+	}
+}
+
+func TestDispatch_UnknownNotificationIsSilent(t *testing.T) {
+	t.Parallel()
+	srv, _ := newFakeServer()
+	// No id ⇒ notification; unknown method ⇒ no response and no error.
+	resp := roundtrip(t, srv, `{"jsonrpc":"2.0","method":"bogus/method"}`)
+	if resp != nil {
+		t.Errorf("unknown notification must be silent, got %v", resp)
+	}
+}
+
+func TestToolsCall_InvalidParams(t *testing.T) {
+	t.Parallel()
+	srv, _ := newFakeServer()
+	resp := roundtrip(t, srv, `{"jsonrpc":"2.0","id":2,"method":"tools/call","params":123}`)
+	if _, ok := resp["error"]; !ok {
+		t.Fatalf("expected invalid-params error, got %v", resp)
+	}
+}
+
+func TestToolsCall_EmptyName(t *testing.T) {
+	t.Parallel()
+	srv, _ := newFakeServer()
+	resp := roundtrip(t, srv, `{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":""}}`)
+	if _, ok := resp["error"]; !ok {
+		t.Fatalf("expected error for empty tool name, got %v", resp)
+	}
+}
+
+func TestServe_SkipsBlankLines(t *testing.T) {
+	t.Parallel()
+	srv, _ := newFakeServer()
+	var out strings.Builder
+	in := "\n" + `{"jsonrpc":"2.0","id":1,"method":"initialize"}` + "\n"
+	if err := srv.Serve(context.Background(), strings.NewReader(in), &out); err != nil {
+		t.Fatalf("Serve: %v", err)
+	}
+	if !strings.Contains(out.String(), "protocolVersion") {
+		t.Errorf("expected initialize result after a blank line, got %q", out.String())
+	}
+}
+
+func TestNewServer_DedupesAndDropsEmpty(t *testing.T) {
+	t.Parallel()
+	caps := streamProbeCaps{}
+	srv := mcp.NewServer(caps, []string{"clone", "clone", ""})
+	resp := roundtrip(t, srv, `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`)
+	tools := resp["result"].(map[string]interface{})["tools"].([]interface{})
+	if len(tools) != 1 {
+		t.Fatalf("expected dedup + empty-drop to leave 1 tool, got %d", len(tools))
+	}
+}
+
+// schemaQuirkCaps returns an error for "no_schema" (covering the skip branch) and
+// an empty InputSchemaJson for "empty_schema" (covering the default "{}" branch).
+type schemaQuirkCaps struct{}
+
+func (schemaQuirkCaps) ExecuteCapability(*zynaxv1.ExecuteCapabilityRequest, zynaxv1.AgentService_ExecuteCapabilityServer) error {
+	return nil
+}
+
+func (schemaQuirkCaps) GetCapabilitySchema(_ context.Context, req *zynaxv1.GetCapabilitySchemaRequest) (*zynaxv1.GetCapabilitySchemaResponse, error) {
+	if req.CapabilityName == "no_schema" {
+		return nil, status.Errorf(codes.NotFound, "no schema for %s", req.CapabilityName)
+	}
+	return &zynaxv1.GetCapabilitySchemaResponse{CapabilityName: req.CapabilityName, InputSchemaJson: ""}, nil
+}
+
+func TestToolsList_SkipsUnschemaedAndDefaultsEmpty(t *testing.T) {
+	t.Parallel()
+	srv := mcp.NewServer(schemaQuirkCaps{}, []string{"no_schema", "empty_schema"})
+	resp := roundtrip(t, srv, `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`)
+	tools := resp["result"].(map[string]interface{})["tools"].([]interface{})
+	if len(tools) != 1 {
+		t.Fatalf("expected the unschemaed tool skipped, leaving 1, got %d", len(tools))
+	}
+}

--- a/agents/adapters/git/internal/mcp/server.go
+++ b/agents/adapters/git/internal/mcp/server.go
@@ -1,0 +1,254 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package mcp is a thin Model Context Protocol (MCP) shim over the existing
+// git-adapter capability handlers. It exposes the adapter's capabilities as MCP
+// tools over a JSON-RPC 2.0 stdio transport so an authoring agent (e.g. Claude
+// Code) can drive Git operations interactively.
+//
+// The shim contains NO Git logic. Every tool call is translated 1:1 into the
+// adapter's existing ExecuteCapability / GetCapabilitySchema handlers (ADR-032:
+// one Git implementation, two surfaces). The set of exposed tools is an explicit
+// allow-list built from the configured capabilities — never "every handler".
+//
+// Credential injection and redaction are out of scope here; they are delivered
+// by G.3 (#1199). This layer never accepts a token as a tool argument and never
+// derives owner/repo from input (the adapter already pins those in config —
+// SSRF prevention), so no caller-supplied value reaches a privileged Git call as
+// a flag or remote.
+package mcp
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+
+	zynaxv1 "github.com/zynax-io/zynax/protos/generated/go/zynax/v1"
+)
+
+// protocolVersion is the MCP revision this shim implements.
+const protocolVersion = "2024-11-05"
+
+// jsonRPCVersion is the JSON-RPC protocol version every request/response carries.
+const jsonRPCVersion = "2.0"
+
+// Capabilities is the minimal surface the shim needs from the git-adapter.
+// *adapter.AgentServer satisfies it, so the MCP layer reuses the exact same
+// handlers as the runtime gRPC path — no Git logic is duplicated here.
+type Capabilities interface {
+	ExecuteCapability(req *zynaxv1.ExecuteCapabilityRequest, stream zynaxv1.AgentService_ExecuteCapabilityServer) error
+	GetCapabilitySchema(ctx context.Context, req *zynaxv1.GetCapabilitySchemaRequest) (*zynaxv1.GetCapabilitySchemaResponse, error)
+}
+
+// Server is a stdio JSON-RPC 2.0 MCP server bound to a fixed allow-list of tools.
+type Server struct {
+	caps  Capabilities
+	tools []string // explicit allow-list; nothing outside this is exposed
+}
+
+// NewServer builds a shim that exposes exactly the named capabilities as MCP
+// tools. toolNames is the allow-list (typically the configured capability names);
+// a tool absent from this slice is never advertised nor dispatchable.
+func NewServer(caps Capabilities, toolNames []string) *Server {
+	allow := make([]string, 0, len(toolNames))
+	seen := make(map[string]struct{}, len(toolNames))
+	for _, n := range toolNames {
+		if n == "" {
+			continue
+		}
+		if _, dup := seen[n]; dup {
+			continue
+		}
+		seen[n] = struct{}{}
+		allow = append(allow, n)
+	}
+	return &Server{caps: caps, tools: allow}
+}
+
+// allowed reports whether name is in the explicit tool allow-list.
+func (s *Server) allowed(name string) bool {
+	for _, t := range s.tools {
+		if t == name {
+			return true
+		}
+	}
+	return false
+}
+
+// ── JSON-RPC 2.0 envelope ──────────────────────────────────────────────────────
+
+type rpcRequest struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+type rpcResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Result  interface{}     `json:"result,omitempty"`
+	Error   *rpcError       `json:"error,omitempty"`
+}
+
+type rpcError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+// JSON-RPC standard error codes used by this shim.
+const (
+	errParse          = -32700
+	errInvalidRequest = -32600
+	errMethodNotFound = -32601
+	errInvalidParams  = -32602
+)
+
+// Serve reads newline-delimited JSON-RPC requests from r and writes responses to
+// w until r is exhausted (the transport closes). It is the stdio MCP loop.
+func (s *Server) Serve(ctx context.Context, r io.Reader, w io.Writer) error {
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), 8*1024*1024)
+	enc := json.NewEncoder(w)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		resp := s.dispatch(ctx, line)
+		if resp == nil {
+			continue // notification — no response
+		}
+		if err := enc.Encode(resp); err != nil {
+			return fmt.Errorf("mcp: encode response: %w", err)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("mcp: read transport: %w", err)
+	}
+	return nil
+}
+
+// dispatch parses one line and routes it. Returns nil for notifications.
+func (s *Server) dispatch(ctx context.Context, line []byte) *rpcResponse {
+	var req rpcRequest
+	if err := json.Unmarshal(line, &req); err != nil {
+		return errResponse(nil, errParse, "parse error")
+	}
+	if req.JSONRPC != jsonRPCVersion {
+		return errResponse(req.ID, errInvalidRequest, "jsonrpc must be \"2.0\"")
+	}
+	// A request without an id is a notification: handle, but never respond.
+	notification := len(req.ID) == 0
+
+	switch req.Method {
+	case "initialize":
+		return s.handleInitialize(req.ID)
+	case "tools/list":
+		return s.handleToolsList(ctx, req.ID)
+	case "tools/call":
+		return s.handleToolsCall(ctx, req.ID, req.Params)
+	case "notifications/initialized", "initialized":
+		return nil // client handshake notification
+	default:
+		if notification {
+			return nil
+		}
+		return errResponse(req.ID, errMethodNotFound, "unknown method: "+req.Method)
+	}
+}
+
+func (s *Server) handleInitialize(id json.RawMessage) *rpcResponse {
+	return &rpcResponse{
+		JSONRPC: jsonRPCVersion,
+		ID:      id,
+		Result: map[string]interface{}{
+			"protocolVersion": protocolVersion,
+			"capabilities":    map[string]interface{}{"tools": map[string]interface{}{}},
+			"serverInfo":      map[string]interface{}{"name": "git-adapter-mcp", "version": "0.1.0"},
+		},
+	}
+}
+
+// toolDescriptor is one entry in the tools/list result.
+type toolDescriptor struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description,omitempty"`
+	InputSchema json.RawMessage `json:"inputSchema"`
+}
+
+func (s *Server) handleToolsList(ctx context.Context, id json.RawMessage) *rpcResponse {
+	tools := make([]toolDescriptor, 0, len(s.tools))
+	for _, name := range s.tools {
+		schema, err := s.caps.GetCapabilitySchema(ctx,
+			&zynaxv1.GetCapabilitySchemaRequest{CapabilityName: name})
+		if err != nil {
+			// A configured tool with no schema is a config defect, not a caller
+			// error; skip it rather than expose an un-described tool.
+			continue
+		}
+		in := schema.GetInputSchemaJson()
+		if in == "" {
+			in = "{}"
+		}
+		tools = append(tools, toolDescriptor{
+			Name:        schema.GetCapabilityName(),
+			Description: schema.GetDescription(),
+			InputSchema: json.RawMessage(in),
+		})
+	}
+	return &rpcResponse{JSONRPC: jsonRPCVersion, ID: id, Result: map[string]interface{}{"tools": tools}}
+}
+
+type toolCallParams struct {
+	Name      string          `json:"name"`
+	Arguments json.RawMessage `json:"arguments,omitempty"`
+}
+
+func (s *Server) handleToolsCall(ctx context.Context, id, params json.RawMessage) *rpcResponse {
+	var p toolCallParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return errResponse(id, errInvalidParams, "invalid params: "+err.Error())
+	}
+	if p.Name == "" {
+		return errResponse(id, errInvalidParams, "tool name is required")
+	}
+	// Explicit allow-list: a tool outside the configured set is never dispatched,
+	// regardless of whether the adapter would recognise it.
+	if !s.allowed(p.Name) {
+		return errResponse(id, errMethodNotFound, "unknown tool: "+p.Name)
+	}
+
+	args := []byte(p.Arguments)
+	if len(args) == 0 {
+		args = []byte("{}")
+	}
+
+	sink := newEventSink(ctx)
+	// 1:1 dispatch into the adapter's existing handler. The owner/repo target is
+	// fixed in adapter config — never taken from these arguments — so no
+	// caller-supplied remote or path reaches the privileged Git call.
+	err := s.caps.ExecuteCapability(&zynaxv1.ExecuteCapabilityRequest{
+		TaskId:         "mcp-" + p.Name,
+		CapabilityName: p.Name,
+		InputPayload:   args,
+	}, sink)
+	if err != nil {
+		return errResponse(id, errInvalidRequest, "tool execution failed: "+err.Error())
+	}
+
+	text, isError := sink.result()
+	return &rpcResponse{
+		JSONRPC: jsonRPCVersion,
+		ID:      id,
+		Result: map[string]interface{}{
+			"content": []map[string]interface{}{{"type": "text", "text": text}},
+			"isError": isError,
+		},
+	}
+}
+
+func errResponse(id json.RawMessage, code int, msg string) *rpcResponse {
+	return &rpcResponse{JSONRPC: jsonRPCVersion, ID: id, Error: &rpcError{Code: code, Message: msg}}
+}

--- a/agents/adapters/git/internal/mcp/server_test.go
+++ b/agents/adapters/git/internal/mcp/server_test.go
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp_test
+
+// Unit tests for the thin MCP shim over git-adapter capabilities (#1198, G.2).
+// These verify the 1:1 mapping into the adapter handlers, the explicit tool
+// allow-list, and the JSON-RPC stdio framing — no Git logic lives in this layer.
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/zynax-io/zynax/agents/adapters/git/internal/mcp"
+	zynaxv1 "github.com/zynax-io/zynax/protos/generated/go/zynax/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// fakeCaps records dispatches and returns canned terminal events. It stands in
+// for *adapter.AgentServer so the test asserts the shim translates 1:1 without
+// touching real Git logic.
+type fakeCaps struct {
+	known      map[string]string // capability name → output payload JSON
+	calledWith []string          // capability names dispatched, in order
+}
+
+func (f *fakeCaps) ExecuteCapability(req *zynaxv1.ExecuteCapabilityRequest, stream zynaxv1.AgentService_ExecuteCapabilityServer) error {
+	f.calledWith = append(f.calledWith, req.CapabilityName)
+	payload, ok := f.known[req.CapabilityName]
+	if !ok {
+		return stream.Send(&zynaxv1.TaskEvent{ //nolint:wrapcheck // test stub mirrors handler send semantics
+			TaskId:    req.TaskId,
+			EventType: zynaxv1.TaskEventType_TASK_EVENT_TYPE_FAILED,
+			Error:     &zynaxv1.CapabilityError{Code: "INVALID_INPUT", Message: "unknown capability"},
+		})
+	}
+	// Emit a PROGRESS first to prove the sink drops it.
+	_ = stream.Send(&zynaxv1.TaskEvent{TaskId: req.TaskId, EventType: zynaxv1.TaskEventType_TASK_EVENT_TYPE_PROGRESS})
+	return stream.Send(&zynaxv1.TaskEvent{ //nolint:wrapcheck // test stub mirrors handler send semantics
+		TaskId:    req.TaskId,
+		EventType: zynaxv1.TaskEventType_TASK_EVENT_TYPE_COMPLETED,
+		Payload:   []byte(payload),
+	})
+}
+
+func (f *fakeCaps) GetCapabilitySchema(_ context.Context, req *zynaxv1.GetCapabilitySchemaRequest) (*zynaxv1.GetCapabilitySchemaResponse, error) {
+	if _, ok := f.known[req.CapabilityName]; !ok {
+		return nil, status.Errorf(codes.NotFound, "unknown capability: %s", req.CapabilityName)
+	}
+	return &zynaxv1.GetCapabilitySchemaResponse{
+		CapabilityName:  req.CapabilityName,
+		InputSchemaJson: `{"type":"object"}`,
+		Description:     "desc for " + req.CapabilityName,
+	}, nil
+}
+
+// roundtrip feeds one JSON-RPC line through Serve and returns the decoded response.
+func roundtrip(t *testing.T, srv *mcp.Server, line string) map[string]interface{} {
+	t.Helper()
+	var out strings.Builder
+	if err := srv.Serve(context.Background(), strings.NewReader(line+"\n"), &out); err != nil {
+		t.Fatalf("Serve: %v", err)
+	}
+	if out.Len() == 0 {
+		return nil
+	}
+	var resp map[string]interface{}
+	if err := json.Unmarshal([]byte(out.String()), &resp); err != nil {
+		t.Fatalf("decode response %q: %v", out.String(), err)
+	}
+	return resp
+}
+
+func newFakeServer() (*mcp.Server, *fakeCaps) {
+	caps := &fakeCaps{known: map[string]string{
+		"open_pr":        `{"pr_url":"https://example/pr/1","pr_number":1}`,
+		"request_review": `{"requested":true}`,
+		"get_diff":       `{"diff":"--- a","truncated":false}`,
+	}}
+	srv := mcp.NewServer(caps, []string{"open_pr", "request_review", "get_diff"})
+	return srv, caps
+}
+
+func TestInitialize(t *testing.T) {
+	t.Parallel()
+	srv, _ := newFakeServer()
+	resp := roundtrip(t, srv, `{"jsonrpc":"2.0","id":1,"method":"initialize"}`)
+	result, ok := resp["result"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("no result: %v", resp)
+	}
+	if result["protocolVersion"] == "" {
+		t.Error("expected protocolVersion")
+	}
+}
+
+func TestToolsList_AllowListOnly(t *testing.T) {
+	t.Parallel()
+	srv, _ := newFakeServer()
+	resp := roundtrip(t, srv, `{"jsonrpc":"2.0","id":2,"method":"tools/list"}`)
+	result := resp["result"].(map[string]interface{})
+	tools := result["tools"].([]interface{})
+	if len(tools) != 3 {
+		t.Fatalf("expected 3 allow-listed tools, got %d", len(tools))
+	}
+	names := map[string]bool{}
+	for _, tl := range tools {
+		names[tl.(map[string]interface{})["name"].(string)] = true
+	}
+	for _, want := range []string{"open_pr", "request_review", "get_diff"} {
+		if !names[want] {
+			t.Errorf("tool %q missing from list", want)
+		}
+	}
+}
+
+func TestToolsCall_DispatchesOneToOne(t *testing.T) {
+	t.Parallel()
+	srv, caps := newFakeServer()
+	resp := roundtrip(t, srv,
+		`{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"open_pr","arguments":{"title":"x","head":"f","base":"main"}}}`)
+	result := resp["result"].(map[string]interface{})
+	if result["isError"].(bool) {
+		t.Fatalf("expected success, got %v", result)
+	}
+	// 1:1: exactly the named capability was dispatched into the adapter.
+	if len(caps.calledWith) != 1 || caps.calledWith[0] != "open_pr" {
+		t.Fatalf("expected single open_pr dispatch, got %v", caps.calledWith)
+	}
+	content := result["content"].([]interface{})
+	text := content[0].(map[string]interface{})["text"].(string)
+	if !strings.Contains(text, "pr_url") {
+		t.Errorf("expected adapter payload verbatim, got %q", text)
+	}
+}
+
+func TestToolsCall_RejectsUnknownTool(t *testing.T) {
+	t.Parallel()
+	srv, caps := newFakeServer()
+	resp := roundtrip(t, srv,
+		`{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"rm_minus_rf"}}`)
+	if _, ok := resp["error"]; !ok {
+		t.Fatalf("expected JSON-RPC error for unknown tool, got %v", resp)
+	}
+	// Allow-list enforced before any adapter dispatch.
+	if len(caps.calledWith) != 0 {
+		t.Errorf("unknown tool must not reach the adapter, got %v", caps.calledWith)
+	}
+}
+
+func TestToolsCall_FailedCapabilityIsToolError(t *testing.T) {
+	t.Parallel()
+	// "get_diff" is allow-listed but we drop it from known so the adapter fails.
+	caps := &fakeCaps{known: map[string]string{}}
+	srv := mcp.NewServer(caps, []string{"get_diff"})
+	resp := roundtrip(t, srv,
+		`{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"get_diff","arguments":{"pr_number":1}}}`)
+	result := resp["result"].(map[string]interface{})
+	if !result["isError"].(bool) {
+		t.Fatalf("expected isError true for failed capability, got %v", result)
+	}
+}
+
+func TestNotification_NoResponse(t *testing.T) {
+	t.Parallel()
+	srv, _ := newFakeServer()
+	resp := roundtrip(t, srv, `{"jsonrpc":"2.0","method":"notifications/initialized"}`)
+	if resp != nil {
+		t.Errorf("notification must not produce a response, got %v", resp)
+	}
+}
+
+func TestUnknownMethod(t *testing.T) {
+	t.Parallel()
+	srv, _ := newFakeServer()
+	resp := roundtrip(t, srv, `{"jsonrpc":"2.0","id":9,"method":"resources/list"}`)
+	if _, ok := resp["error"]; !ok {
+		t.Errorf("expected method-not-found error, got %v", resp)
+	}
+}

--- a/agents/adapters/git/internal/mcp/sink.go
+++ b/agents/adapters/git/internal/mcp/sink.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+
+	zynaxv1 "github.com/zynax-io/zynax/protos/generated/go/zynax/v1"
+	"google.golang.org/grpc/metadata"
+)
+
+// eventSink implements zynaxv1.AgentService_ExecuteCapabilityServer so the MCP
+// shim can drive the adapter's existing streaming handlers and collapse the
+// PROGRESS/COMPLETED/FAILED stream into a single MCP tool result. PROGRESS
+// events are dropped (MCP tool calls are request/response, not streaming).
+type eventSink struct {
+	ctx  context.Context
+	last *zynaxv1.TaskEvent
+}
+
+func newEventSink(ctx context.Context) *eventSink {
+	return &eventSink{ctx: ctx}
+}
+
+func (s *eventSink) Send(e *zynaxv1.TaskEvent) error {
+	// Keep only terminal events; PROGRESS is not surfaced to MCP callers.
+	if e.GetEventType() == zynaxv1.TaskEventType_TASK_EVENT_TYPE_PROGRESS {
+		return nil
+	}
+	s.last = e
+	return nil
+}
+
+func (s *eventSink) Context() context.Context     { return s.ctx }
+func (s *eventSink) SetHeader(metadata.MD) error  { return nil }
+func (s *eventSink) SendHeader(metadata.MD) error { return nil }
+func (s *eventSink) SetTrailer(metadata.MD)       {}
+func (s *eventSink) SendMsg(interface{}) error    { return nil }
+func (s *eventSink) RecvMsg(interface{}) error    { return nil }
+
+// result returns the tool output text and whether it represents an error. On a
+// FAILED terminal event it returns the CapabilityError code+message; on
+// COMPLETED it returns the JSON output payload verbatim (no Git logic here —
+// the payload is whatever the adapter handler produced).
+func (s *eventSink) result() (text string, isError bool) {
+	if s.last == nil {
+		return "no terminal event received from adapter", true
+	}
+	if s.last.GetEventType() == zynaxv1.TaskEventType_TASK_EVENT_TYPE_FAILED {
+		if e := s.last.GetError(); e != nil {
+			return e.GetCode() + ": " + e.GetMessage(), true
+		}
+		return "capability failed", true
+	}
+	return string(s.last.GetPayload()), false
+}

--- a/protos/tests/features/git_mcp_shim.feature
+++ b/protos/tests/features/git_mcp_shim.feature
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: Apache-2.0
+# Zynax — git-adapter MCP shim BDD Contract Specification
+#
+# This file is the SPECIFICATION. It describes the contract the MCP shim must
+# honour. It is a thin Model Context Protocol surface over the existing
+# git-adapter capability handlers — NO Git logic is reimplemented here.
+# See protos/AGENTS.md §7 for contract test rules.
+#
+# Business context: an authoring agent (e.g. Claude Code) drives Git operations
+# over MCP tools. Each tool maps 1:1 onto an existing git-adapter capability
+# (open_pr / request_review / get_diff), so there is a single audited Git and
+# credential surface. (ADR-032 — one Git implementation, two surfaces.)
+#
+# Canvas: docs/spdd/1169-git-mcp-shim/canvas.md  · Step G.2
+# Parent epic: #1169 (Git MCP shim over git-adapter) · Story: #1198
+
+Feature: git-adapter MCP shim — Git capabilities as MCP tools
+  As an authoring agent
+  I want the git-adapter capabilities exposed as MCP tools
+  So that I can open PRs, request reviews, and fetch diffs over MCP
+  without a second Git implementation or a second credential surface
+
+  Background:
+    Given a git-adapter configured with capabilities "open_pr", "request_review", "get_diff"
+    And the MCP shim is started over stdio with that configuration
+
+  # ─── tool discovery (explicit allow-list) ────────────────────────────────────
+
+  Scenario: tools/list advertises exactly the configured capabilities
+    When the client sends a "tools/list" request
+    Then the response lists exactly the tools "open_pr", "request_review", "get_diff"
+    And no tool outside the configured allow-list is advertised
+    And each advertised tool carries the adapter's input schema and description
+
+  # ─── 1:1 dispatch into existing handlers ─────────────────────────────────────
+
+  Scenario: tools/call open_pr dispatches 1:1 into the adapter handler
+    Given a "tools/call" request for tool "open_pr" with arguments title, head, base
+    When the request is dispatched
+    Then exactly the "open_pr" adapter capability is executed once
+    And the tool result text is the adapter's COMPLETED payload verbatim
+    And isError is false
+
+  Scenario: PROGRESS events from the adapter are not surfaced to the MCP caller
+    Given the adapter emits PROGRESS before COMPLETED for "get_diff"
+    When a "tools/call" request for tool "get_diff" is dispatched
+    Then the MCP response contains only the terminal result
+    And no PROGRESS event leaks into the tool result
+
+  Scenario: a FAILED adapter capability becomes an MCP tool error
+    Given the adapter returns a FAILED TaskEvent with code "INVALID_INPUT"
+    When a "tools/call" request for tool "open_pr" is dispatched
+    Then isError is true
+    And the tool result text contains the CapabilityError code and message
+
+  # ─── tool-surface authz (allow-list guard) ───────────────────────────────────
+
+  Scenario: a tool outside the allow-list is rejected before dispatch
+    Given a "tools/call" request for tool "delete_repo"
+    When the request is dispatched
+    Then the response is a JSON-RPC error with code -32601
+    And the adapter is never invoked for that tool
+
+  # ─── arg / SSRF safety (target pinned in adapter config) ─────────────────────
+
+  Scenario: the caller cannot redirect the target repository via tool arguments
+    Given a "tools/call" request for tool "open_pr" with an "owner" or "repo" argument
+    When the request is dispatched
+    Then the adapter still targets the owner and repo pinned in its configuration
+    And no caller-supplied owner, repo, or remote reaches the privileged Git call
+
+  # ─── JSON-RPC framing ────────────────────────────────────────────────────────
+
+  Scenario: initialize returns the MCP protocol version and server info
+    When the client sends an "initialize" request
+    Then the response carries a non-empty protocolVersion
+    And the response advertises the "tools" capability
+
+  Scenario: a notification produces no response
+    When the client sends a "notifications/initialized" notification
+    Then the shim produces no JSON-RPC response
+
+  Scenario: an unknown method returns method-not-found
+    When the client sends a request for method "resources/list"
+    Then the response is a JSON-RPC error with code -32601


### PR DESCRIPTION
Implements **G.2** of EPIC G (#1169) — Git MCP shim.

Exposes the existing git-adapter capabilities as MCP tools over a JSON-RPC 2.0
stdio transport so an authoring agent can clone/branch/commit/open-PR via MCP.
The shim is a thin protocol surface: every `tools/call` dispatches 1:1 into the
existing `ExecuteCapability` handler — no Git logic is reimplemented
(ADR-032, "one implementation, two surfaces"). The exposed tool set is an
explicit allow-list built from the configured capabilities. Adds a contract
`.feature` spec and unit tests.

Canvas: `docs/spdd/1169-git-mcp-shim/canvas.md` (Aligned) · ADR-032.
Credential injection/redaction is out of scope here — that is G.3 (#1199).

Closes #1198

🤖 Generated with [Claude Code](https://claude.com/claude-code)
