### PR TITLE
ci: sync security-agents pip-audit with ci.yml ignore-vuln

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -324,7 +324,7 @@ security-go-adapters: ensure-tools ## govulncheck on all Go adapter modules
 	done && echo "✅ Adapter security scan passed"
 
 security-agents: ensure-tools ## bandit + pip-audit on SDK + all agents
-	@$(TOOLS_RUN) sh -c "cd agents/sdk && uv run bandit -r src/ -ll && uv run pip-audit"
+	@$(TOOLS_RUN) sh -c "cd agents/sdk && uv run bandit -r src/ -ll && uv run pip-audit --ignore-vuln PYSEC-2026-196"
 	@for a in $(AGENTS); do [ -f "agents/examples/$$a/pyproject.toml" ] && \
 		$(TOOLS_RUN) sh -c "cd agents/examples/$$a && uv run bandit -r src/ -ll && uv run pip-audit" || true; done
 


### PR DESCRIPTION
Closes #1302

### Why  (problem & intent)
`make security` (target `security-agents`) ran the SDK `pip-audit` without the `--ignore-vuln PYSEC-2026-196` flag that CI uses at `.github/workflows/ci.yml:666`, so it exited rc=2 locally on a transient `pip 26.1.1` false positive (uv pulls pip into an ephemeral audit env; zynax-sdk does not ship pip, and the tools image already pins `pip==26.1.2`). CI was green, local was red — pure Makefile↔CI drift, not a shipped vulnerability. This advances EPIC Q (#1172): `make ci` green on a clean checkout.

### What you'll get  (deliverables ↔ what changed)
- `make security` exits 0 on a clean checkout with the current tools image ← `Makefile` (`security-agents` SDK `pip-audit` now `--ignore-vuln PYSEC-2026-196`)
- Makefile and ci.yml share one ignore policy — no further drift ← `Makefile` line matches `ci.yml:666` exactly

### Scope & boundaries
- **In scope:** the single SDK `pip-audit` invocation in `security-agents` (one line in `Makefile`).
- **Out of scope (deferred):** the per-example-agent audits — CI does NOT pass `--ignore-vuln` there (ci.yml:677), so the Makefile loop is intentionally left unchanged. N/A otherwise.

### Test plan & acceptance

| Acceptance criterion | How verified (command) | Result |
|----------------------|------------------------|--------|
| `make security` exits 0 on a clean checkout with the current tools image | `make security` | ✅ rc=0 — `No known vulnerabilities found, 1 ignored` (SDK pip-audit) |
| Makefile and ci.yml use the same ignore/pin policy (no drift) | diff of `Makefile:327` vs `ci.yml:666` | ✅ both `uv run pip-audit --ignore-vuln PYSEC-2026-196` |

**Local gates:** `make security` ✅

### Evidence
- **CI:** all required checks green (see this PR's run).
- **Local output:** `make security` → `rc=0`; SDK audit prints `No known vulnerabilities found, 1 ignored` (PYSEC-2026-196 ignored, matching CI).
- **Artifacts / images:** none — no service source changed; `Makefile` only.
- **Post-merge digest sync → main:** N/A — no image rebuild.

### Risk & rollback
Low — single-line change to a developer-facing make target; no behaviour change to CI or any shipped artifact. Rollback = revert this PR.

### Review aids
One file, one line: `Makefile` `security-agents` target. The change makes the local SDK audit match `ci.yml:666` verbatim. Note the per-example-agent loop is deliberately unchanged to mirror CI's per-agent audits, which do not ignore.

**AI:** `Assisted-by: Claude/claude-opus-4-8`
