### PR TITLE
docs: correct libs/zynaxotel -> libs/zynaxobs across EPIC O/C specs

### DIFF
--- a/docs/adr/ADR-030-observability-uptrace.md
+++ b/docs/adr/ADR-030-observability-uptrace.md
@@ -7,7 +7,7 @@
 | **Status** | Accepted |
 | **Date** | 2026-06-16 |
 | **Deciders** | Oscar Gómez Manresa |
-| **Scope** | all services + adapters, `libs/zynaxotel`, observability compose + Helm — M7 EPIC O (#467) |
+| **Scope** | all services + adapters, `libs/zynaxobs`, observability compose + Helm — M7 EPIC O (#467) |
 | **Related** | ADR-022 (event-bus/NATS — trace propagation over message headers), ADR-020 (mTLS — secure OTLP in-cluster), ADR-026 (Postgres distribution — backend storage option) |
 | **Canvas** | `docs/spdd/467-observability-otel-uptrace/canvas.md` step O.1 |
 
@@ -33,7 +33,7 @@ Both the **instrumentation standard** and the **backend** are one-way doors:
 they shape every service's dependencies and the wire format of every span,
 metric, and log record. Reversing either after services are instrumented means
 re-instrumenting the whole platform. The decision is therefore recorded here,
-before any instrumentation code (`libs/zynaxotel`, O.2+) is written.
+before any instrumentation code (`libs/zynaxobs`, O.2+) is written.
 
 ---
 
@@ -116,7 +116,7 @@ before any instrumentation code (`libs/zynaxotel`, O.2+) is written.
 
 | Story | Work |
 |-------|------|
-| O.2 #1185 | Shared `libs/zynaxotel` package (providers + OTLP exporter + semconv) |
+| O.2 #1185 | Shared `libs/zynaxobs` package (providers + OTLP exporter + semconv) |
 | O.3 #1186 | Instrument all 7 services (gRPC/HTTP interceptors) |
 | O.4 #1187 | RED metrics + exemplars |
 | O.5 #1188 | Trace propagation across Temporal + NATS |

--- a/docs/adr/ADR-031-context-propagation.md
+++ b/docs/adr/ADR-031-context-propagation.md
@@ -38,5 +38,5 @@ trace baggage — would be a hard-to-reverse mistake.
 - **Positive:** a request-id set at the gateway is observable in every downstream span+log; handoffs are
   deterministic and documented; data stays run-scoped.
 - **Negative / trade-off:** every boundary (gRPC, Temporal, NATS) needs an explicit carrier
-  inject/extract — more wiring, covered by `libs/zynaxotel` propagators.
+  inject/extract — more wiring, covered by `libs/zynaxobs` propagators.
 - **Neutral / follow-up:** long-term memory, RAG, and context compression are deferred to M-dx.

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -40,7 +40,7 @@ a PR against `docs/adr/`.
 | [ADR-027](ADR-027-shift-left-pipeline.md) | Shift-left pipeline model — build once pre-merge, promote by retag | Accepted | 2026-06-11 | `ci.yml` build-images, `release.yml` retag jobs, GHCR staging lane — EPIC #1109 |
 | [ADR-028](ADR-028-agentdef-vs-workflow-self-hosted-automation.md) | AgentDef-vs-Workflow split for self-hosted automation + context-slice injection contract | Accepted | 2026-06-11 | `automation/workflows/**`, `spec/schemas/agent-def.schema.json`, `spec/schemas/workflow.schema.json` — EPIC #881 |
 | [ADR-029](ADR-029-workflow-data-flow.md) | Workflow data-flow semantics (output/input bindings) | Accepted | 2026-06-16 | `WorkflowIR` proto, workflow-compiler, engine-adapter — M7 EPIC W |
-| [ADR-030](ADR-030-observability-uptrace.md) | Observability — OpenTelemetry + Uptrace backend | Accepted | 2026-06-16 | all services + adapters, `libs/zynaxotel`, observability compose + Helm — M7 EPIC O |
+| [ADR-030](ADR-030-observability-uptrace.md) | Observability — OpenTelemetry + Uptrace backend | Accepted | 2026-06-16 | all services + adapters, `libs/zynaxobs`, observability compose + Helm — M7 EPIC O |
 | [ADR-031](ADR-031-context-propagation.md) | Context propagation model (trace · data · correlation) | Proposed | 2026-06-15 | all services, engine-adapter, agents/sdk — M7 EPIC C |
 | [ADR-032](ADR-032-git-mcp-shim.md) | Git MCP as a thin shim over the git-adapter | Accepted | 2026-06-15 | `agents/adapters/git/`, cli — M7 EPIC G |
 | [ADR-033](ADR-033-expert-agent-substrate.md) | Expert-agent substrate (runtime AgentDef + authoring experts) | Proposed | 2026-06-15 | `agents/examples/`, `automation/workflows/experts/`, agent-registry — M7 EPIC X |

--- a/docs/spdd/1168-context-propagation/canvas.md
+++ b/docs/spdd/1168-context-propagation/canvas.md
@@ -32,7 +32,7 @@ document the agent handoff contract.
 
 ## S — Structure (first S)
 ```
-libs/zynaxotel/ (propagators)   ← inject/extract carriers
+libs/zynaxobs/ (propagators)   ← inject/extract carriers
 services/*/ (interceptors)       ← attach RequestContext to ctx
 services/engine-adapter/         ← Temporal memo/header carrier; data-context scoping
 agents/sdk/                       ← inbound context extraction; handoff helpers

--- a/docs/spdd/467-observability-otel-uptrace/canvas.md
+++ b/docs/spdd/467-observability-otel-uptrace/canvas.md
@@ -23,7 +23,7 @@
 ## E — Entities
 
 ```
-zynaxotel (shared lib)
+zynaxobs (shared lib)
 ├── TracerProvider / MeterProvider / LoggerProvider  ← OTLP/gRPC exporters
 └── ResourceAttributes                                ← semconv (service.name, service.version, …)
 Uptrace (backend)
@@ -47,7 +47,7 @@ pprof (engine-adapter)    ← net/http/pprof on a separate admin port (perf inve
 **We will:**
 - Standardise on **OpenTelemetry**; default backend **Uptrace** (traces+metrics+logs+APM, login UI).
 - Default transport **OTLP/gRPC**; OTLP/HTTP optional. Off unless `ZYNAX_OTEL_EXPORTER_OTLP_ENDPOINT` set.
-- Provide a shared `libs/zynaxotel` Go package and OTEL in the Python SDK.
+- Provide a shared `libs/zynaxobs` Go package and OTEL in the Python SDK.
 - Propagate W3C `traceparent` across gRPC, Temporal activities, and NATS headers.
 - Ship Uptrace in **both** a compose overlay **and** a Helm chart (`observability.enabled`), with the **login UI** exposed.
 - Ship structured logs to Uptrace via **OTLP logs**; keep `/metrics` for Prometheus scrape.
@@ -63,7 +63,7 @@ pprof (engine-adapter)    ← net/http/pprof on a separate admin port (perf inve
 ## S — Structure (first S)
 
 ```
-libs/zynaxotel/                                  ← providers, exporters, interceptors
+libs/zynaxobs/                                  ← providers, exporters, interceptors
 services/*/cmd/*/main.go                          ← init providers; gRPC/HTTP interceptors
 agents/sdk/src/zynax_sdk/                          ← OTEL traces+logs for capability handlers
 infra/docker-compose/docker-compose.observability.yml  ← Uptrace + deps + collector + login UI (70xx)
@@ -83,7 +83,7 @@ Config env prefix: `ZYNAX_OTEL_` · Uptrace UI host port: 70xx (local).
 - As a `maintainer`, I want the backend + transport + sampling decision recorded so the stack is stable.
 - AC: [ ] ADR-030 committed (Uptrace default, OTLP/gRPC, head sampling, logs-via-OTLP); [ ] non-goals listed. Deps: none.
 
-**O.2 — Shared `libs/zynaxotel` package** · M · `feat`
+**O.2 — Shared `libs/zynaxobs` package** · M · `feat`
 - As a `service author`, I want one package for tracer/meter/logger providers so instrumentation is consistent.
 - AC: [ ] providers + OTLP exporter + semconv resource attrs; [ ] no-op when endpoint unset; [ ] unit tests. Deps: O.1.
 


### PR DESCRIPTION
Truth-pass: the shared OTEL providers package shipped as `libs/zynaxobs` (#1185, O.2), not the planned `libs/zynaxotel`. Stale references that present the non-existent package as real are corrected so downstream OTEL work (O.8 Helm #1191, O.9 logs #1192, Python OTEL #1189, EPIC C context propagation) targets the right package.

Files (pure token replacement, 10/10):
- docs/spdd/467-observability-otel-uptrace/canvas.md (EPIC O, Status: Aligned preserved)
- docs/spdd/1168-context-propagation/canvas.md (EPIC C)
- docs/adr/ADR-030-observability-uptrace.md, ADR-031-context-propagation.md, INDEX.md

`docs/milestones/M7-planning.md` intentionally retains its `zynaxotel` mentions — they are reconciliation notes warning that the planned name is wrong, which stays accurate.
