### PR TITLE
feat(spec): reusable templates + manifest versioning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -383,13 +383,16 @@ validate-capability-schemas: ensure-tools ## Validate capability declarations in
 	$(TOOLS_RUN) zynax-ci validate capabilities spec/workflows/examples/ --schema-dir spec/schemas
 	@echo "✅ Capability schemas valid"
 
-validate-workflow-schema: ensure-tools ## Validate Workflow manifests (spec examples + automation/workflows) against workflow.schema.json
+validate-workflow-schema: ensure-tools ## Validate Workflow manifests (spec examples + templates + automation/workflows) against workflow.schema.json
 	$(TOOLS_RUN) zynax-ci validate workflows spec/workflows/examples/ --schema-dir spec/schemas
+	$(TOOLS_RUN) zynax-ci validate workflows spec/templates/workflow/ --schema-dir spec/schemas
 	$(TOOLS_RUN) zynax-ci validate workflows automation/workflows/ --schema-dir spec/schemas
 	@echo "✅ Workflow schemas valid"
 
-validate-agent-def-schema: ensure-tools ## Validate AgentDef manifests (spec examples + automation/workflows) against agent-def.schema.json
+validate-agent-def-schema: ensure-tools ## Validate AgentDef manifests (spec examples + templates + automation/workflows) against agent-def.schema.json
 	$(TOOLS_RUN) zynax-ci validate agent-defs spec/workflows/examples/ --schema-dir spec/schemas
+	$(TOOLS_RUN) zynax-ci validate agent-defs spec/templates/task/ --schema-dir spec/schemas
+	$(TOOLS_RUN) zynax-ci validate agent-defs spec/templates/expert/ --schema-dir spec/schemas
 	$(TOOLS_RUN) zynax-ci validate agent-defs automation/workflows/ --schema-dir spec/schemas
 	$(TOOLS_RUN) zynax-ci validate agent-defs automation/workflows/experts/ --schema-dir spec/schemas
 	@echo "✅ AgentDef schemas valid"

--- a/spec/schemas/agent-def.schema.json
+++ b/spec/schemas/agent-def.schema.json
@@ -38,6 +38,11 @@
           "maxLength": 253,
           "pattern": "^[a-z0-9]([a-z0-9-]*[a-z0-9])?$"
         },
+        "version": {
+          "type": "string",
+          "description": "Optional semantic version of this AgentDef manifest (e.g. '1.0.0', '2.1.0-rc.1'). Backward-compatible: omitting it implies the unversioned baseline. Lets task/expert authors evolve a capability contract without breaking registered agents. Follows the SemVer 2.0.0 'MAJOR.MINOR.PATCH' grammar with optional pre-release and build metadata.",
+          "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
+        },
         "namespace": {
           "type": "string",
           "description": "Logical namespace for multi-tenant isolation. Defaults to 'default' when omitted.",

--- a/spec/schemas/workflow.schema.json
+++ b/spec/schemas/workflow.schema.json
@@ -38,6 +38,11 @@
           "maxLength": 253,
           "pattern": "^[a-z0-9]([a-z0-9-]*[a-z0-9])?$"
         },
