### PR TITLE
docs(workflow-compiler): ADR-034 ManifestWorkflowID collision domain

### DIFF
--- a/docs/adr/ADR-034-manifest-workflow-id-collision-domain.md
+++ b/docs/adr/ADR-034-manifest-workflow-id-collision-domain.md
@@ -7,31 +7,68 @@
 
 ## Context
 
-The workflow-compiler derives a `ManifestWorkflowID` used as the durable identity of a compiled
-workflow. #583 raised that the id's collision domain (a 64-bit space) and the canonicalization that
-feeds the hash are undocumented: it is unclear which manifest fields are canonicalized, in what order,
-and what the practical collision probability is. Without a recorded decision, a future change to
-canonicalization could silently change ids and break idempotent `ApplyWorkflow`.
+The workflow-compiler stamps every compiled `WorkflowIR` with a `ManifestWorkflowID` (the
+`workflow_id` envelope field) that becomes the durable identity of a compiled workflow. #583
+raised that the id's collision domain (a 64-bit space) and its canonical form were never recorded:
+it was unclear how wide the id is, how it is encoded, and what the practical collision probability
+is at expected workflow counts. Without a recorded decision a future change to the derivation could
+silently change ids and break consumers that key on `workflow_id`.
+
+This ADR documents the **current** scheme exactly as implemented in
+`services/workflow-compiler/internal/api/server.go` (`generateWorkflowID`). It does **not** change
+the algorithm — it freezes the present behaviour as a contract.
+
+### Current scheme (as implemented)
+
+```go
+func generateWorkflowID() string {
+    randBytes := make([]byte, 8)            // 8 bytes = 64 bits
+    _, _ = rand.Read(randBytes)             // crypto/rand
+    return fmt.Sprintf("wf-%s", hex.EncodeToString(randBytes))
+}
+```
+
+- **Source of entropy:** 8 bytes (64 bits) drawn from `crypto/rand`. The id is a freshly generated
+  random value per `CompileWorkflow` call — it is **not** a hash of the manifest, and identical
+  manifests therefore produce distinct ids.
+- **Collision domain:** the 64-bit value space, i.e. 2^64 ≈ 1.8 × 10^19 distinct ids.
+- **Canonical string form:** the literal prefix `wf-` followed by exactly 16 lowercase hexadecimal
+  characters (`hex.EncodeToString` is fixed-width, zero-padded, lowercase). Total length 19 chars.
+  This string form — prefix, width, lowercase hex alphabet — **is** the canonicalization that
+  consumers may rely on for parsing, matching, and storage.
 
 ## Decision
 
-(To be finalized during the EPIC-Q canvas alignment.) Record:
+1. **Collision domain is 64 bits.** The id occupies the full 2^64 space drawn from a CSPRNG. By the
+   birthday bound, the expected number of ids before a ~50% chance of any collision is
+   ≈ 1.2 × √(2^64) ≈ 5.1 × 10^9. For a corpus of N compiled workflows the collision probability is
+   approximately N² / 2^65; at N = 1 × 10^6 workflows this is ≈ 2.7 × 10^-8 — negligible at the
+   scales Zynax targets. Widening the id is therefore deferred (see Rationale).
 
-1. The exact **canonicalization** of a manifest before hashing (field set, ordering, normalization).
-2. The **collision domain** (64-bit) and the practical collision bound for expected workflow counts.
-3. The **stability guarantee**: canonicalization is part of the contract — changing it is a breaking
-   change requiring a new ADR and a migration note.
+2. **Canonical form is frozen.** A `ManifestWorkflowID` is canonically `wf-` + 16 lowercase hex
+   characters. The prefix, the 16-char width, and the lowercase-hex alphabet are part of the
+   contract: consumers MAY parse and validate against this shape.
+
+3. **Stability guarantee.** The width (64 bits / 16 hex chars), the `wf-` prefix, and the
+   lowercase-hex encoding are a backward-compatibility contract. Changing any of them — narrowing or
+   widening the entropy, switching to a manifest-derived hash, or altering the encoding — is a
+   **breaking change** that requires a successor ADR and a migration note for stored ids.
 
 ## Rationale
 
 | Option | Assessment |
 |--------|------------|
-| Document + freeze canonicalization (chosen) | ✅ Makes idempotency contractual; prevents silent id drift |
-| Widen to 128-bit id | ✗ Deferred — proto/contract change; not justified at current scale |
-| Leave undocumented | ✗ Rejected — invites accidental breaking changes |
+| Document + freeze the current 64-bit random id (chosen) | ✅ Records reality; makes the id shape a parseable contract; prevents silent drift |
+| Switch to a manifest-derived hash | ✗ Different semantics (would make ids content-addressable / idempotent); a behaviour change, out of scope for #583 |
+| Widen to 128-bit id | ✗ Deferred — proto/contract change with no collision pressure at current scale |
+| Leave undocumented | ✗ Rejected — invites accidental breaking changes to width or encoding |
 
 ## Consequences
 
-- **Positive:** `ApplyWorkflow` idempotency is contractually grounded; future contributors know the rules.
-- **Negative / trade-off:** canonicalization is now frozen — intentional changes cost an ADR + migration.
-- **Neutral / follow-up:** if scale ever warrants a wider id space, a successor ADR handles the migration.
+- **Positive:** the id's width, encoding, and collision bound are now contractual; consumers can
+  parse `workflow_id` against a fixed shape and reason about collision risk.
+- **Negative / trade-off:** the encoding is now frozen — any intentional change costs a successor ADR
+  plus a migration note.
+- **Neutral / follow-up:** ids are random, not content-addressable; if a future requirement needs
+  idempotent (manifest-derived) ids, a successor ADR introduces that scheme and handles migration. If
+  scale ever warrants a wider id space, the same successor-ADR path applies.


### PR DESCRIPTION
## Summary

Finalizes **ADR-034** (previously a stub) to record the `ManifestWorkflowID` scheme exactly as
implemented in `services/workflow-compiler/internal/api/server.go` (`generateWorkflowID`). This is an
`adr-proposal` docs change — it documents existing behaviour and does **not** change the id algorithm.

Tracks canvas step **Q.5** in `docs/spdd/1172-quality-supply-chain/canvas.md` and GitHub #583.

## What the ADR records

- **Collision domain — 64 bits.** The id is 8 bytes from `crypto/rand`, occupying the full 2^64 space.
  The ADR states the birthday bound (≈ N² / 2^65 collision probability; ≈ 2.7 × 10^-8 at N = 1e6).
- **Canonical form — frozen.** `wf-` prefix + exactly 16 lowercase hex chars (fixed-width
  `hex.EncodeToString`). Consumers may parse/validate against this shape.
- **Stability guarantee.** Width, prefix, and encoding are a backward-compat contract; changing any of
  them (including switching to a manifest-derived hash) is a breaking change needing a successor ADR + migration note.

The stub previously described a manifest-hash/idempotent scheme that does **not** exist in the code; the
ADR now describes the actual random 64-bit scheme. The register row in `docs/adr/INDEX.md` already exists
(status Proposed) and is unchanged.

## Acceptance criteria

- [x] ADR-034 committed (canonicalization, collision domain, stability guarantee)

Closes #1216

## Notes

- No code changes — docs/ADR only. Affected services: none.

Assisted-by: Claude/claude-opus-4-8
