### PR TITLE
feat(observability): trace_id exemplars on RED metrics (#1187)

### DIFF
--- a/libs/zynaxobs/metrics.go
+++ b/libs/zynaxobs/metrics.go
@@ -19,6 +19,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/status"
 )
@@ -42,13 +43,67 @@ var (
 		Name: "zynax_eventbus_publish_failed_total",
 		Help: "Total number of failed event-bus publishes, labeled by event type.",
 	}, []string{"event_type"})
+
+	httpRequestsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "zynax_http_requests_total",
+		Help: "Total number of HTTP requests handled, labeled by service, method and status code.",
+	}, []string{"service", "method", "status"})
+
+	httpRequestDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "zynax_http_request_duration_seconds",
+		Help:    "HTTP handler latency in seconds, labeled by service and method.",
+		Buckets: prometheus.DefBuckets,
+	}, []string{"service", "method"})
 )
+
+// traceExemplar returns a single-label exemplar carrying the active span's
+// trace_id, or nil when no sampled span is in flight (telemetry off by default,
+// canvas Norms). trace_id lives only in the exemplar — never as a metric label —
+// so series cardinality stays bounded to service/method/status (canvas Safeguards,
+// O.4). The returned labels link a metric sample to its trace so a dashboard can
+// jump straight to the exemplar's trace in Uptrace.
+func traceExemplar(ctx context.Context) prometheus.Labels {
+	sc := trace.SpanContextFromContext(ctx)
+	if !sc.IsSampled() {
+		return nil
+	}
+	return prometheus.Labels{"trace_id": sc.TraceID().String()}
+}
+
+// addCountWithExemplar increments the counter by one, attaching the trace_id
+// exemplar when present. Prometheus stores one exemplar per series, so this never
+// grows cardinality.
+func addCountWithExemplar(c prometheus.Counter, ex prometheus.Labels) {
+	if ex != nil {
+		if a, ok := c.(prometheus.ExemplarAdder); ok {
+			a.AddWithExemplar(1, ex)
+			return
+		}
+	}
+	c.Inc()
+}
+
+// observeWithExemplar records a duration sample, attaching the trace_id exemplar
+// when present so the histogram bucket links back to a representative trace.
+func observeWithExemplar(o prometheus.Observer, v float64, ex prometheus.Labels) {
+	if ex != nil {
+		if e, ok := o.(prometheus.ExemplarObserver); ok {
+			e.ObserveWithExemplar(v, ex)
+			return
+		}
+	}
+	o.Observe(v)
+}
 
 // RegisterMetrics mounts the Prometheus exposition handler at /metrics on the given
 // mux. Every service calls this on its HTTP mux so that
 // `curl http://localhost:<port>/metrics` returns the standard text exposition.
+// EnableOpenMetrics serializes trace_id exemplars (O.4) when a scraper sends the
+// OpenMetrics Accept header; plain Prometheus scrapers still get the text format.
 func RegisterMetrics(mux *http.ServeMux) {
-	mux.Handle("/metrics", promhttp.Handler())
+	mux.Handle("/metrics", promhttp.HandlerFor(prometheus.DefaultGatherer, promhttp.HandlerOpts{
+		EnableOpenMetrics: true,
+	}))
 }
 
 // StartMetricsServer starts a dedicated HTTP server exposing /metrics on the given
@@ -105,8 +160,50 @@ func MetricsUnaryInterceptor(serviceName string) grpc.UnaryServerInterceptor {
 		start := time.Now()
 		resp, err := handler(ctx, req)
 		code := status.Code(err)
-		grpcRequestsTotal.WithLabelValues(serviceName, info.FullMethod, code.String()).Inc()
-		grpcRequestDuration.WithLabelValues(serviceName, info.FullMethod).Observe(time.Since(start).Seconds())
+		ex := traceExemplar(ctx)
+		addCountWithExemplar(grpcRequestsTotal.WithLabelValues(serviceName, info.FullMethod, code.String()), ex)
+		observeWithExemplar(grpcRequestDuration.WithLabelValues(serviceName, info.FullMethod), time.Since(start).Seconds(), ex)
 		return resp, err
 	}
+}
+
+// MetricsHTTPMiddleware returns an HTTP middleware that records the RED metrics
+// zynax_http_requests_total and zynax_http_request_duration_seconds for every
+// request, attaching the active span's trace_id as an exemplar (O.4). serviceName
+// labels the series; method is the URL path template is intentionally NOT used —
+// labels stay service/method(HTTP verb)/status to keep cardinality bounded (canvas
+// Safeguards). Wire it inside HTTPMiddleware so the otelhttp span is already in the
+// request context when the exemplar is read.
+func MetricsHTTPMiddleware(serviceName string, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		sw := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
+		next.ServeHTTP(sw, r)
+		ex := traceExemplar(r.Context())
+		statusLabel := fmt.Sprintf("%d", sw.status)
+		addCountWithExemplar(httpRequestsTotal.WithLabelValues(serviceName, r.Method, statusLabel), ex)
+		observeWithExemplar(httpRequestDuration.WithLabelValues(serviceName, r.Method), time.Since(start).Seconds(), ex)
+	})
+}
+
+// statusRecorder captures the HTTP status code written by downstream handlers so
+// the RED metrics can label by status without buffering the response body.
+type statusRecorder struct {
+	http.ResponseWriter
+	status      int
+	wroteHeader bool
+}
+
+func (s *statusRecorder) WriteHeader(code int) {
+	if !s.wroteHeader {
+		s.status = code
+		s.wroteHeader = true
+	}
+	s.ResponseWriter.WriteHeader(code)
+}
+
+func (s *statusRecorder) Write(b []byte) (int, error) {
+	s.wroteHeader = true
+	//nolint:wrapcheck // transparent ResponseWriter passthrough; the error must reach the caller unwrapped
+	return s.ResponseWriter.Write(b)
 }

