### PR TITLE
feat(cli): zynax validate + workflow version surfacing

### DIFF
--- a/cmd/zynax/AGENTS.md
+++ b/cmd/zynax/AGENTS.md
@@ -25,6 +25,10 @@ cmd/zynax/
     delete.go       zynax delete workflow <run-id>
     status.go       zynax status workflow <run-id>   (exit 0 = terminal, 2 = running)
     logs.go         zynax logs <run-id> [--format text|json]
+    validate.go      zynax validate <file> [--schema-dir] [--format]  (local: schema + data-flow)
+  validate/
+    manifest.go     JSON Schema validation (validate.Manifest) + combined pipeline (validate.File)
+    dataflow.go     Workflow state-machine checks (initial_state + transition goto targets)
   client/
     gateway.go      HTTP client for all api-gateway endpoints
     gateway_test.go unit tests (no network — uses httptest.Server)

--- a/cmd/zynax/client/gateway.go
+++ b/cmd/zynax/client/gateway.go
@@ -26,6 +26,9 @@ type WorkflowStatus struct {
 	WorkflowID   string `json:"workflow_id"`
 	Status       string `json:"status"`
 	CurrentState string `json:"current_state"`
+	// Version is the manifest's metadata.version (SemVer) when set. Optional and
+	// backward-compatible: older gateways omit it and the CLI hides it then.
+	Version string `json:"version,omitempty"`
 }
 
 // CompileError is a single diagnostic from the workflow compiler.

--- a/cmd/zynax/cmd/cmd_test.go
+++ b/cmd/zynax/cmd/cmd_test.go
@@ -72,7 +72,7 @@ func TestRunValidateManifest_ValidFile(t *testing.T) {
 
 	cmd := fakeCmd(t)
 	fixture := filepath.Join(root, "spec/workflows/examples/code-review.yaml")
-	if err := runValidateManifest(cmd, []string{fixture}); err != nil {
+	if err := runValidate(cmd, []string{fixture}); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 }
@@ -87,7 +87,7 @@ func TestRunValidateManifest_UnknownKind_TextFormat(t *testing.T) {
 	_ = os.WriteFile(f, []byte("kind: Unknown\n"), 0o600)
 
 	cmd := fakeCmd(t)
-	if err := runValidateManifest(cmd, []string{f}); err == nil {
+	if err := runValidate(cmd, []string{f}); err == nil {
 		t.Error("expected error for unknown kind")
 	}
 }
@@ -102,7 +102,7 @@ func TestRunValidateManifest_JSONFormat_Valid(t *testing.T) {
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	fixture := filepath.Join(root, "spec/workflows/examples/code-review.yaml")
-	_ = runValidateManifest(cmd, []string{fixture})
+	_ = runValidate(cmd, []string{fixture})
 
 	var decoded interface{}
 	if err := json.Unmarshal(out.Bytes(), &decoded); err != nil {
@@ -123,7 +123,7 @@ func TestRunValidateManifest_JSONFormat_Errors(t *testing.T) {
 	cmd := fakeCmd(t)
 	var out bytes.Buffer
 	cmd.SetOut(&out)
-	_ = runValidateManifest(cmd, []string{f})
+	_ = runValidate(cmd, []string{f})
 
 	var decoded interface{}
 	if err := json.Unmarshal(out.Bytes(), &decoded); err != nil {
@@ -137,8 +137,26 @@ func TestRunValidateManifest_FileNotFound(t *testing.T) {
 	validateFormat = formatText
 
 	cmd := fakeCmd(t)
-	if err := runValidateManifest(cmd, []string{"/nonexistent/manifest.yaml"}); err == nil {
+	if err := runValidate(cmd, []string{"/nonexistent/manifest.yaml"}); err == nil {
 		t.Error("expected error for missing file")
+	}
+}
+
+func TestRunValidate_DataFlowError(t *testing.T) {
+	root := repoRoot(t)
+	validateSchemaDir = filepath.Join(root, "spec/schemas")
+	validateFormat = formatText
+
+	dir := t.TempDir()
+	f := filepath.Join(dir, "wf.yaml")
+	// Schema-valid Workflow whose initial_state references an undefined state.
+	body := "kind: Workflow\napiVersion: zynax.io/v1\nmetadata:\n  name: wf\n" +
+		"spec:\n  initial_state: ghost\n  states:\n    start:\n      type: terminal\n"
+	_ = os.WriteFile(f, []byte(body), 0o600)
+
+	cmd := fakeCmd(t)
+	if err := runValidate(cmd, []string{f}); err == nil {
+		t.Error("expected data-flow error for undefined initial_state")
 	}
 }
 
@@ -235,6 +253,47 @@ func TestGetWorkflow_OK(t *testing.T) {
 	}
 	if run.Status != "WORKFLOW_STATUS_RUNNING" {
 		t.Errorf("status = %q", run.Status)
+	}
+}
+
+func TestGetWorkflowCmd_SurfacesVersion(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"run_id": "run-1", "status": "WORKFLOW_STATUS_COMPLETED", "version": "1.2.3",
+		})
+	}))
+	defer srv.Close()
+	apiURL = srv.URL
+
+	var out bytes.Buffer
+	getWorkflowCmd.SetOut(&out)
+	getWorkflowCmd.SetContext(context.Background())
+	if err := getWorkflowCmd.RunE(getWorkflowCmd, []string{"run-1"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !bytes.Contains(out.Bytes(), []byte("version:       1.2.3")) {
+		t.Errorf("expected version in output, got:\n%s", out.String())
+	}
+}
+
+func TestStatusCmd_TerminalSurfacesVersion(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"run_id": "run-1", "status": "WORKFLOW_STATUS_COMPLETED", "version": "2.0.0",
+		})
+	}))
+	defer srv.Close()
+	apiURL = srv.URL
+
+	var out bytes.Buffer
+	statusWorkflowCmd.SetOut(&out)
+	statusWorkflowCmd.SetContext(context.Background())
+	// Terminal status returns without os.Exit(2).
+	if err := statusWorkflowCmd.RunE(statusWorkflowCmd, []string{"run-1"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !bytes.Contains(out.Bytes(), []byte("version: 2.0.0")) {
+		t.Errorf("expected version in status output, got:\n%s", out.String())
 	}
 }
 

--- a/cmd/zynax/cmd/get.go
+++ b/cmd/zynax/cmd/get.go
@@ -27,6 +27,9 @@ var getWorkflowCmd = &cobra.Command{
 		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "workflow_id:   %s\n", run.WorkflowID)
 		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "status:        %s\n", run.Status)
 		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "current_state: %s\n", run.CurrentState)
