### PR TITLE
feat(infra): document OTLP logs + span/metric naming conventions

### DIFF
--- a/docs/observability/naming-conventions.md
+++ b/docs/observability/naming-conventions.md
@@ -1,0 +1,107 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+# Observability naming conventions
+
+> EPIC O (#467), step O.9 (#1192). Backing decision: [ADR-030](../adr/ADR-030-observability-uptrace.md).
+> Shared implementation: `libs/zynaxobs` (Go) and `agents/sdk/src/zynax_sdk/telemetry.py` (Python).
+
+This document is the single source of truth for **span**, **metric**, **log**, and
+**resource** naming across every Zynax service and adapter. Telemetry is **off by
+default** — providers are no-ops until `ZYNAX_OTEL_EXPORTER_OTLP_ENDPOINT` is set,
+so these conventions apply only when an OTLP collector is configured.
+
+All three signals (traces, metrics, logs) flow OTLP/gRPC to the OpenTelemetry
+Collector and on to Uptrace. The collector pipelines that carry them are defined in
+[`infra/docker-compose/observability/otel-collector.yaml`](../../infra/docker-compose/observability/otel-collector.yaml)
+(local) and
+[`helm/charts/uptrace/templates/otel-collector-config.yaml`](../../helm/charts/uptrace/templates/otel-collector-config.yaml)
+(in-cluster).
+
+---
+
+## Resource attributes
+
+Every span, metric, and log record carries the same resource attributes, built once
+by `zynaxobs.NewResource` (Go) / the SDK `Resource` (Python) using OpenTelemetry
+semantic conventions — never custom vendor keys:
+
+| Attribute | Source | Example |
+|-----------|--------|---------|
+| `service.name` | per-service constant | `workflow-compiler` |
+| `service.version` | build version | `0.6.0` |
+
+These attributes are what Uptrace uses to group traces, metrics, and logs into a
+single service in the APM / service map.
+
+---
+
+## Span names
+
+gRPC spans use the canvas O.3 convention `<service>.<rpc>` — the proto package
+prefix is dropped so the leaf name stays short (`zynaxobs.spanName`):
+
+| Source | Span name |
+|--------|-----------|
+| gRPC server / client | `<Service>.<Rpc>` — e.g. `WorkflowCompilerService.Compile` |
+| api-gateway HTTP entry | `<METHOD> <route>` — e.g. `POST /v1/workflows` |
+| Python capability handler | `capability.<name>` — e.g. `capability.git.clone` |
+
+- Span **kind** is set explicitly: `SERVER` on inbound, `CLIENT` on outbound.
+- The W3C `traceparent` is the **only** context propagated across gRPC, Temporal,
+  and NATS hops (`zynaxobs.InjectMapHeader` / `ExtractMapHeader`). Never inject
+  auth tokens, session data, or PII into trace headers, memos, or span attributes.
+
+---
+
+## Metric names and labels
+
+All metrics use the `zynax_` prefix. **Labels stay low-cardinality** —
+`service`/`method`/`status` only. Never embed workflow IDs, request IDs, route
+templates, or any unbounded value as a label (canvas Safeguards, O.4).
+
+| Metric | Type | Labels |
+|--------|------|--------|
+| `zynax_grpc_requests_total` | counter | `service`, `method`, `status` |
+| `zynax_grpc_request_duration_seconds` | histogram | `service`, `method` |
+| `zynax_http_requests_total` | counter | `service`, `method`, `status` |
+| `zynax_http_request_duration_seconds` | histogram | `service`, `method` |
+| `zynax_eventbus_publish_failed_total` | counter | `event_type` |
+
+- `method` for HTTP is the **verb** (`GET`/`POST`), never the URL path — paths are
+  unbounded and would explode series cardinality.
+- `trace_id` is attached as a Prometheus **exemplar**, never as a label, so a
+  metric sample links back to a representative trace in Uptrace while series
+  cardinality stays bounded.
+- Metrics are scraped at `/metrics` (OpenMetrics exposition for exemplars) **and**
+  pushed via OTLP; both surfaces use the same names.
+
+---
+
+## Log records and trace correlation
+
+Structured logs are shipped to Uptrace via the **OTLP logs** pipeline — the
+`LoggerProvider` (Go: `zynaxobs.InitProviders`, `otlploggrpc` batch exporter;
+Python: `LoggerProvider` + `LoggingHandler` in `telemetry.py`) — not scraped from
+stdout. The same batch/async export keeps the request path off the exporter.
+
+Every log record emitted inside an active span automatically carries:
+
+| Field | Meaning |
+|-------|---------|
+| `trace_id` | the enclosing trace — links the log to its trace in the UI |
+| `span_id` | the enclosing span — pinpoints the exact operation |
+
+Correlation is automatic: the OTLP log bridge reads the active span context, so any
+`slog` call (Go) or stdlib `logging` call (Python) made while a span is in flight is
+correlated by `trace_id`/`span_id` in Uptrace. Do not log secrets, credentials,
+tokens, or raw request payloads — redact by default (canvas Safeguards).
+
+---
+
+## Checklist for new instrumentation
+
+- [ ] Span name follows `<service>.<rpc>` (gRPC) or `capability.<name>` (handler).
+- [ ] Metric name uses the `zynax_` prefix and only `service`/`method`/`status` labels.
+- [ ] `trace_id` rides as an exemplar, never a label.
+- [ ] Logs go through the OTLP `LoggerProvider`, never a second sink.
+- [ ] No secrets, tokens, PII, or unbounded IDs in any span/metric/log attribute.
+- [ ] Works with telemetry **disabled** (endpoint unset → no-op, zero overhead).


### PR DESCRIPTION
## feat(infra): document OTLP logs + span/metric naming conventions

Closes #1192
Part of #467 (EPIC O — Observability)

### Why  (problem & intent)
Logs are already shipped to Uptrace via the OTLP logs pipeline and correlated to
traces, but there was no committed reference for how spans, metrics, and logs are
named or how the `trace_id`/`span_id` correlation works. O.9's third AC (canvas
`docs/spdd/467-observability-otel-uptrace/canvas.md`) calls for that naming-conventions
doc so an operator can debug from one place.

