### PR TITLE
docs(ai-learnings): append session learnings — 2026-06-16

### DIFF
--- a/docs/ai-learnings/ci-release.md
+++ b/docs/ai-learnings/ci-release.md
@@ -569,3 +569,35 @@ domain: ci-release / post-mrg · M7 batch post-merge verification (3 verifiers; 
 - Rule: NEVER put the literal `[skip ci]`/`[ci skip]` token in a digest PR's commit message OR body, even when quoting the bot's skip-ci digest-sync commit — write "skip-ci marker". The token in a PR body silently skips the PR's CI and leaves auto-merge BLOCKED with "no required checks reported".
   Category: structural-workaround
   Reason: Recurring, hard-to-diagnose, and unique to this verifier role which routinely references the bot's skip-ci digest-sync commits.
+
+## Session — 2026-06-16 (orchestrator finalization — issues #1177 #1186 #1198)
+
+### Effective patterns
+- Orchestrator finalizes PRs from the coordinator worktree: when domain subagents
+  produce the commit + branch + PR but then stall, the coordinator drives push →
+  `gh pr checks --watch` → squash-merge directly. Foreground coordinator work is not
+  subject to the background-agent watchdog, so the long CI wait completes reliably.
+- Transient SBOM flake recovery: the pre-merge build-images "Generate SBOM
+  (CycloneDX JSON)" step intermittently fails with `No files were found ... sbom-<svc>.json`
+  while Build/Trivy pass. It is infra-transient and unrelated to the PR's code —
+  `gh run rerun <run-id> --failed` clears it. Confirmed: it did not recur on rerun.
+
+### Edge cases discovered
+- Post-merge digest maintenance is fully automated here (ADR-027): release.yml commits
+  `chore(images): sync digests after main-<sha>` with a skip-ci marker after each merge.
+  A post-merge verifier is a SKIP when no `bump digest` issues are open — the digest pins
+  are kept current by the pipeline, not by hand.
+
+### Failed approaches
+- Relying on background subagents to complete the merge: all three stalled at ~600s
+  ("stream watchdog") during the terminal push/CI-wait phase. They are fine for
+  implement+commit+push+open-PR, but the orchestrator must own the CI-wait/merge tail.
+
+### Proposed expert prompt update
+- Rule: When a dispatched expert subagent reports a stall/timeout but its `## Result`
+  shows a pushed branch and/or open PR, do NOT discard the work — reconcile live state
+  (`git ls-remote` + `gh pr list --head <branch>`) and finalize the PR from the
+  coordinator worktree (push if unpushed, `gh pr checks --watch`, squash-merge).
+  Category: structural-workaround
+  Reason: Background subagents reliably trip the ~600s stream watchdog during the long
+  CI-wait phase; the implementation work is already done and must not be thrown away.

--- a/docs/ai-learnings/go-services.md
+++ b/docs/ai-learnings/go-services.md
@@ -480,3 +480,42 @@ domain: go-services · M7 batch — O.2 OTEL providers (#1185 PR #1248), L.2 eve
 - Rule: A PR that touches `protos/generated/go/` flips every Go service to changed in the CI `changes` filter. If lint-go/security/test-go fail with "go mod tidy needed", FIRST check whether main itself is drifted (build a service the PR does NOT touch); if so the drift is pre-existing/out-of-scope for the proto PR — document it and route to a `chore(deps)` PR rather than tidying inside the feature PR (which cascades into shared-lib go.sum/Docker-build failures).
   Category: structural-workaround
   Reason: Recurs for any additive-proto or shared-lib PR; tidying inside the feature PR makes it worse and violates scope, while the correct diagnosis (build an untouched module) is non-obvious.
+
+## Session — 2026-06-16 (issues #1177 W.3 · #1186 O.3 · #1198 G.2)
+
+### Effective patterns
+- W.3 data-flow compile: lift the `output:` rejection (manifest compile path) and
+  populate the IR `OutputBindings`/`InputBindings` fields already shipped by W.2 — do
+  not add new proto fields. Unresolved input refs must raise a `COMPILATION_ERROR`
+  carrying the manifest line number.
+- O.3 interceptors: `libs/zynaxobs` already wires `TracingStatsHandler()` in every
+  service `main.go`; O.3 is verify + gap-fill (add api-gateway HTTP middleware, span
+  names `<service>.<rpc>`), not green-field — and never a parallel `zynaxotel` package.
+
+### Edge cases discovered
+- The git-adapter is a GO adapter (`agents/adapters/git/` with its own go.mod), NOT
+  Python. Route git-adapter / Git-MCP work to go-services, not python-adapters. Its MCP
+  shim is Go.
+- Go-adapter coverage gate (`_test-go.yml`): per-adapter MODULE-aggregate ≥85%
+  (`go test ./... -coverprofile` → `total:`), not per-package. A new low-coverage
+  package (e.g. `internal/mcp` at 76%) can drag the whole adapter under the gate even
+  when its own tests pass. Cover the gRPC `ServerStream` sink stubs (Context/SetHeader/
+  SendMsg/etc.) via a fake `Capabilities` whose handler calls every stream method, and
+  cover any new `cmd/<adapter>/main.go` helper (e.g. an `mcp` stdio launch func) with a
+  whitebox `package main` test feeding an empty reader (EOF → nil).
+- `goconst`: a literal repeated ≥3× (e.g. JSON-RPC `"2.0"`) fails lint — extract a
+  named `const`. golangci-lint is available on the host for a fast local check:
+  `cd agents/adapters/<a> && GOWORK=off golangci-lint run ./... --config ../../../tools/golangci-lint.yml`.
+
+### Failed approaches
+- Trusting pre-commit hooks alone for the adapter lint/coverage gates: the goconst and
+  the ≥85% coverage gate are CI-only and were both missed locally by the subagent.
+
+### Proposed expert prompt update
+- Rule: For a feat PR's last-in-batch merge, mergeState may be BEHIND and block the
+  squash-merge (up-to-date branch protection). Rebase the single feature commit onto
+  origin/main and force-push (`--force-with-lease`); SSH signing is preserved across the
+  rebase (rebase.gpgSign), so re-validate CI once and merge.
+  Category: structural-workaround
+  Reason: Sequential batch merges advance main, leaving later PRs behind; rebasing the
+  single commit keeps a clean linear history and satisfies the up-to-date requirement.


### PR DESCRIPTION
Appends this session's orchestrator-observed learnings for the 2026-06-16 batch
(issues #1177 W.3, #1186 O.3, #1198 G.2). The dispatched subagents stalled on the
~600s stream watchdog before emitting their own learnings blocks, so these were
captured by the coordinator.

- **ci-release.md** — finalize stalled PRs from the coordinator worktree; rerun the
  transient SBOM build step; post-merge digest sync is automated (ADR-027) so the
  verifier is a SKIP when no bump-digest issues are open.
- **go-services.md** — W.3/O.3 verify-and-extend notes; the git-adapter is a Go adapter
  (route to go-services); the ≥85% per-adapter module-aggregate coverage gate and how to
  cover gRPC sink stubs; goconst; BEHIND→rebase for the last-in-batch merge.