--- a/libs/zynaxobs/metrics_test.go
+++ b/libs/zynaxobs/metrics_test.go
@@ -5,16 +5,98 @@ package zynaxobs
 import (
 	"context"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
+
+// sampledCtx returns a context carrying a valid, sampled span context with a
+// fixed trace_id, so exemplar extraction is deterministic in tests.
+func sampledCtx(traceHex string) context.Context {
+	tid, _ := trace.TraceIDFromHex(traceHex)
+	sid, _ := trace.SpanIDFromHex("0102030405060708")
+	sc := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    tid,
+		SpanID:     sid,
+		TraceFlags: trace.FlagsSampled,
+	})
+	return trace.ContextWithSpanContext(context.Background(), sc)
+}
+
+func TestTraceExemplarNilWhenUnsampled(t *testing.T) {
+	if got := traceExemplar(context.Background()); got != nil {
+		t.Errorf("exemplar without span = %v, want nil", got)
+	}
+}
+
+func TestTraceExemplarCarriesTraceID(t *testing.T) {
+	const trace32 = "0123456789abcdef0123456789abcdef"
+	ex := traceExemplar(sampledCtx(trace32))
+	if ex == nil {
+		t.Fatal("expected exemplar for sampled span, got nil")
+	}
+	if ex["trace_id"] != trace32 {
+		t.Errorf("exemplar trace_id = %q, want %q", ex["trace_id"], trace32)
+	}
+}
+
+func TestMetricsHTTPMiddlewareRecordsRED(t *testing.T) {
+	mw := MetricsHTTPMiddleware("http-svc", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTeapot)
+	}))
+	srv := httptest.NewServer(mw)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/x")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	got := testutil.ToFloat64(httpRequestsTotal.WithLabelValues("http-svc", http.MethodGet, "418"))
+	if got != 1 {
+		t.Errorf("http counter = %v, want 1", got)
+	}
+	if c := testutil.CollectAndCount(httpRequestDuration); c == 0 {
+		t.Error("http duration histogram has no series")
+	}
+}
+
+func TestMetricsExposesExemplarInOpenMetrics(t *testing.T) {
+	const trace32 = "fedcba9876543210fedcba9876543210"
+	interceptor := MetricsUnaryInterceptor("exemplar-svc")
+	info := &grpc.UnaryServerInfo{FullMethod: "/zynax.v1.Exemplar/Do"}
+	okHandler := func(context.Context, any) (any, error) { return "ok", nil }
+	if _, err := interceptor(sampledCtx(trace32), nil, info, okHandler); err != nil {
+		t.Fatalf("interceptor: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	RegisterMetrics(mux)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	req, _ := http.NewRequest(http.MethodGet, srv.URL+"/metrics", nil)
+	// OpenMetrics Accept header is required for promhttp to serialize exemplars.
+	req.Header.Set("Accept", "application/openmetrics-text")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET /metrics: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "trace_id=\""+trace32+"\"") {
+		t.Errorf("expected exemplar with trace_id %q in /metrics output", trace32)
+	}
+}
 
 func TestMetricsUnaryInterceptorRecordsCounter(t *testing.T) {
 	interceptor := MetricsUnaryInterceptor("test-svc")

--- a/services/api-gateway/cmd/api-gateway/main.go
+++ b/services/api-gateway/cmd/api-gateway/main.go
@@ -99,7 +99,7 @@ func run(cfg config) error {
 
 	srv := &http.Server{
 		Addr:              fmt.Sprintf(":%d", cfg.HTTPPort),
-		Handler:           zynaxobs.HTTPMiddleware("api-gateway", maxBodyMiddleware(api.RequestIDMiddleware(workRecordMiddleware(probes, mux)))),
+		Handler:           zynaxobs.HTTPMiddleware("api-gateway", zynaxobs.MetricsHTTPMiddleware("api-gateway", maxBodyMiddleware(api.RequestIDMiddleware(workRecordMiddleware(probes, mux))))),
 		ReadHeaderTimeout: 5 * time.Second,
 		ReadTimeout:       30 * time.Second,
 		WriteTimeout:      30 * time.Second,


### PR DESCRIPTION
Implements EPIC O step O.4 (#467): trace exemplars on the existing RED metrics.

- `libs/zynaxobs/metrics.go` — attach the active span's `trace_id` as an OpenMetrics exemplar on the RED metric observations; labels stay `service`/`method`/`status` only (low-cardinality), `trace_id` lives in the exemplar
- exposed at `/metrics`; gRPC + HTTP paths via the shared handler/interceptor
- `services/api-gateway/.../main.go` — HTTP status recorder wiring

Recovered from a background agent that crashed (transient API 529) before committing; fixed one wrapcheck lint on the transparent ResponseWriter passthrough. `GOWORK=off go test ./... -race` green in libs/zynaxobs.
