### PR TITLE
feat(engine-adapter): workflow-scoped data context

### DIFF
--- a/services/engine-adapter/internal/domain/datacontext.go
+++ b/services/engine-adapter/internal/domain/datacontext.go
@@ -1,0 +1,214 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package domain contains the core port definitions and value types for the
+// engine-adapter service. It has zero imports from api or infrastructure layers.
+package domain
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// dataRefPrefix marks an input binding value as a JSON-path reference into the
+// workflow-scoped data context rather than a literal value (ADR-029 §1).
+const dataRefPrefix = "$."
+
+// DataReferenceError is a structured error returned when an input binding
+// reference cannot be resolved against the workflow-scoped data context, or
+// when a referenced/extracted value is not a coercible scalar (a typed
+// mismatch). It fails the run loudly per ADR-029 — there is no implicit
+// fallback to an empty value.
+type DataReferenceError struct {
+	// InputKey is the input_bindings key whose value failed to resolve.
+	InputKey string
+	// Reference is the raw binding value (the `$.states.<state>.output.<key>`
+	// path or the offending literal).
+	Reference string
+	// Reason is a human-readable explanation ("not found", "type mismatch", ...).
+	Reason string
+}
+
+func (e *DataReferenceError) Error() string {
+	return fmt.Sprintf(
+		"engine-adapter: input %q reference %q: %s",
+		e.InputKey, e.Reference, e.Reason,
+	)
+}
+
+// WorkflowDataContext is the run-scoped key/value store that backs data-flow
+// between states (ADR-029 §2). It is written only by an action's
+// output_bindings and read only by a downstream action's input_bindings —
+// there is no implicit/global mutable state. It lives for a single workflow
+// run and is never persisted beyond it.
+//
+// Keys are canonical dotted paths of the form "states.<stateID>.output.<key>";
+// values are the scalar string form of the extracted output. The interpreter
+// owns exactly one instance per Run (behind the WorkflowEngine interface).
+type WorkflowDataContext struct {
+	store map[string]string
+}
+
+// NewWorkflowDataContext returns an empty run-scoped data context.
+func NewWorkflowDataContext() *WorkflowDataContext {
+	return &WorkflowDataContext{store: make(map[string]string)}
+}
+
+// WriteOutputs extracts each declared output from the action's result payload
+// and publishes it into the context under "states.<stateID>.output.<key>".
+//
+// bindings maps a context key to a source path within the JSON payload (a
+// dotted path, e.g. "results" or "data.score"). A binding whose source path
+// does not resolve to a scalar value is reported as a typed mismatch so the
+// run fails loudly rather than storing an unusable value. A nil/empty bindings
+// map is a no-op (actions that publish nothing).
+func (c *WorkflowDataContext) WriteOutputs(stateID string, bindings map[string]string, payload []byte) error {
+	if len(bindings) == 0 {
+		return nil
+	}
+	var doc map[string]json.RawMessage
+	if len(payload) > 0 {
+		if err := json.Unmarshal(payload, &doc); err != nil {
+			return &DataReferenceError{
+				InputKey:  stateID,
+				Reference: string(payload),
+				Reason:    fmt.Sprintf("output payload is not a JSON object: %v", err),
+			}
+		}
+	}
+	for key, sourcePath := range bindings {
+		val, err := extractScalar(doc, sourcePath)
+		if err != nil {
+			return &DataReferenceError{
+				InputKey:  key,
+				Reference: sourcePath,
+				Reason:    err.Error(),
+			}
+		}
+		c.store[outputKey(stateID, key)] = val
+	}
+	return nil
+}
+
+// ResolveInputs resolves an action's input_bindings into a flat key/value map
+// ready to merge into the interpreter's template context. Each binding value
+// is either a literal (returned verbatim) or a "$.states.<state>.output.<key>"
+// reference resolved against the store. A reference that does not resolve is a
+// DataReferenceError — the run fails rather than substituting an empty value.
+// A nil/empty bindings map yields a nil result (actions that consume nothing).
+func (c *WorkflowDataContext) ResolveInputs(bindings map[string]string) (map[string]string, error) {
+	if len(bindings) == 0 {
+		return nil, nil
+	}
+	resolved := make(map[string]string, len(bindings))
+	for inputKey, ref := range bindings {
+		if !strings.HasPrefix(ref, dataRefPrefix) {
+			// Literal value — consumed verbatim (ADR-029 §1).
+			resolved[inputKey] = ref
+			continue
+		}
+		key, err := canonicalRefKey(ref)
+		if err != nil {
+			return nil, &DataReferenceError{InputKey: inputKey, Reference: ref, Reason: err.Error()}
+		}
+		val, ok := c.store[key]
+		if !ok {
+			return nil, &DataReferenceError{
+				InputKey:  inputKey,
+				Reference: ref,
+				Reason:    "not found in workflow data context",
+			}
+		}
+		resolved[inputKey] = val
+	}
+	return resolved, nil
+}
+
+// mergeInputs overlays resolved input bindings onto the base template context
+// without mutating base. Resolved inputs win on key collision (an explicit
+// input binding overrides ambient ctx). When inputs is empty the base map is
+// returned unchanged to avoid an allocation on the common no-bindings path.
+func mergeInputs(base, inputs map[string]string) map[string]string {
+	if len(inputs) == 0 {
+		return base
+	}
+	merged := make(map[string]string, len(base)+len(inputs))
+	for k, v := range base {
+		merged[k] = v
+	}
+	for k, v := range inputs {
+		merged[k] = v
+	}
+	return merged
+}
+
+// outputKey returns the canonical store key for a state's named output.
+func outputKey(stateID, key string) string {
+	return "states." + stateID + ".output." + key
+}
+
+// canonicalRefKey converts a "$.states.<state>.output.<key>" reference into the
+// canonical store key "states.<state>.output.<key>". A reference that does not
+// match the only supported shape is rejected — there is no expression language
+// in M7 (ADR-029 §1).
+func canonicalRefKey(ref string) (string, error) {
+	path := strings.TrimPrefix(ref, dataRefPrefix)
+	parts := strings.Split(path, ".")
+	// Expected shape: states.<state>.output.<key> (4 segments, non-empty).
+	if len(parts) != 4 || parts[0] != "states" || parts[2] != "output" ||
+		parts[1] == "" || parts[3] == "" {
+		return "", fmt.Errorf("malformed reference; expected %sstates.<state>.output.<key>", dataRefPrefix)
+	}
+	return path, nil
+}
+
+// extractScalar reads sourcePath (a dotted path) from a JSON object and returns
+// the value as its scalar string form. Strings, numbers, and booleans are
+// supported; an object, array, or null at the target path is a type mismatch.
+// A path segment that is absent is reported as "not found".
+func extractScalar(doc map[string]json.RawMessage, sourcePath string) (string, error) {
+	if sourcePath == "" {
+		return "", fmt.Errorf("empty source path")
+	}
+	segments := strings.Split(sourcePath, ".")
+	cur := doc
+	for i, seg := range segments {
+		raw, ok := cur[seg]
+		if !ok {
+			return "", fmt.Errorf("source path %q not found in output payload", sourcePath)
+		}
+		if i == len(segments)-1 {
+			return scalarString(raw)
+		}
+		var next map[string]json.RawMessage
+		if err := json.Unmarshal(raw, &next); err != nil {
+			return "", fmt.Errorf("source path %q traverses a non-object at %q", sourcePath, seg)
+		}
+		cur = next
+	}
+	return "", fmt.Errorf("source path %q not found in output payload", sourcePath)
+}
+
+// scalarString decodes a JSON value into its string form. Objects, arrays, and
+// null are rejected as typed mismatches (the data context stores scalars only;
+// ADR-029 §3 — no typed schema, stringly-typed paths).
+func scalarString(raw json.RawMessage) (string, error) {
+	var v any
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return "", fmt.Errorf("type mismatch: undecodable value")
+	}
+	switch t := v.(type) {
+	case string:
+		return t, nil
+	case bool:
+		if t {
+			return "true", nil
+		}
+		return "false", nil
+	case float64:
+		// Render without a trailing ".0" for integral values.
+		return strings.TrimSuffix(strings.TrimRight(fmt.Sprintf("%f", t), "0"), "."), nil
+	default:
+		return "", fmt.Errorf("type mismatch: expected scalar, got %T", v)
+	}
+}

