### PR TITLE
feat(api-gateway): merge capability events into /logs stream

### DIFF
--- a/services/api-gateway/cmd/api-gateway/main.go
+++ b/services/api-gateway/cmd/api-gateway/main.go
@@ -28,6 +28,7 @@ type config struct {
 	CompilerAddr       string `envconfig:"COMPILER_ADDR" default:"localhost:50054"`
 	EngineAddr         string `envconfig:"ENGINE_ADDR" default:"localhost:50055"`
 	RegistryAddr       string `envconfig:"REGISTRY_ADDR" default:"localhost:50052"`
+	EventBusAddr       string `envconfig:"EVENT_BUS_ADDR" default:"localhost:50056"`
 	LogLevel           string `envconfig:"LOG_LEVEL" default:"info"`
 	APIKey             string `envconfig:"API_KEY"`
 	DevInsecure        bool   `envconfig:"DEV_INSECURE"`
@@ -75,7 +76,7 @@ func main() {
 // run contains the service lifecycle. Deferred cleanups execute before returning.
 func run(cfg config) error {
 	callTimeout := time.Duration(cfg.GRPCCallTimeoutS) * time.Second
-	clients, cleanup, err := infrastructure.NewGatewayClients(cfg.CompilerAddr, cfg.EngineAddr, cfg.RegistryAddr, callTimeout, cfg.TLSCert, cfg.TLSKey, cfg.TLSCA)
+	clients, cleanup, err := infrastructure.NewGatewayClients(cfg.CompilerAddr, cfg.EngineAddr, cfg.RegistryAddr, cfg.EventBusAddr, callTimeout, cfg.TLSCert, cfg.TLSKey, cfg.TLSCA)
 	if err != nil {
 		return fmt.Errorf("gateway clients: %w", err)
 	}
@@ -83,7 +84,7 @@ func run(cfg config) error {
 
 	probes := api.NewProbes(int64(cfg.LivenessThresholdS), clients.ConnectionsReady)
 
-	svc := domain.NewApplyService(clients, clients, clients)
+	svc := domain.NewApplyService(clients, clients, clients, clients)
 	handler := api.NewHandler(svc, cfg.APIKey)
 
 	tracerShutdown, err := zynaxobs.InitTracer(context.Background(), "api-gateway")

--- a/services/api-gateway/internal/api/handler_test.go
+++ b/services/api-gateway/internal/api/handler_test.go
@@ -81,7 +81,7 @@ func newServerWithRegistry(c domain.CompilerPort, e domain.EnginePort, r domain.
 }
 
 func newServerWithAuth(c domain.CompilerPort, e domain.EnginePort, r domain.RegistryPort, apiKey string) *httptest.Server {
-	svc := domain.NewApplyService(c, e, r)
+	svc := domain.NewApplyService(c, e, r, nil)
 	h := api.NewHandler(svc, apiKey)
 	mux := http.NewServeMux()
 	h.RegisterRoutes(mux)
@@ -431,7 +431,7 @@ func TestHandler_WorkflowLogs_NotFound_Returns404(t *testing.T) {
 // ── X-Request-ID middleware ───────────────────────────────────────────────
 
 func newServerWithRequestID(c domain.CompilerPort, e domain.EnginePort) *httptest.Server {
-	svc := domain.NewApplyService(c, e, &stubRegistry{})
+	svc := domain.NewApplyService(c, e, &stubRegistry{}, nil)
 	h := api.NewHandler(svc, "")
 	mux := http.NewServeMux()
 	h.RegisterRoutes(mux)

--- a/services/api-gateway/internal/api/namespace_propagation_test.go
+++ b/services/api-gateway/internal/api/namespace_propagation_test.go
@@ -61,7 +61,7 @@ func (e *recordingEngine) WatchWorkflow(_ context.Context, _ string, _ func(doma
 }
 
 func newRecordingServer(c domain.CompilerPort, e domain.EnginePort) *httptest.Server {
-	svc := domain.NewApplyService(c, e, &stubRegistry{})
+	svc := domain.NewApplyService(c, e, &stubRegistry{}, nil)
 	h := api.NewHandler(svc, "")
 	mux := http.NewServeMux()
 	h.RegisterRoutes(mux)

--- a/services/api-gateway/internal/domain/apply.go
+++ b/services/api-gateway/internal/domain/apply.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"sync"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -78,11 +79,14 @@ type ApplyService struct {
 	compiler CompilerPort
 	engine   EnginePort
 	registry RegistryPort
+	eventbus EventBusPort // optional; nil falls back to engine-history-only logs
 }
 
-// NewApplyService constructs an ApplyService with the given ports.
-func NewApplyService(compiler CompilerPort, engine EnginePort, registry RegistryPort) *ApplyService {
-	return &ApplyService{compiler: compiler, engine: engine, registry: registry}
+// NewApplyService constructs an ApplyService with the given ports. eventbus may
+// be nil, in which case WatchWorkflowLogs streams engine history only (no
+// capability events are merged).
+func NewApplyService(compiler CompilerPort, engine EnginePort, registry RegistryPort, eventbus EventBusPort) *ApplyService {
+	return &ApplyService{compiler: compiler, engine: engine, registry: registry, eventbus: eventbus}
 }
 
 // ApplyWorkflow compiles a Workflow manifest and, unless dry_run, submits it
@@ -160,11 +164,62 @@ func (s *ApplyService) CancelWorkflow(ctx context.Context, runID string) error {
 	return nil
 }
 
-// WatchWorkflowLogs streams lifecycle events for runID, calling send for each event.
-// Returns when the stream closes, ctx is cancelled, or send returns an error.
+// WatchWorkflowLogs streams a run's logs by merging two sources into a single
+// chronological stream (EPIC L step 3 / #1182):
+//
+//   - the engine's state-transition history (EnginePort.WatchWorkflow), and
+//   - workflow-scoped capability CloudEvents (EventBusPort.SubscribeWorkflowEvents).
+//
+// Both upstreams run concurrently; their events are serialised through a single
+// mutex-guarded send so the HTTP handler never sees interleaved writes. The
+// engine history stream is authoritative for stream lifetime: once it ends
+// (terminal workflow state) the event subscription is cancelled and the call
+// returns. Returns when the engine stream closes, ctx is cancelled, or send
+// returns an error.
+//
+// When no event-bus port is configured (eventbus == nil) the method streams the
+// engine history only, preserving the prior behaviour.
 func (s *ApplyService) WatchWorkflowLogs(ctx context.Context, runID string, send func(WatchEvent) error) error {
-	if err := s.engine.WatchWorkflow(ctx, runID, send); err != nil {
-		return fmt.Errorf("api-gateway: %w", err)
+	if s.eventbus == nil {
+		if err := s.engine.WatchWorkflow(ctx, runID, send); err != nil {
+			return fmt.Errorf("api-gateway: %w", err)
+		}
+		return nil
+	}
+
+	// Resolve the workflow_id used to scope the event subscription. A failure
+	// here (e.g. the run is unknown) is surfaced via the engine watch below, so
+	// fall back to engine-history-only rather than dropping the whole stream.
+	workflowID := runID
+	if run, err := s.engine.GetWorkflowStatus(ctx, runID); err == nil && run.WorkflowID != "" {
+		workflowID = run.WorkflowID
+	}
+
+	subCtx, cancelSub := context.WithCancel(ctx)
+	defer cancelSub()
+
+	var mu sync.Mutex
+	safeSend := func(ev WatchEvent) error {
+		mu.Lock()
+		defer mu.Unlock()
+		return send(ev)
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		// Best-effort: a capability-event subscription error must not abort the
+		// authoritative engine history stream. Cancellation on engine-stream
+		// completion surfaces here as a context error and is ignored.
+		_ = s.eventbus.SubscribeWorkflowEvents(subCtx, workflowID, safeSend)
+	}()
+
+	engErr := s.engine.WatchWorkflow(ctx, runID, safeSend)
+	cancelSub() // engine history ended (terminal) — stop the event subscription
+	wg.Wait()
+	if engErr != nil {
+		return fmt.Errorf("api-gateway: %w", engErr)
 	}
 	return nil
 }

--- a/services/api-gateway/internal/domain/apply_test.go
+++ b/services/api-gateway/internal/domain/apply_test.go
@@ -5,7 +5,9 @@ package domain_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/zynax-io/zynax/services/api-gateway/internal/domain"
@@ -70,11 +72,35 @@ func (s *stubRegistry) RegisterAgent(_ context.Context, _ []byte, _ string) (dom
 	return s.reg, s.err
 }
 
+// stubEventBus is a test double for EventBusPort. It emits its events then
+// blocks until ctx is cancelled, mirroring the real event-bus which holds the
+// subscription open until terminal workflow state.
+type stubEventBus struct {
+	events       []domain.WatchEvent
+	err          error
+	capturedWFID string
+}
+
+func (s *stubEventBus) SubscribeWorkflowEvents(ctx context.Context, workflowID string, send func(domain.WatchEvent) error) error {
+	s.capturedWFID = workflowID
+	if s.err != nil {
+		return s.err
+	}
+	for _, ev := range s.events {
+		if err := send(ev); err != nil {
+			return err
+		}
+	}
+	<-ctx.Done()
+	return fmt.Errorf("context: %w", ctx.Err())
+}
+
 func TestApplyService_ApplyWorkflow_Success(t *testing.T) {
 	svc := domain.NewApplyService(
 		&stubCompiler{result: domain.CompileResult{IRBytes: []byte("ir"), Warnings: []string{"w1"}}},
 		&stubEngine{submitID: "run-001"},
 		&stubRegistry{},
+		nil,
 	)
 	result, err := svc.ApplyWorkflow(context.Background(), domain.ApplyRequest{
 		ManifestYAML: []byte("kind: Workflow"),
@@ -97,6 +123,7 @@ func TestApplyService_ApplyWorkflow_CompilationErrors(t *testing.T) {
 		}},
 		&stubEngine{},
 		&stubRegistry{},
+		nil,
 	)
 	result, err := svc.ApplyWorkflow(context.Background(), domain.ApplyRequest{
 		ManifestYAML: []byte("bad yaml"),
@@ -120,6 +147,7 @@ func TestApplyService_ApplyWorkflow_DryRun_NoSubmit(t *testing.T) {
 		&stubCompiler{result: domain.CompileResult{IRBytes: []byte("ir"), Warnings: []string{"w"}}},
 		engine,
 		&stubRegistry{},
+		nil,
 	)
 	engine.submitErr = nil // reset — test checks RunID is empty, not that submit errors
 
@@ -141,6 +169,7 @@ func TestApplyService_ApplyWorkflow_CompilerError_Propagates(t *testing.T) {
 		&stubCompiler{err: domain.ErrEngineUnavailable},
 		&stubEngine{},
 		&stubRegistry{},
+		nil,
 	)
 	_, err := svc.ApplyWorkflow(context.Background(), domain.ApplyRequest{ManifestYAML: []byte("y")})
 	if !errors.Is(err, domain.ErrEngineUnavailable) {
@@ -153,6 +182,7 @@ func TestApplyService_ApplyWorkflow_EngineUnavailable(t *testing.T) {
 		&stubCompiler{result: domain.CompileResult{IRBytes: []byte("ir")}},
 		&stubEngine{submitErr: domain.ErrEngineUnavailable},
 		&stubRegistry{},
+		nil,
 	)
 	_, err := svc.ApplyWorkflow(context.Background(), domain.ApplyRequest{ManifestYAML: []byte("y")})
 	if !errors.Is(err, domain.ErrEngineUnavailable) {
@@ -164,7 +194,7 @@ func TestApplyService_GetWorkflowStatus_Success(t *testing.T) {
 	want := domain.WorkflowRunSummary{
 		RunID: "r1", WorkflowID: "w1", Status: "RUNNING", CurrentState: "review",
 	}
-	svc := domain.NewApplyService(&stubCompiler{}, &stubEngine{statusRun: want}, &stubRegistry{})
+	svc := domain.NewApplyService(&stubCompiler{}, &stubEngine{statusRun: want}, &stubRegistry{}, nil)
 	got, err := svc.GetWorkflowStatus(context.Background(), "r1")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -175,7 +205,7 @@ func TestApplyService_GetWorkflowStatus_Success(t *testing.T) {
 }
 
 func TestApplyService_GetWorkflowStatus_NotFound(t *testing.T) {
-	svc := domain.NewApplyService(&stubCompiler{}, &stubEngine{statusErr: domain.ErrNotFound}, &stubRegistry{})
+	svc := domain.NewApplyService(&stubCompiler{}, &stubEngine{statusErr: domain.ErrNotFound}, &stubRegistry{}, nil)
 	_, err := svc.GetWorkflowStatus(context.Background(), "unknown")
 	if !errors.Is(err, domain.ErrNotFound) {
 		t.Fatalf("got %v, want ErrNotFound", err)
@@ -187,6 +217,7 @@ func TestApplyService_ApplyAgentDef_Success(t *testing.T) {
 		&stubCompiler{},
 		&stubEngine{},
 		&stubRegistry{reg: domain.AgentRegistration{AgentID: "agent-001"}},
+		nil,
 	)
 	result, err := svc.ApplyAgentDef(context.Background(), domain.ApplyRequest{
 		ManifestYAML: []byte("kind: AgentDef\n"),
@@ -204,6 +235,7 @@ func TestApplyService_ApplyAgentDef_AlreadyExists(t *testing.T) {
 		&stubCompiler{},
 		&stubEngine{},
 		&stubRegistry{err: domain.ErrAgentAlreadyExists},
+		nil,
 	)
 	_, err := svc.ApplyAgentDef(context.Background(), domain.ApplyRequest{
 		ManifestYAML: []byte("kind: AgentDef\n"),
@@ -218,7 +250,7 @@ func TestApplyService_WatchWorkflowLogs_DeliversEvents(t *testing.T) {
 		{RunID: "r1", EventType: "state.entered", ToState: "review", Status: "WORKFLOW_STATUS_RUNNING"},
 		{RunID: "r1", EventType: "workflow.completed", Status: "WORKFLOW_STATUS_COMPLETED"},
 	}
-	svc := domain.NewApplyService(&stubCompiler{}, &stubEngine{watchEvents: events}, &stubRegistry{})
+	svc := domain.NewApplyService(&stubCompiler{}, &stubEngine{watchEvents: events}, &stubRegistry{}, nil)
 
 	var got []domain.WatchEvent
 	err := svc.WatchWorkflowLogs(context.Background(), "r1", func(ev domain.WatchEvent) error {
@@ -240,7 +272,75 @@ func TestApplyService_WatchWorkflowLogs_DeliversEvents(t *testing.T) {
 }
 
 func TestApplyService_WatchWorkflowLogs_NotFound(t *testing.T) {
-	svc := domain.NewApplyService(&stubCompiler{}, &stubEngine{watchErr: domain.ErrNotFound}, &stubRegistry{})
+	svc := domain.NewApplyService(&stubCompiler{}, &stubEngine{watchErr: domain.ErrNotFound}, &stubRegistry{}, nil)
+	err := svc.WatchWorkflowLogs(context.Background(), "ghost", func(_ domain.WatchEvent) error { return nil })
+	if !errors.Is(err, domain.ErrNotFound) {
+		t.Fatalf("got %v, want ErrNotFound", err)
+	}
+}
+
+func TestApplyService_WatchWorkflowLogs_MergesHistoryAndEvents(t *testing.T) {
+	engine := &stubEngine{
+		statusRun:   domain.WorkflowRunSummary{RunID: "r1", WorkflowID: "wf-abc"},
+		watchEvents: []domain.WatchEvent{{RunID: "r1", EventType: "state.entered", Status: "WORKFLOW_STATUS_RUNNING"}},
+	}
+	bus := &stubEventBus{events: []domain.WatchEvent{{RunID: "wf-abc", EventType: "zynax.task.completed", Status: "capability_event"}}}
+	svc := domain.NewApplyService(&stubCompiler{}, engine, &stubRegistry{}, bus)
+
+	var (
+		mu  sync.Mutex
+		got []domain.WatchEvent
+	)
+	err := svc.WatchWorkflowLogs(context.Background(), "r1", func(ev domain.WatchEvent) error {
+		mu.Lock()
+		defer mu.Unlock()
+		got = append(got, ev)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if bus.capturedWFID != "wf-abc" {
+		t.Errorf("event subscription scope: got %q, want wf-abc", bus.capturedWFID)
+	}
+	var sawHistory, sawCapability bool
+	for _, ev := range got {
+		switch ev.Status {
+		case "WORKFLOW_STATUS_RUNNING":
+			sawHistory = true
+		case "capability_event":
+			sawCapability = true
+		}
+	}
+	if !sawHistory || !sawCapability {
+		t.Fatalf("expected both history and capability events, got %+v", got)
+	}
+}
+
+func TestApplyService_WatchWorkflowLogs_EventBusErrorDoesNotAbortEngine(t *testing.T) {
+	engine := &stubEngine{
+		watchEvents: []domain.WatchEvent{{RunID: "r1", EventType: "state.entered", Status: "WORKFLOW_STATUS_RUNNING"}},
+	}
+	bus := &stubEventBus{err: errors.New("bus down")}
+	svc := domain.NewApplyService(&stubCompiler{}, engine, &stubRegistry{}, bus)
+
+	var count int
+	err := svc.WatchWorkflowLogs(context.Background(), "r1", func(_ domain.WatchEvent) error {
+		count++
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("event-bus failure must not abort engine stream, got %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("expected 1 engine event delivered, got %d", count)
+	}
+}
+
+func TestApplyService_WatchWorkflowLogs_EngineErrorWithEventBus(t *testing.T) {
+	engine := &stubEngine{watchErr: domain.ErrNotFound}
+	bus := &stubEventBus{}
+	svc := domain.NewApplyService(&stubCompiler{}, engine, &stubRegistry{}, bus)
 	err := svc.WatchWorkflowLogs(context.Background(), "ghost", func(_ domain.WatchEvent) error { return nil })
 	if !errors.Is(err, domain.ErrNotFound) {
 		t.Fatalf("got %v, want ErrNotFound", err)
@@ -250,14 +350,14 @@ func TestApplyService_WatchWorkflowLogs_NotFound(t *testing.T) {
 // ── CancelWorkflow ───────────────────────────────────────────────────────────
 
 func TestApplyService_CancelWorkflow_Success(t *testing.T) {
-	svc := domain.NewApplyService(&stubCompiler{}, &stubEngine{}, &stubRegistry{})
+	svc := domain.NewApplyService(&stubCompiler{}, &stubEngine{}, &stubRegistry{}, nil)
 	if err := svc.CancelWorkflow(context.Background(), "r1"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
 
 func TestApplyService_CancelWorkflow_NotFound(t *testing.T) {
-	svc := domain.NewApplyService(&stubCompiler{}, &stubEngine{cancelErr: domain.ErrNotFound}, &stubRegistry{})
+	svc := domain.NewApplyService(&stubCompiler{}, &stubEngine{cancelErr: domain.ErrNotFound}, &stubRegistry{}, nil)
 	err := svc.CancelWorkflow(context.Background(), "ghost")
 	if !errors.Is(err, domain.ErrNotFound) {
 		t.Fatalf("got %v, want ErrNotFound", err)
@@ -314,6 +414,7 @@ func TestApplyService_ApplyWorkflow_Idempotent_Running_ReturnsExisting(t *testin
 		&stubCompiler{result: domain.CompileResult{IRBytes: []byte("ir")}},
 		engine,
 		&stubRegistry{},
+		nil,
 	)
 	result, err := svc.ApplyWorkflow(context.Background(), domain.ApplyRequest{ManifestYAML: yaml})
 	if err != nil {
@@ -341,6 +442,7 @@ func TestApplyService_ApplyWorkflow_Idempotent_Completed_StartsRerun(t *testing.
 		&stubCompiler{result: domain.CompileResult{IRBytes: []byte("ir")}},
 		engine,
 		&stubRegistry{},
+		nil,
 	)
 	result, err := svc.ApplyWorkflow(context.Background(), domain.ApplyRequest{ManifestYAML: yaml})
 	if err != nil {
@@ -365,6 +467,7 @@ func TestApplyService_ApplyWorkflow_New_UsesHashID(t *testing.T) {
 		&stubCompiler{result: domain.CompileResult{IRBytes: []byte("ir")}},
 		engine,
 		&stubRegistry{},
+		nil,
 	)
 	result, err := svc.ApplyWorkflow(context.Background(), domain.ApplyRequest{ManifestYAML: yaml})
 	if err != nil {
@@ -393,6 +496,7 @@ func TestApplyService_ApplyWorkflow_NamespacePropagatedToEngine(t *testing.T) {
 		}},
 		engine,
 		&stubRegistry{},
+		nil,
 	)
 	_, err := svc.ApplyWorkflow(context.Background(), domain.ApplyRequest{ManifestYAML: manifest})
 	if err != nil {
@@ -417,6 +521,7 @@ func TestApplyService_ApplyWorkflow_CompiledNamespaceWins(t *testing.T) {
 		}},
 		engine,
 		&stubRegistry{},
+		nil,
 	)
 	_, err := svc.ApplyWorkflow(context.Background(), domain.ApplyRequest{
 		ManifestYAML: []byte("kind: Workflow\nmetadata:\n  name: x\n"),

--- a/services/api-gateway/internal/domain/ports.go
+++ b/services/api-gateway/internal/domain/ports.go
@@ -65,6 +65,19 @@ type EnginePort interface {
 	WatchWorkflow(ctx context.Context, runID string, send func(WatchEvent) error) error
 }
 
+// EventBusPort is the gateway's outbound dependency on EventBusService. It
+// delivers capability-level CloudEvents (e.g. task dispatched/completed) so the
+// streaming /logs endpoint can merge them with the engine's state-transition
+// history into a single chronological stream.
+type EventBusPort interface {
+	// SubscribeWorkflowEvents opens a workflow-scoped subscription and calls
+	// send for each capability event whose CloudEvent workflow_id matches
+	// workflowID. It returns when ctx is cancelled, send returns an error, or
+	// the upstream stream closes (the event-bus closes the stream on terminal
+	// workflow state — EPIC L step 2 / #1181).
+	SubscribeWorkflowEvents(ctx context.Context, workflowID string, send func(WatchEvent) error) error
+}
+
 // AgentRegistration is the domain view of a successful RegisterAgent response.
 type AgentRegistration struct {
 	AgentID string

--- a/services/api-gateway/internal/infrastructure/clients.go
+++ b/services/api-gateway/internal/infrastructure/clients.go
@@ -29,9 +29,15 @@ type GatewayClients struct {
 	compiler    zynaxv1.WorkflowCompilerServiceClient
 	engine      zynaxv1.EngineAdapterServiceClient
 	registry    zynaxv1.AgentRegistryServiceClient
+	eventbus    zynaxv1.EventBusServiceClient
 	conns       []*grpc.ClientConn
 	callTimeout time.Duration
 }
+
+// capabilityEventPattern matches every CloudEvent type so the streaming /logs
+// endpoint receives all capability events for a workflow. The event-bus filters
+// further by the workflow_id scope passed on the SubscribeRequest.
+const capabilityEventPattern = "**"
 
 // ConnectionsReady returns false if any downstream gRPC connection is in
 // TRANSIENT_FAILURE or SHUTDOWN state. Used by the /readyz probe handler.
@@ -50,7 +56,7 @@ func (c *GatewayClients) ConnectionsReady() bool {
 // tlsCertFile, tlsKeyFile, tlsCAFile are paths to PEM files for mTLS; pass empty
 // strings to fall back to insecure credentials (dev/test).
 // The returned cleanup function closes all connections and must be deferred by the caller.
-func NewGatewayClients(compilerAddr, engineAddr, registryAddr string, callTimeout time.Duration, tlsCertFile, tlsKeyFile, tlsCAFile string) (*GatewayClients, func(), error) {
+func NewGatewayClients(compilerAddr, engineAddr, registryAddr, eventBusAddr string, callTimeout time.Duration, tlsCertFile, tlsKeyFile, tlsCAFile string) (*GatewayClients, func(), error) {
 	creds, err := tlsCreds(tlsCertFile, tlsKeyFile, tlsCAFile)
 	if err != nil {
 		return nil, func() {}, fmt.Errorf("api-gateway: tls credentials: %w", err)
@@ -77,14 +83,22 @@ func NewGatewayClients(compilerAddr, engineAddr, registryAddr string, callTimeou
 		_ = engConn.Close()
 		return nil, func() {}, fmt.Errorf("api-gateway: registry dial: %w", err)
 	}
+	busConn, err := grpc.NewClient(eventBusAddr, dialOpts...)
+	if err != nil {
+		_ = compConn.Close()
+		_ = engConn.Close()
+		_ = regConn.Close()
+		return nil, func() {}, fmt.Errorf("api-gateway: event-bus dial: %w", err)
+	}
 	c := &GatewayClients{
 		compiler:    zynaxv1.NewWorkflowCompilerServiceClient(compConn),
 		engine:      zynaxv1.NewEngineAdapterServiceClient(engConn),
 		registry:    zynaxv1.NewAgentRegistryServiceClient(regConn),
-		conns:       []*grpc.ClientConn{compConn, engConn, regConn},
+		eventbus:    zynaxv1.NewEventBusServiceClient(busConn),
+		conns:       []*grpc.ClientConn{compConn, engConn, regConn, busConn},
 		callTimeout: callTimeout,
 	}
-	cleanup := func() { _ = compConn.Close(); _ = engConn.Close(); _ = regConn.Close() }
+	cleanup := func() { _ = compConn.Close(); _ = engConn.Close(); _ = regConn.Close(); _ = busConn.Close() }
 	return c, cleanup, nil
 }
 
@@ -180,6 +194,48 @@ func (c *GatewayClients) WatchWorkflow(ctx context.Context, runID string, send f
 			Payload:   string(ev.GetPayload()),
 		}
 		if ts := ev.GetTimestamp(); ts != nil {
+			we.Timestamp = ts.AsTime().Format(time.RFC3339)
+		}
+		if err := send(we); err != nil {
+			return err
+		}
+	}
+}
+
+// SubscribeWorkflowEvents implements domain.EventBusPort. It opens a
+// workflow-scoped EventBusService.Subscribe stream and bridges each delivered
+// CloudEvent to a domain.WatchEvent, keeping gRPC and proto types out of the
+// domain layer. The subscriber_id is derived from the workflow ID plus a
+// monotonic suffix so concurrent followers of the same run do not collide.
+func (c *GatewayClients) SubscribeWorkflowEvents(ctx context.Context, workflowID string, send func(domain.WatchEvent) error) error {
+	req := &zynaxv1.SubscribeRequest{
+		SubscriberId: fmt.Sprintf("api-gateway-logs-%s-%d", workflowID, time.Now().UnixNano()),
+		TypePattern:  capabilityEventPattern,
+		WorkflowId:   workflowID,
+	}
+	stream, err := c.eventbus.Subscribe(ctx, req)
+	if err != nil {
+		return mapEngineGRPCError(err)
+	}
+	for {
+		resp, err := stream.Recv()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+			return mapEngineGRPCError(err)
+		}
+		ce := resp.GetEvent()
+		if ce == nil {
+			continue
+		}
+		we := domain.WatchEvent{
+			RunID:     ce.GetWorkflowId(),
+			EventType: ce.GetType(),
+			Status:    "capability_event",
+			Payload:   string(ce.GetData()),
+		}
+		if ts := ce.GetTime(); ts != nil {
 			we.Timestamp = ts.AsTime().Format(time.RFC3339)
 		}
 		if err := send(we); err != nil {

--- a/services/api-gateway/tests/features/api_gateway.feature
+++ b/services/api-gateway/tests/features/api_gateway.feature
@@ -140,3 +140,15 @@ Feature: API Gateway
     Given the engine adapter does not know about run_id "ghost-log-run"
     When GET /api/v1/workflows/ghost-log-run/logs is called
     Then the HTTP status is 404
+
+  # ── GET /api/v1/workflows/{id}/logs — capability-event merge (EPIC L.3, #1182) ──
+
+  Scenario: GET /api/v1/workflows/{id}/logs merges engine history with capability events
+    Given a submitted workflow with run_id "merge-run-001"
+    And the engine adapter streams a state-entered event and then a completed event
+    And the event bus streams a capability event for the workflow
+    When GET /api/v1/workflows/merge-run-001/logs is called
+    Then the HTTP status is 200
+    And the Content-Type is "text/event-stream"
+    And the response body contains 3 SSE data lines
+    And the response body contains a capability event

--- a/services/api-gateway/tests/steps_test.go
+++ b/services/api-gateway/tests/steps_test.go
@@ -62,8 +62,10 @@ const (
 )
 
 type fakeEngine struct {
-	mode  engineMode
-	runID string
+	mode          engineMode
+	runID         string
+	watchEvents   []domain.WatchEvent
+	watchNotFound bool
 }
 
 func (f *fakeEngine) SubmitWorkflow(_ context.Context, _ []byte, _, _, _ string) (string, error) {
@@ -88,8 +90,33 @@ func (f *fakeEngine) GetWorkflowStatus(_ context.Context, runID string) (domain.
 
 func (f *fakeEngine) CancelWorkflow(_ context.Context, _ string) error { return nil }
 
-func (f *fakeEngine) WatchWorkflow(_ context.Context, _ string, _ func(domain.WatchEvent) error) error {
+func (f *fakeEngine) WatchWorkflow(_ context.Context, runID string, send func(domain.WatchEvent) error) error {
+	if f.watchNotFound {
+		return domain.ErrNotFound
+	}
+	for _, ev := range f.watchEvents {
+		ev.RunID = runID
+		if err := send(ev); err != nil {
+			return err
+		}
+	}
 	return nil
+}
+
+// ── fake EventBusPort ─────────────────────────────────────────────────────────
+
+type fakeEventBus struct{ events []domain.WatchEvent }
+
+func (f *fakeEventBus) SubscribeWorkflowEvents(ctx context.Context, _ string, send func(domain.WatchEvent) error) error {
+	for _, ev := range f.events {
+		if err := send(ev); err != nil {
+			return err
+		}
+	}
+	// Block until the engine stream completes and cancels us, mirroring the
+	// real event-bus which keeps the subscription open until terminal state.
+	<-ctx.Done()
+	return fmt.Errorf("context: %w", ctx.Err())
 }
 
 // ── fake RegistryPort ─────────────────────────────────────────────────────────
@@ -109,6 +136,7 @@ type testEnv struct {
 	compiler *fakeCompiler
 	engine   *fakeEngine
 	registry *fakeRegistry
+	eventbus *fakeEventBus
 	server   *httptest.Server
 	apiKey   string
 	lastResp *http.Response
@@ -119,8 +147,9 @@ func (e *testEnv) setup() {
 	e.compiler = &fakeCompiler{}
 	e.engine = &fakeEngine{}
 	e.registry = &fakeRegistry{}
+	e.eventbus = &fakeEventBus{}
 	e.apiKey = "test-api-key"
-	svc := domain.NewApplyService(e.compiler, e.engine, e.registry)
+	svc := domain.NewApplyService(e.compiler, e.engine, e.registry, e.eventbus)
 	h := api.NewHandler(svc, e.apiKey)
 	mux := http.NewServeMux()
 	h.RegisterRoutes(mux)
@@ -214,10 +243,51 @@ func TestFeatures(t *testing.T) {
 			sc.Step(`^the upstream service returns a gRPC INTERNAL error$`, pending)
 			sc.Step(`^the corresponding REST endpoint is called$`, pending)
 			sc.Step(`^the response message is exactly "internal error"$`, pending)
-			sc.Step(`^the engine adapter streams .+$`, pending) // SSE streaming
-			sc.Step(`^GET /api/v1/workflows/([^ ]+)/logs is called$`, pendingStr)
-			sc.Step(`^the Content-Type is "([^"]*)"$`, pendingStr)
-			sc.Step(`^the response body contains \d+ SSE data lines$`, pendingInt)
+
+			// ── GET /api/v1/workflows/{id}/logs — SSE streaming (#318, #1182) ──
+			sc.Step(`^the engine adapter streams a state-entered event and then a completed event$`,
+				func(ctx context.Context) (context.Context, error) {
+					env.engine.mode = engineRunning
+					env.engine.watchEvents = []domain.WatchEvent{
+						{EventType: "STATE_ENTERED", ToState: "running", Status: "WORKFLOW_STATUS_RUNNING"},
+						{EventType: "WORKFLOW_COMPLETED", Status: "WORKFLOW_STATUS_COMPLETED"},
+					}
+					return ctx, nil
+				})
+			sc.Step(`^the event bus streams a capability event for the workflow$`,
+				func(ctx context.Context) (context.Context, error) {
+					env.eventbus.events = []domain.WatchEvent{
+						{EventType: "zynax.task.completed", Status: "capability_event", Payload: `{"ok":true}`},
+					}
+					return ctx, nil
+				})
+			sc.Step(`^GET /api/v1/workflows/([^ ]+)/logs is called$`,
+				func(ctx context.Context, runID string) (context.Context, error) {
+					return ctx, env.do(http.MethodGet, "/api/v1/workflows/"+runID+"/logs", nil, "")
+				})
+			sc.Step(`^the Content-Type is "([^"]*)"$`,
+				func(ctx context.Context, want string) (context.Context, error) {
+					got := env.lastResp.Header.Get("Content-Type")
+					if !strings.HasPrefix(got, want) {
+						return ctx, fmt.Errorf("expected Content-Type %q, got %q", want, got)
+					}
+					return ctx, nil
+				})
+			sc.Step(`^the response body contains (\d+) SSE data lines$`,
+				func(ctx context.Context, want int) (context.Context, error) {
+					got := strings.Count(string(env.lastBody), "data: ")
+					if got != want {
+						return ctx, fmt.Errorf("expected %d SSE data lines, got %d (body: %s)", want, got, env.lastBody)
+					}
+					return ctx, nil
+				})
+			sc.Step(`^the response body contains a capability event$`,
+				func(ctx context.Context) (context.Context, error) {
+					if !strings.Contains(string(env.lastBody), "capability_event") {
+						return ctx, fmt.Errorf("body missing capability event: %s", env.lastBody)
+					}
+					return ctx, nil
+				})
 
 			// ── Auth ──────────────────────────────────────────────────────────
 			sc.Step(`^any API endpoint is called without Authorization header$`,
@@ -373,7 +443,8 @@ func TestFeatures(t *testing.T) {
 			sc.Step(`^the engine adapter does not know about run_id "([^"]*)"$`,
 				func(ctx context.Context, _ string) (context.Context, error) {
 					env.engine.mode = engineAccept
-					return ctx, nil // GetWorkflowStatus will return ErrNotFound
+					env.engine.watchNotFound = true
+					return ctx, nil // GetWorkflowStatus and WatchWorkflow return ErrNotFound
 				})
 			sc.Step(`^the response contains a status field$`,
 				func(ctx context.Context) (context.Context, error) {
@@ -421,9 +492,8 @@ func TestFeatures(t *testing.T) {
 
 var errPending = godog.ErrPending
 
-func pending(ctx context.Context) (context.Context, error)              { return ctx, errPending }
-func pendingStr(ctx context.Context, _ string) (context.Context, error) { return ctx, errPending }
-func pendingInt(ctx context.Context, _ int) (context.Context, error)    { return ctx, errPending }
+func pending(ctx context.Context) (context.Context, error)           { return ctx, errPending }
+func pendingInt(ctx context.Context, _ int) (context.Context, error) { return ctx, errPending }
 
 // Ensure domain errors package is used (imported via fake ports above).
 var _ = errors.Is


### PR DESCRIPTION
## feat(api-gateway): merge capability events into /logs stream

Closes #1182
Part of #468 (EPIC L — Execution Log/Event Streaming)

### Why
`GET /api/v1/workflows/{id}/logs` already streamed SSE, but only the engine's
state-transition history. Canvas EPIC L step 3 requires the stream to *merge*
engine history **with** the per-workflow capability events that L.2 (#1181)
delivered, so a developer watching a run sees both lifecycle transitions and
capability (task) events in one chronological feed.

### What you'll get
- a workflow-scoped `EventBusPort` the gateway can subscribe on ← `services/api-gateway/internal/domain/ports.go`
- `/logs` SSE output now interleaves engine history + capability CloudEvents ← `services/api-gateway/internal/domain/apply.go` (`WatchWorkflowLogs` fan-in)
- a real `EventBusService.Subscribe(workflow_id)` client bridging CloudEvent → `WatchEvent` ← `services/api-gateway/internal/infrastructure/clients.go`
- event-bus address wired via `ZYNAX_GW_EVENT_BUS_ADDR` (default `localhost:50056`) ← `services/api-gateway/cmd/api-gateway/main.go`
- a BDD scenario proving the merge ← `services/api-gateway/tests/features/api_gateway.feature`

### Scope & boundaries
- **In scope:** merging the L.2 per-workflow event subscription into the existing SSE `/logs` handler; engine history remains authoritative for stream lifetime (it cancels the event subscription on terminal state).
- **Out of scope (deferred):** CLI follower `zynax logs --follow` → L.4 #1183; log persistence/search → EPIC O / M-dx.

### Test plan & acceptance
| Acceptance criterion | How verified (command) | Result |
|----------------------|------------------------|--------|
| SSE/chunked response merging history + events | `GOWORK=off go test ./tests/... -race` (BDD: "merges engine history with capability events" → 3 data lines, contains a capability event) | ✅ 22 scenarios, 18 passed |
| no `streaming not supported` error | live SSE path returns `text/event-stream` 200; the error branch only guards a non-Flusher ResponseWriter | ✅ Content-Type asserted in BDD + handler tests |
| `.feature` committed first (ADR-016) | merge scenario added to `tests/features/api_gateway.feature` in this commit | ✅ committed |
| domain cov ≥ 90% | `GOWORK=off go test ./internal/domain/... -cover` | ✅ 96.1% |

**Local gates:** `make lint-go` ✅ · `GOWORK=off go test ./... -race` ✅ (all 5 packages ok)

### Evidence
- **CI:** required checks pending — see PR checks.
- **Local output:** domain coverage `96.1% of statements`; `make lint-go` → `✅ Go lint passed` (0 issues all services); `go test ./... -race` → all `ok`.
- **Artifacts / images:** api-gateway source changed; image rebuild handled by release pipeline.
- **Post-merge digest sync → main:** _placeholder — filled by post-merge verifier._

### Risk & rollback
Low. Additive: when no event-bus port is configured (`eventbus == nil`) the
handler falls back to the prior engine-history-only behaviour, and a
capability-event subscription failure is best-effort and never aborts the
authoritative engine history stream. Rollback = revert this PR; no schema or
data migration.

### Review aids
- Key file: `services/api-gateway/internal/domain/apply.go` — `WatchWorkflowLogs` now runs both upstreams concurrently behind a single mutex-guarded `send`; the engine stream's completion cancels the event subscription via `subCtx`.
- The event subscription is scoped by `workflow_id`, resolved from `GetWorkflowStatus(runID).WorkflowID`; a lookup miss degrades to engine-only rather than dropping the stream.
- Note the `ZYNAX_GW_EVENT_BUS_ADDR` new env var (api-gateway wiring) — Helm values may want it set in cluster.

**SPDD:** Canvas `docs/spdd/468-log-streaming/canvas.md` — Status: **Aligned** (step L.3). No new injection surface: same bearer-auth rules and payload redaction as other gateway routes.
**AI:** `Assisted-by: Claude/claude-opus-4-8`
