### PR TITLE
docs: add canonical PR body template + wire milestone commands

### DIFF
--- a/.claude/commands/experts/bdd-contract.md
+++ b/.claude/commands/experts/bdd-contract.md
@@ -25,7 +25,7 @@ Output a progress line at the start of each phase — before any tool call for t
 | `STEPS` | When writing Go step definitions |
 | `TEST` | Before running `make test-bdd` or `buf breaking` |
 | `COMMIT` | Before `git add` / `git commit` — handing off to git-ops |
-| `PR` | Before `gh pr create` |
+| `PR` | Before `gh pr create` — build the PR body from docs/contributing/pr-templates.md (your type variant) |
 | `CI_WAIT` | On entering the CI polling loop |
 | `DONE` | On successful merge and cleanup |
 | `ERROR` | On any failure — include the reason |

--- a/.claude/commands/experts/ci-release.md
+++ b/.claude/commands/experts/ci-release.md
@@ -24,7 +24,7 @@ Output a progress line at the start of each phase — before any tool call for t
 | `CODE` | When beginning to create or edit workflow / CI files |
 | `VALIDATE` | Before running `make lint` or local workflow validation |
 | `COMMIT` | Before `git add` / `git commit` — handing off to git-ops |
-| `PR` | Before `gh pr create` |
+| `PR` | Before `gh pr create` — build the PR body from docs/contributing/pr-templates.md (your type variant) |
 | `CI_WAIT` | On entering the CI polling loop |
 | `IMAGE_CHECK` | When verifying Docker/GHCR artifact publication post-merge |
 | `DONE` | On successful merge and cleanup |

--- a/.claude/commands/experts/git-ops.md
+++ b/.claude/commands/experts/git-ops.md
@@ -24,7 +24,7 @@ Output a progress line at the start of each phase — before any tool call for t
 | `STAGE` | Before `git add` |
 | `COMMIT` | Before `git commit` |
 | `PUSH` | Before `git push` |
-| `PR` | Before `gh pr create` |
+| `PR` | Before `gh pr create` — build the PR body from docs/contributing/pr-templates.md (your type variant) |
 | `REBASE` | Before `git rebase` or conflict resolution |
 | `MERGE` | Before `gh pr merge` |
 | `CLEANUP` | Before branch delete + worktree remove |

--- a/.claude/commands/experts/go-services.md
+++ b/.claude/commands/experts/go-services.md
@@ -24,7 +24,7 @@ Output a progress line at the start of each phase — before any tool call for t
 | `CODE` | When beginning to create or edit source files |
 | `TEST` | Before running `go build`, `go test`, `make lint` |
 | `COMMIT` | Before `git add` / `git commit` — handing off to git-ops |
-| `PR` | Before `gh pr create` |
+| `PR` | Before `gh pr create` — build the PR body from docs/contributing/pr-templates.md (your type variant) |
 | `CI_WAIT` | On entering the CI polling loop |
 | `DONE` | On successful merge and cleanup |
 | `ERROR` | On any failure — include the reason |

--- a/.claude/commands/experts/infra-helm.md
+++ b/.claude/commands/experts/infra-helm.md
@@ -24,7 +24,7 @@ Output a progress line at the start of each phase — before any tool call for t
 | `CODE` | When beginning to create or edit Helm/K8s/infra files |
 | `VALIDATE` | Before running `helm lint` / `make lint` |
 | `COMMIT` | Before `git add` / `git commit` — handing off to git-ops |
-| `PR` | Before `gh pr create` |
+| `PR` | Before `gh pr create` — build the PR body from docs/contributing/pr-templates.md (your type variant) |
 | `CI_WAIT` | On entering the CI polling loop |
 | `DONE` | On successful merge and cleanup |
 | `ERROR` | On any failure — include the reason |

--- a/.claude/commands/experts/post-merge.md
+++ b/.claude/commands/experts/post-merge.md
@@ -23,7 +23,7 @@ structured evidence of every action taken.
 | `DIGEST_UPDATE` | Before updating digest pins in files |
 | `ISSUE_TRIAGE` | Before processing open digest-bump issues |
 | `COMMIT` | Before git add / git commit |
-| `PR` | Before gh pr create |
+| `PR` | Before gh pr create — chore(ci) digest PR body per docs/contributing/pr-templates.md |
 | `CI_WAIT` | Polling for the digest-bump PR's own CI |
 | `DONE` | All steps complete — print evidence block |
 | `SKIP` | Nothing to do (no affected services in matrix) |

