### PR TITLE
test(workflow-compiler): fuzz the YAML->IR compiler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,10 @@ GO_SERVICES   := $(shell grep -E '^\s+\./services/' go.work | sed 's|.*services/
 GO_ADAPTERS   := $(shell grep -E '^\s+\./agents/adapters/' go.work | sed 's|.*agents/adapters/||' | tr -d '\t ' | sort)
 # Services carrying Go benchmarks (EPIC R / #493). Add a service here when it gains a Benchmark* test.
 BENCH_SERVICES := engine-adapter workflow-compiler
+# Services carrying Go fuzz targets (EPIC R / #1210). Add a service here when it gains a Fuzz* test.
+FUZZ_SERVICES := workflow-compiler
+# Per-target fuzz campaign duration for `make fuzz` (override: make fuzz DURATION=60s).
+DURATION ?= 60s
 # Committed benchmark baseline — CI compares fresh runs against this with benchstat.
 BENCH_BASELINE := tools/bench-baseline.txt
 # Auto-discovered from agents/examples/*/pyproject.toml — no manual update needed when adding a new agent.
@@ -172,7 +176,7 @@ lint-fix: ensure-tools ## Auto-fix Python agent lint errors
 		$(TOOLS_RUN) sh -c "cd agents/examples/$$a && uv run ruff check --fix src/ tests/ && uv run ruff format src/ tests/" || true; done
 
 # ── Tests ──────────────────────────────────────────────────────────────────
-.PHONY: test test-unit test-unit-go test-unit-adapters test-unit-svc test-unit-agents test-unit-agent test-bdd test-coverage test-coverage-adapters test-integration bench
+.PHONY: test test-unit test-unit-go test-unit-adapters test-unit-svc test-unit-agents test-unit-agent test-bdd test-coverage test-coverage-adapters test-integration bench fuzz
 test: validate-spec test-unit test-bdd test-coverage test-coverage-adapters ## ★ Full local test suite — mirrors CI (spec + Go + Python + BDD + coverage gate)
 test-unit: test-unit-go test-unit-adapters test-unit-agents ## All unit tests (Go services + Go adapters + Python)
 
@@ -275,6 +279,18 @@ bench: ensure-tools ## Run domain benchmarks and regenerate $(BENCH_BASELINE) (-
 			| tee -a "$(BENCH_BASELINE)" || exit 1; \
 	done
 	@echo "✅ Benchmarks complete — baseline written to $(BENCH_BASELINE)"
+
+fuzz: ensure-tools ## Run domain fuzz campaigns locally (override duration: make fuzz DURATION=60s)
+	@echo "🎲 Running fuzz campaigns (DURATION=$(DURATION) per target)"
+	@for svc in $(FUZZ_SERVICES); do \
+		echo "── fuzz: services/$$svc"; \
+		$(TOOLS_RUN) sh -c "cd services/$$svc && \
+			for fn in \$$(GOWORK=off go test ./internal/domain/... -list='^Fuzz' 2>/dev/null | grep '^Fuzz'); do \
+				echo \"   campaign: \$$fn\"; \
+				GOWORK=off go test ./internal/domain/... -run='^\$$' -fuzz=\"^\$$fn\$$\" -fuzztime=$(DURATION) || exit 1; \
+			done" || exit 1; \
+	done
+	@echo "✅ Fuzz campaigns complete — no crashers found"
 
 # ── Proto generation + lint ────────────────────────────────────────────────
 .PHONY: generate-protos go-generate lint-protos

--- a/services/workflow-compiler/internal/domain/manifest_fuzz_test.go
+++ b/services/workflow-compiler/internal/domain/manifest_fuzz_test.go
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package domain
+
+import (
+	"context"
+	"embed"
+	"io/fs"
+	"testing"
+)
+
+// fuzzCorpus embeds the seed corpus for FuzzParseManifest. The files are copies
+// of spec/workflows/examples/*.yaml — the canvas-mandated seed source (EPIC R
+// canvas step R.2, #1210). They are embedded (not read from the repo-root spec/
+// tree) so the domain fuzz target stays self-contained and runs from the package
+// directory under GOWORK=off, with no dependency on the working directory —
+// mirroring the BenchmarkParseManifest embed pattern. Keep them in sync with
+// spec/workflows/examples/.
+//
+//go:embed testdata/fuzz_corpus/*.yaml
+var fuzzCorpus embed.FS
+
+// FuzzParseManifest fuzzes the YAML->IR compiler entry point ParseManifest with
+// untrusted bytes. ParseManifest accepts arbitrary external manifest input, so a
+// malformed manifest must never panic — it must return a structured ParseErrors
+// instead (EPIC R canvas, review gap M2/R14; #1210).
+//
+// The seed corpus is the set of real example workflows under
+// spec/workflows/examples/ (valid Workflow manifests plus non-Workflow kinds such
+// as Policy/AgentDef that exercise the rejection path), augmented with hand-picked
+// edge cases. CI runs this seed-only (no fuzz campaign) via `go test`; longer
+// campaigns run locally via `make fuzz DURATION=60s`.
+//
+// The fuzz body asserts only structural invariants — never a specific output,
+// since fuzz inputs are by definition unknown (canvas Safeguards):
+//   - ParseManifest never panics.
+//   - It returns exactly one of: (non-nil manifest, no errors) or
+//     (nil manifest, at least one error). A non-nil manifest with errors, or a
+//     nil manifest with no errors, is a contract violation.
+func FuzzParseManifest(f *testing.F) {
+	seedFromCorpus(f)
+
+	// Hand-picked edge cases beyond the example corpus.
+	for _, seed := range [][]byte{
+		nil,
+		[]byte(""),
+		[]byte("\x00"),
+		[]byte("kind: Workflow"),
+		[]byte("not: yaml: : :"),
+		[]byte("- - - - -"),
+		minimalValid(),
+	} {
+		f.Add(seed)
+	}
+
+	ctx := context.Background()
+	f.Fuzz(func(t *testing.T, data []byte) {
+		manifest, errs := ParseManifest(ctx, data)
+		switch {
+		case manifest == nil && len(errs) == 0:
+			t.Fatalf("ParseManifest returned nil manifest with no errors for input %q", data)
+		case manifest != nil && len(errs) != 0:
+			t.Fatalf("ParseManifest returned a manifest AND %d errors for input %q", len(errs), data)
+		}
+	})
+}
+
+// seedFromCorpus adds every embedded example YAML as a fuzz seed.
+func seedFromCorpus(f *testing.F) {
+	f.Helper()
+	entries, err := fs.ReadDir(fuzzCorpus, "testdata/fuzz_corpus")
+	if err != nil {
+		f.Fatalf("read embedded fuzz corpus: %v", err)
+	}
+	if len(entries) == 0 {
+		f.Fatal("fuzz corpus is empty: expected seeds from spec/workflows/examples")
+	}
+	for _, e := range entries {
+		data, readErr := fuzzCorpus.ReadFile("testdata/fuzz_corpus/" + e.Name())
+		if readErr != nil {
+			f.Fatalf("read seed %s: %v", e.Name(), readErr)
+		}
+		f.Add(data)
+	}
+}

--- a/services/workflow-compiler/internal/domain/testdata/fuzz_corpus/agent-def-example.yaml
+++ b/services/workflow-compiler/internal/domain/testdata/fuzz_corpus/agent-def-example.yaml
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: Apache-2.0
+# Example AgentDef manifest — illustrates valid capability declarations
+# and runtime configuration for a gRPC capability provider.
+# Validated by: make validate-spec (against spec/schemas/agent-def.schema.json)
+
+apiVersion: zynax.io/v1alpha1
+kind: AgentDef
+
+metadata:
+  name: code-review-agent
+  namespace: default
+  labels:
+    team: platform
+
+spec:
+  capabilities:
+    - name: summarize
+      description: >
+        Produces a concise summary of a pull request diff.
+        Returns a plain-text summary and an estimated word count.
+      input_schema:
+        type: object
+        required: [text]
+        properties:
+          text:
+            type: string
+            description: The raw diff or PR body text to summarize.
+          max_words:
+            type: integer
+            description: Upper bound on summary length in words.
+            default: 200
+            minimum: 10
+      output_schema:
+        type: object
+        required: [summary, word_count]
+        properties:
+          summary:
+            type: string
+            description: The generated summary text.
+          word_count:
+            type: integer
+            description: Number of words in the returned summary.
+      timeout_seconds: 30
+      max_retries: 2
+
+    - name: score_complexity
+      description: >
+        Assigns a complexity score (1–10) to a code change based on
+        cyclomatic complexity heuristics.
+      input_schema:
+        type: object
+        required: [diff]
+        properties:
+          diff:
+            type: string
+            description: Unified diff of the code change.
+          language:
+            type: string
+            description: Programming language hint (e.g. "go", "python").
+      output_schema:
+        type: object
+        required: [score]
+        properties:
+          score:
+            type: integer
+            description: Complexity score from 1 (trivial) to 10 (very complex).
+            minimum: 1
+            maximum: 10
+          rationale:
+            type: string
+            description: Human-readable explanation of the score.
+      timeout_seconds: 15
+      max_retries: 1
+
+    - name: ping
+      description: Health-check capability. Returns immediately with no payload processing.
+      timeout_seconds: 5
+      max_retries: 0
+
+  runtime:
+    image: ghcr.io/zynax-io/code-review-agent:v0.1.0
+    env:
+      LOG_LEVEL: info
+      GRPC_PORT: "50051"
+    resources:
+      requests:
+        cpu: "100m"
+        memory: "128Mi"
+      limits:
+        cpu: "500m"
+        memory: "512Mi"
+    replicas: 2

--- a/services/workflow-compiler/internal/domain/testdata/fuzz_corpus/agent-def-expert.yaml
+++ b/services/workflow-compiler/internal/domain/testdata/fuzz_corpus/agent-def-expert.yaml
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: Apache-2.0
+# Runtime expert template (kind: AgentDef) — EPIC X (#1170) step X.3 (#1203).
+#
+# A "runtime expert" is an ordinary AgentDef whose capabilities encode an expert
+# review loop, declared so it registers in agent-registry and is dispatchable by
+# the task broker inside a workflow. This template mirrors the go-review-expert
+# reference agent (agents/examples/go-review-expert, X.2) so the manifest and the
+# running agent advertise the same capability routing key (go_review).
+#
+# Distinguishing label: agent.zynax.io/kind=expert marks this AgentDef as a
+# runtime expert (vs a plain capability provider) so operators and the authoring
+# ↔ runtime mapping (X.5) can select experts via a ListAgents label selector.
+#
+# Dispatch + tracing: the task broker routes ActionIR.capability=go_review to this
+# agent's endpoint via FindByCapability; ExecuteCapability calls are OTEL-traced by
+# the broker/agent gRPC interceptors (M7) under the workflow's propagated context.
+#
+# Validated by: make validate-spec (against spec/schemas/agent-def.schema.json).
+apiVersion: zynax.io/v1alpha1
+kind: AgentDef
+
+metadata:
+  name: go-review-expert
+  namespace: default
+  labels:
+    team: platform
+    agent.zynax.io/kind: expert
+    agent.zynax.io/expert: go-review
+
+spec:
+  capabilities:
+    - name: go_review
+      description: >
+        Rule-based Go code review. Inspects a Go diff or source file and returns
+        structured findings (line, severity, message), a finding count, and an
+        approval flag that is false when any finding has severity 'error'.
+      input_schema:
+        type: object
+        required: [diff]
+        properties:
+          diff:
+            type: string
+            description: Go source or unified-diff text to review.
+        additionalProperties: false
+      output_schema:
+        type: object
+        required: [findings, finding_count, approved]
+        properties:
+          findings:
+            type: array
+            description: Ordered review findings.
+            items:
+              type: object
+          finding_count:
+            type: integer
+            description: Number of findings returned.
+            minimum: 0
+          approved:
+            type: boolean
+            description: False when any finding has severity 'error'.
+        additionalProperties: false
+      timeout_seconds: 30
+      max_retries: 1
+
+  runtime:
+    image: ghcr.io/zynax-io/zynax/go-review-expert:latest
+    env:
+      LOG_LEVEL: info
+      GRPC_PORT: "50051"
+    resources:
+      requests:
+        cpu: "100m"
+        memory: "128Mi"
+      limits:
+        cpu: "500m"
+        memory: "512Mi"
+    replicas: 1

--- a/services/workflow-compiler/internal/domain/testdata/fuzz_corpus/ci-pipeline.yaml
+++ b/services/workflow-compiler/internal/domain/testdata/fuzz_corpus/ci-pipeline.yaml
@@ -1,0 +1,123 @@
+# CI Pipeline Workflow — Reference Example
+# Demonstrates: parallel actions, CI integration, failure recovery
+
+kind: Workflow
+apiVersion: zynax.io/v1
+
+metadata:
+  name: ci-pipeline-workflow
+  namespace: platform
+
+spec:
+  initial_state: test
+
+  triggers:
+    - event: github.push
+      filter:
+        branch: "main"
+
+  states:
+    test:
+      actions:
+        - capability: run_tests
+          input:
+            repo: "{{ .trigger.repo }}"
+            commit: "{{ .trigger.commit_sha }}"
+          timeout: 30m
+      on:
+        - event: tests.passed
+          goto: security_scan
+        - event: tests.failed
+          goto: notify_failure
+        - event: tests.timeout
+          goto: notify_failure
+
+    security_scan:
+      actions:
+        - capability: run_security_scan
+          input:
+            commit: "{{ .trigger.commit_sha }}"
+          timeout: 15m
+      on:
+        - event: scan.passed
+          goto: build
+        - event: scan.failed
+          goto: block_merge
+        - event: scan.findings
+          guard: "{{ .event.severity }} == 'low'"
+          goto: build    # low severity findings don't block
+
+    build:
+      actions:
+        - capability: build_image
+          input:
+            commit: "{{ .trigger.commit_sha }}"
+            registry: "ghcr.io/zynax-io"
+          timeout: 20m
+      on:
+        - event: build.success
+          goto: deploy_staging
+        - event: build.failed
+          goto: notify_failure
+
+    deploy_staging:
+      actions:
+        - capability: deploy
+          input:
+            environment: "staging"
+            image: "{{ .context.built_image }}"
+          timeout: 10m
+      on:
+        - event: deploy.success
+          goto: integration_test
+        - event: deploy.failed
+          goto: rollback
+
+    integration_test:
+      actions:
+        - capability: run_integration_tests
+          input:
+            environment: "staging"
+          timeout: 20m
+      on:
+        - event: integration.passed
+          goto: done
+        - event: integration.failed
+          goto: rollback
+
+    rollback:
+      actions:
+        - capability: rollback_deploy
+          input:
+            environment: "staging"
+      on:
+        - event: rollback.complete
+          goto: notify_failure
+
+    block_merge:
+      type: human_in_the_loop
+      actions:
+        - capability: notify_human
+          input:
+            channel: "#security"
+            message: "Security scan found HIGH findings on {{ .trigger.commit_sha }}"
+      on:
+        - event: human.approved
+          goto: build
+        - event: human.rejected
+          goto: notify_failure
+
+    notify_failure:
+      type: terminal
+      actions:
+        - capability: notify_author
+          input:
+            message: "CI pipeline failed for {{ .trigger.commit_sha }}"
+            channel: "#ci-failures"
+
+    done:
+      type: terminal
+      actions:
+        - capability: notify_author
+          input:
+            message: "CI pipeline passed ✅ — staging deployment live"

--- a/services/workflow-compiler/internal/domain/testdata/fuzz_corpus/code-review.yaml
+++ b/services/workflow-compiler/internal/domain/testdata/fuzz_corpus/code-review.yaml
@@ -1,0 +1,131 @@
+# Code Review Workflow — Reference Example
+# Demonstrates: loops, async events, human-in-the-loop, timeout handling
+#
+# To apply: zynax apply spec/workflows/examples/code-review.yaml
+# To dry-run: zynax apply --dry-run spec/workflows/examples/code-review.yaml
+
+kind: Workflow
+apiVersion: zynax.io/v1
+
+metadata:
+  name: code-review-workflow
+  namespace: engineering
+  labels:
+    team: platform
+    tier: production
+  annotations:
+    description: "Automated code review with human escalation"
+
+spec:
+  initial_state: review
+
+  # Events that automatically trigger a NEW workflow instance
+  triggers:
+    - event: github.pull_request.opened
+      filter:
+        repo: "zynax/zynax"
+        base_branch: "main"
+
+  states:
+    # ── Review state ─────────────────────────────────────────────
+    review:
+      actions:
+        - capability: request_review
+          input:
+            pr_url: "{{ .trigger.pr_url }}"
+            reviewers: "{{ .context.assigned_reviewers }}"
+          timeout: 24h   # If no review in 24h, emit review.timeout
+
+      on:
+        - event: review.approved
+          goto: merge
+
+        - event: review.needswork
+          goto: fix
+          # Store the feedback in workflow context for the fix state
+          set:
+            context.latest_feedback: "{{ .event.comments }}"
+
+        - event: review.timeout
+          goto: escalate
+          guard: "{{ .context.escalation_count }} < 2"
+
+        - event: review.timeout
+          goto: abandon
+          guard: "{{ .context.escalation_count }} >= 2"
+
+    # ── Fix state ────────────────────────────────────────────────
+    fix:
+      actions:
+        # Summarise the feedback so the agent knows what to fix
+        - capability: summarize_feedback
+          input:
+            feedback: "{{ .context.latest_feedback }}"
+          output:
+            context.feedback_summary: "{{ .result.summary }}"
+
+      on:
+        # Developer pushes a new commit → go back to review (the loop)
+        - event: github.push
+          goto: review
+          set:
+            context.escalation_count: 0
+
+        # Developer explicitly requests a re-review
+        - event: review.requested
+          goto: review
+
+    # ── Merge state ──────────────────────────────────────────────
+    merge:
+      actions:
+        - capability: merge_pr
+          input:
+            pr_url: "{{ .trigger.pr_url }}"
+            merge_strategy: "squash"
+      on:
+        - event: merge.success
+          goto: done
+
+        - event: merge.conflict
+          goto: fix
+          set:
+            context.latest_feedback: "Merge conflict — please rebase"
+
+    # ── Escalate state (human-in-the-loop) ───────────────────────
+    escalate:
+      type: human_in_the_loop    # Workflow pauses here until a human signals
+      actions:
+        - capability: notify_human
+          input:
+            channel: "#engineering"
+            message: "PR {{ .trigger.pr_url }} needs manual review — timed out"
+      on:
+        # Human approves via Slack command or dashboard
+        - event: human.approved
+          goto: merge
+        # Human requests more changes
+        - event: human.needswork
+          goto: fix
+          set:
+            context.latest_feedback: "{{ .event.feedback }}"
+            context.escalation_count: "{{ add .context.escalation_count 1 }}"
+
+    # ── Terminal states ──────────────────────────────────────────
+    done:
+      type: terminal
+      actions:
+        - capability: notify_author
+          input:
+            pr_url: "{{ .trigger.pr_url }}"
+            message: "Your PR has been merged. 🎉"
+
+    abandon:
+      type: terminal
+      actions:
+        - capability: notify_author
+          input:
+            pr_url: "{{ .trigger.pr_url }}"
+            message: "PR closed after repeated review timeouts."
+        - capability: close_pr
+          input:
+            pr_url: "{{ .trigger.pr_url }}"

--- a/services/workflow-compiler/internal/domain/testdata/fuzz_corpus/e2e-demo.yaml
+++ b/services/workflow-compiler/internal/domain/testdata/fuzz_corpus/e2e-demo.yaml
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+# E2E Demo Workflow — minimal capability dispatch fixture
+#
+# Exercises the full dispatch chain end-to-end:
+#   api-gateway → workflow-compiler → engine-adapter → Temporal
+#   → task-broker → agent-registry → langgraph-adapter (echo)
+#   → TASK_EVENT_TYPE_COMPLETED
+#
+# Prerequisites: make run-local (all services + langgraph-adapter in compose)
+#
+# Usage:
+#   zynax apply spec/workflows/examples/e2e-demo.yaml
+#
+# Expected outcome: workflow starts, dispatches "echo" to the langgraph-adapter,
+# receives {"reply": "Hello from Zynax E2E demo"} back, and reaches terminal state.
+# Observable in Temporal UI at http://localhost:7088.
+
+kind: Workflow
+apiVersion: zynax.io/v1
+
+metadata:
+  name: e2e-demo
+  namespace: demo
+
+spec:
+  initial_state: greet
+
+  states:
+
+    # ── greet — dispatches the echo capability ───────────────────────────────
+    greet:
+      actions:
+        - capability: echo
+          input:
+            message: "Hello from Zynax E2E demo"
+      on:
+        - event: echo.completed
+          goto: done
+
+    # ── done — terminal; workflow completes ──────────────────────────────────
+    done:
+      type: terminal

--- a/services/workflow-compiler/internal/domain/testdata/fuzz_corpus/policy-example.yaml
+++ b/services/workflow-compiler/internal/domain/testdata/fuzz_corpus/policy-example.yaml
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: Apache-2.0
+# Example Policy manifest — illustrates capability routing, rate limiting,
+# and quota rules for the platform namespace.
+# Validated by: make validate-spec (against spec/schemas/policy.schema.json)
+# Note: Policy enforcement is implemented in M6. This manifest is valid for
+# schema validation and compiler policy-reference checks in M2+.
+
+apiVersion: zynax.io/v1alpha1
+kind: Policy
+
+metadata:
+  name: platform-policy
+  namespace: platform
+  labels:
+    tier: production
+    managed-by: platform-team
+
+spec:
+  rules:
+    # Route all LLM inference capabilities from the platform namespace
+    # to the shared ml-infra namespace where GPU agents are registered.
+    - type: capability_routing
+      capability_selector: "llm_*"
+      namespace_selector: "platform"
+      target_namespace: ml-infra
+
+    # Rate-limit the summarize capability globally to protect against
+    # runaway workflow loops that spam the LLM gateway.
+    - type: rate_limit
+      capability_selector: "summarize"
+      max_rps: 10.0
+      burst: 20
+
+    # Limit concurrent code review invocations per workflow namespace
+    # to prevent one team from exhausting the review agent pool.
+    - type: quota
+      capability_selector: "review_*"
+      namespace_selector: "team-*"
+      max_concurrent: 5
+
+    # Hard quota on all capabilities in the staging namespace to prevent
+    # runaway test workflows from affecting production throughput.
+    - type: quota
+      capability_selector: "*"
+      namespace_selector: "staging"
+      max_concurrent: 20

--- a/services/workflow-compiler/internal/domain/testdata/fuzz_corpus/research-task.yaml
+++ b/services/workflow-compiler/internal/domain/testdata/fuzz_corpus/research-task.yaml
@@ -1,0 +1,151 @@
+# Research Task Workflow — Reference Example
+# Demonstrates: iterative event-driven loop, human-in-the-loop review,
+# context accumulation across states, and terminal success/abandon paths.
+#
+# Business purpose: A research agent searches the web for information on a
+# topic, summarises the findings, and presents them to a human reviewer.
+# The human can approve the summary, request another iteration (up to a
+# configurable limit), or abandon the task. This pattern is reusable for
+# any iterative AI task that requires human sign-off before completion.
+#
+# To apply: zynax apply spec/workflows/examples/research-task.yaml
+# To dry-run: zynax apply --dry-run spec/workflows/examples/research-task.yaml
+
+kind: Workflow
+apiVersion: zynax.io/v1
+
+metadata:
+  name: research-task-workflow
+  namespace: research
+  labels:
+    team: platform
+    tier: staging
+  annotations:
+    description: "Iterative web research with human review and approval"
+
+spec:
+  initial_state: search
+
+  # Triggered when a research request is submitted via the API or CLI
+  triggers:
+    - event: research.requested
+      filter:
+        namespace: research
+
+  states:
+    # ── Search state ──────────────────────────────────────────────
+    search:
+      actions:
+        - capability: search_web
+          input:
+            query: "{{ .trigger.topic }}"
+            max_results: "{{ .context.max_results | default 10 }}"
+          output:
+            context.raw_results: "{{ .result.results }}"
+          timeout: 30s
+
+      on:
+        - event: search.completed
+          goto: summarize
+
+        - event: search.noresults
+          goto: abandon
+          set:
+            context.abandon_reason: "No results found for topic"
+
+        - event: search.failed
+          goto: abandon
+          set:
+            context.abandon_reason: "Search capability failed"
+
+    # ── Summarize state ───────────────────────────────────────────
+    summarize:
+      actions:
+        - capability: summarize
+          input:
+            text: "{{ .context.raw_results }}"
+            max_words: 500
+          output:
+            context.summary: "{{ .result.summary }}"
+            context.word_count: "{{ .result.word_count }}"
+          timeout: 60s
+
+      on:
+        - event: summarize.completed
+          goto: human_review
+
+        - event: summarize.failed
+          goto: abandon
+          set:
+            context.abandon_reason: "Summarize capability failed"
+
+    # ── Human review state (human-in-the-loop) ────────────────────
+    human_review:
+      type: human_in_the_loop
+      actions:
+        - capability: notify_human
+          input:
+            channel: "#research-reviews"
+            message: "Research summary ready for review: {{ .context.summary }}"
+            workflow_id: "{{ .trigger.workflow_id }}"
+
+      on:
+        # Human approves — deliver the final summary
+        - event: human.approved
+          goto: deliver
+
+        # Human requests another search iteration (loop back)
+        - event: human.iterate
+          goto: search
+          guard: "{{ .context.iteration_count }} < 3"
+          set:
+            context.iteration_count: "{{ add .context.iteration_count 1 }}"
+            context.search_refinement: "{{ .event.feedback }}"
+
+        # Too many iterations — escalate to abandon
+        - event: human.iterate
+          goto: abandon
+          guard: "{{ .context.iteration_count }} >= 3"
+          set:
+            context.abandon_reason: "Maximum iteration limit reached"
+
+        # Human explicitly rejects — abandon
+        - event: human.rejected
+          goto: abandon
+          set:
+            context.abandon_reason: "Rejected by reviewer: {{ .event.reason }}"
+
+    # ── Deliver state ─────────────────────────────────────────────
+    deliver:
+      actions:
+        - capability: deliver_result
+          input:
+            recipient: "{{ .trigger.requester }}"
+            summary: "{{ .context.summary }}"
+            word_count: "{{ .context.word_count }}"
+            iterations: "{{ .context.iteration_count }}"
+      on:
+        - event: deliver.success
+          goto: done
+
+        - event: deliver.failed
+          goto: abandon
+          set:
+            context.abandon_reason: "Delivery failed"
+
+    # ── Terminal states ───────────────────────────────────────────
+    done:
+      type: terminal
+      actions:
+        - capability: notify_author
+          input:
+            recipient: "{{ .trigger.requester }}"
+            message: "Research task complete. Summary delivered."
+
+    abandon:
+      type: terminal
+      actions:
+        - capability: notify_author
+          input:
+            recipient: "{{ .trigger.requester }}"
+            message: "Research task abandoned: {{ .context.abandon_reason }}"


### PR DESCRIPTION
## test(workflow-compiler): fuzz the YAML->IR compiler

Closes #1210 · EPIC R (#469) step R.2 · Canvas: `docs/spdd/469-test-rigor/canvas.md` (Aligned)

### Why  (problem & intent)
`domain.ParseManifest` is the YAML->IR compiler entry point and accepts untrusted
manifest bytes (`zynax apply <file>`). The 2026-05 architectural review (§11.2, gap
M2/R14) flagged it as an obvious fuzz target with no fuzz coverage: a malformed
manifest could crash the compiler. This adds a Go native fuzz target so malformed
manifests provably can't panic the parser.

### What you'll get  (scenarios/coverage added)
- `FuzzParseManifest` in `services/workflow-compiler/internal/domain/` — fuzzes
  `ParseManifest` with untrusted bytes and asserts only structural invariants
  (no specific output): it never panics, and returns exactly one of
  (non-nil manifest, no errors) or (nil manifest, ≥1 error).
- Seed corpus = the real `spec/workflows/examples/*.yaml` set (valid Workflow
  manifests + non-Workflow kinds like Policy/AgentDef that exercise the rejection
  path), embedded into `testdata/fuzz_corpus/` and fed via `f.Add`, plus hand-picked
  edge cases (empty, NUL byte, partial, malformed YAML).
- `make fuzz DURATION=60s` target running full fuzz campaigns locally
  (auto-discovers `Fuzz*` targets per service in `FUZZ_SERVICES`).

### Scope & boundaries
- In scope: the YAML->IR compiler fuzz path only (R.2's compiler half).
- Out of scope: benchmarks (R.1 / #493, already landed) and `FuzzEvalGuard`
  (engine-adapter guard evaluator) per this issue's compiler scope; the CI gate
  uses the existing `go test` seed-only run (no fuzz campaign in CI, per canvas Norms).

### Test plan & acceptance
| Acceptance criterion | How verified (command) | Result |
|----------------------|------------------------|--------|
| `FuzzParseManifest` target committed | `GOWORK=off go test ./... -list='^Fuzz' -C services/workflow-compiler` lists `FuzzParseManifest` | PASS |
| Runs in CI (seed-only, no campaign) | `GOWORK=off go test ./... -race` runs the embedded seeds as ordinary subtests | PASS (all `ok`) |
| Seed corpus from `spec/workflows/examples/*.yaml` | 7 examples copied to `testdata/fuzz_corpus/` + embedded via `//go:embed`; `seedFromCorpus` `f.Add`s each | PASS |
| `make fuzz DURATION=60s` target | target added to Makefile (`.PHONY: fuzz`, `FUZZ_SERVICES`, `DURATION ?= 60s`) | PASS |
| No panic under bounded fuzzing | `GOWORK=off go test -run='^$' -fuzz='^FuzzParseManifest$' -fuzztime=20s ./internal/domain` | PASS (355k execs, 0 crashers) |
| Domain coverage ≥90% | `GOWORK=off go test ./internal/domain/... -cover` | PASS (97.5%) |

### Evidence
```
$ GOWORK=off go test -run='^$' -fuzz='^FuzzParseManifest$' -fuzztime=20s ./internal/domain
fuzz: elapsed: 0s, gathering baseline coverage: 13/13 completed, now fuzzing with 16 workers
fuzz: elapsed: 21s, execs: 355623 (0/sec), new interesting: 71 (total: 84)
PASS
ok  	.../workflow-compiler/internal/domain	21.104s

$ GOWORK=off go test ./internal/domain/... -cover
ok  	.../workflow-compiler/internal/domain	coverage: 97.5% of statements

$ make lint
All checks passed!   # proto + Go (golangci-lint) + Python
```

### Risk & rollback
- Risk: low. Test-only + Makefile addition; no production code, proto, or runtime
  path changed. Worst case a flaky seed — but seeds are deterministic example files.
- Rollback: revert this commit; nothing else depends on it.

### Review aids
- Start with `manifest_fuzz_test.go` (the target + invariants), then the `fuzz`
  Makefile target. Corpus files are verbatim copies of `spec/workflows/examples/`.
- Invariant rationale: fuzz inputs are unknown, so the body asserts the
  `(manifest XOR errors)` contract and no-panic — never a specific parse result
  (canvas Safeguards).

<!-- post-merge digest: PENDING -->
