### PR TITLE
docs(spdd): align EPIC X canvas + security review (#1170)

### DIFF
--- a/docs/spdd/1170-expert-substrate/SECURITY-REVIEW.md
+++ b/docs/spdd/1170-expert-substrate/SECURITY-REVIEW.md
@@ -1,0 +1,33 @@
+# Security Review — EPIC X: Expert-Agent Substrate + agents/examples
+
+**Canvas:** `docs/spdd/1170-expert-substrate/canvas.md` (Status: Draft → Aligned)
+**Issue:** #1170 · **Date:** 2026-06-16 · **Reviewer:** SPDD Canvas expert (pre-alignment gate)
+**Authority:** `docs/knowledge-base-policy.md` (Tier 1/2/3), ADR-019 (SPDD governance)
+
+## Verdict: PASS
+
+No Tier-2 content, prompt injection, abstraction leak, or authority violation found in the
+canvas. No companion `canvas.private.md` exists or is required. None of the notes below block the
+human alignment decision; they are implementation-time guards already bound as Feature Safeguards.
+
+## Five-check results
+
+| Check | Result | Notes |
+|-------|--------|-------|
+| 1. Tier-2 content scan | PASS | No real hostnames/IPs/TLDs/namespaces, no credentials, no deployment specifics, no OpSec. The paths (`agents/examples/`, `automation/workflows/experts/`, `spec/workflows/examples/`) are repo code paths, not infrastructure topology. |
+| 2. Prompt-injection scan | PASS | All prose is human-facing user stories + ADR references; no AI-directed instructions, override attempts, or conditional triggers. |
+| 3. Abstraction check | PASS | E (Entities) and O (Operations) describe code structure, intent, and patterns — not a specific environment. Nothing internal is inferable by a stranger. |
+| 4. Authority hierarchy | PASS | N/S sections reinforce AGENTS.md (DCO, `Assisted-by`, gitleaks PII gate, least-privilege capability scope); no Canvas content contradicts or overrides an AGENTS.md rule. |
+| 5. Completeness | PASS-with-note | All 7 REASONS sections present (R, E, A, S-structure, O, N, S-safeguards); Context Security checklist present; `**Status:**` valid. Status was `Draft` (expected — the human owns the align flip, performed alongside this review). |
+
+## Notes (implementation-time guards — already bound as canvas Safeguards)
+
+- **Least-privilege capability scope (X.3 #1203):** the runtime `kind: AgentDef` expert must never
+  be granted broader capability scope than it declares — enforce least-privilege per capability at
+  registration time.
+- **No silent runtime↔authoring drift (X.5 #1205):** the mapping table is the SoT and must be
+  CI-checked so a runtime expert and its authoring counterpart cannot diverge unnoticed.
+- **SDK-optional (X.2 #1202):** `agents/examples/*` use the SDK, but adapters must remain
+  SDK-optional per ADR-013 — examples may depend on the SDK, the platform contract may not.
+- **PII hygiene:** agent examples and their tests/fixtures must not embed literal email addresses
+  (gitleaks PII gate); reference commit-hygiene rules by name per AGENTS.md §Hard Constraints.

--- a/docs/spdd/1170-expert-substrate/canvas.md
+++ b/docs/spdd/1170-expert-substrate/canvas.md
@@ -3,7 +3,7 @@
 > Tier 1 (public-safe). Tier 2 → `canvas.private.md`. Run `/spdd-security-review` before committing.
 
 **Issue:** #1170 · **Milestone:** M7 (v0.6.0)
-**Author:** M7 program plan · **Date:** 2026-06-15 · **Status:** Draft
+**Author:** M7 program plan · **Date:** 2026-06-15 · **Status:** Aligned
 
 ---
 
@@ -73,7 +73,7 @@ Config: Python 3.12 + uv (ADR-002/003).
 
 ## S — Safeguards (second S)
 ### Context Security
-- [ ] No Tier 2 content; [ ] no PII / no literal emails; [ ] no prompt-injection; [ ] `/spdd-security-review` — PENDING
+- [x] No Tier 2 content; [x] no PII / no literal emails; [x] no prompt-injection; [x] `/spdd-security-review` — PASS (2026-06-16, see `SECURITY-REVIEW.md`)
 
 ### Feature Safeguards
 - Never grant an expert broader capability scope than declared — least-privilege per capability.


### PR DESCRIPTION
Aligns the EPIC X (#1170) canvas so the expert-substrate cluster can be implemented.

- `/spdd-security-review` verdict **PASS** — no Tier-2 content, prompt injection, abstraction leak, or authority violation; no `canvas.private.md` needed.
- Adds `docs/spdd/1170-expert-substrate/SECURITY-REVIEW.md` (five-check evidence + implementation-time guards bound as Feature Safeguards).
- Flips canvas `Status: Draft → Aligned` and marks the Context Security checklist.

Unblocks X.2 #1202 (agents/examples), and—after their own deps—X.3 #1203 / X.4 #1204 / X.5 #1205. X.1 #1201 (ADR-033) is already closed.