--- a/.claude/commands/experts/python-adapters.md
+++ b/.claude/commands/experts/python-adapters.md
@@ -24,7 +24,7 @@ Output a progress line at the start of each phase — before any tool call for t
 | `CODE` | When beginning to create or edit source files |
 | `TEST` | Before running `make lint-python` / `make test-python` |
 | `COMMIT` | Before `git add` / `git commit` — handing off to git-ops |
-| `PR` | Before `gh pr create` |
+| `PR` | Before `gh pr create` — build the PR body from docs/contributing/pr-templates.md (your type variant) |
 | `CI_WAIT` | On entering the CI polling loop |
 | `DONE` | On successful merge and cleanup |
 | `ERROR` | On any failure — include the reason |

--- a/.claude/commands/experts/spdd-canvas.md
+++ b/.claude/commands/experts/spdd-canvas.md
@@ -27,7 +27,7 @@ Output a progress line at the start of each phase — before any tool call for t
 | `ALIGN` | When setting `Status: Aligned` on the canvas |
 | `STORIES` | When creating story issues via `/spdd-story` |
 | `COMMIT` | Before `git add` / `git commit` — handing off to git-ops |
-| `PR` | Before `gh pr create` |
+| `PR` | Before `gh pr create` — build the PR body from docs/contributing/pr-templates.md (your type variant) |
 | `CI_WAIT` | On entering the CI polling loop |
 | `DONE` | On successful merge and cleanup |
 | `ERROR` | On any failure — include the reason |

--- a/.claude/commands/issue-deliver.md
+++ b/.claude/commands/issue-deliver.md
@@ -487,42 +487,53 @@ echo -n "${COMMIT_TYPE}(<scope>): <subject>" | wc -c   # replace before committi
 
 git add -p   # stage intentionally (never git add -A)
 
-# PR body file (used in STEP 9)
+# PR body file (used in STEP 9). Build it from the canonical template — see
+# docs/contributing/pr-templates.md (skeleton + per-type variants + filled example).
 cat > /tmp/pr-body-${ISSUE_N}.md << 'EOF'
-## Summary
-<1-3 sentences — what changes and why, referencing the canvas O-step>
+## ${COMMIT_TYPE}(<scope>): <subject>
 
-## EPIC canvas
-`docs/spdd/<EPIC_N>-<slug>/canvas.md` — O-step <N>  (N/A for SPDD-exempt issues)
+Closes #${ISSUE_N}
+<!-- canvas-step: also add "Part of #${EPIC_N}" -->
 
-## Acceptance criteria
-- [x] <criterion 1>  [evidence: test output / file:line / log]
-- [x] <criterion 2>  [evidence]
-- [x] <criterion 3>  [evidence]
+### Why  (problem & intent)
+<1-3 sentences — what is missing/broken and why this is needed; for feat: link the canvas O-step>
 
-## Test plan
+### What you'll get  (deliverables ↔ what changed)
+- <deliverable a reviewer/operator will observe> ← `path/to/change`
 
-### Build & unit
-- [x] `GOWORK=off go build ./...` — exit 0  [evidence]
-- [x] `GOWORK=off go test ./... -race -timeout 60s` — all pass  [evidence]
-- [x] Domain coverage ≥90%  [evidence / N/A]
+### Scope & boundaries
+- **In scope:** <…>
+- **Out of scope (deferred):** <… → #<issue> / M-dx / N/A>
 
-### Lint & security
-- [x] `make lint` — exit 0  [evidence]
-- [x] `make security` — no new findings  [evidence]
+### Test plan & acceptance
+| Acceptance criterion (from issue/canvas) | How verified (command) | Result |
+|------------------------------------------|------------------------|--------|
+| <AC 1 verbatim>                          | `<exact command>`      | ✅ <number / output> |
+**Local gates:** `GOWORK=off go test ./... -race` ✅ · `make lint` ✅ · `make security` ✅ · `make test-bdd` ✅/N/A
 
