### PR TITLE
docs: repo truth-pass — reconcile M7 surfaces to live state (add EPICs P & S)

### DIFF
--- a/docs/milestones/M7-planning.md
+++ b/docs/milestones/M7-planning.md
@@ -216,14 +216,14 @@ The remaining open rows are tracked explicitly in the acceptance matrix ([§13](
 | D.3 Context + Git MCP guides | [#1219](https://github.com/zynax-io/zynax/issues/1219) | D #1173 | ⬜ | |
 | D.4 Observability (OTEL + Uptrace) guides | [#1220](https://github.com/zynax-io/zynax/issues/1220) | D #1173 | ⬜ | |
 | D.5 Examples index + best practices + FAQ + migration | [#1221](https://github.com/zynax-io/zynax/issues/1221) | D #1173 | ⬜ | |
-| P.1 ADR-035 adapter language boundary | [#1277](https://github.com/zynax-io/zynax/issues/1277) | P #1276 | ⬜ | accept ADR-035 on canvas-P alignment |
+| P.1 ADR-035 adapter language boundary | [#1277](https://github.com/zynax-io/zynax/issues/1277) | P #1276 | ✅ | ADR-035 Accepted; canvas-P Aligned |
 | P.2 Go scaffold + config | [#1278](https://github.com/zynax-io/zynax/issues/1278) | P #1276 | ⬜ | `GOWORK=off` module; dep P.1 |
 | P.3 Go providers (OpenAI/Bedrock/Ollama) | [#1279](https://github.com/zynax-io/zynax/issues/1279) | P #1276 | ⬜ | dep P.2 |
 | P.4 Go AgentService server (parity) | [#1280](https://github.com/zynax-io/zynax/issues/1280) | P #1276 | ⬜ | reuses `llm_adapter.feature`; dep P.3 |
 | P.5 registry + bootstrap + health | [#1281](https://github.com/zynax-io/zynax/issues/1281) | P #1276 | ⬜ | dep P.4 |
 | P.6 Dockerfile + images.yaml cutover | [#1282](https://github.com/zynax-io/zynax/issues/1282) | P #1276 | ⬜ | dep P.5; ADR-024 |
 | P.7 retire Python llm-adapter | [#1283](https://github.com/zynax-io/zynax/issues/1283) | P #1276 | ⬜ | dep P.6 |
-| S.1 ADR-036 CI logic as a Go CLI | [#1286](https://github.com/zynax-io/zynax/issues/1286) | S #1285 | ⬜ | accept ADR-036 on canvas-S alignment |
+| S.1 ADR-036 CI logic as a Go CLI | [#1286](https://github.com/zynax-io/zynax/issues/1286) | S #1285 | ✅ | ADR-036 Accepted; canvas-S Aligned |
 | S.2 `zynax-ci coverage-comment` | [#1287](https://github.com/zynax-io/zynax/issues/1287) | S #1285 | ⬜ | ← build-coverage-comment.sh; dep S.1 |
 | S.3 `zynax-ci bench-gate` + `bdd-select` | [#1288](https://github.com/zynax-io/zynax/issues/1288) | S #1285 | ⬜ | ← bench-regression + bdd-select scripts; dep S.1 |
 | S.4 `zynax-ci bump-runner` | [#1289](https://github.com/zynax-io/zynax/issues/1289) | S #1285 | ⬜ | ← bump-ci-runner.sh; images.yaml SoT; dep S.1 |

--- a/state/current-milestone.md
+++ b/state/current-milestone.md
@@ -37,7 +37,7 @@ Goal: a developer authors a real multi-step workflow, runs it locally (`docker c
 **Uptrace**), watches it execute state→state with **data-flow**, **streamed logs**, and a connected
 **distributed trace** in the Uptrace login UI — with green `make ci`.
 
-### EPICs (10) — one REASONS Canvas each under `docs/spdd/<letter>-<slug>/`
+### EPICs (12) — one REASONS Canvas each under `docs/spdd/<letter>-<slug>/`
 | EPIC | Title | Type | Canvas |
 |------|-------|------|--------|
 | W | Workflow data-flow (output/input bindings) — **keystone** | feat | [W](../docs/spdd/1167-workflow-data-flow/canvas.md) |
@@ -50,17 +50,22 @@ Goal: a developer authors a real multi-step workflow, runs it locally (`docker c
 | R | Test rigor (absorbs #469; #493 #553 #1103) | test | [R](../docs/spdd/469-test-rigor/canvas.md) |
 | Q | Quality & supply-chain fixes (pip CVE · coverage gate · PyPI Trusted Publisher) | chore/ci | [Q](../docs/spdd/1172-quality-supply-chain/canvas.md) |
 | D | Docs — quick-start · authoring · observability | docs | [D](../docs/spdd/1173-docs/canvas.md) |
+| P | Port `llm-adapter` to Go (language-boundary cleanup, ADR-035) | refactor | [P](../docs/spdd/1276-llm-adapter-go/canvas.md) |
+| S | Consolidate CI bash into the `zynax-ci` Go CLI (ADR-036) | ci | [S](../docs/spdd/1285-ci-bash-to-go/canvas.md) |
 
 Pre-existing M7 EPICs #467 (OTel) / #468 (history streaming) / #469 (test rigor) are **absorbed** into
 O / L / R respectively. New ADRs: ADR-029…034 (Proposed).
 
-**Delivery (as of 2026-06-16):** GitHub milestone #7 — **27 closed / 42 open**. EPIC canvases
-**X #1170 and T #1171 aligned** this pass (security-reviewed PASS); O/L/R/W/G/470/471 already
-Aligned; C/Q/D still Draft. Shipped this pass: O.4 #1187 + O.7 #1190 + O.8 #1191 (Observability —
-exemplars, compose & Helm Uptrace), X.2 #1202 (`agents/examples`), R.1 #493 (benchmarks + benchstat
-gate), Q.4 #1215 / Q.5 #1216 (Go-module consumption doc + ADR-034). **Security tab clean** — all 8
+**Delivery (as of 2026-06-17):** GitHub milestone #7 — **30 closed / 56 open** (two EPICs added
+2026-06-16: **P #1276** llm-adapter Go-port and **S #1285** CI-bash-to-Go, both canvases Aligned).
+X #1170 / T #1171 aligned earlier; O/L/R/W/G/470/471 already Aligned; C/Q/D still Draft. Shipped:
+O.4 #1187 + O.7 #1190 + O.8 #1191 (Observability — exemplars, compose & Helm Uptrace), X.2 #1202
+(`agents/examples`), R.1 #493 (benchmarks + benchstat gate), Q.4 #1215 / Q.5 #1216 (Go-module
+consumption + ADR-034), P.1 #1277 / S.1 #1286 (ADR-035 / ADR-036). **Security tab clean** — all 8
 Dependabot (aiohttp → 3.14.1) and ~200 Trivy code-scanning alerts fixed (adapters rebuilt on fresh
-`python:3.12-alpine`; stale pre-alpine Debian CVEs superseded, not dismissed).
+`python:3.12-alpine`; stale pre-alpine Debian CVEs superseded, not dismissed). Process: 8
+expert-guide learnings applied (#1275); BEHIND-rebase / skip-ci / crashed-agent-recovery routed into
+the orchestrator commands (#1293).
 
 ---
 


### PR DESCRIPTION
## docs: repo truth-pass — reconcile M7 surfaces to live state (add EPICs P & S)

Closes #_ (no issue — /repo-clean truth-pass)

### Why
Two EPICs were scaffolded after the last truth-pass (P #1276 llm-adapter Go-port / S #1285 CI-bash-to-Go, ADR-035/036), and their first steps merged. `state/current-milestone.md` lagged. Reconciled to **live GitHub state**.

### What was stale (and is now fixed)
| Surface | Was | Now | Driver |
|---|---|---|---|
| current-milestone EPIC table | "EPICs (10)", W…D only | **"EPICs (12)"** + P (#1276, canvas Aligned) & S (#1285, canvas Aligned) rows | 2 new `type: epic` issues |
| current-milestone Delivery block | "27 closed / 42 open (2026-06-16)" | **"30 closed / 56 open (2026-06-17)"** + P/S aligned, learnings #1275 + command-routing #1293 noted | gh milestones |
| M7-planning P.1 #1277 | ⬜ | ✅ | #1277 closed (ADR-035 Accepted) |
| M7-planning S.1 #1286 | ⬜ | ✅ | #1286 closed (ADR-036 Accepted) |

### Verified consistent — no change
README / ROADMAP / ARCHITECTURE / CLAUDE = **M7 🚧 Active**. M7-planning already carried the P/S EPIC rows (you added them when scaffolding). No canvas `Status:` flips (no EPIC fully delivered — 56 open). `make check-images` → **aligned** (no images.yaml drift). 0 `[AUTO]` issues.

### Not touched
AGENTS.md, ADRs (incl. ADR-035/036), .feature contracts.