--- a/services/engine-adapter/internal/domain/datacontext_test.go
+++ b/services/engine-adapter/internal/domain/datacontext_test.go
@@ -1,0 +1,311 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package domain contains the core port definitions and value types for the
+// engine-adapter service. It has zero imports from api or infrastructure layers.
+package domain
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	zynaxv1 "github.com/zynax-io/zynax/protos/generated/go/zynax/v1"
+)
+
+func TestWorkflowDataContext_WriteOutputs(t *testing.T) {
+	cases := []struct {
+		name     string
+		stateID  string
+		bindings map[string]string
+		payload  string
+		wantKey  string
+		wantVal  string
+	}{
+		{"string output", "search", map[string]string{"results": "results"}, `{"results":"found-it"}`, "states.search.output.results", "found-it"},
+		{"integral number drops trailing zeros", "score", map[string]string{"n": "value"}, `{"value":42}`, "states.score.output.n", "42"},
+		{"fractional number keeps decimals", "score", map[string]string{"n": "value"}, `{"value":3.5}`, "states.score.output.n", "3.5"},
+		{"bool output", "gate", map[string]string{"ok": "passed"}, `{"passed":true}`, "states.gate.output.ok", "true"},
+		{"false bool output", "gate", map[string]string{"ok": "passed"}, `{"passed":false}`, "states.gate.output.ok", "false"},
+		{"nested source path", "build", map[string]string{"sha": "meta.sha"}, `{"meta":{"sha":"abc123"}}`, "states.build.output.sha", "abc123"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dc := NewWorkflowDataContext()
+			if err := dc.WriteOutputs(tc.stateID, tc.bindings, []byte(tc.payload)); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got := dc.store[tc.wantKey]; got != tc.wantVal {
+				t.Errorf("store[%q] = %q; want %q", tc.wantKey, got, tc.wantVal)
+			}
+		})
+	}
+}
+
+func TestWorkflowDataContext_WriteOutputs_Errors(t *testing.T) {
+	cases := []struct {
+		name     string
+		bindings map[string]string
+		payload  string
+	}{
+		{"missing source path", map[string]string{"results": "absent"}, `{"results":"x"}`},
+		{"object value is a type mismatch", map[string]string{"results": "obj"}, `{"obj":{"k":"v"}}`},
+		{"array value is a type mismatch", map[string]string{"results": "arr"}, `{"arr":[1,2,3]}`},
+		{"null value is a type mismatch", map[string]string{"results": "n"}, `{"n":null}`},
+		{"non-object payload", map[string]string{"results": "x"}, `not-json`},
+		{"traversing a non-object segment", map[string]string{"sha": "meta.sha"}, `{"meta":"flat"}`},
+		{"empty source path", map[string]string{"results": ""}, `{"results":"x"}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dc := NewWorkflowDataContext()
+			err := dc.WriteOutputs("search", tc.bindings, []byte(tc.payload))
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			var dre *DataReferenceError
+			if !errors.As(err, &dre) {
+				t.Fatalf("expected *DataReferenceError, got %T: %v", err, err)
+			}
+		})
+	}
+}
+
+func TestWorkflowDataContext_WriteOutputs_NoBindings(t *testing.T) {
+	dc := NewWorkflowDataContext()
+	if err := dc.WriteOutputs("s", nil, []byte(`{"x":"y"}`)); err != nil {
+		t.Fatalf("nil bindings should be a no-op, got: %v", err)
+	}
+	if len(dc.store) != 0 {
+		t.Errorf("store should be empty, got %d entries", len(dc.store))
+	}
+}
+
+func TestWorkflowDataContext_WriteOutputs_EmptyPayload(t *testing.T) {
+	dc := NewWorkflowDataContext()
+	err := dc.WriteOutputs("s", map[string]string{"k": "v"}, nil)
+	if err == nil {
+		t.Fatal("expected error extracting from empty payload")
+	}
+}
+
+func TestWorkflowDataContext_ResolveInputs(t *testing.T) {
+	dc := NewWorkflowDataContext()
+	if err := dc.WriteOutputs("search", map[string]string{"results": "results"}, []byte(`{"results":"data"}`)); err != nil {
+		t.Fatalf("seed write failed: %v", err)
+	}
+
+	cases := []struct {
+		name     string
+		bindings map[string]string
+		wantKey  string
+		wantVal  string
+		wantErr  bool
+	}{
+		{
+			name:     "reference resolves",
+			bindings: map[string]string{"query": "$.states.search.output.results"},
+			wantKey:  "query",
+			wantVal:  "data",
+		},
+		{
+			name:     "literal passes through",
+			bindings: map[string]string{"mode": "fast"},
+			wantKey:  "mode",
+			wantVal:  "fast",
+		},
+		{
+			name:     "missing reference is an error",
+			bindings: map[string]string{"q": "$.states.search.output.absent"},
+			wantErr:  true,
+		},
+		{
+			name:     "reference to unknown state is an error",
+			bindings: map[string]string{"q": "$.states.nope.output.results"},
+			wantErr:  true,
+		},
+		{
+			name:     "malformed reference is an error",
+			bindings: map[string]string{"q": "$.states.search.results"},
+			wantErr:  true,
+		},
+		{
+			name:     "empty-segment reference is an error",
+			bindings: map[string]string{"q": "$.states..output.results"},
+			wantErr:  true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := dc.ResolveInputs(tc.bindings)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil (resolved=%v)", got)
+				}
+				var dre *DataReferenceError
+				if !errors.As(err, &dre) {
+					t.Fatalf("expected *DataReferenceError, got %T: %v", err, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got[tc.wantKey] != tc.wantVal {
+				t.Errorf("resolved[%q] = %q; want %q", tc.wantKey, got[tc.wantKey], tc.wantVal)
+			}
+		})
+	}
+}
+
+func TestWorkflowDataContext_ResolveInputs_NoBindings(t *testing.T) {
+	dc := NewWorkflowDataContext()
+	got, err := dc.ResolveInputs(nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil result for nil bindings, got %v", got)
+	}
+}
+
+func TestDataReferenceError_Error(t *testing.T) {
+	e := &DataReferenceError{InputKey: "q", Reference: "$.states.s.output.k", Reason: "not found"}
+	want := `engine-adapter: input "q" reference "$.states.s.output.k": not found`
+	if got := e.Error(); got != want {
+		t.Errorf("Error() = %q; want %q", got, want)
+	}
+}
+
+func TestMergeInputs(t *testing.T) {
+	base := map[string]string{"a": "1", "b": "2"}
+	if got := mergeInputs(base, nil); got["a"] != "1" || got["b"] != "2" {
+		t.Fatalf("nil inputs should return base unchanged, got %v", got)
+	}
+	merged := mergeInputs(base, map[string]string{"b": "override", "c": "3"})
+	if merged["a"] != "1" || merged["b"] != "override" || merged["c"] != "3" {
+		t.Errorf("merge = %v; want a=1 b=override c=3", merged)
+	}
+	// base must not be mutated.
+	if base["b"] != "2" {
+		t.Errorf("base was mutated: %v", base)
+	}
+}
+
+// TestIRInterpreter_DataFlowHappyPath proves an upstream output is stored and a
+// downstream state's input binding resolves it (acceptance criterion 1).
+func TestIRInterpreter_DataFlowHappyPath(t *testing.T) {
+	exec := &stubExecutor{
+		results: map[string]*ActivityResult{
+			"search": {
+				EventType: "search.done",
+				Payload:   []byte(`{"_event":"search.done","results":"the-answer"}`),
+			},
+			"summarize": {EventType: "summarize.done"},
+		},
+	}
+	var captured ActivityInput
+	capExec := &captureNamed{inner: exec, name: "summarize", capture: &captured}
+	ir := buildIR("wf-dataflow", "search",
+		normal("search",
+			[]*zynaxv1.ActionIR{{
+				Capability:     "search",
+				OutputBindings: map[string]string{"results": "results"},
+			}},
+			[]*zynaxv1.TransitionIR{transition("search.done", "summarize", nil)},
+		),
+		normal("summarize",
+			[]*zynaxv1.ActionIR{{
+				Capability:        "summarize",
+				InputBindings:     map[string]string{"text": "$.states.search.output.results"},
+				InputTemplateJson: `{"in":"{{ .ctx.text }}"}`,
+			}},
+			[]*zynaxv1.TransitionIR{transition("summarize.done", "done", nil)},
+		),
+		terminal("done"),
+	)
+	if err := (&IRInterpreter{}).Run(context.Background(), ir, capExec, &stubPublisher{}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(captured.InputPayload) != `{"in":"the-answer"}` {
+		t.Errorf("downstream input = %s; want {\"in\":\"the-answer\"}", captured.InputPayload)
+	}
+}
+
+// TestIRInterpreter_DataFlowMissingReferenceFailsRun proves an unresolved input
+// reference fails the run with a structured error and emits the failed event
+// (acceptance criterion 2).
+func TestIRInterpreter_DataFlowMissingReferenceFailsRun(t *testing.T) {
+	ir := buildIR("wf-dataflow-missing", "summarize",
+		normal("summarize",
+			[]*zynaxv1.ActionIR{{
+				Capability:    "summarize",
+				InputBindings: map[string]string{"text": "$.states.search.output.results"},
+			}},
+			[]*zynaxv1.TransitionIR{transition("summarize.done", "done", nil)},
+		),
+		terminal("done"),
+	)
+	pub := &stubPublisher{}
+	err := (&IRInterpreter{}).Run(context.Background(), ir, &stubExecutor{}, pub)
+	if err == nil {
+		t.Fatal("expected run to fail on unresolved reference")
+	}
+	var dre *DataReferenceError
+	if !errors.As(err, &dre) {
+		t.Fatalf("expected *DataReferenceError, got %T: %v", err, err)
+	}
+	found := false
+	for _, e := range pub.events {
+		if e == "zynax.workflow.failed" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected zynax.workflow.failed event, got: %v", pub.events)
+	}
+}
+
+// TestIRInterpreter_DataFlowTypeMismatchFailsRun proves a typed-mismatch output
+// (a non-scalar value at the source path) fails the run (acceptance criterion 2).
+func TestIRInterpreter_DataFlowTypeMismatchFailsRun(t *testing.T) {
+	exec := &stubExecutor{
+		results: map[string]*ActivityResult{
+			"search": {
+				EventType: "search.done",
+				Payload:   []byte(`{"_event":"search.done","results":{"nested":"obj"}}`),
+			},
+		},
+	}
+	ir := buildIR("wf-dataflow-mismatch", "search",
+		normal("search",
+			[]*zynaxv1.ActionIR{{
+				Capability:     "search",
+				OutputBindings: map[string]string{"results": "results"},
+			}},
+			[]*zynaxv1.TransitionIR{transition("search.done", "done", nil)},
+		),
+		terminal("done"),
+	)
+	err := (&IRInterpreter{}).Run(context.Background(), ir, exec, &stubPublisher{})
+	if err == nil {
+		t.Fatal("expected run to fail on typed-mismatch output")
+	}
+	var dre *DataReferenceError
+	if !errors.As(err, &dre) {
+		t.Fatalf("expected *DataReferenceError, got %T: %v", err, err)
+	}
+}
+
+// captureNamed wraps an executor and records the ActivityInput for a named capability.
+type captureNamed struct {
+	inner   *stubExecutor
+	name    string
+	capture *ActivityInput
+}
+
+func (c *captureNamed) DispatchCapability(ctx context.Context, in ActivityInput) (*ActivityResult, error) {
+	if in.CapabilityName == c.name {
+		*c.capture = in
+	}
+	return c.inner.DispatchCapability(ctx, in)
+}

--- a/services/engine-adapter/internal/domain/interpreter.go
+++ b/services/engine-adapter/internal/domain/interpreter.go
@@ -57,6 +57,9 @@ func (i *IRInterpreter) Run(
 		CurrentState: ir.GetInitialState(),
 		Ctx:          make(map[string]string),
 	}
+	// data is the run-scoped data context (ADR-029): written by output_bindings,
+	// read by input_bindings. It lives for this Run only and is never persisted.
+	data := NewWorkflowDataContext()
 	for {
 		state := findState(ir, ec.CurrentState)
 		if state == nil {
@@ -71,7 +74,7 @@ func (i *IRInterpreter) Run(
 		if err := pub.Publish(ctx, "zynax.workflow.state.entered", ec.WorkflowID, ec.CurrentState); err != nil {
 			return fmt.Errorf("engine-adapter: publish state.entered: %w", err)
 		}
-		result, err := executeActions(ctx, state, ec, exec)
+		result, err := executeActions(ctx, state, ec, exec, data)
 		if err != nil {
 			if perr := pub.Publish(ctx, "zynax.workflow.failed", ec.WorkflowID, ec.CurrentState); perr != nil {
 				slog.Warn("lifecycle event publish failed", "event", "zynax.workflow.failed", "workflow_id", ec.WorkflowID, "err", perr)
@@ -102,6 +105,7 @@ func executeActions(
 	state *zynaxv1.StateIR,
 	ec *ExecutionContext,
 	exec ActivityExecutor,
+	data *WorkflowDataContext,
 ) (*ActivityResult, error) {
 	var last *ActivityResult
 	for _, action := range state.GetActions() {
@@ -116,7 +120,15 @@ func executeActions(
 			}
 			timeoutSec = int32(sec)
 		}
-		resolved, err := resolveTemplate(action.GetInputTemplateJson(), ec.Ctx)
+		// Resolve input_bindings from the run-scoped data context (ADR-029) and
+		// merge them into the template context. A missing or typed-mismatch
+		// reference fails the run with a structured DataReferenceError.
+		inputs, err := data.ResolveInputs(action.GetInputBindings())
+		if err != nil {
+			return nil, err
+		}
+		tmplCtx := mergeInputs(ec.Ctx, inputs)
+		resolved, err := resolveTemplate(action.GetInputTemplateJson(), tmplCtx)
 		if err != nil {
 			return nil, fmt.Errorf("engine-adapter: action %q template error: %w", action.GetCapability(), err)
 		}
@@ -129,6 +141,11 @@ func executeActions(
 		result, err := exec.DispatchCapability(ctx, in)
 		if err != nil {
 			return nil, fmt.Errorf("engine-adapter: action %q: %w", action.GetCapability(), err)
+		}
+		// Publish this action's declared output_bindings into the data context
+		// so downstream states can consume them (ADR-029).
+		if err := data.WriteOutputs(state.GetId(), action.GetOutputBindings(), result.Payload); err != nil {
+			return nil, err
 		}
 		last = result
 	}


### PR DESCRIPTION
## feat(engine-adapter): workflow-scoped data context

Closes #1178
Part of #1167 (EPIC W — Workflow Data-Flow)

### Why
W.3 lifted the compiler's `output:` rejection and compiles output/input bindings into the IR,
but the interpreter still ignored them — so a compiled binding never moved a value between
states at run time. W.4 (canvas `docs/spdd/1167-workflow-data-flow/canvas.md`) threads a
run-scoped data context through `IRInterpreter` so outputs are stored and downstream inputs
resolve from them (ADR-029).

### What you'll get
- a run-scoped `WorkflowDataContext` (written by `output_bindings`, read by `input_bindings`, never persisted) ← `services/engine-adapter/internal/domain/datacontext.go`
- the interpreter publishes each action's outputs and resolves a downstream action's inputs before dispatch ← `services/engine-adapter/internal/domain/interpreter.go`
- a structured `DataReferenceError` that fails the run on a missing reference or a typed (non-scalar) mismatch ← `datacontext.go`

### Scope & boundaries
- **In scope:** store outputs under `states.<state>.output.<key>`; resolve `input_bindings` literals and `$.states.<state>.output.<key>` references; merge resolved inputs into the template context; fail the run with a structured error on a missing/typed-mismatch reference.
- **Out of scope (deferred):** persistence of the context beyond the run (ADR-029 non-goal); any expression/transform language (→ M-dx); end-to-end example workflows running green (→ W.5 #1179).

### Test plan & acceptance
| Acceptance criterion | How verified (command) | Result |
|----------------------|------------------------|--------|
| interpreter writes action outputs into a run-scoped context and resolves inputs from it | `GOWORK=off go test ./internal/domain/... -race -run DataFlowHappyPath` | ✅ pass — downstream input resolved to `{"in":"the-answer"}` |
| missing/typed-mismatch reference fails the run with a structured error | `GOWORK=off go test ./internal/domain/... -race -run 'DataFlowMissingReferenceFailsRun|DataFlowTypeMismatchFailsRun'` | ✅ pass — `*DataReferenceError` + `zynax.workflow.failed` emitted |
| domain coverage ≥90% | `GOWORK=off go test ./internal/domain/... -coverprofile=… && go tool cover -func` | ✅ 93.1% |

**Local gates:** `make lint-go` ✅ (0 issues) · `GOWORK=off go test ./... -race` ✅ (all packages ok)

### Evidence
- **CI:** required checks pending → will be green before merge.
- **Local output:** domain coverage `93.1% of statements`; full suite `ok` across `cmd/`, `internal/api`, `internal/domain`, `internal/infrastructure`, `tests`.
- **Artifacts / images:** none — engine-adapter source changed but no image rebuild in this PR.
- **Post-merge digest sync → main:** _placeholder — filled by the post-merge verifier after the release pipeline runs._

### Risk & rollback
Low — additive. New file `datacontext.go` plus an extended `executeActions` signature (internal, unexported). Actions with no bindings keep the existing behaviour byte-for-byte (`mergeInputs` returns the base ctx unchanged; `WriteOutputs`/`ResolveInputs` are no-ops on empty maps). Revert this PR to roll back; no data/migration concern (context is in-memory, run-scoped only).

### Review aids
- The ONE key file is `datacontext.go` — the data context, reference parsing (`$.states.<state>.output.<key>`), scalar coercion, and the structured error all live there.
- Subtlety: input bindings are read-only and overlaid per-action via `mergeInputs` without mutating `ec.Ctx`, so they never leak into transition guards or later states.
- Typed-mismatch is interpreted per ADR-029 §3 (stringly-typed paths, no schema): a source path resolving to an object/array/null is rejected as a type mismatch.

**SPDD:** Canvas `docs/spdd/1167-workflow-data-flow/canvas.md` — Status: **Aligned** · `/spdd-security-review` **PASS** (Tier-2 scan: no Tier-2 content introduced; new code is pure in-memory domain logic, no hostnames/credentials/PII).
**AI:** `Assisted-by: Claude/claude-opus-4-8`