-### Contract
-- [x] `.feature` file committed before implementation  [evidence / N/A]
-- [x] `make test-bdd` — all scenarios pass  [evidence / N/A]
+### Evidence
+- **CI:** <required checks green / link to run>
+- **Local output:** <coverage %, benchmark ns/op, the decisive line>
+- **Artifacts / images:** <`service:tag@sha256:…` or "none — no service source changed">
+- **Post-merge digest sync → main:** <placeholder — filled by the post-merge verifier with the
+  `chore(images): sync digests after main-<sha>` commit, or "N/A — no image rebuild">
+
+### Risk & rollback
+<blast radius · revert path. "Low — additive only, no behaviour change to existing paths" is fine>
+
+### Review aids
+<suggested reading order · the ONE key file · anything subtle>
 
 ### Engineering hygiene
 - [x] Planning-doc row ⬜→✅ in this diff
 - [x] `current-milestone.md` updated in this diff
-- [x] Canvas O-step ✅; `/spdd-sync` run if impl diverged
-- [x] Branched off fresh `origin/main` · PR ≤900 lines · trailers on every commit
+- [x] Canvas O-step ✅ (feat:); `/spdd-sync` run if impl diverged · Status Aligned
+- [x] Branched off fresh `origin/main` · PR ≤900 lines · DCO + `Assisted-by` on every commit
+
+<!-- feat: only --> **SPDD:** Canvas `docs/spdd/<EPIC_N>-<slug>/canvas.md` — Status: Aligned · `/spdd-security-review` PASS
 EOF
 
-# Fill in evidence from STEP 7 output before committing PR body
+# Fill in every <placeholder> with real evidence from STEP 7 output before committing the PR body.
 
 git commit -s -m "$(cat <<EOF
 ${COMMIT_TYPE}(<scope>): <subject>

