### PR TITLE
docs(spdd): align M7 EPIC C/Q/D canvases (Draft to Aligned)

### DIFF
--- a/docs/spdd/1168-context-propagation/canvas.md
+++ b/docs/spdd/1168-context-propagation/canvas.md
@@ -3,7 +3,7 @@
 > Tier 1 (public-safe). Tier 2 → `canvas.private.md`. Run `/spdd-security-review` before committing.
 
 **Issue:** #1168 · **Milestone:** M7 (v0.6.0)
-**Author:** M7 program plan · **Date:** 2026-06-15 · **Status:** Draft
+**Author:** M7 program plan · **Date:** 2026-06-15 · **Status:** Aligned (operator-approved 2026-06-17; Tier-2/injection scan clean)
 
 ---
 

--- a/docs/spdd/1172-quality-supply-chain/canvas.md
+++ b/docs/spdd/1172-quality-supply-chain/canvas.md
@@ -3,7 +3,7 @@
 > Tier 1 (public-safe). `chore:`/`ci:`/`docs:` work is SPDD-exempt; committed for traceability.
 
 **Issue:** #1172 + #582 #583 · **Milestone:** M7 (v0.6.0)
-**Author:** M7 program plan · **Date:** 2026-06-15 · **Status:** Draft
+**Author:** M7 program plan · **Date:** 2026-06-15 · **Status:** Aligned (operator-approved 2026-06-17; chore/ci/docs SPDD-exempt)
 
 ---
 

--- a/docs/spdd/1173-docs/canvas.md
+++ b/docs/spdd/1173-docs/canvas.md
@@ -3,7 +3,7 @@
 > Tier 1 (public-safe). `docs:` work is SPDD-exempt; committed for traceability.
 
 **Issue:** #1173 · **Milestone:** M7 (v0.6.0)
-**Author:** M7 program plan · **Date:** 2026-06-15 · **Status:** Draft
+**Author:** M7 program plan · **Date:** 2026-06-15 · **Status:** Aligned (operator-approved 2026-06-17; docs SPDD-exempt)
 
 ---
 


### PR DESCRIPTION
Operator-approved alignment of the three remaining Draft canvases (C #1168, Q #1172, D #1173) to unblock their stories. C is feat: — Tier-2/injection scan clean; Q/D are SPDD-exempt.

Assisted-by: Claude/claude-opus-4-8

🤖 Generated with [Claude Code](https://claude.com/claude-code)