### PR TITLE
feat(agents/sdk): OTEL traces+logs in Python adapters

### DIFF
--- a/agents/sdk/pyproject.toml
+++ b/agents/sdk/pyproject.toml
@@ -13,6 +13,14 @@ description = "Minimal Python SDK for Zynax capability adapters — Agent base c
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }
 
+# NOTE: the OTLP/gRPC exporter (opentelemetry-exporter-otlp-proto-grpc) is
+# intentionally NOT a dependency — its opentelemetry-proto pin caps protobuf<7
+# while this SDK pins protobuf>=7.35.0, so the two are mutually exclusive in one
+# resolved environment. The tracer/logger API and W3C context extraction here run
+# on opentelemetry-api + opentelemetry-sdk (protobuf-7 compatible). Live OTLP
+# export is a deployment concern: an adapter image installs the exporter in an
+# environment that relaxes the protobuf floor. init_telemetry degrades gracefully
+# (in-process providers + a warning) when the exporter is not importable.
 dependencies = [
     "grpcio>=1.80.0",
     "urllib3>=2.7.0",  # CVE-2026-44431, CVE-2026-44432 — pin floor via transitive grpcio dep

--- a/agents/sdk/src/zynax_sdk/__init__.py
+++ b/agents/sdk/src/zynax_sdk/__init__.py
@@ -4,5 +4,19 @@
 __version__ = "0.1.0"
 
 from zynax_sdk.agent import Agent, capability
+from zynax_sdk.telemetry import (
+    capability_span,
+    extract_context,
+    init_telemetry,
+    is_enabled,
+)
 
-__all__ = ["Agent", "capability", "__version__"]
+__all__ = [
+    "Agent",
+    "capability",
+    "capability_span",
+    "extract_context",
+    "init_telemetry",
+    "is_enabled",
+    "__version__",
+]

--- a/agents/sdk/src/zynax_sdk/agent.py
+++ b/agents/sdk/src/zynax_sdk/agent.py
@@ -14,6 +14,7 @@ import grpc
 from google.protobuf import timestamp_pb2
 
 from zynax.v1 import agent_pb2, agent_pb2_grpc
+from zynax_sdk.telemetry import capability_span
 
 
 def capability(name: str) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
@@ -99,6 +100,8 @@ class Agent(agent_pb2_grpc.AgentServiceServicer, ABC):  # type: ignore[misc]
 
         Validates ``capability_name``, ``task_id``, and ``input_payload`` before
         dispatching.  Unknown capabilities yield a FAILED event rather than raising.
+        The dispatched handler runs inside a ``capability.<name>`` span stitched to
+        the inbound trace context (no-op when telemetry is disabled — canvas O.6).
 
         Args:
             request: ``ExecuteCapabilityRequest`` proto message.
@@ -133,13 +136,14 @@ class Agent(agent_pb2_grpc.AgentServiceServicer, ABC):  # type: ignore[misc]
 
         loop = asyncio.new_event_loop()
         try:
-            agen = handler(self, request, context)
-            while True:
-                try:
-                    event = loop.run_until_complete(agen.__anext__())
-                    yield event
-                except StopAsyncIteration:
-                    break
+            with capability_span(request.capability_name, context):
+                agen = handler(self, request, context)
+                while True:
+                    try:
+                        event = loop.run_until_complete(agen.__anext__())
+                        yield event
+                    except StopAsyncIteration:
+                        break
         finally:
             loop.close()
 

--- a/agents/sdk/src/zynax_sdk/telemetry.py
+++ b/agents/sdk/src/zynax_sdk/telemetry.py
@@ -1,0 +1,256 @@
+# SPDX-License-Identifier: Apache-2.0
+"""OpenTelemetry traces + logs for Zynax capability handlers (canvas O.6).
+
+This module mirrors the Go ``libs/zynaxobs`` provider bootstrap: telemetry is
+**off by default** and only activates when ``ZYNAX_OTEL_EXPORTER_OTLP_ENDPOINT``
+is set, so an agent runs with zero exporter overhead and no collector configured.
+
+What it provides:
+
+* :func:`init_telemetry` — installs OTLP/gRPC tracer + logger providers and the
+  W3C trace-context propagator as the OpenTelemetry globals (no-op when unset).
+* :func:`extract_context` — reads the inbound W3C ``traceparent`` from a gRPC
+  request's invocation metadata so a handler span is stitched to the broker's
+  trace across the dispatch hop.
+* :func:`capability_span` — starts a ``capability.<name>`` span as a child of the
+  extracted context; logs emitted inside are correlated by ``trace_id``.
+
+Only trace context is read from inbound metadata — never auth tokens or session
+data (canvas O.5 / Safeguards).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from collections.abc import Iterator, Sequence
+from contextlib import contextmanager
+from typing import Any
+
+from opentelemetry import trace
+from opentelemetry.context import Context
+from opentelemetry.trace import Span, Status, StatusCode
+
+# Zynax-prefixed OTLP collector endpoint (canvas Norms: env prefix `ZYNAX_OTEL_`).
+# Telemetry is opt-in: unset ⇒ no providers installed ⇒ no-op tracer/logger.
+_ENDPOINT_ENV = "ZYNAX_OTEL_EXPORTER_OTLP_ENDPOINT"
+
+# Instrumentation scope name for the tracer obtained from the global provider.
+_TRACER_NAME = "zynax_sdk"
+
+# W3C trace-context header carried in inbound gRPC metadata by the upstream
+# otelgrpc client stats handler (see services/*/tracing.go).
+_TRACEPARENT_KEY = "traceparent"
+_TRACESTATE_KEY = "tracestate"
+
+_initialized = False
+
+
+def _endpoint() -> str:
+    """Return the configured OTLP endpoint, or an empty string when disabled."""
+    return os.getenv(_ENDPOINT_ENV, "")
+
+
+def is_enabled() -> bool:
+    """Return ``True`` when an OTLP endpoint is configured (telemetry is on)."""
+    return bool(_endpoint())
+
+
+def init_telemetry(
+    service_name: str,
+    service_version: str = "0.1.0",
+) -> bool:
+    """Install OTLP/gRPC tracer + logger providers and the W3C propagator.
+
+    Idempotent. When ``ZYNAX_OTEL_EXPORTER_OTLP_ENDPOINT`` is unset this is a
+    no-op and the global no-op tracer/logger remain in place, so an agent runs
+    unchanged without a collector (canvas Norms: off by default, zero overhead
+    when disabled). When set, span and log records carry the semconv resource
+    attributes ``service.name`` / ``service.version`` and are exported via
+    OTLP/gRPC, identically to the Go services.
+
+    Args:
+        service_name: ``service.name`` resource attribute (e.g. ``"llm-adapter"``).
+        service_version: ``service.version`` resource attribute.
+
+    Returns:
+        ``True`` when real providers were installed, ``False`` when telemetry is
+        disabled (endpoint unset) or already initialised.
+    """
+    global _initialized
+
+    # The W3C propagator is cheap and harmless to install even when disabled, so
+    # extract_context() works the moment an endpoint is configured upstream.
+    from opentelemetry.propagate import set_global_textmap
+    from opentelemetry.trace.propagation.tracecontext import (
+        TraceContextTextMapPropagator,
+    )
+
+    set_global_textmap(TraceContextTextMapPropagator())
+
+    if _initialized:
+        return False
+
+    endpoint = _endpoint()
+    if not endpoint:
+        return False
+
+    # Imported lazily: the SDK is only needed when telemetry is on, keeping the
+    # import cost off the disabled path.
+    from opentelemetry._logs import set_logger_provider
+    from opentelemetry.sdk._logs import LoggerProvider, LoggingHandler
+    from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
+    from opentelemetry.sdk.resources import Resource
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+    resource = Resource.create(
+        {
+            "service.name": service_name,
+            "service.version": service_version,
+        }
+    )
+
+    span_exporter, log_exporter = _otlp_exporters(endpoint)
+
+    tracer_provider = TracerProvider(resource=resource)
+    if span_exporter is not None:
+        tracer_provider.add_span_processor(BatchSpanProcessor(span_exporter))
+    trace.set_tracer_provider(tracer_provider)
+
+    logger_provider = LoggerProvider(resource=resource)
+    if log_exporter is not None:
+        logger_provider.add_log_record_processor(BatchLogRecordProcessor(log_exporter))
+    set_logger_provider(logger_provider)
+
+    # Bridge stdlib logging into the OTLP logs pipeline so handler log lines are
+    # exported and correlated with the active span's trace_id in the UI.
+    handler = LoggingHandler(level=logging.NOTSET, logger_provider=logger_provider)
+    root = logging.getLogger()
+    if not any(isinstance(h, LoggingHandler) for h in root.handlers):
+        root.addHandler(handler)
+
+    _initialized = True
+    return True
+
+
+def _otlp_exporters(endpoint: str) -> tuple[Any | None, Any | None]:
+    """Build the OTLP/gRPC span + log exporters, or ``(None, None)`` if absent.
+
+    The OTLP exporter pins ``protobuf<7`` while the SDK core pins ``protobuf>=7``,
+    so it is an optional ``[otlp]`` extra. When it is not installed this returns
+    no exporters and logs a warning rather than raising — providers are still
+    installed so spans/logs flow to any in-process processor and the agent never
+    crashes on a telemetry import (canvas Safeguards: never block the request
+    path on the exporter).
+    """
+    try:
+        from opentelemetry.exporter.otlp.proto.grpc._log_exporter import (
+            OTLPLogExporter,
+        )
+        from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
+            OTLPSpanExporter,
+        )
+    except ImportError:
+        logging.getLogger(__name__).warning(
+            "OTLP exporter not installed; spans/logs will not be exported. "
+            "Install the 'otlp' extra (zynax-sdk[otlp]) to enable live export."
+        )
+        return None, None
+    return (
+        OTLPSpanExporter(endpoint=endpoint),
+        OTLPLogExporter(endpoint=endpoint),
+    )
+
+
+def _metadata_to_carrier(
+    metadata: Sequence[tuple[str, Any]] | None,
+) -> dict[str, str]:
+    """Build a W3C carrier dict from gRPC invocation metadata.
+
+    Only the ``traceparent`` / ``tracestate`` keys are read — never auth tokens
+    or session data (canvas O.5 safeguard). gRPC metadata keys are lower-cased.
+    """
+    carrier: dict[str, str] = {}
+    if not metadata:
+        return carrier
+    for key, value in metadata:
+        lower = key.lower()
+        if lower in (_TRACEPARENT_KEY, _TRACESTATE_KEY):
+            carrier[lower] = value.decode() if isinstance(value, bytes) else str(value)
+    return carrier
+
+
+def extract_context(
+    metadata: Sequence[tuple[str, Any]] | None,
+) -> Context | None:
+    """Extract the W3C trace context from inbound gRPC invocation metadata.
+
+    The upstream broker injects ``traceparent`` into the metadata of the
+    outbound ``ExecuteCapability`` call via the otelgrpc client stats handler;
+    extracting it here stitches the handler span to the originating trace.
+
+    Args:
+        metadata: The request's invocation metadata
+            (``context.invocation_metadata()``), or ``None``.
+
+    Returns:
+        A propagation :class:`Context` carrying the remote span, or ``None`` when
+        no ``traceparent`` is present (so the handler span starts a new trace).
+    """
+    carrier = _metadata_to_carrier(metadata)
+    if _TRACEPARENT_KEY not in carrier:
+        return None
+    from opentelemetry.propagate import extract
+
+    return extract(carrier)
+
+
+def _invocation_metadata(context: Any) -> Sequence[tuple[str, Any]] | None:
+    """Return ``context.invocation_metadata()`` if the context exposes it."""
+    getter = getattr(context, "invocation_metadata", None)
+    if getter is None:
+        return None
+    try:
+        metadata: Sequence[tuple[str, Any]] = getter()
+    except Exception:  # pragma: no cover — defensive: never fail a handler on telemetry
+        return None
+    return metadata
+
+
+@contextmanager
+def capability_span(
+    capability_name: str,
+    context: Any = None,
+) -> Iterator[Span]:
+    """Start a ``capability.<name>`` span around a capability handler.
+
+    The span is a child of the trace context extracted from ``context``'s inbound
+    gRPC metadata when present, otherwise a new root span. When telemetry is
+    disabled the global no-op tracer yields a no-op span — zero overhead. The
+    span is marked ``ERROR`` and the exception recorded if the handler raises.
+
+    Args:
+        capability_name: The capability identifier; the span is named
+            ``capability.<capability_name>``.
+        context: The gRPC ``ServicerContext`` (or any object exposing
+            ``invocation_metadata()``); used to extract the parent trace context.
+
+    Yields:
+        The active :class:`~opentelemetry.trace.Span`.
+    """
+    tracer = trace.get_tracer(_TRACER_NAME)
+    parent = extract_context(_invocation_metadata(context))
+    with tracer.start_as_current_span(
+        f"capability.{capability_name}",
+        context=parent,
+        attributes={"zynax.capability.name": capability_name},
+    ) as span:
+        try:
+            yield span
+        except (
+            BaseException
+        ) as exc:  # re-raised: telemetry never swallows handler errors
+            span.set_status(Status(StatusCode.ERROR, str(exc)))
+            span.record_exception(exc)
+            raise

--- a/agents/sdk/tests/test_telemetry.py
+++ b/agents/sdk/tests/test_telemetry.py
@@ -1,0 +1,269 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for SDK OpenTelemetry traces + logs (canvas O.6)."""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from typing import Any
+
+import pytest
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
+from opentelemetry.trace import format_trace_id
+
+sys.path.insert(
+    0, os.path.join(os.path.dirname(__file__), "../../../protos/generated/python")
+)
+from zynax.v1 import agent_pb2  # noqa: E402
+
+from zynax_sdk import Agent, capability  # noqa: E402
+from zynax_sdk import telemetry  # noqa: E402
+
+# A valid W3C traceparent (version-traceid-spanid-flags). 32-hex trace id.
+_TRACE_ID_HEX = "0af7651916cd43dd8448eb211c80319c"
+_TRACEPARENT = f"00-{_TRACE_ID_HEX}-b7ad6b7169203331-01"
+
+
+@pytest.fixture()
+def in_memory_tracer(monkeypatch: Any) -> Any:
+    """Route spans into an in-memory exporter via a controlled tracer.
+
+    OpenTelemetry's global TracerProvider can only be set once per process, so we
+    cannot rely on ``set_tracer_provider`` here. Instead we patch the module-level
+    ``trace.get_tracer`` so ``capability_span`` obtains a tracer from a provider
+    we own and can inspect.
+    """
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    tracer = provider.get_tracer("zynax_sdk_test")
+    monkeypatch.setattr(telemetry.trace, "get_tracer", lambda *_a, **_k: tracer)
+    telemetry._initialized = False
+    yield exporter
+    exporter.clear()
+
+
+class _MockContext:
+    """gRPC context mock exposing invocation_metadata()."""
+
+    def __init__(self, metadata: list[tuple[str, Any]] | None = None) -> None:
+        self._metadata = metadata or []
+
+    def invocation_metadata(self) -> list[tuple[str, Any]]:
+        return self._metadata
+
+
+def _make_request(**kwargs: Any) -> Any:
+    defaults: dict[str, Any] = dict(
+        capability_name="greet",
+        task_id="task-1",
+        input_payload=b"{}",
+    )
+    defaults.update(kwargs)
+    return agent_pb2.ExecuteCapabilityRequest(**defaults)
+
+
+# ── is_enabled / endpoint gating ───────────────────────────────────────────────
+
+
+class TestEnabledGating:
+    def test_disabled_when_endpoint_unset(self, monkeypatch: Any) -> None:
+        monkeypatch.delenv(telemetry._ENDPOINT_ENV, raising=False)
+        assert telemetry.is_enabled() is False
+
+    def test_enabled_when_endpoint_set(self, monkeypatch: Any) -> None:
+        monkeypatch.setenv(telemetry._ENDPOINT_ENV, "http://collector:4317")
+        assert telemetry.is_enabled() is True
+
+
+# ── init_telemetry ──────────────────────────────────────────────────────────────
+
+
+class TestInitTelemetry:
+    def test_init_noop_when_endpoint_unset(self, monkeypatch: Any) -> None:
+        monkeypatch.delenv(telemetry._ENDPOINT_ENV, raising=False)
+        telemetry._initialized = False
+        assert telemetry.init_telemetry("test-svc") is False
+
+    def test_init_idempotent_when_already_initialised(self, monkeypatch: Any) -> None:
+        monkeypatch.setenv(telemetry._ENDPOINT_ENV, "http://collector:4317")
+        telemetry._initialized = True
+        assert telemetry.init_telemetry("test-svc") is False
+
+    def test_otlp_exporters_absent_returns_none(self, monkeypatch: Any) -> None:
+        # The OTLP extra is not installed in CI; the import fails and degrades.
+        span_exp, log_exp = telemetry._otlp_exporters("http://collector:4317")
+        assert span_exp is None
+        assert log_exp is None
+
+    def test_otlp_exporters_present_when_importable(self, monkeypatch: Any) -> None:
+        import types as _types
+
+        grpc_pkg = "opentelemetry.exporter.otlp.proto.grpc"
+        log_mod = _types.ModuleType(f"{grpc_pkg}._log_exporter")
+        trace_mod = _types.ModuleType(f"{grpc_pkg}.trace_exporter")
+
+        class _FakeLogExporter:
+            def __init__(self, endpoint: str) -> None:
+                self.endpoint = endpoint
+
+        class _FakeSpanExporter:
+            def __init__(self, endpoint: str) -> None:
+                self.endpoint = endpoint
+
+        log_mod.OTLPLogExporter = _FakeLogExporter  # type: ignore[attr-defined]
+        trace_mod.OTLPSpanExporter = _FakeSpanExporter  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, f"{grpc_pkg}._log_exporter", log_mod)
+        monkeypatch.setitem(sys.modules, f"{grpc_pkg}.trace_exporter", trace_mod)
+
+        span_exp, log_exp = telemetry._otlp_exporters("http://collector:4317")
+        assert isinstance(span_exp, _FakeSpanExporter)
+        assert isinstance(log_exp, _FakeLogExporter)
+        assert span_exp.endpoint == "http://collector:4317"
+
+    def test_init_installs_providers_when_endpoint_set(self, monkeypatch: Any) -> None:
+        monkeypatch.setenv(telemetry._ENDPOINT_ENV, "http://collector:4317")
+        telemetry._initialized = False
+        root = logging.getLogger()
+        try:
+            assert telemetry.init_telemetry("test-svc", "9.9.9") is True
+            assert telemetry._initialized is True
+            from opentelemetry.sdk._logs import LoggingHandler
+
+            assert any(isinstance(h, LoggingHandler) for h in root.handlers)
+            # second call no-ops (already initialised) and does not duplicate handler
+            assert telemetry.init_telemetry("test-svc") is False
+            n = sum(isinstance(h, LoggingHandler) for h in root.handlers)
+            assert n == 1
+        finally:
+            for h in list(root.handlers):
+                from opentelemetry.sdk._logs import LoggingHandler as _LH
+
+                if isinstance(h, _LH):
+                    root.removeHandler(h)
+            telemetry._initialized = False
+
+
+# ── metadata carrier / extract_context ─────────────────────────────────────────
+
+
+class TestExtractContext:
+    def test_extract_none_metadata_returns_none(self) -> None:
+        assert telemetry.extract_context(None) is None
+
+    def test_extract_without_traceparent_returns_none(self) -> None:
+        assert telemetry.extract_context([("authorization", "secret")]) is None
+
+    def test_carrier_only_reads_trace_keys(self) -> None:
+        carrier = telemetry._metadata_to_carrier(
+            [
+                ("traceparent", _TRACEPARENT),
+                ("tracestate", "foo=bar"),
+                ("authorization", "Bearer secret"),
+                ("x-session", "sess-1"),
+            ]
+        )
+        assert carrier == {"traceparent": _TRACEPARENT, "tracestate": "foo=bar"}
+
+    def test_carrier_decodes_bytes_values(self) -> None:
+        carrier = telemetry._metadata_to_carrier(
+            [("traceparent", _TRACEPARENT.encode())]
+        )
+        assert carrier["traceparent"] == _TRACEPARENT
+
+    def test_extract_with_traceparent_returns_context(self) -> None:
+        from opentelemetry.propagate import set_global_textmap
+        from opentelemetry.trace.propagation.tracecontext import (
+            TraceContextTextMapPropagator,
+        )
+
+        set_global_textmap(TraceContextTextMapPropagator())
+        ctx = telemetry.extract_context([("traceparent", _TRACEPARENT)])
+        assert ctx is not None
+        span_ctx = trace.get_current_span(ctx).get_span_context()
+        assert format_trace_id(span_ctx.trace_id) == _TRACE_ID_HEX
+
+
+# ── capability_span ─────────────────────────────────────────────────────────────
+
+
+class TestCapabilitySpan:
+    def test_span_named_capability_dot_name(self, in_memory_tracer: Any) -> None:
+        with telemetry.capability_span("summarize", _MockContext()):
+            pass
+        spans = in_memory_tracer.get_finished_spans()
+        assert len(spans) == 1
+        assert spans[0].name == "capability.summarize"
+        assert spans[0].attributes["zynax.capability.name"] == "summarize"
+
+    def test_span_child_of_inbound_traceparent(self, in_memory_tracer: Any) -> None:
+        from opentelemetry.propagate import set_global_textmap
+        from opentelemetry.trace.propagation.tracecontext import (
+            TraceContextTextMapPropagator,
+        )
+
+        set_global_textmap(TraceContextTextMapPropagator())
+        ctx = _MockContext([("traceparent", _TRACEPARENT)])
+        with telemetry.capability_span("greet", ctx):
+            pass
+        spans = in_memory_tracer.get_finished_spans()
+        assert format_trace_id(spans[0].context.trace_id) == _TRACE_ID_HEX
+
+    def test_span_records_exception_and_reraises(self, in_memory_tracer: Any) -> None:
+        with pytest.raises(ValueError, match="boom"):
+            with telemetry.capability_span("fail", _MockContext()):
+                raise ValueError("boom")
+        spans = in_memory_tracer.get_finished_spans()
+        assert spans[0].status.status_code.name == "ERROR"
+        assert any(e.name == "exception" for e in spans[0].events)
+
+    def test_span_with_none_context(self, in_memory_tracer: Any) -> None:
+        with telemetry.capability_span("nocontext", None):
+            pass
+        spans = in_memory_tracer.get_finished_spans()
+        assert spans[0].name == "capability.nocontext"
+
+    def test_invocation_metadata_failure_is_swallowed(
+        self, in_memory_tracer: Any
+    ) -> None:
+        class _Bad:
+            def invocation_metadata(self) -> Any:
+                raise RuntimeError("metadata unavailable")
+
+        with telemetry.capability_span("robust", _Bad()):
+            pass
+        spans = in_memory_tracer.get_finished_spans()
+        assert spans[0].name == "capability.robust"
+
+
+# ── integration: Agent.ExecuteCapability wraps handlers in a span ───────────────
+
+
+class _GreetAgent(Agent):
+    @capability("greet")
+    async def greet(self, request: Any, context: Any) -> Any:
+        yield self.report_completed(request.task_id, {"ok": True})
+
+
+class TestAgentDispatchTracing:
+    def test_dispatch_emits_capability_span(self, in_memory_tracer: Any) -> None:
+        agent = _GreetAgent()
+        events = list(agent.ExecuteCapability(_make_request(), _MockContext()))
+        assert events[0].event_type == agent_pb2.TASK_EVENT_TYPE_COMPLETED
+        spans = in_memory_tracer.get_finished_spans()
+        assert [s.name for s in spans] == ["capability.greet"]
+
+    def test_unknown_capability_emits_no_span(self, in_memory_tracer: Any) -> None:
+        agent = _GreetAgent()
+        list(
+            agent.ExecuteCapability(
+                _make_request(capability_name="unknown"), _MockContext()
+            )
+        )
+        assert in_memory_tracer.get_finished_spans() == ()


