### PR TITLE
docs(ai-learnings): append session learnings — 2026-06-16

### DIFF
--- a/docs/ai-learnings/ci-release.md
+++ b/docs/ai-learnings/ci-release.md
@@ -601,3 +601,23 @@ domain: ci-release / post-mrg · M7 batch post-merge verification (3 verifiers; 
   Category: structural-workaround
   Reason: Background subagents reliably trip the ~600s stream watchdog during the long
   CI-wait phase; the implementation work is already done and must not be thrown away.
+
+## Session — 2026-06-16 (issue #1215)
+Story: Q.4 — verify + document Go module consumption path (pkg.go.dev). PR #1258, `docs/contributing/go-module-consumption.md`.
+
+### Effective patterns
+- proxy.golang.org `@latest` as import-availability proof: `curl -s https://proxy.golang.org/<module>/@latest` returns JSON with the correct `Subdir` + pseudo-version, definitively proving a monorepo submodule is `go get`-able without a tagged release. Empty `@v/list` (200, no body) distinguishes "no semver tags" from "not resolvable."
+- Empty-branch atomic claim then push commit: pushing `docs/<N>` empty first won the mutex; ls-remote check before push confirmed no contention.
+- DCO `-s` flag + an explicit Signed-off-by in the `-F` message file does NOT duplicate the trailer — git dedupes identical trailers.
+
+### Edge cases discovered
+- pkg.go.dev returns 404 for a module page until it has been requested via the proxy at least once (lazy indexing). A 404 on the HTML page is NOT evidence of non-consumability — the proxy `@latest` JSON is the authoritative signal.
+- This gh version rejects `merged`/`closingIssuesReferences` JSON fields; use `state`/`mergeCommit`/`mergedAt` and verify closure via `gh issue view`.
+
+### Failed approaches
+- None.
+
+### Proposed expert prompt update
+- Rule: For docs/release issues asking to verify Go module consumption / pkg.go.dev import path in a monorepo, the authoritative verification is `curl -s https://proxy.golang.org/<module-path>/@latest` (non-empty JSON with Version+Subdir = consumable). Empty `@v/list` means no module-path-prefixed semver tags exist (proxy serves a `v0.0.0-<ts>-<commit>` pseudo-version); a 404 on the pkg.go.dev HTML page is lazy-indexing, not non-consumability. Document both the proxy evidence and the monorepo caveats (repo-level vs `<subdir>/vX.Y.Z` tags; in-repo `replace`/`go.work` per ADR-017 are internal-only, ignored by downstream consumers).
+  Category: domain
+  Reason: Module-consumption verification recurs for any monorepo release/docs task; the proxy-vs-pkg.go.dev distinction is non-obvious and easy to misreport as a failure.

--- a/docs/ai-learnings/go-services.md
+++ b/docs/ai-learnings/go-services.md
@@ -519,3 +519,22 @@ domain: go-services · M7 batch — O.2 OTEL providers (#1185 PR #1248), L.2 eve
   Category: structural-workaround
   Reason: Sequential batch merges advance main, leaving later PRs behind; rebasing the
   single commit keeps a clean linear history and satisfies the up-to-date requirement.
+
+## Session — 2026-06-16 (issue #1216)
+Story: Q.5 — ADR-034 ManifestWorkflowID 64-bit collision domain + canonicalization. PR #1257.
+
+### Effective patterns
+- Read the actual source before trusting a stub ADR: `grep ManifestWorkflowID` returned nothing in service code because the symbol is the proto envelope field `workflow_id`, derived by `generateWorkflowID()` in `services/workflow-compiler/internal/api/server.go`. Tracing the real function revealed the stub's premise (hash of canonicalized manifest) was fictional — the actual scheme draws 8 bytes from `crypto/rand` and renders `wf-` + 16 lowercase hex (random 64-bit, not a hash). The ADR was rewritten to document the real scheme (64-bit collision domain w/ birthday bound, canonical `wf-`+16-hex form, stability guarantee) without changing the algorithm.
+- For docs-only PRs the repo `changes` path filter skips all Go/Python/build jobs; only image/CI checks register. The first `gh pr checks --watch` can exit immediately ("no checks reported") before checks register — confirm via `gh pr view --json statusCheckRollup`, then re-watch.
+
+### Edge cases discovered
+- ADR-034 file + INDEX row were pre-staged on main (placeholder stub). The task was to finalize the stub, not create from scratch — INDEX needed no change, only the ADR body (53 ins / 16 del).
+- This gh version rejects `--json merged`; use `mergedAt`/`mergeCommit`/`state`.
+
+### Failed approaches
+- Initial `grep "ManifestWorkflowID"` (exact symbol) returned nothing — the id is a proto envelope field `workflow_id`/`WorkflowId`, not a literal `ManifestWorkflowID` identifier. Broadening to `workflowid|hash|rand|hex` located `generateWorkflowID`.
+
+### Proposed expert prompt update
+- Rule: When an issue says "document the existing X scheme", trace X to its actual implementation (the proto envelope field name often differs from the prose name — e.g. `ManifestWorkflowID` is the `workflow_id` field set by `generateWorkflowID`) and verify any pre-existing stub against the real code before finalizing; stubs may describe a scheme that was never built.
+  Category: domain
+  Reason: ADR/docs tasks that "record existing behaviour" are only correct if grounded in the real implementation; pre-staged stubs can carry an aspirational/wrong description that would otherwise merge verbatim.

--- a/docs/ai-learnings/infra-helm.md
+++ b/docs/ai-learnings/infra-helm.md
@@ -120,3 +120,27 @@ ADR-proposal docs story (ADR-030 OTEL + Uptrace). Docs-only — no helm lint/val
 
 ### Edge cases discovered
 - Keep ADR file status and the INDEX register row in sync — both must move Proposed→Accepted.
+
+## Session — 2026-06-16 (issue #1190)
+Story: O.7 — local Uptrace docker-compose observability stack (Uptrace + ClickHouse + Postgres + OTel Collector), UI on 127.0.0.1:7020. PR #1259.
+
+### Effective patterns
+- `docker compose config --quiet` with a throwaway gitignored `.env` (deleted after): validates the full overlay including `${VAR:?}` required-var guards without standing up containers — fast local gate for substitution/YAML errors.
+- Loopback-pinned port mappings (`127.0.0.1:HOST:CONTAINER`) verified via `config --format json` `host_ip`: reviewable proof the "OTLP not publicly exposed" safeguard is met.
+- `:?` required-var guards on every credential env: enforces "no committed defaults" — `make obs-up` fails loud if `.env.observability` is missing.
+- Mirrored existing compose conventions (plain pinned third-party tags like `postgres:16-alpine`, healthchecks, `depends_on: service_healthy`) instead of registering digests in images.yaml — the dev compose is not an images.yaml consumer, so the overlay stays out of the digest-alignment gate while still passing it.
+
+### Edge cases discovered
+- The shared OTEL lib is `libs/zynaxobs` (NOT `zynaxotel`); the OTLP endpoint env var is `ZYNAX_OTEL_EXPORTER_OTLP_ENDPOINT` (`libs/zynaxobs/providers.go`). Matching that exact name is what lets services point at the collector.
+- gitleaks CI (`tools/gitleaks-ai-context.toml`) scans the FULL PR commit range with `--source .`; its `email-address` rule allowlist is path-scoped to AI-context files only. A literal `admin`-at-`example.com` style address in a non-AI infra `.env.example` WOULD be flagged. Use `you-at-example-dot-com`.
+- Issue carried both `status: ready` and `status: in-progress` labels but no `feat/1190` remote branch — the deterministic empty-branch claim push is the true mutex, so labels were not a blocker.
+
+### Failed approaches
+- `gh pr view --json merged`/`closingIssuesReferences`: rejected by this gh version; use `mergedAt`/`state`/`mergeCommit`.
+
+### Proposed expert prompt update
+- Rule: Compose credential files — commit only a `.env.<name>.example` with non-email placeholders (e.g. `you-at-example-dot-com`, never a real `x`-at-`y.com` address), gitignore the real `.env.<name>`, and put `${VAR:?msg}` required-var guards on every credential. gitleaks scans the full PR range and flags literal emails outside the AI-context allowlist.
+  Category: domain
+- Rule: The shared OTEL package is `libs/zynaxobs`; the OTLP exporter endpoint env var is `ZYNAX_OTEL_EXPORTER_OTLP_ENDPOINT`. Any collector/OTLP wiring must match this name.
+  Category: domain
+  Reason: Permanent naming fact other observability stories (O.8 Helm chart, O.9 logs) will need.


### PR DESCRIPTION
Appends orchestrator session learnings from the 2026-06-16 batch (3 issues):

- infra-helm.md — #1190 Uptrace docker-compose stack (O.7): zynaxobs/OTLP env naming, gitleaks email gate, compose required-var guards.
- ci-release.md — #1215 Go module consumption path (Q.4): proxy.golang.org @latest as authoritative import-availability proof.
- go-services.md — #1216 ADR-034 ManifestWorkflowID (Q.5): the real id scheme is random 64-bit crypto/rand, not a manifest hash.

Docs-only; excluded from the PR-size gate.
