### PR TITLE
docs(automation): route BEHIND-rebase, skip-ci, crash-recovery to commands

### DIFF
--- a/.claude/commands/issue-deliver.md
+++ b/.claude/commands/issue-deliver.md
@@ -534,6 +534,8 @@ Closes #${ISSUE_N}
 EOF
 
 # Fill in every <placeholder> with real evidence from STEP 7 output before committing the PR body.
+# NEVER put a literal `[skip ci]` / `[ci skip]` / `[no ci]` token in the commit message or PR body —
+# it silently skips this PR's CI AND the post-merge squash CI on main. Write "skip-ci marker" to refer to it.
 
 git commit -s -m "$(cat <<EOF
 ${COMMIT_TYPE}(<scope>): <subject>

--- a/.claude/commands/milestone-orchestrate.md
+++ b/.claude/commands/milestone-orchestrate.md
@@ -301,7 +301,12 @@ Agent({
        result), **Evidence**, **Risk & rollback**, **Review aids**. For `feat:` add the SPDD line
        (canvas Aligned + security-review PASS). Leave the "Post-merge digest sync → main" evidence
        line as a placeholder — STEP 7.5's verifier fills it after the release pipeline runs.
-    4. Wait for CI. Report result.
+    4. Wait for CI (`gh pr checks <PR> --watch --interval 30`). When green and required checks
+       pass, squash-merge (`gh pr merge <PR> --squash`; never `--rebase`). If the PR is `BEHIND`
+       (sequential batch merges advance main; required up-to-date + `required_signatures` block
+       GitHub's unsigned "Update branch"), rebase your single commit onto `origin/main` and
+       `git push --force-with-lease` (SSH signing is preserved via `rebase.gpgSign`), re-validate,
+       then merge. Report the result.
     5. Cleanup — your LAST action, always, success or failure (a SINGLE Bash call, literal path):
        ```bash
        git -C <REPO> worktree remove /tmp/zynax-orch-<RUN_ID>-<N> --force
@@ -352,6 +357,9 @@ Agent({
     - Never read files outside the issue scope.
     - Use GOWORK=off for all go commands inside service dirs (a worktree is a normal checkout).
     - Commit format: <type>(<scope>): <subject> ≤72 chars, -s flag, Assisted-by trailer.
+    - Never put a literal `[skip ci]` / `[ci skip]` / `[no ci]` token in a commit message or PR
+      body — it silently skips the PR CI **and** the post-merge squash CI on main. Write
+      "skip-ci marker" when you need to refer to it.
   """
 })
 ```
@@ -429,6 +437,39 @@ agent's output (fall back to `?` if the agent didn't emit ctx stats).
 For any agent that reported CI failure: report to user with the failing check name.
 For any agent with `compress >= 1` in its result: flag it — that expert may need splitting next time.
 Do not retry automatically — human intervention required for CI failures.
+
+### Crashed-agent delivery recovery (finalize BEFORE sweeping)
+
+An agent that crashes mid-delivery (transient API 5xx/529, OOM, classifier outage) leaves its work
+in its worktree and may already have pushed the claim branch — **do not sweep it blindly or the
+work is lost.** For every agent whose result is missing or an API-error (no `## Result` block) AND
+whose claim branch `<type>/<N>` exists on origin, **recover the delivery from the coordinator**
+before the sweep below:
+
+```bash
+# For each crashed/stalled agent N (literal worktree path):
+WT="/tmp/zynax-orch-${ORCH_RUN_ID}-${N}"
+git ls-remote origin "refs/heads/<type>/${N}" | grep -q . || continue   # no claim → nothing to recover
+PR=$(gh pr list --head "<type>/${N}" --state open --json number --jq '.[0].number // empty')
+if [ -n "$PR" ]; then
+  # PR already open — just finish it: gh pr checks "$PR" --watch --interval 30, then squash-merge.
+  echo "RECOVER: #$N has open PR #$PR — finishing"; continue
+fi
+# No PR yet → inspect the worktree and finish the delivery:
+git -C "$WT" log origin/main..HEAD --oneline    # committed-but-unpushed work?
+git -C "$WT" status --short                      # uncommitted work?
+#   uncommitted → review the diff, run the local gates, then `git -C "$WT" commit -s -F <msgfile>`
+#   committed   → already done; just push
+git -C "$WT" push -u origin "<type>/${N}"        # fast-forward (the empty claim is already there);
+#   if rejected because origin advanced → rebase onto origin/main + push --force-with-lease (see
+#   STEP 6 delivery contract step 4 — the BEHIND rule).
+# Then open the PR (canonical template body), wait for CI, squash-merge. NOW the tree is safe to sweep.
+```
+
+Recovery is the orchestrator's job, not the dead agent's: validate the recovered diff against the
+issue's acceptance criteria yourself — CI is the safety net (a broken/incomplete diff red-walls and
+you fix it or re-dispatch). Only worktrees with **no** recoverable work (no claim branch, empty tree)
+fall through to the sweep below.
 
 ### Leftover worktree sweep (crashed-agent cleanup)
 


### PR DESCRIPTION
## docs(automation): route BEHIND-rebase, skip-ci, crash-recovery to commands

Closes #_ (no issue — follow-up to /milestone-learn #1275)

### Why
`/milestone-learn` surfaced three recurring lessons but flagged them `rejected`/`pending` because they don't belong in **domain expert guides** (`--apply`'s only scope). Two were also mislabeled `structural-workaround` — they aren't shared-tree bandages (worktree isolation doesn't fix them), they're a branch-protection reality and orchestrator-recovery logic. This lands all three in their **correct layer**.

### What you'll get  (deliverables ↔ what changed)
- Subagents told to rebase + `--force-with-lease` when a PR goes `BEHIND` (sequential batch merges + `required_signatures` block GitHub's unsigned Update-branch) ← `milestone-orchestrate.md` dispatch step 4
- Both dispatch preambles forbid a literal `[skip ci]` token (silently skips PR CI **and** post-merge squash CI on main) ← `milestone-orchestrate.md` Constraints + `issue-deliver.md` commit block
- The orchestrator **finalizes a crashed agent's in-flight delivery** (commit/push/PR) before sweeping its worktree, instead of discarding the work ← `milestone-orchestrate.md` STEP 7 (new "Crashed-agent delivery recovery" subsection)

### Scope & boundaries
- **In scope:** dispatch-preamble + STEP 7 of the orchestrator commands.
- **Out of scope:** the domain expert guides (untouched — these are cross-cutting); the APPLY_LOG reclassification of rows #9/#10/#11 lands on the `/milestone-learn` PR #1275 branch.

### Test plan & acceptance
| Acceptance criterion | How verified | Result |
|---|---|---|
| BEHIND→rebase rule in orchestrate dispatch | grep step 4 | ✅ |
| skip-ci rule in both preambles | grep both files | ✅ |
| STEP 7 finalizes before sweep | new subsection precedes the sweep | ✅ |
| No expert-guide noise | diff = orchestrate + issue-deliver only | ✅ +44/-1 |

### Evidence
- CI: required checks (pending at open).
- Local: commit signed (`%G?=G`), DCO; gitleaks-clean (no emails).
- Artifacts/images: none — command-prompt docs only.
- Post-merge digest sync → main: N/A.

### Risk & rollback
None — orchestrator/agent prompt prose; no runtime/code impact. Revert to undo.

### Review aids
The STEP 7 "Crashed-agent delivery recovery" subsection is the substantive add — it codifies the manual rescue of #1187/#1202/#493/#1191 after today's API-529 crashes so the orchestrator never silently drops crashed work again.