### PR DESCRIPTION
## feat(agents/sdk): OTEL traces+logs in Python adapters

Closes #1189

### Why  (problem & intent)
EPIC O (#467) gives the Go services an OTLP→Uptrace pipeline, but Python agent
work was still a black box: capability handlers produced no spans, and their
logs were not correlated to the trace. This wires the Python SDK into the same
W3C-propagated trace so an agent's work appears in the Uptrace UI as part of the
end-to-end run. Canvas O-step **O.6** (`docs/spdd/467-observability-otel-uptrace/canvas.md`).

### What you'll get  (deliverables ↔ what changed)
- New `agents/sdk/src/zynax_sdk/telemetry.py`:
  - `init_telemetry(service_name, version)` — installs OTLP/gRPC tracer + logger
    providers and the W3C propagator; **no-op unless `ZYNAX_OTEL_EXPORTER_OTLP_ENDPOINT`
    is set**, mirroring Go `libs/zynaxobs` (off by default, zero overhead).
  - `extract_context(metadata)` — reads the inbound W3C `traceparent` from gRPC
    invocation metadata (only trace keys — never auth/session data).
  - `capability_span(name, context)` — opens a `capability.<name>` span as a child
    of the extracted context; records exceptions and re-raises.
- `Agent.ExecuteCapability` now wraps each dispatched handler in its `capability.<name>` span.
- Logs bridge into the OTLP logs pipeline (stdlib `LoggingHandler`) so log lines
  carry the active span's `trace_id`.
- `__init__.py` exports the new helpers.

### Scope & boundaries
- In scope: the Python SDK (`agents/sdk`). The llm-adapter and langgraph-adapter
  inherit auto-tracing through the SDK helpers; no adapter business logic changed.
- Out of scope: UI deploy (O.7/O.8). The OTLP **exporter** package is intentionally
  not a dependency — its `opentelemetry-proto` pin caps `protobuf<7` while this SDK
  pins `protobuf>=7.35.0`. The tracer/logger API + context extraction run on
  `opentelemetry-api`/`-sdk` (protobuf-7 compatible); live OTLP export is a
  deployment concern (adapter image installs the exporter), and `init_telemetry`
  degrades gracefully (in-process providers + warning) when it is absent.
- PR size: 559 lines, ~270 of which are tests; source/config ~290. Justified by
  test rigor (full coverage of the new module).

### Test plan & acceptance
Per canvas O.6 acceptance criteria:
- [x] **OTEL traces+logs in `agents/sdk`** — `telemetry.py` installs tracer +
  logger providers; `TestInitTelemetry` covers enabled/disabled/idempotent and the
  stdlib→OTLP logging bridge.
- [x] **`capability.<name>` spans** — `TestCapabilitySpan` + `TestAgentDispatchTracing`
  assert the span name is `capability.<name>`, carries `zynax.capability.name`, and
  is emitted exactly once per dispatched handler (none for unknown capabilities).
- [x] **trace context extracted from inbound task** — `TestExtractContext` +
  `test_span_child_of_inbound_traceparent` assert the W3C `traceparent` from gRPC
  metadata produces a child span on the same trace id; only trace keys are read.

### Evidence
```
make lint-agents   → All checks passed! / Success: no issues found (ruff + mypy --strict)
make test-unit-agents → 76 passed
  src/zynax_sdk/telemetry.py   90   2   98%
  TOTAL                       172   2   99%   (cov-fail-under=90 met)
```

### Risk & rollback
Low. Telemetry is off by default (endpoint unset ⇒ no-op tracer/logger), so an
agent runs unchanged without a collector. The handler path never blocks on the
exporter and never crashes on a missing exporter import. Rollback = revert the
single commit.

### Review aids
Start at `telemetry.py` (`init_telemetry`, `extract_context`, `capability_span`),
then the 3-line wrap in `agent.py::ExecuteCapability`. Mirrors `libs/zynaxobs/providers.go`
+ `propagation.go`.

**SPDD:** Canvas `docs/spdd/467-observability-otel-uptrace/canvas.md` — Status: **Aligned** · `/spdd-security-review` **PASS**

<!-- post-merge: image digest sync placeholder -->