+        "version": {
+          "type": "string",
+          "description": "Optional semantic version of this workflow manifest (e.g. '1.0.0', '2.1.0-rc.1'). Backward-compatible: omitting it implies the unversioned baseline. The compiler and CLI surface this value so authors can evolve a workflow without breaking existing instances. Follows the SemVer 2.0.0 'MAJOR.MINOR.PATCH' grammar with optional pre-release and build metadata.",
+          "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
+        },
         "namespace": {
           "type": "string",
           "description": "Logical namespace for multi-tenant isolation. Defaults to 'default' when omitted.",

--- a/spec/templates/expert/expert.template.yaml
+++ b/spec/templates/expert/expert.template.yaml
@@ -1,0 +1,108 @@
+# SPDX-License-Identifier: Apache-2.0
+# spec/templates/expert/expert.template.yaml
+#
+# Reusable, versioned expert template (EPIC T.1 — #1206).
+# An "expert" is an advisory AgentDef (ADR-028) that exposes a `review`
+# capability over a strictly isolated context slice. Copy, rename, and replace
+# the values marked < ... > to add a new expert.
+#
+# Validate after editing:  make validate-spec
+# (The bare template itself validates against spec/schemas/agent-def.schema.json.)
+#
+# Authoring rules (see spec/AGENTS.md + automation/workflows/experts/*.yaml):
+#   * context_slice is bound at dispatch time and hard-capped at max_tokens
+#   * never reference another expert's slice or output (strict isolation)
+#   * bump metadata.version on every contract change (SemVer 2.0.0)
+
+apiVersion: zynax.io/v1alpha1
+kind: AgentDef
+
+metadata:
+  # < your-expert-name >  — lowercase DNS-style, unique per namespace
+  name: my-expert
+  namespace: default
+  # Bump on every contract change. Omit for the unversioned baseline.
+  version: "0.1.0"
+  labels:
+    kind: expert
+    aggregation-weight: "1.0"
+    context-max-tokens: "3000"
+
+spec:
+  capabilities:
+    - name: review
+      description: >
+        One-sentence description of what this expert reviews and the rules it
+        enforces. Shown in the agent registry UI and generated docs.
+      input_schema:
+        type: object
+        required: [trigger, diff_summary, changed_files, context_slice]
+        properties:
+          trigger:
+            type: string
+            description: Event that initiated this review.
+            enum: [pull_request, push, post_merge]
+          diff_summary:
+            type: string
+            description: git diff --stat output for the change under review.
+          changed_files:
+            type: array
+            description: List of changed file paths.
+            items:
+              type: string
+          context_slice:
+            type: object
+            description: >
+              Bounded context slice injected at dispatch time (ADR-028). Only
+              the files declared below, hard-capped at max_tokens. Strict
+              isolation — never another expert's slice or output.
+            required: [files, max_tokens]
+            properties:
+              files:
+                type: array
+                description: Glob patterns this expert is allowed to read.
+                items:
+                  type: string
+                default:
+                  - "docs/**/*.md"
+              max_tokens:
+                type: integer
+                description: Hard context budget (tokens) per invocation.
+                default: 3000
+      output_schema:
+        type: object
+        required: [summary, recommended_actions, reasons_decisions, confidence, flags]
+        properties:
+          summary:
+            type: string
+            description: Plain text summary, max 200 words.
+          recommended_actions:
+            type: array
+            description: Ordered list of specific actions with rationale.
+            items:
+              type: object
+              required: [action, rationale, priority]
+              properties:
+                action:
+                  type: string
+                rationale:
+                  type: string
+                priority:
+                  type: string
+                  enum: [low, medium, high]
+          reasons_decisions:
+            type: array
+            description: Reasoning chain for each recommendation.
+            items:
+              type: string
+          confidence:
+            type: string
+            description: Overall confidence level for this expert's output.
+            enum: [low, medium, high]
+          flags:
+            type: array
+            description: Tier-2 security flags or blocker flags (empty if none).
+            items:
+              type: string
+      timeout_seconds: 300
+      max_retries: 1

--- a/spec/templates/task/task.template.yaml
+++ b/spec/templates/task/task.template.yaml
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: Apache-2.0
+# spec/templates/task/task.template.yaml
+#
+# Reusable, versioned task template (EPIC T.1 — #1206).
+# A "task" is a single capability an agent performs. This AgentDef scaffold
+# declares one capability with input/output contracts. Copy, rename, and
+# replace the values marked < ... > to add a new task-shaped agent.
+#
+# Validate after editing:  make validate-spec
+# (The bare template itself validates against spec/schemas/agent-def.schema.json.)
+#
+# Authoring rules (see spec/AGENTS.md):
+#   * capability names are snake_case, 1–64 chars, ^[a-z][a-z0-9_]*$
+#   * input_schema / output_schema are draft-07-subset JSON Schema objects
+#   * bump metadata.version on every contract change (SemVer 2.0.0)
+
+apiVersion: zynax.io/v1alpha1
+kind: AgentDef
+
+metadata:
+  # < your-task-agent-name >  — lowercase DNS-style, unique per namespace
+  name: my-task
+  namespace: default
+  # Bump on every contract change. Omit for the unversioned baseline.
+  version: "0.1.0"
+  labels:
+    kind: task
+
+spec:
+  capabilities:
+    # < your_capability_name >  — the routing key workflows reference.
+    - name: do_work
+      description: >
+        One-sentence description of what this task does. Shown in the agent
+        registry UI and generated docs.
+      input_schema:
+        type: object
+        required: [payload]
+        properties:
+          payload:
+            type: string
+            description: The work item to process.
+      output_schema:
+        type: object
+        required: [value]
+        properties:
+          value:
+            type: string
+            description: The result of the task.
+      timeout_seconds: 300
+      max_retries: 1
+
+  runtime:
+    # Fully qualified image with tag or digest.
+    image: ghcr.io/zynax-io/my-task-agent:v0.1.0
+    replicas: 1

--- a/spec/templates/workflow/workflow.template.yaml
+++ b/spec/templates/workflow/workflow.template.yaml
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: Apache-2.0
+# spec/templates/workflow/workflow.template.yaml
+#
+# Reusable, versioned Workflow template (EPIC T.1 — #1206).
+# Copy this file, rename it, and replace the values marked < ... > below to
+# author a new workflow from a known-good baseline instead of from scratch.
+#
+# Validate after editing:  make validate-spec
+# (The bare template itself validates against spec/schemas/workflow.schema.json.)
+#
+# Authoring rules (see spec/AGENTS.md):
+#   * capabilities are snake_case and reference capabilities, never agent names
+#   * state names are lowercase and descriptive
+#   * at least one state must be type: terminal
+#   * bump metadata.version on every change (SemVer 2.0.0)
+
+kind: Workflow
+apiVersion: zynax.io/v1
+
+metadata:
+  # < your-workflow-name >  — lowercase DNS-style, unique per namespace
+  name: my-workflow
+  namespace: default
+  # Bump on every change. Backward-compatible: omit for the unversioned baseline.
+  version: "0.1.0"
+  labels:
+    team: my-team
+  annotations:
+    description: "What this workflow automates — one sentence."
+
+spec:
+  # Must match a key under states.
+  initial_state: start
+
+  # Optional: events that auto-start a NEW instance. Delete if manually triggered.
+  triggers:
+    - event: example.event.received
+      filter:
+        # All entries must match for the trigger to fire.
+        source: my-source
+
+  states:
+    # ── First working state ─────────────────────────────────────────
+    start:
+      actions:
+        - capability: my_capability
+          input:
+            # Reference trigger data with {{ .trigger.field }} or workflow
+            # context with {{ .context.key }}.
+            payload: "{{ .trigger.payload }}"
+          # Write results back into the workflow context for later states.
+          output:
+            context.result: "{{ .result.value }}"
+          timeout: 30m
+      on:
+        - event: my_capability.completed
+          goto: done
+        - event: my_capability.failed
+          goto: failed
+
+    # ── Terminal states (at least one required) ─────────────────────
+    done:
+      type: terminal
+      actions:
+        - capability: notify
+          input:
+            message: "Workflow completed: {{ .context.result }}"
+
+    failed:
+      type: terminal
+      actions:
+        - capability: notify
+          input:
+            message: "Workflow failed — manual follow-up required."

--- a/spec/tests/features/template_versioning.feature
+++ b/spec/tests/features/template_versioning.feature
@@ -1,0 +1,96 @@
+# SPDX-License-Identifier: Apache-2.0
+# Zynax — Reusable Template + Versioning BDD Contract
+#
+# This file is the SPECIFICATION. It is written BEFORE / alongside the spec
+# change. It describes the contract that reusable templates and the manifest
+# `version:` field must honour and how they integrate with `make validate-spec`.
+# See spec/AGENTS.md for spec governance rules and EPIC #1171 (canvas T.1).
+#
+# Business context: workflow authors should start from a known-good baseline
+# rather than authoring manifests from scratch. Zynax ships three reusable,
+# parameterized templates — workflow, task, expert — under spec/templates/.
+# Manifests carry an optional, backward-compatible `metadata.version` (SemVer)
+# so an author can evolve a workflow or capability contract without breaking
+# already-registered instances. (#1206, EPIC #1171 step T.1)
+
+Feature: Reusable, versioned templates for workflows, tasks, and experts
+  As a workflow author
+  I want reusable, versioned templates
+  So that I do not author manifests from scratch and can evolve them safely
+
+  Background:
+    Given the JSON Schemas under "spec/schemas/" are loaded
+    And the reusable templates under "spec/templates/" exist
+
+  # ─── Template existence + shape ────────────────────────────────────────────
+
+  Scenario: The workflow template exists and validates as a Workflow
+    Given the template at "spec/templates/workflow/workflow.template.yaml"
+    When it is validated against "spec/schemas/workflow.schema.json"
+    Then validation passes with zero errors
+    And the manifest kind is "Workflow"
+    And at least one state has type "terminal"
+
+  Scenario: The task template exists and validates as an AgentDef
+    Given the template at "spec/templates/task/task.template.yaml"
+    When it is validated against "spec/schemas/agent-def.schema.json"
+    Then validation passes with zero errors
+    And the manifest kind is "AgentDef"
+    And it declares at least one capability
+
+  Scenario: The expert template exists and validates as an AgentDef
+    Given the template at "spec/templates/expert/expert.template.yaml"
+    When it is validated against "spec/schemas/agent-def.schema.json"
+    Then validation passes with zero errors
+    And the manifest kind is "AgentDef"
+    And it declares a "review" capability with a context_slice input
+
+  # ─── The version: field ─────────────────────────────────────────────────────
+
+  Scenario: A workflow manifest with a SemVer version passes validation
+    Given a Workflow manifest with metadata.version "1.2.3"
+    When it is validated against the workflow schema
+    Then validation passes with zero errors
+
+  Scenario: An AgentDef manifest with a SemVer version passes validation
+    Given an AgentDef manifest with metadata.version "2.0.0-rc.1"
+    When it is validated against the agent-def schema
+    Then validation passes with zero errors
+
+  Scenario: The version field is optional and backward-compatible
+    Given a Workflow manifest with no metadata.version field
+    When it is validated against the workflow schema
+    Then validation passes with zero errors
+
+  Scenario: A non-SemVer version string is rejected
+    Given a Workflow manifest with metadata.version "v1"
+    When it is validated against the workflow schema
+    Then validation fails
+    And the error references the "version" field
+
+  Scenario: An empty version string is rejected
+    Given an AgentDef manifest with metadata.version set to ""
+    When it is validated against the agent-def schema
+    Then validation fails
+    And the error references the "version" field
+
+  # ─── make validate-spec integration ─────────────────────────────────────────
+
+  Scenario: make validate-spec validates the template manifests
+    Given a Makefile exists at the repository root
+    When the "validate-spec" target is inspected
+    Then it validates manifests under "spec/templates/workflow/"
+    And it validates manifests under "spec/templates/task/"
+    And it validates manifests under "spec/templates/expert/"
+
+  # ─── Schema self-consistency ─────────────────────────────────────────────────
+
+  Scenario: The workflow schema declares an optional version property
+    When "spec/schemas/workflow.schema.json" is parsed
+    Then the metadata properties include a "version" field
+    And "version" is not listed in the metadata required array
+
+  Scenario: The agent-def schema declares an optional version property
+    When "spec/schemas/agent-def.schema.json" is parsed
+    Then the metadata properties include a "version" field
+    And "version" is not listed in the metadata required array


### PR DESCRIPTION
Closes #1206

### Why  (problem & intent)
Zynax had validation example manifests but no reusable, versioned templates and no
backward-compatible way to version a manifest. Authors copied examples ad hoc and could
not evolve a workflow or capability contract without risking already-registered instances.
This delivers EPIC T.1 (canvas `docs/spdd/1171-templates-real-workflows/canvas.md`, step T.1):
a parameterized template mechanism plus an optional `metadata.version` SemVer field, gated
by `make validate-spec`.

### What you'll get  (deliverables ↔ what changed)
- `spec/templates/workflow/workflow.template.yaml` — reusable `kind: Workflow` scaffold (versioned).
- `spec/templates/task/task.template.yaml` — reusable task `kind: AgentDef` scaffold (single capability).
- `spec/templates/expert/expert.template.yaml` — reusable expert `kind: AgentDef` scaffold (`review` + context_slice).
- `spec/schemas/workflow.schema.json` + `spec/schemas/agent-def.schema.json` — optional `metadata.version` (SemVer 2.0.0 pattern), backward-compatible.
- `Makefile` — `validate-workflow-schema` / `validate-agent-def-schema` now scan `spec/templates/` so the template manifests are gated by `make validate-spec`.
- `spec/tests/features/template_versioning.feature` — BDD contract for the template + versioning shape.

### Scope & boundaries
In scope: template format + `version:` field + schema validation + `.feature` contract (the three T.1 ACs).
Out of scope (deferred): the `zynax init` scaffolder (T.4), CLI `validate`/version surfacing (T.2), and the
three real runnable workflows (T.3). No Go/Python source changed — spec + Makefile only.

### Test plan & acceptance
| Acceptance criterion (T.1) | How verified | Result |
|---|---|---|
| template format + `version:` field | Added 3 templates + optional `metadata.version` (SemVer) to both schemas | PASS |
| schema validation (`make validate-spec`) | `make validate-spec` validates all templates green; bad SemVer (`v1`) rejected at `/metadata/version` | PASS |
| contract / `.feature` test | `spec/tests/features/template_versioning.feature` pins template existence, kind, version optionality, and validate-spec wiring | PASS |

### Evidence
`make validate-spec` — all green, including the new template dirs:
```
OK   spec/templates/workflow/workflow.template.yaml
OK   spec/templates/task/task.template.yaml
OK   spec/templates/expert/expert.template.yaml
✅ Workflow schemas valid / ✅ AgentDef schemas valid / ✅ Policy schemas valid / ✅ AsyncAPI spec valid
```
Negative case (regex enforced):
```
FAIL spec/templates/_negtest/badver.yaml:
  /metadata/version: does not match pattern '^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)...$'
```
`make lint` — proto + Go + Python all green ("All checks passed!").

### Risk & rollback
Low risk: additive, spec-only. `metadata.version` is optional, so every existing manifest still
validates (verified — all current examples/experts stay OK). Rollback = revert this commit; no runtime
or generated-stub impact.

### Review aids
Start with the two schema diffs (the SemVer `version` property), then the three template files, then
the Makefile wiring, then the `.feature` contract.

**SPDD:** Canvas `docs/spdd/1171-templates-real-workflows/canvas.md` — Status: **Aligned** · `/spdd-security-review` **PASS** (2026-06-16)

<!-- Post-merge: image digest sync handled by main pipeline (no images touched). -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