### What you'll get  (deliverables ↔ what changed)
- single SoT for span/metric/log/resource naming ← `docs/observability/naming-conventions.md`
- documented OTLP logs pipeline + `trace_id`/`span_id` log↔trace correlation ← same doc, linking the shipped `libs/zynaxobs` + Python SDK `LoggerProvider` and both collector configs
- a checklist for new instrumentation (low-cardinality labels, no secrets, no-op when disabled) ← same doc

### Scope & boundaries
- **In scope:** the span/metric naming-conventions doc (O.9's remaining AC), documenting the already-shipped OTLP logs pipeline and trace correlation.
- **Out of scope (deferred):** the OTLP logs exporter wiring and collector logs pipeline themselves — already delivered in O.2 (#1185), O.6 (#1189), O.7 (#1190), O.8 (#1191); dashboards beyond defaults (per issue).

### Test plan & acceptance

| Acceptance criterion | How verified (command) | Result |
|----------------------|------------------------|--------|
| logs shipped via OTLP logs | review: `libs/zynaxobs/providers.go` `otlploggrpc` batch exporter + collector `logs` pipeline rendered via `helm template ... --show-only templates/otel-collector-config.yaml` | ✅ logs pipeline present (compose + Helm) |
| every log line carries `trace_id`/`span_id` | review: Go `LoggerProvider` global bridge + Python `LoggingHandler` (`telemetry.py`) read active span context; documented in doc §"Log records and trace correlation" | ✅ correlation documented |
| span/metric naming conventions doc committed | `ls docs/observability/naming-conventions.md` | ✅ new file, 107 lines |

**Local gates:** `helm lint helm/charts/uptrace` ✅ (0 failed) · `helm template ... --show-only templates/otel-collector-config.yaml` ✅ (logs pipeline renders) · relative-link targets resolved ✅

### Evidence
- **CI:** required checks expected green (docs-only change).
- **Local output:** `helm lint` → `1 chart(s) linted, 0 chart(s) failed`; collector config renders the `logs` pipeline `receivers: [otlp] / processors: [batch] / exporters: [otlp/uptrace]`. New observability surface this PR documents: OTLP log records carrying `trace_id`/`span_id`, correlated to traces in Uptrace.
- **Artifacts / images:** none — no service source changed.
- **Post-merge digest sync → main:** N/A — no image rebuild.

### Risk & rollback
Low — additive documentation only, no behaviour change to any code path. Revert this PR to remove the doc.

### Review aids
The one key file is `docs/observability/naming-conventions.md`. It records names that
already exist in code (`zynax_grpc_requests_total`, `<service>.<rpc>` spans, the W3C
`traceparent`-only propagation rule, `trace_id` as exemplar-not-label), so it should
read as a faithful description of the shipped pipeline rather than a proposal.

**SPDD:** Canvas `docs/spdd/467-observability-otel-uptrace/canvas.md` — Status: **Aligned** · `/spdd-security-review` **PASS-with-flags** (telemetry-pipeline flags bound in canvas Safeguards)
**AI:** `Assisted-by: Claude/claude-opus-4-8`
