### PR TITLE
feat(agents/adapters): credential injection + redaction

### DIFF
--- a/agents/adapters/git/AGENTS.md
+++ b/agents/adapters/git/AGENTS.md
@@ -49,7 +49,16 @@ port and needs no registry. MCP tools map 1:1 onto the capabilities above; the
 exposed tool set is an explicit allow-list built from `capabilities[].name` — no
 Git logic is reimplemented in `internal/mcp/`. The owner/repo target stays pinned
 in config, so no caller-supplied owner/repo/remote reaches a Git call (SSRF guard).
-Credential injection + redaction are delivered by G.3 (#1199), not this layer.
+
+### Credential injection + redaction (G.3 / #1199)
+
+The token is **injected at process start** — resolved once from the env var named
+in `git.auth_env` (see `config.ResolveToken`), held only in process memory, never
+a config field, never a tool argument, never serialized. `internal/redact` is the
+egress backstop: a `redact.Redactor` built from the injected token scrubs the
+secret (replaced with `[REDACTED]`) from every caller-visible CapabilityError
+message and COMPLETED payload, and again at the MCP prompt boundary where the
+tool-result text becomes model context. The token value itself is never logged.
 
 ## Testing
 

--- a/agents/adapters/git/cmd/git-adapter/main.go
+++ b/agents/adapters/git/cmd/git-adapter/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/zynax-io/zynax/agents/adapters/git/internal/adapter"
 	"github.com/zynax-io/zynax/agents/adapters/git/internal/config"
 	"github.com/zynax-io/zynax/agents/adapters/git/internal/mcp"
+	"github.com/zynax-io/zynax/agents/adapters/git/internal/redact"
 	"github.com/zynax-io/zynax/agents/adapters/git/internal/registry"
 	zynaxv1 "github.com/zynax-io/zynax/protos/generated/go/zynax/v1"
 	"google.golang.org/grpc"
@@ -76,8 +77,11 @@ func serveMCP(cfg *config.AdapterConfig, token string, in io.Reader, out io.Writ
 	for _, c := range cfg.Capabilities {
 		tools = append(tools, c.Name)
 	}
+	// The injected token is scrubbed from every tool result at the prompt
+	// boundary (G.3 / #1199); the token value itself is never logged here.
+	red := redact.New(token)
 	slog.Info("git-adapter mcp serving over stdio", "tools", tools) //nolint:gosec
-	if err := mcp.NewServer(srv, tools).Serve(context.Background(), in, out); err != nil {
+	if err := mcp.NewServerWithRedactor(srv, tools, red).Serve(context.Background(), in, out); err != nil {
 		return fmt.Errorf("mcp serve: %w", err)
 	}
 	return nil

--- a/agents/adapters/git/internal/adapter/handler.go
+++ b/agents/adapters/git/internal/adapter/handler.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/google/go-github/v67/github"
 	"github.com/zynax-io/zynax/agents/adapters/git/internal/config"
+	"github.com/zynax-io/zynax/agents/adapters/git/internal/redact"
 	zynaxv1 "github.com/zynax-io/zynax/protos/generated/go/zynax/v1"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -31,11 +32,12 @@ type executeStream interface {
 }
 
 type gitHandler struct {
-	gh *github.Client
+	gh  *github.Client
+	red redact.Redactor // scrubs the token from any caller-visible text (G.3 / #1199)
 }
 
 func newGitHandler(token string) *gitHandler {
-	return &gitHandler{gh: newGitHubClient(token)}
+	return &gitHandler{gh: newGitHubClient(token), red: redact.New(token)}
 }
 
 // newGitHandlerWithURL creates a handler pointed at a custom base URL (for tests).
@@ -50,7 +52,7 @@ func newGitHandlerWithURL(token, baseURL string) *gitHandler {
 		return newGitHandler(token)
 	}
 	client.BaseURL = parsed
-	return &gitHandler{gh: client}
+	return &gitHandler{gh: client, red: redact.New(token)}
 }
 
 func (h *gitHandler) execute(
@@ -94,7 +96,7 @@ func (h *gitHandler) openPR(
 ) error {
 	var inp openPRInput
 	if err := parsePayload(payload, &inp); err != nil {
-		return sendFailed(stream, taskID, "INVALID_INPUT", sanitise(err.Error()))
+		return sendFailed(stream, taskID, "INVALID_INPUT", h.sanitise(err.Error()))
 	}
 	if inp.Title == "" || inp.Head == "" || inp.Base == "" {
 		return sendFailed(stream, taskID, "INVALID_INPUT", "title, head, and base are required")
@@ -122,7 +124,7 @@ func (h *gitHandler) openPR(
 			}
 		case res := <-ch:
 			if res.err != nil {
-				return sendFailed(stream, taskID, githubErrCode(res.err), sanitise(res.err.Error()))
+				return sendFailed(stream, taskID, githubErrCode(res.err), h.sanitise(res.err.Error()))
 			}
 			out, err := marshalPayload(map[string]interface{}{
 				"pr_url":    res.pr.GetHTMLURL(),
@@ -131,7 +133,7 @@ func (h *gitHandler) openPR(
 			if err != nil {
 				return sendFailed(stream, taskID, "UPSTREAM_ERROR", "failed to marshal response")
 			}
-			return stream.Send(completedEvent(taskID, out)) //nolint:wrapcheck
+			return stream.Send(completedEvent(taskID, h.red.Bytes(out))) //nolint:wrapcheck
 		case <-ctx.Done():
 			return sendFailed(stream, taskID, "TIMEOUT", "request exceeded timeout_seconds")
 		}
@@ -159,7 +161,7 @@ func (h *gitHandler) requestReview(
 ) error {
 	var inp requestReviewInput
 	if err := parsePayload(payload, &inp); err != nil {
-		return sendFailed(stream, taskID, "INVALID_INPUT", sanitise(err.Error()))
+		return sendFailed(stream, taskID, "INVALID_INPUT", h.sanitise(err.Error()))
 	}
 	if inp.PRNumber <= 0 {
 		return sendFailed(stream, taskID, "INVALID_INPUT", "pr_number must be a positive integer")
@@ -171,7 +173,7 @@ func (h *gitHandler) requestReview(
 	_, _, err := h.gh.PullRequests.RequestReviewers(ctx, gcap.Owner, gcap.Repo, inp.PRNumber,
 		github.ReviewersRequest{Reviewers: inp.Reviewers})
 	if err != nil {
-		return sendFailed(stream, taskID, githubErrCode(err), sanitise(err.Error()))
+		return sendFailed(stream, taskID, githubErrCode(err), h.sanitise(err.Error()))
 	}
 
 	// Poll for reviewer assignment confirmation (up to maxPollCycles).
@@ -187,7 +189,7 @@ func (h *gitHandler) requestReview(
 
 		pr, _, err := h.gh.PullRequests.Get(ctx, gcap.Owner, gcap.Repo, inp.PRNumber)
 		if err != nil {
-			return sendFailed(stream, taskID, githubErrCode(err), sanitise(err.Error()))
+			return sendFailed(stream, taskID, githubErrCode(err), h.sanitise(err.Error()))
 		}
 		for _, r := range pr.RequestedReviewers {
 			for _, want := range inp.Reviewers {
@@ -218,7 +220,7 @@ func (h *gitHandler) getDiff(
 ) error {
 	var inp getDiffInput
 	if err := parsePayload(payload, &inp); err != nil {
-		return sendFailed(stream, taskID, "INVALID_INPUT", sanitise(err.Error()))
+		return sendFailed(stream, taskID, "INVALID_INPUT", h.sanitise(err.Error()))
 	}
 	if inp.PRNumber <= 0 {
 		return sendFailed(stream, taskID, "INVALID_INPUT", "pr_number must be a positive integer")
@@ -267,7 +269,7 @@ func (h *gitHandler) getDiff(
 			}
 		case res := <-ch:
 			if res.err != nil {
-				return sendFailed(stream, taskID, githubErrCode(res.err), sanitise(res.err.Error()))
+				return sendFailed(stream, taskID, githubErrCode(res.err), h.sanitise(res.err.Error()))
 			}
 			out, err := marshalPayload(map[string]interface{}{
 				"diff":      res.diff,
@@ -276,7 +278,7 @@ func (h *gitHandler) getDiff(
 			if err != nil {
 				return sendFailed(stream, taskID, "UPSTREAM_ERROR", "failed to marshal diff response")
 			}
-			return stream.Send(completedEvent(taskID, out)) //nolint:wrapcheck
+			return stream.Send(completedEvent(taskID, h.red.Bytes(out))) //nolint:wrapcheck
 		case <-ctx.Done():
 			return sendFailed(stream, taskID, "TIMEOUT", "request exceeded timeout_seconds")
 		}
@@ -317,7 +319,12 @@ func sendFailed(stream executeStream, taskID, code, msg string) error {
 	})
 }
 
-func sanitise(s string) string {
+// sanitise scrubs the credential from caller-visible error text, then caps its
+// length. Redaction runs first so truncation can never split a token in two and
+// leave a usable fragment. This is the egress backstop for the one path a token
+// could reach a caller — an upstream/git error string that embeds it (G.3 / #1199).
+func (h *gitHandler) sanitise(s string) string {
+	s = h.red.String(s)
 	if len(s) > maxErrMsgLen {
 		return s[:maxErrMsgLen]
 	}

--- a/agents/adapters/git/internal/adapter/redaction_test.go
+++ b/agents/adapters/git/internal/adapter/redaction_test.go
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package adapter_test
+
+// Redaction integration tests (G.3 / #1199, type: security): prove the injected
+// token never reaches a caller-visible CapabilityError message or COMPLETED
+// payload — even when an upstream GitHub error body echoes it back. The token
+// here is a syntactically PAT-shaped placeholder, never a real credential.
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/zynax-io/zynax/agents/adapters/git/internal/adapter"
+	"github.com/zynax-io/zynax/agents/adapters/git/internal/config"
+	zynaxv1 "github.com/zynax-io/zynax/protos/generated/go/zynax/v1"
+)
+
+// fakeToken is long enough to be redacted (≥ minSecretLen) and is not a real secret.
+const fakeToken = "ghp_FAKE0000000000000000000000000000fake" //nolint:gosec // test fixture
+
+func newRedactionServer(t *testing.T, baseURL string) *adapter.AgentServer {
+	t.Helper()
+	cfg := &config.AdapterConfig{
+		AgentID:          "git-redact-test",
+		Name:             "Git Redact Test",
+		Endpoint:         ":50062",
+		RegistryEndpoint: "localhost:50052",
+		Git:              config.GitConfig{Provider: "github", AuthEnv: "TEST_TOKEN"},
+		Capabilities: []config.GitCapabilityConfig{
+			{Name: "open_pr", Owner: "test-owner", Repo: "test-repo", TimeoutSeconds: 5},
+			{Name: "get_diff", Owner: "test-owner", Repo: "test-repo", TimeoutSeconds: 5},
+		},
+	}
+	return adapter.NewAgentServerWithURL(cfg, fakeToken, baseURL)
+}
+
+// TestRedaction_ErrorMessageScrubsToken: an upstream error body that embeds the
+// token (e.g. an authenticated remote URL) must be redacted before the message
+// reaches the caller.
+func TestRedaction_ErrorMessageScrubsToken(t *testing.T) {
+	t.Parallel()
+	leaky := "remote rejected: https://x-access-token:" + fakeToken + "@github.com/o/r 403"
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/test-owner/test-repo/pulls",
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			_ = json.NewEncoder(w).Encode(map[string]string{"message": leaky})
+		})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	srv := newRedactionServer(t, ts.URL)
+	stream := &stubStream{ctx: context.Background()}
+	payload, _ := json.Marshal(map[string]string{"title": "t", "head": "feat", "base": "main"})
+	req := &zynaxv1.ExecuteCapabilityRequest{TaskId: "t-redact", CapabilityName: "open_pr", InputPayload: payload}
+	_ = srv.ExecuteCapability(req, stream)
+
+	last := stream.last()
+	if last.Error == nil {
+		t.Fatalf("expected FAILED with error, got %+v", last)
+	}
+	if strings.Contains(last.Error.Message, fakeToken) {
+		t.Fatalf("token leaked into error message: %q", last.Error.Message)
+	}
+	if !strings.Contains(last.Error.Message, "[REDACTED]") {
+		t.Errorf("expected [REDACTED] placeholder in error message, got %q", last.Error.Message)
+	}
+}
+
+// TestRedaction_CompletedPayloadScrubsToken: a COMPLETED payload that happens to
+// echo the token (a diff body) must be redacted before it leaves the adapter.
+func TestRedaction_CompletedPayloadScrubsToken(t *testing.T) {
+	t.Parallel()
+	leakyDiff := "+ url = https://x-access-token:" + fakeToken + "@github.com/o/r"
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/test-owner/test-repo/pulls/7",
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/vnd.github.diff")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(leakyDiff))
+		})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	srv := newRedactionServer(t, ts.URL)
+	stream := &stubStream{ctx: context.Background()}
+	payload, _ := json.Marshal(map[string]int{"pr_number": 7})
+	req := &zynaxv1.ExecuteCapabilityRequest{TaskId: "t-diff-redact", CapabilityName: "get_diff", InputPayload: payload}
+	_ = srv.ExecuteCapability(req, stream)
+
+	last := stream.last()
+	if last.EventType != zynaxv1.TaskEventType_TASK_EVENT_TYPE_COMPLETED {
+		t.Fatalf("expected COMPLETED, got %v (err=%+v)", last.EventType, last.Error)
+	}
+	if strings.Contains(string(last.Payload), fakeToken) {
+		t.Fatalf("token leaked into COMPLETED payload: %q", last.Payload)
+	}
+	if !strings.Contains(string(last.Payload), "[REDACTED]") {
+		t.Errorf("expected [REDACTED] in diff payload, got %q", last.Payload)
+	}
+}

--- a/agents/adapters/git/internal/adapter/server.go
+++ b/agents/adapters/git/internal/adapter/server.go
@@ -25,6 +25,7 @@ type AgentServer struct {
 }
 
 // NewAgentServer builds an AgentServer from a validated AdapterConfig and a GitHub token.
+// The token is redacted from every caller-visible error and payload (G.3 / #1199).
 func NewAgentServer(cfg *config.AdapterConfig, token string) *AgentServer {
 	return newAgentServer(cfg, newGitHandler(token))
 }

--- a/agents/adapters/git/internal/mcp/redaction_test.go
+++ b/agents/adapters/git/internal/mcp/redaction_test.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp_test
+
+// Prompt-boundary redaction test (G.3 / #1199, type: security): the tool-result
+// text the shim returns becomes model context, so the injected token must never
+// appear in it — even if an upstream payload echoes the token back. The token is
+// a PAT-shaped placeholder, never a real credential.
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/zynax-io/zynax/agents/adapters/git/internal/mcp"
+	"github.com/zynax-io/zynax/agents/adapters/git/internal/redact"
+	zynaxv1 "github.com/zynax-io/zynax/protos/generated/go/zynax/v1"
+)
+
+const fakeTokenMCP = "ghp_FAKE0000000000000000000000000000fake" //nolint:gosec // test fixture
+
+// leakyCaps returns a COMPLETED payload that embeds the token, simulating an
+// adapter path that did not redact, so the shim's prompt-boundary scrub is the
+// last line of defense.
+type leakyCaps struct{}
+
+func (leakyCaps) ExecuteCapability(req *zynaxv1.ExecuteCapabilityRequest, stream zynaxv1.AgentService_ExecuteCapabilityServer) error {
+	return stream.Send(&zynaxv1.TaskEvent{ //nolint:wrapcheck // test stub mirrors handler send semantics
+		TaskId:    req.TaskId,
+		EventType: zynaxv1.TaskEventType_TASK_EVENT_TYPE_COMPLETED,
+		Payload:   []byte(`{"diff":"token=` + fakeTokenMCP + `"}`),
+	})
+}
+
+func (leakyCaps) GetCapabilitySchema(_ context.Context, req *zynaxv1.GetCapabilitySchemaRequest) (*zynaxv1.GetCapabilitySchemaResponse, error) {
+	return &zynaxv1.GetCapabilitySchemaResponse{CapabilityName: req.CapabilityName, InputSchemaJson: `{"type":"object"}`}, nil
+}
+
+func TestToolsCall_RedactsTokenInResult(t *testing.T) {
+	t.Parallel()
+	srv := mcp.NewServerWithRedactor(leakyCaps{}, []string{"get_diff"}, redact.New(fakeTokenMCP))
+	resp := roundtrip(t, srv, `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"get_diff"}}`)
+	result := resp["result"].(map[string]interface{})
+	content := result["content"].([]interface{})
+	text := content[0].(map[string]interface{})["text"].(string)
+	if strings.Contains(text, fakeTokenMCP) {
+		t.Fatalf("token leaked into MCP tool result (prompt content): %q", text)
+	}
+	if !strings.Contains(text, "[REDACTED]") {
+		t.Errorf("expected [REDACTED] in tool result, got %q", text)
+	}
+}

--- a/agents/adapters/git/internal/mcp/server.go
+++ b/agents/adapters/git/internal/mcp/server.go
@@ -10,11 +10,16 @@
 // one Git implementation, two surfaces). The set of exposed tools is an explicit
 // allow-list built from the configured capabilities — never "every handler".
 //
-// Credential injection and redaction are out of scope here; they are delivered
-// by G.3 (#1199). This layer never accepts a token as a tool argument and never
-// derives owner/repo from input (the adapter already pins those in config —
-// SSRF prevention), so no caller-supplied value reaches a privileged Git call as
-// a flag or remote.
+// This layer never accepts a token as a tool argument and never derives
+// owner/repo from input (the adapter already pins those in config — SSRF
+// prevention), so no caller-supplied value reaches a privileged Git call as a
+// flag or remote.
+//
+// Credential redaction (G.3 / #1199): the tool-result text returned to the
+// authoring agent is model prompt content, so it is the most sensitive egress
+// for a secret. A redact.Redactor built from the injected token scrubs the
+// terminal-event payload before it leaves this layer, backstopping the
+// adapter's own redaction at the actual prompt boundary.
 package mcp
 
 import (
@@ -24,6 +29,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/zynax-io/zynax/agents/adapters/git/internal/redact"
 	zynaxv1 "github.com/zynax-io/zynax/protos/generated/go/zynax/v1"
 )
 
@@ -44,13 +50,23 @@ type Capabilities interface {
 // Server is a stdio JSON-RPC 2.0 MCP server bound to a fixed allow-list of tools.
 type Server struct {
 	caps  Capabilities
-	tools []string // explicit allow-list; nothing outside this is exposed
+	tools []string        // explicit allow-list; nothing outside this is exposed
+	red   redact.Redactor // scrubs the injected token from prompt-facing tool results
 }
 
 // NewServer builds a shim that exposes exactly the named capabilities as MCP
 // tools. toolNames is the allow-list (typically the configured capability names);
-// a tool absent from this slice is never advertised nor dispatchable.
+// a tool absent from this slice is never advertised nor dispatchable. The
+// redactor is the zero (no-op) value — use NewServerWithRedactor to scrub the
+// injected token from tool-result text at the prompt boundary.
 func NewServer(caps Capabilities, toolNames []string) *Server {
+	return NewServerWithRedactor(caps, toolNames, redact.Redactor{})
+}
+
+// NewServerWithRedactor is NewServer plus a credential redactor (G.3 / #1199).
+// Every tool result the shim returns is passed through red before it reaches the
+// authoring agent, so an injected token can never surface in prompt content.
+func NewServerWithRedactor(caps Capabilities, toolNames []string, red redact.Redactor) *Server {
 	allow := make([]string, 0, len(toolNames))
 	seen := make(map[string]struct{}, len(toolNames))
 	for _, n := range toolNames {
@@ -63,7 +79,7 @@ func NewServer(caps Capabilities, toolNames []string) *Server {
 		seen[n] = struct{}{}
 		allow = append(allow, n)
 	}
-	return &Server{caps: caps, tools: allow}
+	return &Server{caps: caps, tools: allow, red: red}
 }
 
 // allowed reports whether name is in the explicit tool allow-list.
@@ -239,6 +255,9 @@ func (s *Server) handleToolsCall(ctx context.Context, id, params json.RawMessage
 	}
 
 	text, isError := sink.result()
+	// Final prompt-boundary redaction: tool-result text becomes model context, so
+	// scrub the injected token here even if the adapter already redacted upstream.
+	text = s.red.String(text)
 	return &rpcResponse{
 		JSONRPC: jsonRPCVersion,
 		ID:      id,

--- a/agents/adapters/git/internal/redact/redact.go
+++ b/agents/adapters/git/internal/redact/redact.go
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package redact scrubs credential material from any string that may reach a
+// log line, gRPC trace, or — most sensitively — an MCP tool result that becomes
+// model prompt content (EPIC G, story G.3 / #1199, ADR-032).
+//
+// The credential model is inject-at-start: the token is resolved once from an
+// env var (see internal/config.ResolveToken) and held only in process memory; it
+// is never a config field, never a tool argument, and never serialized. This
+// package is the egress backstop for the one path a token could still slip
+// through — a transport or git error message that embeds the token (for example
+// an authenticated remote URL of the form https://x-access-token:TOKEN@host/...
+// echoed back inside an upstream error string).
+//
+// A Redactor is value-type, immutable after construction, and safe for
+// concurrent use. The empty (zero) Redactor is a valid no-op.
+package redact
+
+import "strings"
+
+// placeholder replaces every occurrence of a registered secret.
+const placeholder = "[REDACTED]"
+
+// minSecretLen guards against redacting trivially short or empty tokens, which
+// would scrub innocuous substrings out of every message. A real GitHub PAT or
+// App token is well above this length; anything shorter is treated as absent.
+const minSecretLen = 8
+
+// Redactor replaces known secret values with a fixed placeholder. It never holds
+// the env-var name or any metadata — only the literal secret values to scrub —
+// and it exposes no accessor that returns them, so the secret cannot be read
+// back out once registered.
+type Redactor struct {
+	secrets []string
+}
+
+// New builds a Redactor for the given secret values. Empty values and values
+// shorter than minSecretLen are ignored (a short or absent token cannot be
+// meaningfully scrubbed and would over-redact). Duplicate values are collapsed.
+func New(secrets ...string) Redactor {
+	seen := make(map[string]struct{}, len(secrets))
+	kept := make([]string, 0, len(secrets))
+	for _, s := range secrets {
+		if len(s) < minSecretLen {
+			continue
+		}
+		if _, dup := seen[s]; dup {
+			continue
+		}
+		seen[s] = struct{}{}
+		kept = append(kept, s)
+	}
+	return Redactor{secrets: kept}
+}
+
+// String replaces every occurrence of every registered secret in s with
+// placeholder. With no registered secrets it returns s unchanged. The result
+// never contains a registered secret value.
+func (r Redactor) String(s string) string {
+	if s == "" || len(r.secrets) == 0 {
+		return s
+	}
+	for _, secret := range r.secrets {
+		s = strings.ReplaceAll(s, secret, placeholder)
+	}
+	return s
+}
+
+// Bytes redacts a byte slice (e.g. a JSON output payload that becomes a tool
+// result) and returns a freshly allocated, scrubbed slice. The input is never
+// mutated. A nil input returns nil.
+func (r Redactor) Bytes(b []byte) []byte {
+	if b == nil {
+		return nil
+	}
+	if len(r.secrets) == 0 {
+		return b
+	}
+	return []byte(r.String(string(b)))
+}

--- a/agents/adapters/git/internal/redact/redact_test.go
+++ b/agents/adapters/git/internal/redact/redact_test.go
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package redact_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/zynax-io/zynax/agents/adapters/git/internal/redact"
+)
+
+// fakeToken is a syntactically PAT-shaped placeholder — never a real credential.
+const fakeToken = "ghp_FAKE0000000000000000000000000000fake" //nolint:gosec // test fixture, not a real secret
+
+func TestString_RedactsToken(t *testing.T) {
+	t.Parallel()
+	r := redact.New(fakeToken)
+	// Simulate the one real leak path: an authenticated remote URL echoed inside
+	// an upstream error message.
+	in := "fatal: unable to access 'https://x-access-token:" + fakeToken + "@github.com/o/r.git/': 403"
+	got := r.String(in)
+	if strings.Contains(got, fakeToken) {
+		t.Fatalf("token leaked through redaction: %q", got)
+	}
+	if !strings.Contains(got, "[REDACTED]") {
+		t.Errorf("expected [REDACTED] placeholder, got %q", got)
+	}
+}
+
+func TestString_NoSecretsIsNoOp(t *testing.T) {
+	t.Parallel()
+	r := redact.New()
+	in := "no secrets here"
+	if got := r.String(in); got != in {
+		t.Errorf("empty redactor mutated input: got %q want %q", got, in)
+	}
+}
+
+func TestString_EmptyInput(t *testing.T) {
+	t.Parallel()
+	r := redact.New(fakeToken)
+	if got := r.String(""); got != "" {
+		t.Errorf("empty input should return empty, got %q", got)
+	}
+}
+
+func TestZeroRedactorIsNoOp(t *testing.T) {
+	t.Parallel()
+	var r redact.Redactor // zero value
+	in := "anything " + fakeToken
+	if got := r.String(in); got != in {
+		t.Errorf("zero redactor must be a no-op, got %q", got)
+	}
+}
+
+func TestNew_IgnoresShortAndEmptyAndDuplicates(t *testing.T) {
+	t.Parallel()
+	// "short" (< minSecretLen) and "" must be ignored; the long token deduped.
+	r := redact.New("", "short", fakeToken, fakeToken)
+	out := r.String("x short y " + fakeToken)
+	if strings.Contains(out, fakeToken) {
+		t.Fatalf("token leaked: %q", out)
+	}
+	// "short" must survive — redacting it would scrub innocuous substrings.
+	if !strings.Contains(out, "short") {
+		t.Errorf("a sub-minimum-length value must not be redacted, got %q", out)
+	}
+}
+
+func TestBytes_RedactsAndDoesNotMutateInput(t *testing.T) {
+	t.Parallel()
+	r := redact.New(fakeToken)
+	in := []byte(`{"diff":"token=` + fakeToken + `"}`)
+	orig := string(in)
+	out := r.Bytes(in)
+	if strings.Contains(string(out), fakeToken) {
+		t.Fatalf("token leaked through Bytes: %q", out)
+	}
+	if string(in) != orig {
+		t.Errorf("Bytes mutated its input: %q", in)
+	}
+}
+
+func TestBytes_NilAndNoSecrets(t *testing.T) {
+	t.Parallel()
+	if got := redact.New(fakeToken).Bytes(nil); got != nil {
+		t.Errorf("nil input must return nil, got %v", got)
+	}
+	plain := []byte("plain")
+	if got := redact.New().Bytes(plain); string(got) != "plain" {
+		t.Errorf("no-secret redactor must pass bytes through, got %q", got)
+	}
+}


### PR DESCRIPTION
## feat(agents/adapters): credential injection + redaction

Closes #1199
Part of #1169 (EPIC G — Git MCP shim over git-adapter, step G.3)

### Why  (problem & intent)
EPIC-G canvas step **G.3** is a `security` story: the git-adapter token is injected
at process start, but nothing scrubbed it from caller-visible egress. The most
sensitive egress is the **MCP tool result**, which becomes model **prompt content** —
a token echoed there (e.g. inside an authenticated remote URL in a git error) would
leak a live credential into a prompt/log/trace.

### What you'll get  (deliverables ↔ what changed)
- A reusable credential scrubber that replaces the injected token with `[REDACTED]` ← `internal/redact/redact.go`
- Adapter error messages and COMPLETED payloads are redacted before they leave the handler ← `internal/adapter/handler.go` (`sanitise` now redacts-then-truncates; diff/PR payloads passed through `red.Bytes`)
- A final prompt-boundary scrub on every MCP tool-result text ← `internal/mcp/server.go` (`NewServerWithRedactor`) wired from the injected token ← `cmd/git-adapter/main.go`
- Truthful layer docs: redaction is now in place, not deferred ← `agents/adapters/git/AGENTS.md`

### Scope & boundaries
- **In scope:** credential injection-at-start invariant (already satisfied — token resolved from `git.auth_env` only, never a config field or tool arg) + redaction backstop at all caller-visible egress + redaction tests.
- **Out of scope (deferred):** CLI wiring (`zynax mcp git`) → G.4 (#1200); startup token-scope validation → G.5 (#1260); refreshable App tokens → G.7 (#1262).

### Test plan & acceptance

| Acceptance criterion | How verified (command) | Result |
|----------------------|------------------------|--------|
| token from env/secret-ref only | `GOWORK=off go test ./internal/config/... -run ResolveToken` | ✅ token resolved from `auth_env` env var only; config struct holds no token field |
| never serialized to prompt/log/trace | `GOWORK=off go test ./internal/mcp/... -run RedactsTokenInResult` + `./internal/adapter/... -run Redaction` | ✅ token scrubbed from MCP tool-result text, error message, and COMPLETED diff payload — asserted absent, `[REDACTED]` present |
| redaction test | `GOWORK=off go test ./internal/redact/... -race` | ✅ `redact` package 100.0% coverage; leak-path (auth'd remote URL) scrubbed |

**Local gates:** `make lint-go-adapters` ✅ (git-adapter 0 issues) · `GOWORK=off go test ./... -race` ✅ · `make security-go-adapters` ✅ (0 vulnerabilities)

### Evidence
- **CI:** required checks expected green (see run on this PR).
- **Local output:** module aggregate coverage `total: 88.0%` (≥85% go-adapter gate); `internal/redact` `100.0%`; `go vet ./...` clean; `gofmt -l` clean.
- **Artifacts / images:** none — adapter source changed but no image was rebuilt in this PR; digest sync is post-merge.
- **Post-merge digest sync → main:** _placeholder — filled by post-merge verifier after the release pipeline runs._

### Risk & rollback
Low. Additive: a new `internal/redact` package plus redact-on-egress hooks. No behaviour change to success paths beyond scrubbing a secret that must never have been emitted. The zero-value `Redactor` is a no-op, so the change degrades safely. Rollback = revert this PR.

### Review aids
- The ONE key file: `internal/redact/redact.go` (the scrubber — redacts before truncation so a token can't be split into a usable fragment; ignores sub-8-char values to avoid over-redaction).
- Then `internal/mcp/server.go` `handleToolsCall` — the prompt-boundary scrub, the last line of defense even if the adapter redacted upstream.
- No real credential appears anywhere; tests use the PAT-shaped placeholder `ghp_FAKE...fake`.

**SPDD:** Canvas `docs/spdd/1169-git-mcp-shim/canvas.md` — Status: **Aligned** · `/spdd-security-review` **PASS** (2026-06-16) · this is a `type: security` story (G is a security-sensitive EPIC; the G.3 threat-row is "credential leakage to prompt/log/trace").
**AI:** `Assisted-by: Claude/claude-opus-4-8`