+		if run.Version != "" {
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "version:       %s\n", run.Version)
+		}
 		return nil
 	},
 }

--- a/cmd/zynax/cmd/status.go
+++ b/cmd/zynax/cmd/status.go
@@ -32,6 +32,9 @@ var statusWorkflowCmd = &cobra.Command{
 			return err
 		}
 		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s\n", run.Status)
+		if run.Version != "" {
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "version: %s\n", run.Version)
+		}
 		if !terminalStatuses[run.Status] {
 			os.Exit(2)
 		}

--- a/cmd/zynax/cmd/validate.go
+++ b/cmd/zynax/cmd/validate.go
@@ -11,8 +11,20 @@ import (
 )
 
 var validateCmd = &cobra.Command{
-	Use:   "validate",
-	Short: "Validate manifests, Canvases, and JSON Schemas",
+	Use:   "validate <file>",
+	Short: "Validate a manifest locally for schema and data-flow errors",
+	Long: `Validate <file> locally against its JSON Schema and (for Workflow
+manifests) its state-machine data-flow.
+
+The kind is read from the 'kind:' field in the YAML. The matching schema is
+loaded from <schema-dir>/<kind>.schema.json. Supported kinds: Workflow, AgentDef,
+Policy. For Workflow manifests, data-flow checks also verify that initial_state
+and every transition 'goto' reference a defined state.
+
+Runs entirely locally — no api-gateway connection required.
+Exits 0 on success, 1 on any validation error.`,
+	Args: cobra.ExactArgs(1),
+	RunE: runValidate,
 }
 
 var (
@@ -20,31 +32,28 @@ var (
 	validateFormat    string
 )
 
+// validateManifestCmd is the explicit 'validate manifest <file>' form, kept as a
+// subcommand for backward compatibility. It is equivalent to 'validate <file>'.
 var validateManifestCmd = &cobra.Command{
-	Use:   "manifest <file>",
-	Short: "Validate a YAML manifest against its JSON schema",
-	Long: `Validate <file> against the JSON Schema for its kind.
-
-The kind is read from the 'kind:' field in the YAML. The matching schema is
-loaded from <schema-dir>/<kind>.schema.json. Supported kinds: Workflow, AgentDef, Policy.
-
-Exits 0 on success, 1 on any validation error.`,
-	Args: cobra.ExactArgs(1),
-	RunE: runValidateManifest,
+	Use:    "manifest <file>",
+	Short:  "Validate a YAML manifest (alias for 'validate <file>')",
+	Args:   cobra.ExactArgs(1),
+	RunE:   runValidate,
+	Hidden: true,
 }
 
 func init() {
-	validateManifestCmd.Flags().StringVar(&validateSchemaDir, "schema-dir", "spec/schemas",
+	validateCmd.PersistentFlags().StringVar(&validateSchemaDir, "schema-dir", "spec/schemas",
 		"directory containing <kind>.schema.json files")
-	validateManifestCmd.Flags().StringVar(&validateFormat, "format", "text",
+	validateCmd.PersistentFlags().StringVar(&validateFormat, "format", "text",
 		"output format: text or json")
 	validateCmd.AddCommand(validateManifestCmd)
 	rootCmd.AddCommand(validateCmd)
 }
 
-func runValidateManifest(cmd *cobra.Command, args []string) error {
+func runValidate(cmd *cobra.Command, args []string) error {
 	file := args[0]
-	errs, err := validate.Manifest(file, validateSchemaDir)
+	errs, err := validate.File(file, validateSchemaDir)
 	if err != nil {
 		return err
 	}

--- a/cmd/zynax/validate/dataflow.go
+++ b/cmd/zynax/validate/dataflow.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package validate
+
+import (
+	"fmt"
+	"os"
+	"sort"
+
+	"gopkg.in/yaml.v3"
+)
+
+// DataFlow validates the state-machine data-flow of a Workflow manifest beyond
+// what the JSON Schema can express: it checks that spec.initial_state resolves
+// to a defined state and that every transition 'goto' targets a defined state.
+//
+// These are the compiler-enforced invariants the workflow.schema.json explicitly
+// defers (see its 'states'/'initial_state' descriptions). DataFlow only inspects
+// kind: Workflow manifests; for any other kind it returns (nil, nil).
+//
+// Returns (nil, nil) when the data-flow is sound; ([errors…], nil) on data-flow
+// violations; (nil, err) on I/O or structural failures.
+func DataFlow(filePath string) ([]ValidationError, error) {
+	raw, err := os.ReadFile(filePath) //nolint:gosec // filePath is caller-supplied manifest path
+	if err != nil {
+		return nil, fmt.Errorf("validate: read %q: %w", filePath, err)
+	}
+
+	var doc struct {
+		Kind string `yaml:"kind"`
+		Spec struct {
+			InitialState string `yaml:"initial_state"`
+			States       map[string]struct {
+				On []struct {
+					Goto string `yaml:"goto"`
+				} `yaml:"on"`
+			} `yaml:"states"`
+		} `yaml:"spec"`
+	}
+	if err := yaml.Unmarshal(raw, &doc); err != nil {
+		// Structural/YAML errors are surfaced by Manifest's schema pass; skip here.
+		return nil, nil //nolint:nilerr // schema validation owns parse-error reporting
+	}
+	if doc.Kind != "Workflow" {
+		return nil, nil
+	}
+
+	var errs []ValidationError
+
+	if doc.Spec.InitialState != "" {
+		if _, ok := doc.Spec.States[doc.Spec.InitialState]; !ok {
+			errs = append(errs, ValidationError{
+				File:    filePath,
+				Path:    "/spec/initial_state",
+				Message: fmt.Sprintf("initial_state %q is not a defined state", doc.Spec.InitialState),
+			})
+		}
+	}
+
+	// Iterate states in sorted order for deterministic error output.
+	names := make([]string, 0, len(doc.Spec.States))
+	for name := range doc.Spec.States {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		state := doc.Spec.States[name]
+		for i, tr := range state.On {
+			if tr.Goto == "" {
+				continue
+			}
+			if _, ok := doc.Spec.States[tr.Goto]; !ok {
+				errs = append(errs, ValidationError{
+					File:    filePath,
+					Path:    fmt.Sprintf("/spec/states/%s/on/%d/goto", name, i),
+					Message: fmt.Sprintf("transition target %q is not a defined state", tr.Goto),
+				})
+			}
+		}
+	}
+
+	return errs, nil
+}

--- a/cmd/zynax/validate/dataflow_test.go
+++ b/cmd/zynax/validate/dataflow_test.go
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package validate_test
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/zynax-io/zynax/cmd/zynax/validate"
+)
+
+const validWorkflow = `kind: Workflow
+apiVersion: zynax.io/v1
+metadata:
+  name: wf
+spec:
+  initial_state: start
+  states:
+    start:
+      on:
+        - event: done
+          goto: finish
+    finish:
+      type: terminal
+`
+
+func writeTmp(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	f := filepath.Join(dir, "wf.yaml")
+	if err := os.WriteFile(f, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return f
+}
+
+func TestDataFlow_Valid(t *testing.T) {
+	errs, err := validate.DataFlow(writeTmp(t, validWorkflow))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(errs) != 0 {
+		t.Fatalf("expected no data-flow errors, got %v", errs)
+	}
+}
+
+func TestDataFlow_UndefinedInitialState(t *testing.T) {
+	body := `kind: Workflow
+apiVersion: zynax.io/v1
+metadata:
+  name: wf
+spec:
+  initial_state: nope
+  states:
+    start:
+      type: terminal
+`
+	errs, err := validate.DataFlow(writeTmp(t, body))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(errs) != 1 || errs[0].Path != "/spec/initial_state" {
+		t.Fatalf("expected initial_state error, got %v", errs)
+	}
+}
+
+func TestDataFlow_UndefinedGotoTarget(t *testing.T) {
+	body := `kind: Workflow
+apiVersion: zynax.io/v1
+metadata:
+  name: wf
+spec:
+  initial_state: start
+  states:
+    start:
+      on:
+        - event: done
+          goto: missing
+`
+	errs, err := validate.DataFlow(writeTmp(t, body))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(errs) != 1 || errs[0].Path != "/spec/states/start/on/0/goto" {
+		t.Fatalf("expected goto error, got %v", errs)
+	}
+}
+
+func TestDataFlow_NonWorkflowKindSkipped(t *testing.T) {
+	body := "kind: AgentDef\napiVersion: zynax.io/v1\n"
+	errs, err := validate.DataFlow(writeTmp(t, body))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(errs) != 0 {
+		t.Fatalf("expected non-Workflow to be skipped, got %v", errs)
+	}
+}
+
+func TestDataFlow_FileNotFound(t *testing.T) {
+	if _, err := validate.DataFlow("/nonexistent/wf.yaml"); err == nil {
+		t.Fatal("expected error for missing file")
+	}
+}
+
+func TestDataFlow_InvalidYAMLSkipped(t *testing.T) {
+	// Parse errors are owned by the schema pass; DataFlow returns no errors.
+	errs, err := validate.DataFlow(writeTmp(t, ":\t bad yaml {{{"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(errs) != 0 {
+		t.Fatalf("expected parse errors to be skipped, got %v", errs)
+	}
+}
+
+func TestFile_MissingFile(t *testing.T) {
+	if _, err := validate.File("/nonexistent/wf.yaml", "spec/schemas"); err == nil {
+		t.Fatal("expected error for missing file")
+	}
+}
+
+func TestFile_SchemaAndDataFlowCombined(t *testing.T) {
+	// initial_state references an undefined state — data-flow catches it even
+	// though the manifest is schema-valid.
+	body := `kind: Workflow
+apiVersion: zynax.io/v1
+metadata:
+  name: wf
+spec:
+  initial_state: ghost
+  states:
+    start:
+      type: terminal
+`
+	_, file, _, _ := runtime.Caller(0)
+	schemaDir := filepath.Join(filepath.Dir(file), "../../../spec/schemas")
+	errs, err := validate.File(writeTmp(t, body), schemaDir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(errs) == 0 {
+		t.Fatal("expected combined validation to report the data-flow error")
+	}
+}

--- a/cmd/zynax/validate/manifest.go
+++ b/cmd/zynax/validate/manifest.go
@@ -91,6 +91,25 @@ func Manifest(filePath, schemaDir string) ([]ValidationError, error) {
 	return nil, nil
 }
 
+// File runs the full local validation pipeline over the manifest at filePath:
+// JSON Schema validation (Manifest) followed by state-machine data-flow checks
+// (DataFlow) for Workflow manifests. It returns the combined list of errors.
+//
+// Returns (nil, nil) when the manifest is valid; ([errors…], nil) on schema or
+// data-flow violations; (nil, err) on I/O or structural failures.
+func File(filePath, schemaDir string) ([]ValidationError, error) {
+	schemaErrs, err := Manifest(filePath, schemaDir)
+	if err != nil {
+		return nil, err
+	}
+	flowErrs, err := DataFlow(filePath)
+	if err != nil {
+		return nil, err
+	}
+	combined := append(schemaErrs, flowErrs...) //nolint:gocritic // intentional new slice
+	return combined, nil
+}
+
 // compileSchema compiles a JSON Schema from an absolute file path.
 func compileSchema(absPath string) (*jsonschema.Schema, error) {
 	c := jsonschema.NewCompiler()


### PR DESCRIPTION
Closes #1207

## Why
EPIC T (#1171) step T.2. There was no way to catch manifest errors before
`apply`, and a workflow's `metadata.version` (added optionally in #1206) was
never surfaced to operators. Authors need a fast, local pre-flight check and
visible versioning so they can evolve workflows safely.

## What you'll get
- `zynax validate <file>` — fully local validation (no api-gateway). Runs JSON
  Schema validation, then, for `kind: Workflow`, state-machine **data-flow**
  checks: `spec.initial_state` and every transition `goto` must reference a
  defined state. `--schema-dir` and `--format text|json` flags. Exit 0 on
  success, 1 on any error.
- `zynax validate manifest <file>` retained as a hidden alias (back-compat).
- `version:` surfaced in `zynax status workflow <id>` and `zynax get workflow <id>`
  when the run carries a `metadata.version`.

## Scope & boundaries
- **In:** `cmd/zynax/` only — new `validate.DataFlow` + `validate.File`, the
  refactored `validate` command, `WorkflowStatus.Version` field, and version
  printing in get/status.
- **Out:** `zynax init` scaffolding (T.4), real workflows (T.3), any api-gateway
  / service code. CLI stays HTTP-only, no gRPC, no `services/*/internal/` imports
  (cmd/zynax AGENTS.md).
- `Version` is decoded with `omitempty`: older gateways that omit it leave the
  CLI output unchanged — backward-compatible.

## Test plan & acceptance
- [x] **AC1 — `zynax validate <file>` reports schema/data-flow errors:**
  `validate.File` chains `Manifest` (schema) + `DataFlow` (state machine).
  Covered by `validate/dataflow_test.go` (undefined initial_state, undefined
  goto, combined pipeline) and `cmd_test.go::TestRunValidate_DataFlowError`.
- [x] **AC2 — `version:` shown in status:** `status` and `get` print `version:`
  when present. Covered by `TestStatusCmd_TerminalSurfacesVersion` and
  `TestGetWorkflowCmd_SurfacesVersion`.

## Evidence
```
GOWORK=off go build ./...        # exit 0
GOWORK=off go test ./... -race   # client/cmd/gitops/validate all ok
coverage: validate 87.0% · runValidate/printValidate 100% · DataFlow 95.8%
make lint                        # Proto/Go/Go-adapter/Python lint all passed
```

## Risk & rollback
Low. Additive CLI behavior; new validation is local and opt-in via the
`validate` command. `version:` printing is gated on a non-empty field. Rollback
= revert this commit; no schema, proto, or persistence changes.

## Review aids
- `cmd/zynax/validate/dataflow.go` — the only new validation logic.
- `cmd/zynax/validate/manifest.go::File` — combines schema + data-flow.
- `cmd/zynax/cmd/validate.go` — `validate <file>` direct form + hidden `manifest` alias.

## SPDD
Canvas: `docs/spdd/1171-templates-real-workflows/canvas.md` — EPIC T, step T.2, status Aligned.

<!-- post-merge: image digest sync runs on main; no digest changes in this PR -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
