### PR TITLE
docs: scaffold M7.P + M7.S planning EPICs (ADR-035/036)

### DIFF
--- a/docs/adr/ADR-035-adapter-language-boundary.md
+++ b/docs/adr/ADR-035-adapter-language-boundary.md
@@ -1,0 +1,97 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# ADR-035 — Adapter language boundary: Go for provider/proxy adapters, Python for AI-framework adapters
+
+| Field | Value |
+|-------|-------|
+| **Status** | Accepted |
+| **Date** | 2026-06-16 |
+| **Deciders** | Oscar Gómez Manresa |
+| **Scope** | `agents/adapters/*` — language selection for capability adapters; refines (does not reverse) ADR-009 — M7 EPIC P (#1276) |
+| **Related** | ADR-009 (Go for platform, Python for agents), ADR-013 (adapter-first, no mandatory SDK), ADR-002 (Python 3.12 runtime), ADR-003 (uv package manager) |
+
+---
+
+## Context
+
+ADR-009 set the language strategy at the *layer* granularity: **Go for the platform
+services, Python for agents** — justified by Python's AI/ML ecosystem (LangChain,
+LangGraph, AutoGen, CrewAI). That rule is correct for AI *agents*, but capability
+**adapters** are a different animal, and the repository has already drifted to a finer
+rule that ADR-009 never wrote down:
+
+| Adapter | Language (today) | What it actually is |
+|---------|------------------|---------------------|
+| `http`  | **Go**    | stateless proxy over an arbitrary REST API |
+| `git`   | **Go**    | stateless proxy over GitHub/GitLab APIs |
+| `ci`    | **Go**    | stateless proxy over CI systems |
+| `llm`   | **Python** | stateless proxy over OpenAI / Bedrock / Ollama HTTP APIs |
+| `langgraph` | **Python** | mounts a Python-only `StateGraph` as a capability |
+
+Three of five adapters are already Go. The split is not "platform vs agents" — it is
+**stateless provider proxy vs AI-framework integration**. The `llm-adapter` is on the
+wrong side of that line: it holds no framework state, runs no Python-only library, and
+performs the same send-prompt / stream-tokens / return-response pattern as the
+http-adapter. Yet by living in Python it drags in the `openai` / `aiobotocore` /
+`aiohttp` transitive tree, which has repeatedly required Dependabot-driven security
+floors (the adapter's `pyproject.toml` pins `aiohttp>=3.14.1` "fixes the GHSA set").
+
+Maintaining a Python toolchain for an adapter that has no Python-specific reason to
+exist multiplies the dependency surface, the CVE-patch cadence, and the blast radius
+for no capability gain.
+
+## Decision
+
+Choose adapter implementation language by **what the adapter wraps**, not by which
+layer it sits in:
+
+1. **Go** is the default for **stateless provider/proxy adapters** — adapters whose job
+   is to translate a Zynax capability into calls against an external HTTP/gRPC/SDK API
+   and stream results back. This covers `http`, `git`, `ci`, **and `llm`**.
+
+2. **Python** is reserved for **AI-framework adapters** — adapters that embed or wrap a
+   Python-only library (LangGraph, LangChain, AutoGen, CrewAI) where no Go equivalent
+   exists. This covers `langgraph` and any future framework adapter.
+
+3. The **Python SDK** (`agents/sdk/`) and **`agents/examples/`** remain Python, unchanged
+   — agent *authoring* keeps Python's AI ecosystem (ADR-009 §Rationale stands for agents).
+
+The boundary between Go and Python is unchanged at the wire: the gRPC `AgentService`
+proto contract (ADR-001/ADR-013). An adapter's language is an internal implementation
+detail invisible to the platform and to the language-agnostic BDD `.feature` contract.
+
+## Consequences
+
+**Positive**
+
+- `llm-adapter` ports to Go (M7 EPIC P / #1276): one fewer Python deployable, the
+  `openai` / `aiobotocore` / `aiohttp` tree leaves the supply chain, and the adapter
+  ships as a single static distroless binary — smaller image, smaller attack surface.
+- The Go↔Python split is now stated by an explicit, testable rule rather than tribal
+  knowledge, so the next adapter lands in the right language by default.
+- Uniform tooling for 4 of 5 adapters (one lint/test/build path) lowers maintenance and
+  contributor context-switching.
+
+**Negative / accepted**
+
+- `langgraph-adapter` **cannot** be ported to Go — LangGraph is Python-only. This ADR
+  makes that explicit: de-Pythonization stops at the framework boundary; it is not a path
+  to a Python-free repo. Python stays in CI for `langgraph`, the SDK, and examples.
+- The port is behavioural-equivalence work, not new capability. It is justified by
+  supply-chain/maintenance reduction, and is gated on the existing
+  `protos/tests/features/llm_adapter.feature` staying green (the parity oracle) — so the
+  contract risk is bounded.
+- ADR-009's one-line "Python for agents" summary now needs reading together with this
+  finer adapter rule; ADR-009 is **refined, not reversed**, and its agent rationale is
+  untouched.
+
+## Alternatives considered
+
+- **Keep `llm-adapter` in Python (status quo).** Rejected: pays the Python dependency/CVE
+  tax for an adapter with no Python-specific need, against the grain of the three Go
+  adapters already shipped.
+- **Port everything including `langgraph` to Go.** Rejected: impossible without deleting
+  LangGraph support, which is a deliberate capability (ADR-013) and a competitive
+  differentiator.
+- **Remove all Python (SDK + examples + adapters).** Rejected: reverses the agent-authoring
+  thesis of ADR-009/010/013/033 — a strategic product pivot, not a maintenance change.

--- a/docs/adr/ADR-036-ci-logic-as-go-cli.md
+++ b/docs/adr/ADR-036-ci-logic-as-go-cli.md
@@ -1,0 +1,84 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# ADR-036 — CI logic belongs in a tested Go CLI (zynax-ci), not inline workflow bash
+
+| Field | Value |
+|-------|-------|
+| **Status** | Accepted |
+| **Date** | 2026-06-16 |
+| **Deciders** | Oscar Gómez Manresa |
+| **Scope** | `cmd/zynax-ci/`, `.github/workflows/*`, `scripts/`, `tools/ci/`, `Makefile` — M7 EPIC S (#1285) |
+| **Related** | ADR-024 (images.yaml SoT), ADR-027 (shift-left pipeline), ADR-017 (GOWORK=off / contract-test isolation), ADR-006 (monorepo) |
+
+---
+
+## Context
+
+Zynax CI logic is spread across three substrates that get no test coverage and no type
+checking:
+
+- **Standalone shell scripts** (~457 LOC of deterministic logic: coverage-comment assembly,
+  benchmark-regression gating, BDD package selection, CI-runner version bumping).
+- **Inline workflow `run:` blocks** (~1,578 LOC across 21 workflows: `gh api`/`jq` parsing,
+  `crane`/`cosign` digest + attestation orchestration, image retag, image-meta reporting,
+  release-notes assembly, validation gates).
+- **Makefile recipes** (~234 shell lines).
+
+Bash here is a maintenance and supply-chain liability: it is untested, it duplicates parsing
+logic across workflows, it is hard to review (a 658-line `release.yml` carries ~27 logic blocks),
+and a mistake in a digest/retag/attest step is a supply-chain risk. The repository already proved
+the alternative: **`cmd/zynax-ci`** is a Cobra CLI that hosts exactly this class of logic
+(`validate-*`, `images sync/check`, `check deps`, `ai-context`) with unit tests and `make lint` /
+`govulncheck` coverage. New CI logic, however, keeps landing as inline bash by default.
+
+The e2e harness (`scripts/e2e/*`, ~1,617 LOC) is a different animal: it is thin orchestration over
+`kind` / `kubectl` / `helm` / `docker` and carries little decision logic of its own. Porting it to
+Go would add `client-go` / Helm-SDK dependencies for rarely-run test scaffolding — cost without a
+proportional maintenance win.
+
+## Decision
+
+1. **Deterministic CI logic is implemented as a tested `zynax-ci` subcommand**, not as inline
+   workflow `run:` bash or a standalone script. "Deterministic logic" = parsing, gating,
+   assembly, transformation, and orchestration decisions (what to retag, which packages to run,
+   pass/fail thresholds, comment/notes rendering).
+
+2. **Workflow `run:` steps stay thin** — ideally a single `zynax-ci <verb>` invocation plus
+   environment wiring. Multi-line logic blocks are a smell to be extracted.
+
+3. **External-tool invocation that carries no decision logic stays shell** — calling `cosign`,
+   `crane`, `docker buildx`, `kubectl`, `helm` as binaries is fine; the *decisions around* those
+   calls move to Go. `zynax-ci` does not re-implement signing/attestation crypto; it orchestrates
+   the cosign/crane binaries.
+
+4. **The e2e harness stays bash** (ADR-036 §Context). De-bashing stops at the test-driver boundary.
+
+5. Behaviour parity is mandatory: a ported gate must fire identically (same pass/fail, same
+   outputs) — verified by unit tests on the Go command and by the unchanged CI result.
+
+## Consequences
+
+**Positive**
+
+- Every CI gate gains unit tests, types, and `make lint` / `govulncheck` coverage.
+- Workflow YAML shrinks (~1,000+ inline `run:` lines collapse to `zynax-ci` calls); reviewers
+  audit Go with tests instead of unreviewed bash.
+- One versioned binary (released via `zynax-ci-release.yml`) replaces N copies of parsing logic.
+- Supply-chain-sensitive steps (digest, retag, release assembly) become testable and reviewable.
+
+**Negative / accepted**
+
+- The e2e harness remains bash — Shell does not drop to zero; this is a deliberate cost/value line.
+- Migrating supply-chain steps (digest/retag/attest orchestration) must be done carefully with
+  parity tests; a regression there is high-impact. Mitigated by S-step sequencing and keeping
+  cosign/crane as the actual signing/copy primitives.
+- `zynax-ci` grows in surface; offset by deleting the scripts and inline blocks it replaces.
+
+## Alternatives considered
+
+- **Keep CI logic in bash (status quo).** Rejected: untested, duplicated, hard to review, a
+  supply-chain liability — against the grain of the existing `zynax-ci` commands.
+- **A new dedicated tool (`cmd/zynax-dev`).** Rejected for now: adds a second module, release
+  pipeline, and versioning stream; `zynax-ci` is already the CI/dev-tooling home.
+- **Port everything including the e2e harness to Go.** Rejected: adds heavy k8s/Helm client deps
+  for rarely-run test glue with little decision logic — cost without proportional benefit.

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -45,6 +45,7 @@ a PR against `docs/adr/`.
 | [ADR-032](ADR-032-git-mcp-shim.md) | Git MCP as a thin shim over the git-adapter | Accepted | 2026-06-15 | `agents/adapters/git/`, cli — M7 EPIC G |
 | [ADR-033](ADR-033-expert-agent-substrate.md) | Expert-agent substrate (runtime AgentDef + authoring experts) | Proposed | 2026-06-15 | `agents/examples/`, `automation/workflows/experts/`, agent-registry — M7 EPIC X |
 | [ADR-034](ADR-034-manifest-workflow-id-collision-domain.md) | ManifestWorkflowID 64-bit collision domain + canonicalization stability | Proposed | 2026-06-15 | workflow-compiler — M7 EPIC Q (#583) |
+| [ADR-035](ADR-035-adapter-language-boundary.md) | Adapter language boundary — Go for provider/proxy adapters, Python for AI-framework adapters | Accepted | 2026-06-16 | `agents/adapters/*` — refines ADR-009 — M7 EPIC P (#1276) |
 
 ---
 

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -46,6 +46,7 @@ a PR against `docs/adr/`.
 | [ADR-033](ADR-033-expert-agent-substrate.md) | Expert-agent substrate (runtime AgentDef + authoring experts) | Proposed | 2026-06-15 | `agents/examples/`, `automation/workflows/experts/`, agent-registry — M7 EPIC X |
 | [ADR-034](ADR-034-manifest-workflow-id-collision-domain.md) | ManifestWorkflowID 64-bit collision domain + canonicalization stability | Proposed | 2026-06-15 | workflow-compiler — M7 EPIC Q (#583) |
 | [ADR-035](ADR-035-adapter-language-boundary.md) | Adapter language boundary — Go for provider/proxy adapters, Python for AI-framework adapters | Accepted | 2026-06-16 | `agents/adapters/*` — refines ADR-009 — M7 EPIC P (#1276) |
+| [ADR-036](ADR-036-ci-logic-as-go-cli.md) | CI logic belongs in a tested Go CLI (zynax-ci), not inline workflow bash | Accepted | 2026-06-16 | `cmd/zynax-ci/`, `.github/workflows/*`, `scripts/`, `Makefile` — M7 EPIC S (#1285) |
 
 ---
 

--- a/docs/milestones/M7-planning.md
+++ b/docs/milestones/M7-planning.md
@@ -216,8 +216,15 @@ The remaining open rows are tracked explicitly in the acceptance matrix ([§13](
 | D.3 Context + Git MCP guides | [#1219](https://github.com/zynax-io/zynax/issues/1219) | D #1173 | ⬜ | |
 | D.4 Observability (OTEL + Uptrace) guides | [#1220](https://github.com/zynax-io/zynax/issues/1220) | D #1173 | ⬜ | |
 | D.5 Examples index + best practices + FAQ + migration | [#1221](https://github.com/zynax-io/zynax/issues/1221) | D #1173 | ⬜ | |
+| P.1 ADR-035 adapter language boundary | [#1277](https://github.com/zynax-io/zynax/issues/1277) | P #1276 | ⬜ | accept ADR-035 on canvas-P alignment |
+| P.2 Go scaffold + config | [#1278](https://github.com/zynax-io/zynax/issues/1278) | P #1276 | ⬜ | `GOWORK=off` module; dep P.1 |
+| P.3 Go providers (OpenAI/Bedrock/Ollama) | [#1279](https://github.com/zynax-io/zynax/issues/1279) | P #1276 | ⬜ | dep P.2 |
+| P.4 Go AgentService server (parity) | [#1280](https://github.com/zynax-io/zynax/issues/1280) | P #1276 | ⬜ | reuses `llm_adapter.feature`; dep P.3 |
+| P.5 registry + bootstrap + health | [#1281](https://github.com/zynax-io/zynax/issues/1281) | P #1276 | ⬜ | dep P.4 |
+| P.6 Dockerfile + images.yaml cutover | [#1282](https://github.com/zynax-io/zynax/issues/1282) | P #1276 | ⬜ | dep P.5; ADR-024 |
+| P.7 retire Python llm-adapter | [#1283](https://github.com/zynax-io/zynax/issues/1283) | P #1276 | ⬜ | dep P.6 |
 
-**Tally:** 11 closed / 39 open across 10 EPICs.
+**Tally:** 11 closed / 46 open across 11 EPICs.
 
 ### Ready to claim now for `/milestone-orchestrate` (priority order, ≤3 per batch)
 **Strictly unblocked** = every dependency is closed/none. Each EPIC's `*.1` ADR step is closed, so:
@@ -230,7 +237,8 @@ The remaining open rows are tracked explicitly in the acceptance matrix ([§13](
 
 Also strictly-ready for later batches (deps closed/none): **G.2 [#1198]**, **X.2 [#1202]**,
 **R.1 [#493]**, **R.3 [#553]**, **R.4 [#1103]**, **Q.4 [#1215]**, **Q.5 [#1216]**,
-**G.5 [#1260]**, **G.6 [#1261]** (docs, no canvas — claim anytime), **G.7 [#1262]**.
+**G.5 [#1260]**, **G.6 [#1261]** (docs, no canvas — claim anytime), **G.7 [#1262]**,
+**P.1 [#1277]** (ADR/docs — accept ADR-035 on canvas-P alignment; gates P.2→P.7).
 Unblock after W.2 merges: **W.3 [#1177]** → then **R.2 [#1210]**, **T.1 [#1206]** (both dep W.3).
 Do **not** front-load O.7 #1190 / O.8 #1191 — they depend on O.2 #1185.
 
@@ -242,8 +250,8 @@ Do **not** front-load O.7 #1190 / O.8 #1191 — they depend on O.2 #1185.
   is mutated **only** by `/milestone-new` / `/milestone-close` — flag for the next milestone op.
 - **EPIC #467 title** still reads the pre-absorption "Wire Prometheus + OTel"; scope is the broader
   OTEL+Uptrace EPIC O. Cosmetic; retitle on next touch.
-- **ADRs 031 / 033 / 034 are still `Proposed`** while their docs issues are closed — promote to
-  `Accepted` as each canvas (C / X / Q) reaches `Aligned`.
+- **ADRs 031 / 033 / 034 / 035 are still `Proposed`** while their docs issues are closed/open —
+  promote to `Accepted` as each canvas (C / X / Q / P) reaches `Aligned`.
 - **Issue dependency markers are inconsistent.** Many open stories express deps as bare step
   labels (e.g. #1177 `Dependencies: W.2`, #1186 `Dependencies: O.2`) with no issue number, while
   others use `#N` (e.g. #1195, #1208). The §4a table above is the authoritative step→`#N` map the

--- a/docs/milestones/M7-planning.md
+++ b/docs/milestones/M7-planning.md
@@ -223,8 +223,15 @@ The remaining open rows are tracked explicitly in the acceptance matrix ([§13](
 | P.5 registry + bootstrap + health | [#1281](https://github.com/zynax-io/zynax/issues/1281) | P #1276 | ⬜ | dep P.4 |
 | P.6 Dockerfile + images.yaml cutover | [#1282](https://github.com/zynax-io/zynax/issues/1282) | P #1276 | ⬜ | dep P.5; ADR-024 |
 | P.7 retire Python llm-adapter | [#1283](https://github.com/zynax-io/zynax/issues/1283) | P #1276 | ⬜ | dep P.6 |
+| S.1 ADR-036 CI logic as a Go CLI | [#1286](https://github.com/zynax-io/zynax/issues/1286) | S #1285 | ⬜ | accept ADR-036 on canvas-S alignment |
+| S.2 `zynax-ci coverage-comment` | [#1287](https://github.com/zynax-io/zynax/issues/1287) | S #1285 | ⬜ | ← build-coverage-comment.sh; dep S.1 |
+| S.3 `zynax-ci bench-gate` + `bdd-select` | [#1288](https://github.com/zynax-io/zynax/issues/1288) | S #1285 | ⬜ | ← bench-regression + bdd-select scripts; dep S.1 |
+| S.4 `zynax-ci bump-runner` | [#1289](https://github.com/zynax-io/zynax/issues/1289) | S #1285 | ⬜ | ← bump-ci-runner.sh; images.yaml SoT; dep S.1 |
+| S.5 `zynax-ci images meta/cleanup/retag` | [#1290](https://github.com/zynax-io/zynax/issues/1290) | S #1285 | ⬜ | ← report-image-meta + cleanup/retag blocks; dep S.1 |
+| S.6 `zynax-ci release` helpers | [#1291](https://github.com/zynax-io/zynax/issues/1291) | S #1285 | ⬜ | ← release.yml assembly; cosign stays shell; dep S.5 |
+| S.7 retire scripts + thin workflows | [#1292](https://github.com/zynax-io/zynax/issues/1292) | S #1285 | ⬜ | dep S.2–S.6 |
 
-**Tally:** 11 closed / 46 open across 11 EPICs.
+**Tally:** 11 closed / 53 open across 12 EPICs.
 
 ### Ready to claim now for `/milestone-orchestrate` (priority order, ≤3 per batch)
 **Strictly unblocked** = every dependency is closed/none. Each EPIC's `*.1` ADR step is closed, so:
@@ -238,7 +245,10 @@ The remaining open rows are tracked explicitly in the acceptance matrix ([§13](
 Also strictly-ready for later batches (deps closed/none): **G.2 [#1198]**, **X.2 [#1202]**,
 **R.1 [#493]**, **R.3 [#553]**, **R.4 [#1103]**, **Q.4 [#1215]**, **Q.5 [#1216]**,
 **G.5 [#1260]**, **G.6 [#1261]** (docs, no canvas — claim anytime), **G.7 [#1262]**,
-**P.1 [#1277]** (ADR/docs — accept ADR-035 on canvas-P alignment; gates P.2→P.7).
+**P.1 [#1277]** (ADR/docs — accept ADR-035 on canvas-P alignment; gates P.2→P.7),
+**P.2–P.6 [#1278–#1282]** (canvas-P Aligned; P.2 ready after P.1, then chain),
+**S.1 [#1286]** (ADR/docs — accept ADR-036 on canvas-S alignment; gates S.2→S.7),
+**S.2–S.5 [#1287–#1290]** (canvas-S Aligned; parallel after S.1; S.6 dep S.5; S.7 last).
 Unblock after W.2 merges: **W.3 [#1177]** → then **R.2 [#1210]**, **T.1 [#1206]** (both dep W.3).
 Do **not** front-load O.7 #1190 / O.8 #1191 — they depend on O.2 #1185.
 
@@ -250,8 +260,9 @@ Do **not** front-load O.7 #1190 / O.8 #1191 — they depend on O.2 #1185.
   is mutated **only** by `/milestone-new` / `/milestone-close` — flag for the next milestone op.
 - **EPIC #467 title** still reads the pre-absorption "Wire Prometheus + OTel"; scope is the broader
   OTEL+Uptrace EPIC O. Cosmetic; retitle on next touch.
-- **ADRs 031 / 033 / 034 / 035 are still `Proposed`** while their docs issues are closed/open —
-  promote to `Accepted` as each canvas (C / X / Q / P) reaches `Aligned`.
+- **ADRs 031 / 033 / 034 are still `Proposed`** while their docs issues are closed — promote to
+  `Accepted` as each canvas (C / X / Q) reaches `Aligned`. (ADR-035 / ADR-036 are already `Accepted`
+  — canvases P #1276 and S #1285 are Aligned.)
 - **Issue dependency markers are inconsistent.** Many open stories express deps as bare step
   labels (e.g. #1177 `Dependencies: W.2`, #1186 `Dependencies: O.2`) with no issue number, while
   others use `#N` (e.g. #1195, #1208). The §4a table above is the authoritative step→`#N` map the

--- a/docs/spdd/1276-llm-adapter-go/canvas.md
+++ b/docs/spdd/1276-llm-adapter-go/canvas.md
@@ -1,0 +1,231 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# REASONS Canvas — Port llm-adapter to Go (M7.P)
+
+> **All content in this Canvas is Tier 1 (public-safe).**
+> Tier 2 content (internal hostnames, IPs, credentials, deployment specifics) belongs in
+> `canvas.private.md` (gitignored). Run `/spdd-security-review <path>` before committing.
+
+**Issue:** #1276
+**Author:** Oscar Gómez Manresa
+**Date:** 2026-06-16
+**Status:** Aligned
+
+---
+
+## R — Requirements
+
+- **Problem:** The `llm-adapter` is a stateless provider proxy — it streams `chat_completion`
+  to OpenAI / Bedrock / Ollama over their HTTP/SDK APIs and holds no AI-framework state — yet it
+  is written in Python. That drags in the `openai` / `aiobotocore` / `aiohttp` transitive tree,
+  which has repeatedly forced Dependabot-driven security floors (its `pyproject.toml` pins
+  `aiohttp>=3.14.1` "fixes the GHSA set"). Three of five adapters (`http`, `git`, `ci`) are
+  already Go; only `llm` and the genuinely-Python `langgraph` remain. Keeping `llm` in Python pays
+  a dependency / CVE-patch / blast-radius tax for no Python-specific need.
+- **Missing state:** A Go `llm-adapter` that implements the **unchanged** `AgentService` gRPC
+  contract, routes by config to the three providers, streams per-token PROGRESS events, ships as a
+  single static distroless binary, and removes the Python toolchain for this adapter.
+- **Definition of done — observable outcomes:**
+  - `protos/tests/features/llm_adapter.feature` passes against the **Go** adapter (behavioural parity).
+  - Provider routing is config-only: switching `openai` ↔ `bedrock` ↔ `ollama` needs no code change.
+  - Per-token chunks arrive as `TASK_EVENT_TYPE_PROGRESS`; exactly one terminal event per stream.
+  - `timeout_seconds` exceeded → `FAILED` / `"TIMEOUT"`; invalid `input_payload` → `"INVALID_INPUT"`;
+    provider error → `"UPSTREAM_ERROR"` with a sanitised message (no bodies, no credentials).
+  - `images/images.yaml` points the `llm-adapter` image at the Go build; `make check-images` green.
+  - The Python `agents/adapters/llm/` tree is removed; `make security` carries no llm Python deps.
+  - `internal/domain` unit coverage ≥ 90%; `GOWORK=off go test ./... -race` green; ADR-035 Accepted.
+
+---
+
+## E — Entities
+
+### Existing entities consumed (unchanged by this EPIC)
+
+- **`AgentService`** (`protos/zynax/v1/agent.proto`) — `ExecuteCapability` (server-streaming
+  `TaskEvent`) + `GetCapabilitySchema`. Contract invariants: exactly one terminal event;
+  `task_id` echoed on every event; `timeout_seconds` honoured; no events after terminal.
+- **`AgentRegistryService`** — `RegisterAgent` at startup; `DeregisterAgent` on shutdown.
+- **`AgentDef` / `CapabilityDef` / `ExecuteCapabilityRequest` / `TaskEvent` / `CapabilityError`** —
+  the same proto messages the Python adapter used; well-known error codes `"TIMEOUT"`,
+  `"INVALID_INPUT"`, `"UPSTREAM_ERROR"`, `"RESOURCE_EXHAUSTED"`, `"INTERNAL"`.
+- **`protos/tests/features/llm_adapter.feature`** — the language-agnostic BDD contract. It is the
+  **parity oracle**: because the wire contract does not change, this existing file (ADR-016) is
+  re-used as-is; no new `.feature` is authored.
+
+### New entities (Go re-implementation of the Python design)
+
+- **`AdapterConfig`** — top-level config parsed from YAML at startup. Fields mirror the Python
+  struct: `agent_id`, `name`, `description`, `endpoint` (bind `host:port`), `registry_endpoint`,
+  `capabilities[]`, `provider`. Holds **only** env-var name references for API keys — never values.
+- **`ProviderConfig`** — per-provider config: `name` (`openai|bedrock|ollama`), `model`,
+  `ollama_base_url`, `api_key_env`, `max_tokens`, `region`. The API-key value is resolved from the
+  named env var at startup into a redacting secret type (never printed by `String()`/logs).
+- **`Provider` (interface)** — `Stream(ctx, prompt, cfg) (<-chan Chunk, error)`; implemented by
+  `OpenAIProvider`, `BedrockProvider`, `OllamaProvider`. Selected by a factory from `ProviderConfig`,
+  immutable after init.
+- **`ChatCompletionHandler`** — validates `input_payload` against the declared JSON Schema, invokes
+  the selected `Provider`, emits per-chunk PROGRESS, then exactly one terminal event. Stateless.
+- **`CapabilityRouter`** — `capability_name → handler`; built from `AdapterConfig`; immutable.
+- **`AgentServer`** — gRPC server implementing `AgentService`; owns the router; serves the gRPC
+  health service; drains on SIGTERM.
+
+### Entity relationships
+
+```
+Task Broker
+    │ gRPC ExecuteCapabilityRequest
+    ▼
+AgentServer (AgentServiceServer, Go)
+    ├── CapabilityRouter ──► "chat_completion" → ChatCompletionHandler
+    │                               │ input_payload validated vs JSON Schema
+    │                               ▼
+    │                        Provider (interface)
+    │            ┌──────────────────┼───────────────────┐
+    │            ▼                  ▼                    ▼
+    │     OpenAIProvider     BedrockProvider      OllamaProvider
+    │     (openai-go)        (aws-sdk-go-v2,      (net/http,
+    │                         bedrockruntime)      /api/chat)
+    │            └──────────────────┴───────────────────┘ token chunks
+    │                               ▼
+    │            PROGRESS(chunk) × N → COMPLETED(full) | FAILED(code)
+    └── stream TaskEvent (task_id + timestamp on every event)
+
+Startup: load AdapterConfig (env path) → resolve api_key_env → secret type
+         → build providers + router → dial registry → RegisterAgent (backoff ×5)
+         → serve gRPC (+ health).
+Shutdown (SIGTERM): DeregisterAgent → graceful stop → close clients (defer).
+```
+
+---
+
+## A — Approach
+
+**We will:**
+
+- Implement `agents/adapters/llm/` as a Go module (`go.mod`, NOT in `go.work`; `GOWORK=off` for all
+  `go` commands — ADR-017), structured like the existing `http`/`git`/`ci` Go adapters.
+- Resolve API keys from env-var **references** at startup into a redacting secret type; never log,
+  never place in `CapabilityError.message`, never read from `input_payload`.
+- Implement `ExecuteCapability` with JSON-Schema input validation, `context`-deadline timeout,
+  per-token PROGRESS, exactly one terminal event; `GetCapabilitySchema` returns declared schemas.
+- Implement the three providers with their first-party Go paths: `openai-go` (streaming),
+  `aws-sdk-go-v2/.../bedrockruntime` ConverseStream, Ollama `/api/chat` over `net/http` chunked.
+- Re-use `protos/tests/features/llm_adapter.feature` unchanged as the parity oracle; keep it green.
+- Build a multi-stage Dockerfile → distroless static nonroot; register/keep the `llm-adapter`
+  consumer in `images/images.yaml` (ADR-024) and flip its build to Go; wire compose/Helm/e2e.
+- Retire the Python tree and drop it from the Python CI matrix once the Go image is live (P.7).
+
+**We will NOT:**
+
+- Touch any proto contract — `protos/zynax/v1/` is finalised for this adapter.
+- Migrate the `langgraph-adapter` (Python-only library — cannot be ported; ADR-035 §Consequences),
+  the Python SDK, or `agents/examples/`.
+- Accept provider selection, model id, or API keys from `input_payload`.
+- Add providers beyond `openai`, `bedrock`, `ollama`.
+- Implement retry (owned by the task broker) or auth flows beyond API-key env references.
+
+**Governing ADRs:** ADR-035 (adapter language boundary — this EPIC), ADR-009 (language strategy,
+refined), ADR-013 (adapter-first, no SDK import), ADR-001 (gRPC only), ADR-016 (BDD parity oracle),
+ADR-017 (`GOWORK=off`), ADR-024 (images.yaml SoT), ADR-019 (this Canvas before code).
+
+---
+
+## S — Structure
+
+```
+agents/adapters/llm/                 (Go module — replaces the Python tree)
+├── go.mod                           NOT in go.work (ADR-017); GOWORK=off
+├── cmd/llm-adapter/main.go          bootstrap: config → providers → registry → serve (+health)
+├── internal/
+│   ├── config/config.go             AdapterConfig + ProviderConfig; load from YAML; secret type
+│   ├── provider/
+│   │   ├── provider.go              Provider interface + factory
+│   │   ├── openai.go                OpenAIProvider (openai-go streaming)
+│   │   ├── bedrock.go               BedrockProvider (aws-sdk-go-v2 ConverseStream)
+│   │   └── ollama.go                OllamaProvider (net/http /api/chat)
+│   ├── domain/handler.go            ChatCompletionHandler (validate → stream → terminal)
+│   ├── domain/router.go             CapabilityRouter
+│   ├── registry/client.go           RegisterAgent / DeregisterAgent (backoff)
+│   └── server/server.go             AgentServiceServer impl + grpc health
+├── Dockerfile                       multi-stage → distroless static nonroot; base via images.yaml
+└── agent-def.yaml.example           operator doc (chat_completion schema)
+```
+
+Config env prefix: `ZYNAX_LLM_` · Reused unchanged: `protos/tests/features/llm_adapter.feature`,
+`images/images.yaml` (`llm-adapter` consumer + image entry), `infra/docker-compose/`, Helm
+`values.yaml`. Removed at P.7: `agents/adapters/llm/{src,tests,pyproject.toml}` (Python).
+
+---
+
+## O — Operations
+
+Each step is one reviewable PR. Order and GitHub issues:
+
+1. **P.1 — ADR-035** (#1277): commit `docs/adr/ADR-035-adapter-language-boundary.md` (Proposed) +
+   INDEX row; flips to Accepted when this Canvas is Aligned. Gate for all code steps.
+2. **P.2 — scaffold + config** (#1278): Go module, `AdapterConfig`/`ProviderConfig`, YAML load,
+   secret type; unit tests (valid/missing/unknown-provider/secret-not-leaked). `GOWORK=off` green.
+3. **P.3 — providers** (#1279): `Provider` interface + factory + OpenAI/Bedrock/Ollama streaming;
+   unit tests with mocked clients; `UPSTREAM_ERROR` mapping; sanitised messages.
+4. **P.4 — server** (#1280): `ExecuteCapability` (validate → timeout → PROGRESS → one terminal) +
+   `GetCapabilitySchema`; `internal/domain` coverage ≥ 90%; `llm_adapter.feature` green (parity).
+5. **P.5 — registry + bootstrap + health** (#1281): `RegisterAgent`/`DeregisterAgent` (backoff),
+   `main`, gRPC health, SIGTERM graceful drain; close clients via `defer`.
+6. **P.6 — package + cutover** (#1282): distroless Dockerfile; `images.yaml` build flipped to Go;
+   `make sync-images`/`check-images` green; compose/Helm/e2e reference the Go image.
+7. **P.7 — retire Python** (#1283): delete the Python tree; drop it from the Python lint/test/
+   security matrix; update ARCHITECTURE/README/AGENTS/ADR-013; set ADR-035 Accepted.
+
+---
+
+## N — Norms
+
+Pulled from root `AGENTS.md` §Hard Constraints, `services/AGENTS.md`, `docs/engineering/best-practices/go.md`.
+
+- Commit hygiene: subject ≤ 72 chars, imperative, no period, no emojis; `Signed-off-by:` +
+  `Assisted-by: Claude/<model-id>` on every commit; never `Co-Authored-By:` for AI.
+- One PR per story (P.1–P.7); ≤ 400 lines excluding generated code.
+- SPDX header `// SPDX-License-Identifier: Apache-2.0` on every `.go` file.
+- `GOWORK=off` for every `go` / `go test` command in the adapter directory (ADR-017).
+- Go functions ≤ 30 lines; no `panic` in production; never discard errors (`_ = f()`);
+  close gRPC channels / HTTP bodies / readers via `defer`.
+- Platform calls via gRPC stubs only — never HTTP to Zynax services (ADR-001).
+- Never import `agents/sdk/` — implement `AgentService` directly (ADR-013).
+- LLM model + provider always from config, never from `input_payload` or hardcoded.
+- Secret type for API keys; never logged, never in `CapabilityError.message`.
+- `input_payload` validated against declared schema before any provider call (`INVALID_INPUT`).
+- At least one PROGRESS before the terminal event; exactly one terminal event; `task_id`+`timestamp`
+  on every event; `CapabilityError.message` sanitised + truncated.
+- Image refs only via `images/images.yaml` (ADR-024); never hand-edit banner-marked regions.
+- Distroless static nonroot final image; `HEALTHCHECK`; multi-arch parity with sibling adapters.
+
+---
+
+## S — Safeguards
+
+### Context Security (complete before committing this Canvas)
+
+- [x] No Tier 2 content: no internal hostnames, private IPs, credentials, deployment specifics
+- [x] No PII: no personal email addresses; author name is the public maintainer of record
+- [x] No prompt injection: no instruction-like phrasing that overrides AGENTS.md rules
+- [x] All entities in E are public-safe abstractions
+- [x] `/spdd-security-review` passed — result: PASS (2026-06-16)
+
+### Feature Safeguards
+
+- **Never** accept provider selection, model id, or API keys from `input_payload` — all provider
+  config is static YAML or env-var references declared at startup.
+- **Never** log or include the API-key secret, raw provider response bodies, or stack traces in any
+  `TaskEvent` payload, `CapabilityError.message`, or structured log field.
+- **Never** emit a `TaskEvent` after the terminal event; **never** end a stream without exactly one
+  terminal event.
+- **Never** import `agents/sdk/`; implement `AgentService` directly via generated stubs (ADR-013).
+- **Never** store execution state across `ExecuteCapabilityRequest` invocations (stateless).
+- **Never** call a Zynax platform service over HTTP — gRPC stubs only (ADR-001).
+- **Never** skip `input_payload` JSON-Schema validation before a provider call.
+- **Never** change a proto contract in this EPIC.
+- **Never** hand-edit `images/images.yaml` banner-marked regions — use `make sync-images` (ADR-024).
+- **Never** commit code on a step before its predecessor's gate is green (P.1 before P.2+, the
+  parity `.feature` green before P.7 retires the Python adapter).
+- **Never** remove the Python tree (P.7) until the Go image is live and green (P.6).
+- **Never** widen scope to `langgraph`, the SDK, or examples — Python stays there (ADR-035).

--- a/docs/spdd/1285-ci-bash-to-go/canvas.md
+++ b/docs/spdd/1285-ci-bash-to-go/canvas.md
@@ -1,0 +1,190 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# REASONS Canvas — Consolidate CI bash into zynax-ci (M7.S)
+
+> **All content in this Canvas is Tier 1 (public-safe).**
+> Tier 2 content (internal hostnames, IPs, credentials, deployment specifics) belongs in
+> `canvas.private.md` (gitignored). Run `/spdd-security-review <path>` before committing.
+
+**Issue:** #1285
+**Author:** Oscar Gómez Manresa
+**Date:** 2026-06-16
+**Status:** Aligned
+
+---
+
+## R — Requirements
+
+- **Problem:** Deterministic CI logic lives in untested substrates — ~457 LOC of standalone shell
+  scripts, ~1,578 LOC of inline workflow `run:` blocks across 21 workflows, and Makefile recipes.
+  This logic (coverage-comment assembly, benchmark-regression gating, BDD selection, runner bumps,
+  image meta/cleanup/retag, release-notes/digest assembly) gets no unit tests, no type checking, and
+  no `make lint` / `govulncheck` coverage, and it is duplicated and hard to review (a 658-line
+  `release.yml` carries ~27 logic blocks). A digest/retag/attest mistake in bash is a supply-chain risk.
+- **Missing state:** the deterministic logic implemented as tested `zynax-ci` subcommands, with each
+  consuming workflow step reduced to a single `zynax-ci <verb>` call — exactly the pattern already
+  used for `validate-*`, `images sync/check`, `check deps`, `ai-context`.
+- **Definition of done — observable outcomes:**
+  - Each ported script's behaviour is reproduced by a `zynax-ci` subcommand with unit tests.
+  - Each corresponding workflow step is a single `zynax-ci <verb>` invocation.
+  - The replaced `.sh` files and the `report-image-meta` composite action are removed.
+  - CI gates fire identically (same pass/fail and outputs) — behaviour parity, verified by tests + CI.
+  - `make lint` + `govulncheck` green; net CI-YAML + shell line reduction recorded; ADR-036 Accepted.
+  - The e2e harness (`scripts/e2e/*`) is unchanged — it stays bash (ADR-036).
+
+---
+
+## E — Entities
+
+### Existing entities consumed (unchanged)
+
+- **`zynax-ci`** (`cmd/zynax-ci`) — the Cobra CLI that already hosts CI/dev verbs: `validate <schema|
+  canvas|policies|capabilities|agent-defs|workflows>`, `images sync|check`, `check deps`,
+  `ai-context`. Released via `zynax-ci-release.yml`. This EPIC adds subcommands to it.
+- **`images/images.yaml`** — the image-reference SoT (ADR-024); `zynax-ci images` already reads it.
+- **GitHub Actions workflows** (`.github/workflows/*`) — the consumers whose `run:` steps collapse to
+  `zynax-ci <verb>` calls. External binaries `cosign` / `crane` / `kubectl` / `helm` remain the
+  primitives; only the decisions around them move to Go.
+
+### New entities (zynax-ci subcommands)
+
+- **`coverage-comment`** — renders the PR coverage markdown from a coverage profile/summary.
+- **`bench-gate`** — parses `benchstat` output and applies the regression threshold (pass/fail).
+- **`bdd-select`** — emits the BDD package/service matrix.
+- **`bump-runner`** — computes the next CI-runner ref and updates `images.yaml` via the existing
+  `images` internals.
+- **`images meta` / `images cleanup` / `images retag`** — image-ref/digest reporting, stale PR-image
+  cleanup via the packages API, and release-tag retag orchestration (over `crane`).
+- **`release notes` / `release matrix`** — release-notes assembly and the per-service image+digest
+  matrix that feeds the cosign/crane signing steps.
+
+### Relationship
+
+```
+GitHub workflow step  ──►  zynax-ci <verb>  ──►  (tested Go logic)
+                                   │
+                                   ├─ reads images.yaml (SoT, ADR-024)
+                                   ├─ calls GitHub API (gh/packages) for cleanup/meta
+                                   └─ emits matrix/refs consumed by thin shell that runs
+                                      cosign / crane / docker (unchanged primitives)
+
+Kept as bash (ADR-036):  scripts/e2e/*  (kind / kubectl / helm / docker drivers)
+```
+
+---
+
+## A — Approach
+
+**We will:**
+
+- Add subcommands to `cmd/zynax-ci` for each block of deterministic CI logic, each with unit tests
+  (`GOWORK=off go test ./...`), SPDX headers, functions ≤ 30 lines.
+- Migrate one gate at a time, proving behaviour parity (same pass/fail + outputs) against the bash
+  before deleting it; the consuming workflow step becomes a single `zynax-ci <verb>` call.
+- Keep `cosign` / `crane` / `kubectl` / `helm` / `docker` as the external primitives — `zynax-ci`
+  orchestrates and computes; it does not re-implement signing/attestation crypto (ADR-036 §3).
+- Reuse the existing `zynax-ci images` internals and the `images.yaml` SoT rather than re-parsing YAML.
+- Delete replaced scripts + the `report-image-meta` action and simplify Makefile recipes in the
+  cutover step (S.7), only after the new verbs are green in CI.
+
+**We will NOT:**
+
+- Port the e2e harness (`scripts/e2e/*`) — thin orchestration over external CLIs; stays bash (ADR-036).
+- Change what any gate asserts (thresholds, selection policy, which images are built/deleted) — this
+  is behaviour parity, not a policy change.
+- Re-implement cosign/SLSA attestation in Go (ADR-025 unchanged).
+- Touch the user-facing `zynax` CLI, or rewrite the Makefile wholesale.
+
+**Governing ADRs:** ADR-036 (CI logic as a Go CLI — this EPIC), ADR-024 (images.yaml SoT),
+ADR-027 (shift-left pipeline), ADR-025 (SLSA provenance — unchanged), ADR-017 (`GOWORK=off`),
+ADR-019 (this Canvas before code).
+
+---
+
+## S — Structure
+
+```
+cmd/zynax-ci/
+├── cmd/
+│   ├── coverage_comment.go      ← build-coverage-comment.sh (79)
+│   ├── bench_gate.go            ← tools/ci/bench-regression.sh (96)
+│   ├── bdd_select.go           ← tools/ci/bdd-select-packages.sh (61)
+│   ├── bump_runner.go          ← scripts/bump-ci-runner.sh (153); reuses images internals
+│   ├── images_meta.go          ← .github/actions/report-image-meta/action.yml
+│   ├── images_cleanup.go       ← pr-image-cleanup.yml gh-api/jq blocks
+│   ├── images_retag.go         ← tools-image.yml retag run: blocks (over crane)
+│   └── release_notes.go / release_matrix.go ← release.yml gh-api/jq + assembly blocks
+└── internal/…                   shared helpers + unit tests (table-driven, fixtures)
+
+Thinned (verb calls): .github/workflows/{ci,release,tools-image,pr-image-cleanup,pr-checks,*}.yml
+Removed at S.7: the replaced *.sh + report-image-meta/action.yml
+Unchanged: scripts/e2e/* (bash), cosign/crane/kubectl/helm invocations
+```
+
+Config: subcommands read env (`$GITHUB_OUTPUT`, `$GITHUB_TOKEN`, refs) — 12-Factor; no new secrets.
+
+---
+
+## O — Operations
+
+Each step is one reviewable PR. Order and GitHub issues:
+
+1. **S.1 — ADR-036** (#1286): commit the ADR (Proposed) + INDEX row; Accepted on canvas alignment.
+   Gate for all code steps.
+2. **S.2 — `coverage-comment`** (#1287): Go command + unit tests; wire the workflow step; parity on a
+   sample profile.
+3. **S.3 — `bench-gate` + `bdd-select`** (#1288): Go commands + unit tests for threshold + matrix;
+   wire both steps.
+4. **S.4 — `bump-runner`** (#1289): Go command reusing `images` internals; `make check-images` green
+   after a simulated bump.
+5. **S.5 — `images meta|cleanup|retag`** (#1290): extend the `images` group; remove the composite
+   action; wire cleanup/retag steps.
+6. **S.6 — `release` helpers** (#1291): `release notes` + `release matrix`; feed the cosign/crane
+   steps; parity dry-run. (dep S.5)
+7. **S.7 — cutover + retire** (#1292): delete replaced scripts/action; thin workflow blocks; simplify
+   Makefile; update CI best-practices docs; set ADR-036 Accepted. (dep S.2–S.6)
+
+---
+
+## N — Norms
+
+Pulled from root `AGENTS.md` §Hard Constraints, `docs/engineering/best-practices/github-ci.md`,
+`docs/engineering/best-practices/go.md`, `cmd/zynax/AGENTS.md`.
+
+- Commit hygiene: subject ≤ 72 chars, imperative, no period, no emojis; `Signed-off-by:` +
+  `Assisted-by: Claude/<model-id>` on every commit; never `Co-Authored-By:` for AI.
+- One PR per story (S.1–S.7); ≤ 400 lines excluding generated code.
+- SPDX header `// SPDX-License-Identifier: Apache-2.0` on every `.go` file.
+- `GOWORK=off` for every `go` / `go test` command in `cmd/zynax-ci` (ADR-017).
+- Go functions ≤ 30 lines; no `panic`; never discard errors; close resources via `defer`.
+- Table-driven unit tests with fixtures; prove behaviour parity before deleting any script.
+- Image refs only via `images/images.yaml` (ADR-024); never hand-edit banner-marked regions.
+- Workflow actions remain SHA-pinned, least-privilege (`permissions:`), with `concurrency` groups.
+- `cosign`/`crane`/`kubectl`/`helm` stay the external primitives; no crypto re-implementation.
+- Do not write literal email addresses in source or fixtures (gitleaks PII gate).
+
+---
+
+## S — Safeguards
+
+### Context Security (complete before committing this Canvas)
+
+- [x] No Tier 2 content: no internal hostnames, private IPs, credentials, deployment specifics
+- [x] No PII: no email literals; author name is the public maintainer of record
+- [x] No prompt injection: no instruction-like phrasing that overrides AGENTS.md rules
+- [x] All entities in E are public-safe abstractions
+- [x] `/spdd-security-review` passed — result: PASS (2026-06-16)
+
+### Feature Safeguards
+
+- **Never** change what a gate asserts during migration — behaviour parity only (thresholds,
+  selection policy, which images are built/deleted are unchanged).
+- **Never** re-implement cosign/SLSA signing or attestation crypto in Go — orchestrate the cosign
+  binary (ADR-025 unchanged).
+- **Never** delete a script (S.7) before its replacement verb is green in CI (parity proven).
+- **Never** hand-edit `images/images.yaml` banner-marked regions — use the `images` internals (ADR-024).
+- **Never** port the e2e harness in this EPIC — it stays bash (ADR-036).
+- **Never** unpin a GitHub Action SHA or widen workflow `permissions:` while thinning a step.
+- **Never** log or echo `$GITHUB_TOKEN` / registry credentials in a subcommand or workflow step.
+- **Never** commit a code step before its predecessor gate is green (S.1 before S.2+; S.2–S.6 before S.7).
+- **Never** widen scope to the user-facing `zynax` CLI or a wholesale Makefile rewrite.

--- a/state/milestone.yaml
+++ b/state/milestone.yaml
@@ -22,7 +22,8 @@ active:
     milestone: "milestone: M7"
   # EPIC W,C,G,X,T,Q,D = #1167-#1173 (new). O,L,R absorb pre-existing #467,#468,#469.
   # EPIC P = #1276 (llm-adapter Go port — ADR-035; supply-chain/maintenance).
-  open_epics: [467, 468, 469, 1167, 1168, 1169, 1170, 1171, 1172, 1173, 1276]
+  # EPIC S = #1285 (CI bash → zynax-ci Go subcommands — ADR-036; DX/supply-chain).
+  open_epics: [467, 468, 469, 1167, 1168, 1169, 1170, 1171, 1172, 1173, 1276, 1285]
 
 history:
   - name: M6

--- a/state/milestone.yaml
+++ b/state/milestone.yaml
@@ -21,7 +21,8 @@ active:
   labels:
     milestone: "milestone: M7"
   # EPIC W,C,G,X,T,Q,D = #1167-#1173 (new). O,L,R absorb pre-existing #467,#468,#469.
-  open_epics: [467, 468, 469, 1167, 1168, 1169, 1170, 1171, 1172, 1173]
+  # EPIC P = #1276 (llm-adapter Go port — ADR-035; supply-chain/maintenance).
+  open_epics: [467, 468, 469, 1167, 1168, 1169, 1170, 1171, 1172, 1173, 1276]
 
 history:
   - name: M6


### PR DESCRIPTION
## Why  (problem & intent)

The `llm-adapter` is a stateless provider proxy (streams `chat_completion` to OpenAI/Bedrock/Ollama)
yet is written in Python, dragging in the `openai`/`aiobotocore`/`aiohttp` tree that repeatedly forces
Dependabot security floors. Three of five adapters (`http`/`git`/`ci`) are already Go. This PR lands the
**planning artifacts** for M7 EPIC P — porting llm-adapter to Go — so delivery can start via `/milestone-*`.

Closes #1277 · Part of #1276

---

## What you'll get  (deliverables ↔ what changed)

- ADR-035 (the keystone decision: adapter language boundary) ← `docs/adr/ADR-035-adapter-language-boundary.md` + INDEX row
- Aligned REASONS Canvas (security-review PASS) ← `docs/spdd/1276-llm-adapter-go/canvas.md`
- EPIC P registered in milestone SoT ← `state/milestone.yaml` (`open_epics += 1276`)
- P.1–P.7 delivery rows + tally + ready-to-claim ← `docs/milestones/M7-planning.md`

GitHub artifacts already created: EPIC #1276; stories #1277–#1283 (milestone "Full Observability (M7)").

---

## Scope & boundaries

- **In scope:** planning only — ADR, canvas, milestone wiring. No adapter code in this PR.
- **Out of scope (deferred):** the Go implementation (P.2–P.7 / #1278–#1283); `langgraph` migration
  (cannot be ported — ADR-035 §Consequences); Python SDK / examples (stay Python). → #1276

---

## Type of Change

- [x] `docs` — documentation only (ADR + canvas + milestone planning/state)

---

## SPDD Canvas

- Canvas: `docs/spdd/1276-llm-adapter-go/canvas.md`
- [x] Canvas status is `Aligned`
- [x] `/spdd-security-review` passed — PASS, noted in Canvas Safeguards
- [x] Canvas commit precedes all implementation commits (no implementation in this branch)

> Note: this PR is `docs:` (planning). The `feat:` implementation PRs P.2–P.7 reference this Canvas.

---

## PR Size Self-Check

Lines changed (excluding generated/lock/fixtures): ~343 — all under `docs/` + `state/` (PR-size excluded).

- [x] ≤ 400 lines — proceed

Assisted-by: Claude/claude-opus-4-8