--- a/.claude/commands/milestone-orchestrate.md
+++ b/.claude/commands/milestone-orchestrate.md
@@ -292,7 +292,15 @@ Agent({
        sole mutex: if a sibling already pushed `<type>/<N>` your push is rejected → stop,
        run cleanup, report "claim lost". Apply any human-readable slug only AFTER the push
        wins (rename + push the slugged ref); never let a slug into the claim push.
-    3. Implement, run all local gates, commit (DCO + Assisted-by), open PR.
+    3. Implement and run all local gates. Commit (DCO `-s` + `Assisted-by: Claude/<model>`, never
+       Co-Authored-By). Open the PR with a body **built from the canonical template**
+       `docs/contributing/pr-templates.md` (your commit type's variant). REQUIRED sections, in order:
+       `Closes #<N>` (auto-close — a bare mention does not close it), **Why**, **What you'll get**
+       (deliverables ↔ the change that provides each), **Scope & boundaries**, **Test plan &
+       acceptance** (one row per issue/canvas Acceptance Criterion with the EXACT verify command +
+       result), **Evidence**, **Risk & rollback**, **Review aids**. For `feat:` add the SPDD line
+       (canvas Aligned + security-review PASS). Leave the "Post-merge digest sync → main" evidence
+       line as a placeholder — STEP 7.5's verifier fills it after the release pipeline runs.
     4. Wait for CI. Report result.
     5. Cleanup — your LAST action, always, success or failure (a SINGLE Bash call, literal path):
        ```bash
@@ -511,13 +519,19 @@ Agent({
     5. Update images/images.yaml if ci-runner or a base image was rebuilt; run make sync-images.
     6. Find all open "bump <image> digest" issues; close stale duplicates; implement newest.
     7. Commit all digest updates as a single chore(ci) PR; squash-merge.
-    8. Output the full ## Post-Merge Evidence block.
-    9. Cleanup — your LAST action, always (a SINGLE Bash call, literal path):
+    8. Back-fill the delivered PR's Evidence block: replace the "Post-merge digest sync → main"
+       placeholder (from the canonical PR template, `docs/contributing/pr-templates.md`) on the
+       originating PR #PR_N with the real `chore(images): sync digests after main-<sha>` commit SHA
+       (the one from step 7, or "N/A — no image rebuild" if none). Use a PR comment if PR_N is
+       already merged. This closes the loop the template promises: from "PR merged" to
+       "main is digest-consistent".
+    9. Output the full ## Post-Merge Evidence block.
+    10. Cleanup — your LAST action, always (a SINGLE Bash call, literal path):
        ```bash
        git -C <REPO> worktree remove /tmp/zynax-postmerge-<RUN_ID>-<PR_N> --force
        ```
        Do NOT chain an `rm -rf` (denied); the STEP 7 sweep reclaims any lingering path.
-    10. End with ## Session Learnings.
+    11. End with ## Session Learnings.
 
     ## Constraints
     - Context budget: stay under 20K tokens.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,24 +4,54 @@ Before opening this PR, confirm:
   2. You have read CONTRIBUTING.md and docs/git-workflow.md.
   3. The .feature file was committed BEFORE any implementation.
   4. All CI checks pass locally: make lint test-unit test-integration
+Body structure (skeleton + per-type variants + filled example): docs/contributing/pr-templates.md
 -->
 
-## Why
+## Why  (problem & intent)
 
-> Explain the problem this change solves. What breaks or is missing without it?
-> Link to the issue. Do NOT describe what the code does — the diff shows that.
+> What is missing or broken, and why is this change needed? Link the issue.
+> Do NOT restate what the code does — the diff shows that. For `feat:`, link the canvas O-step.
 
 Closes #
 
 ---
 
-## What Changed
+## What you'll get  (deliverables ↔ what changed)
 
-> One sentence per logical change. Focus on intent, not implementation.
-> If this is a stacked PR, reference the parent: `Stacked on #NNN`
+> Pair each deliverable with the concrete change that provides it — "expect X because Y changed."
+> One line per logical change; focus on what a reviewer/operator will observe.
 
+- <deliverable> ← `path/to/change`
 -
--
+
+---
+
+## Scope & boundaries
+
+- **In scope:**
+- **Out of scope (deferred):**  → #_ / M-dx / N/A
+
+---
+
+## Test plan & acceptance
+
+> One row per Acceptance Criterion from the issue/canvas. Show the exact command and the result —
+> not "tested manually".
+
+| Acceptance criterion | How verified (command) | Result |
+|----------------------|------------------------|--------|
+|                      |                        |        |
+
+**Local gates:** `make lint` ☐ · `make test-unit` ☐ · `make test-integration` ☐ · `make security` ☐ · `make validate-spec` ☐
+
+---
+
+## Evidence
+
+- **CI:** _(required checks green / link to the run)_
+- **Local output:** _(coverage %, benchmark `ns/op`, `helm lint`, render preview — paste the decisive line)_
+- **Artifacts / images:** _(`service:tag@sha256:…` if images were built, or "none — no service source changed")_
+- **Post-merge digest sync → main:** _(`chore(images): sync digests after main-<sha>` commit SHA, or "N/A — no image rebuild"; left as a placeholder and filled by the post-merge verifier)_
 
 ---
 

--- a/docs/contributing/pr-templates.md
+++ b/docs/contributing/pr-templates.md
@@ -1,0 +1,152 @@
+# PR Body Templates
+
+The single source of truth for **how a pull request body is structured** in Zynax.
+
+Use it for every PR — opened by a human or by the milestone automation
+(`/milestone-orchestrate`, `/issue-deliver`, and the expert subagents). The goal is a
+review that is *fast and complete*: a reviewer can see **what to expect, why, how it was
+verified, and the evidence** without reading the whole diff, and nothing gets lost.
+
+> **Why this exists separately from `.github/PULL_REQUEST_TEMPLATE.md`:** GitHub only
+> auto-applies that native template when a PR is opened *interactively* (web UI, or
+> `gh pr create` with no body flag). The automation opens PRs with
+> `gh pr create --body-file …`, and an explicit body **silently overrides** the native
+> template. So the automation must *build* the body from this document. The native
+> template mirrors the same skeleton so human and automated PRs look identical.
+
+---
+
+## The skeleton (every PR, every type)
+
+Fill every section. Delete a section only if the per-type table below says it does not apply.
+
+```markdown
+## <type>(<scope>): <subject>
+
+Closes #<issue>          <!-- REQUIRED: auto-closes the issue on merge.
+                              For a canvas-step add: "Part of #<epic>" -->
+
+### Why  (problem & intent)
+<1–3 sentences: what is missing or broken, and why this change is needed.
+ Do NOT restate what the code does — the diff shows that. For feat:, link the canvas O-step.>
+
+### What you'll get  (deliverables ↔ what changed)
+<Pair each deliverable with the concrete change that provides it — "expect X because Y changed".
+ This is the "what to expect to be delivered and why" view, derived from the diff.>
+- <deliverable a reviewer/operator will observe> ← `path/to/change`
+- …
+
+### Scope & boundaries
+- **In scope:** <…>
+- **Out of scope (deferred):** <… → #<issue> / M-dx / N/A>
+
+### Test plan & acceptance
+<The heart of the review. One row per Acceptance Criterion from the issue/canvas.
+ Show the EXACT command used to verify and the observed result — not "tested manually".>
+
+| Acceptance criterion | How verified (command) | Result |
+|----------------------|------------------------|--------|
+| <AC 1 verbatim>      | `<exact command>`      | ✅ <number / output snippet> |
+| <AC 2 verbatim>      | `<exact command>`      | ✅ <…> |
+
+**Local gates:** `make lint` ✅ · `GOWORK=off go test ./… -race` ✅ · `make security` ✅ · `make validate-spec` ✅
+<list only the gates that apply to this change>
+
+### Evidence
+- **CI:** <all required checks green / link to the run>
+- **Local output:** <coverage %, benchmark `ns/op`, `helm lint`, render preview — paste the decisive line>
+- **Artifacts / images:** <`service:tag@sha256:…` if images were built, or "none — no service source changed">
+- **Post-merge digest sync → main:** <`chore(images): sync digests after main-<sha>` commit SHA, or "N/A — no image rebuild">
+  <!-- Left as a placeholder by the author; the post-merge verifier fills it after the
+       release pipeline runs (see /milestone-orchestrate STEP 7.5). -->
+
+### Risk & rollback
+<Blast radius · how to revert (revert this PR? flip a flag?) · any data/migration concern.
+ "Low — additive only, no behaviour change to existing paths" is an acceptable answer.>
+
+### Review aids
+<Make the review easy: suggested reading order, the ONE key file, any subtlety a reviewer
+ would otherwise miss, anything intentionally left for a follow-up.>
+
+<!-- feat: only --> **SPDD:** Canvas `docs/spdd/<id>/canvas.md` — Status: **Aligned** · `/spdd-security-review` **PASS**
+**AI:** `Assisted-by: Claude/<model-id>`   (and set the `ai-assisted` label)
+```
+
+---
+
+## Per-type emphasis
+
+The skeleton is the same; each type *emphasises* different sections. Keep the others, but spend
+your words where the table says.
+
+| Type | Emphasis / required extras | Sections that are usually `N/A` |
+|------|----------------------------|---------------------------------|
+| **feat** | Full template. **SPDD line required** (canvas Aligned + security-review PASS). Test plan maps every canvas AC. Evidence shows new observability (log event / metric / trace). | — |
+| **fix** | **Why = symptom + root cause** (not just "fixes bug"). A **regression test is mandatory** in the matrix: the test that fails on `main` and passes here. Evidence shows the repro **before → after**. | SPDD |
+| **docs** | Test plan = render/preview check, link-check, and `make validate-spec` when specs/schemas change. Evidence = preview link. | Artifacts/images; SPDD; observability |
+| **test** | "What you'll get" = the scenarios/coverage added. Evidence = coverage % and/or benchmark baseline numbers + the exact command to reproduce. | SPDD (unless the issue is `feat:`) |
+| **ci** | Test plan = a **green run of the changed workflow** (paste the link). Evidence = that run + what it now gates. | SPDD |
+| **chore** | Why = the maintenance rationale (CVE id, dep bump reason, tooling). Evidence = the dep/digest diff and that build+lint stay green. | SPDD; observability |
+
+---
+
+## Filled example (a `feat:` canvas-step)
+
+```markdown
+## feat(observability): trace_id exemplars on RED metrics
+
+Closes #1187
+Part of #467 (EPIC O — Observability)
+
+### Why
+Dashboards show rate/error/duration but cannot jump from a spiking metric to the trace that
+caused it. O.4 adds OpenTelemetry exemplars so a metric carries its originating `trace_id`.
+
+### What you'll get
+- a `trace_id` exemplar on every RED metric observation ← `libs/zynaxobs/metrics.go`
+- exemplars surfaced on the HTTP path ← `services/api-gateway/cmd/api-gateway/main.go`
+
+### Scope & boundaries
+- In scope: exemplars on existing gRPC + HTTP RED metrics, exposed at `/metrics`.
+- Out of scope (deferred): log export → O.9 #1192.
+
+### Test plan & acceptance
+| Acceptance criterion | How verified | Result |
+|---|---|---|
+| RED metrics on gRPC + HTTP carry exemplars | `GOWORK=off go test ./... -race` (libs/zynaxobs) | ✅ ok 1.031s |
+| exemplars carry `trace_id` | unit asserts exemplar label `trace_id` present | ✅ pass |
+| labels stay low-cardinality | review: labels = service/method/status only | ✅ |
+
+**Local gates:** `make lint` ✅ (1 wrapcheck nolint on the transparent ResponseWriter passthrough) · `go test -race` ✅
+
+### Evidence
+- CI: all required checks green.
+- Local output: `libs/zynaxobs` tests ok 1.031s.
+- Artifacts / images: api-gateway image rebuilt.
+- Post-merge digest sync → main: `a53cb12 chore(images): sync digests after main-93d2dff`.
+
+### Risk & rollback
+Low — additive instrumentation; revert this PR to remove. No change to existing metric labels.
+
+### Review aids
+Start at `libs/zynaxobs/metrics.go` (the exemplar attach point); `main.go` is just the HTTP wiring.
+
+**SPDD:** Canvas `docs/spdd/467-observability-otel-uptrace/canvas.md` — Status: Aligned · `/spdd-security-review` PASS
+**AI:** `Assisted-by: Claude/claude-opus-4-8`  (label: ai-assisted)
+```
+
+---
+
+## Rules that make the body work
+
+- **`Closes #N` is mandatory.** Without a closing keyword the issue stays open after merge —
+  the automation must include it (a bare `#N` mention does not auto-close).
+- **The test-plan matrix mirrors the issue/canvas Acceptance Criteria verbatim** — one row each —
+  so a reviewer can check delivery against the contract, not against the author's paraphrase.
+- **Evidence is concrete:** paste the decisive line (coverage %, `ns/op`, `ok … s`, a run link),
+  not "tested locally".
+- **The post-merge digest line is a placeholder the author leaves and the post-merge verifier
+  fills** once the release pipeline produces the `chore(images): sync digests …` commit on `main`
+  (see `/milestone-orchestrate` STEP 7.5). It closes the loop from "PR merged" to "main is
+  digest-consistent".
+- Keep it tight. Long is not the goal — *complete and scannable* is.


### PR DESCRIPTION
## docs: add canonical PR body template + wire milestone commands

Closes #_ (no issue — direct request)

### Why  (problem & intent)
PRs from `/milestone-orchestrate`, `/issue-deliver`, and the expert subagents are opened with `gh pr create --body-file`, which **silently overrides** GitHub's native `.github/PULL_REQUEST_TEMPLATE.md`. Result: every automated PR this milestone had a freeform body — no deliverables-vs-changes view, no acceptance/test-plan matrix, no evidence block. Reviews were harder and details got lost.

### What you'll get  (deliverables ↔ what changed)
- One source-of-truth PR-body template (skeleton + per-type variants + filled example) ← `docs/contributing/pr-templates.md`
- The native template restructured to the same shape (Why / What-you'll-get / Scope / Test-plan matrix / Evidence) ← `.github/PULL_REQUEST_TEMPLATE.md`
- Orchestrator experts now build the body from the template + leave a digest placeholder ← `.claude/commands/milestone-orchestrate.md`
- The post-merge verifier back-fills the "digest sync → main" evidence line ← `milestone-orchestrate.md` STEP 7.5
- `/issue-deliver` PR body upgraded to the same skeleton ← `.claude/commands/issue-deliver.md`
- All 8 experts point at the template at their `PR` phase ← `.claude/commands/experts/*.md`

### Scope & boundaries
- **In scope:** PR-body structure for all commit types (feat/fix/docs/test/ci/chore); the automation + native template.
- **Out of scope:** the existing engineering/KB/AI checklists in the native template (kept as-is, below the new skeleton).

### Test plan & acceptance
| Acceptance criterion | How verified | Result |
|---|---|---|
| Template covers what-to-expect-&-why, test plan/acceptance, evidence incl. digest commit | review of `docs/contributing/pr-templates.md` | ✅ all present |
| Applies to all issue types | per-type table + variants | ✅ feat/fix/docs/test/ci/chore |
| Automation references the template | grep `pr-templates.md` in commands/experts | ✅ orchestrate, issue-deliver, 8 experts |
| This PR body follows the template | self (you're reading it) | ✅ dogfooded |

**Local gates:** pre-commit hooks (gitleaks/gofmt/ruff/mypy) ✅ · no literal emails ✅

### Evidence
- **CI:** required checks (pending at open).
- **Local output:** 12 files changed, +249/-42; commit signed (`%G? = G`).
- **Artifacts / images:** none — docs + command prompts only.
- **Post-merge digest sync → main:** N/A — no image rebuild.

### Risk & rollback
Low — documentation + command-prompt text only; no code or runtime behaviour changes. Revert this PR to undo.

### Review aids
Start at `docs/contributing/pr-templates.md` (the SoT); everything else references it. The native-template diff is just the top section restructure.
