### PR TITLE
feat(cli): zynax mcp git + .mcp.json example

### DIFF
--- a/.mcp.json.example
+++ b/.mcp.json.example
@@ -1,0 +1,22 @@
+{
+  "$comment": [
+    "Zynax Git MCP server — example wiring for an authoring loop (e.g. Claude Code).",
+    "Copy to .mcp.json and adjust paths. See docs/git-mcp/README.md (ADR-032).",
+    "SECURITY: never put a literal token here. The token is injected into the",
+    "process environment at start and read once by the git-adapter; it is never a",
+    "tool argument and never reaches a prompt. Reference it by env name only.",
+    "Use a LEAST-PRIVILEGE, fine-grained PAT scoped to exactly the owner/repo in",
+    "ADAPTER_CONFIG (Contents + Pull requests: Read/Write only) — not a broad",
+    "classic `repo` PAT."
+  ],
+  "mcpServers": {
+    "zynax-git": {
+      "command": "zynax",
+      "args": ["mcp", "git"],
+      "env": {
+        "ADAPTER_CONFIG": "agents/adapters/git/config.yaml",
+        "GITHUB_TOKEN": "${GITHUB_TOKEN}"
+      }
+    }
+  }
+}

--- a/cmd/zynax/AGENTS.md
+++ b/cmd/zynax/AGENTS.md
@@ -25,6 +25,7 @@ cmd/zynax/
     delete.go       zynax delete workflow <run-id>
     status.go       zynax status workflow <run-id>   (exit 0 = terminal, 2 = running)
     logs.go         zynax logs <run-id> [--follow|-f] [--format text|json]
+    mcp.go          zynax mcp git   (launch Git MCP server — execs `git-adapter mcp`, ADR-032)
     validate.go      zynax validate <file> [--schema-dir] [--format]  (local: schema + data-flow)
   validate/
     manifest.go     JSON Schema validation (validate.Manifest) + combined pipeline (validate.File)

--- a/cmd/zynax/cmd/mcp.go
+++ b/cmd/zynax/cmd/mcp.go
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+
+	"github.com/spf13/cobra"
+)
+
+// gitAdapterBinEnv names the env var that overrides the git-adapter binary path.
+// Default is "git-adapter" (resolved via $PATH).
+const gitAdapterBinEnv = "GIT_ADAPTER_BIN"
+
+// defaultGitAdapterBin is the binary launched when GIT_ADAPTER_BIN is unset.
+const defaultGitAdapterBin = "git-adapter"
+
+var mcpCmd = &cobra.Command{
+	Use:   "mcp",
+	Short: "Run a Zynax MCP server for the authoring loop",
+}
+
+var mcpGitCmd = &cobra.Command{
+	Use:   "git",
+	Short: "Launch the Git MCP server (thin shim over git-adapter)",
+	Long: `Launch the Git MCP stdio server so an authoring loop (e.g. Claude Code)
+can perform Git operations — clone/branch/commit/PR/review — as MCP tools.
+
+This is a thin launcher (ADR-032): it execs the git-adapter binary in its
+"mcp" mode and wires the adapter's stdio to this process. The single Git
+implementation lives in the git-adapter; no Git logic is duplicated here.
+
+Configuration (injected at process start — never as a CLI flag, never from a
+prompt):
+
+  ADAPTER_CONFIG   path to the git-adapter YAML config (required)
+  <auth_env>       the token env var named by git.auth_env in that config
+                   (e.g. GITHUB_TOKEN) — a least-privilege, fine-grained PAT
+  GIT_ADAPTER_BIN  override the git-adapter binary path (default: git-adapter)
+
+The token is read once from the environment by the git-adapter at startup. It is
+never accepted as a tool argument, never read from prompt content, and never
+written to any committed config. Wire this command into .mcp.json (see
+.mcp.json.example) and reference the token by env/secret-ref only.
+
+Press Ctrl+C to stop.`,
+	Args: cobra.NoArgs,
+	RunE: func(c *cobra.Command, _ []string) error {
+		return runMCPGit(c.Context(), c.OutOrStdout(), c.ErrOrStderr(), os.Stdin, os.Environ())
+	},
+}
+
+// runMCPGit execs the git-adapter binary in MCP mode, wiring stdio through so it
+// speaks the MCP stdio protocol to the caller. The git-adapter binary is
+// resolved from $GIT_ADAPTER_BIN (default "git-adapter"); the token and config
+// are inherited from the process environment (env) — never passed as arguments.
+func runMCPGit(ctx context.Context, stdout, stderr io.Writer, stdin io.Reader, env []string) error {
+	bin := defaultGitAdapterBin
+	for _, kv := range env {
+		if v, ok := envValue(kv, gitAdapterBinEnv); ok && v != "" {
+			bin = v
+		}
+	}
+
+	// #nosec G204 — bin is operator-controlled (GIT_ADAPTER_BIN or a fixed
+	// default), never derived from prompt/tool input; the only argument is the
+	// constant "mcp" subcommand.
+	cmd := exec.CommandContext(ctx, bin, "mcp")
+	cmd.Stdin = stdin
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	cmd.Env = env
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("mcp git: launch %q: %w", bin, err)
+	}
+	return nil
+}
+
+// envValue returns the value of key from a "KEY=VALUE" entry and whether it
+// matched key. It avoids a strings.SplitN allocation on the hot path.
+func envValue(entry, key string) (string, bool) {
+	n := len(key)
+	if len(entry) > n && entry[:n] == key && entry[n] == '=' {
+		return entry[n+1:], true
+	}
+	return "", false
+}
+
+func init() {
+	mcpCmd.AddCommand(mcpGitCmd)
+	rootCmd.AddCommand(mcpCmd)
+}

--- a/cmd/zynax/cmd/mcp_test.go
+++ b/cmd/zynax/cmd/mcp_test.go
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestEnvValue(t *testing.T) {
+	tests := []struct {
+		name      string
+		entry     string
+		key       string
+		wantVal   string
+		wantMatch bool
+	}{
+		{"exact match", "GIT_ADAPTER_BIN=/usr/bin/git-adapter", gitAdapterBinEnv, "/usr/bin/git-adapter", true},
+		{"empty value still matches", "GIT_ADAPTER_BIN=", gitAdapterBinEnv, "", true},
+		{"different key", "PATH=/bin", gitAdapterBinEnv, "", false},
+		{"prefix only, no equals", "GIT_ADAPTER_BIN", gitAdapterBinEnv, "", false},
+		{"key is a prefix of entry key", "GIT_ADAPTER_BINX=y", gitAdapterBinEnv, "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := envValue(tt.entry, tt.key)
+			if ok != tt.wantMatch || got != tt.wantVal {
+				t.Errorf("envValue(%q,%q) = (%q,%v), want (%q,%v)",
+					tt.entry, tt.key, got, ok, tt.wantVal, tt.wantMatch)
+			}
+		})
+	}
+}
+
+// writeFakeAdapter creates an executable shell script standing in for the
+// git-adapter binary. It echoes its first arg and the two security-relevant env
+// vars so the test can assert they were passed through (and the token was NOT an
+// argument). Skips on non-POSIX platforms.
+func writeFakeAdapter(t *testing.T, body string) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fake binary not supported on windows")
+	}
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "git-adapter")
+	script := "#!/bin/sh\n" + body
+	if err := os.WriteFile(bin, []byte(script), 0o700); err != nil { //nolint:gosec // test fixture
+		t.Fatalf("write fake binary: %v", err)
+	}
+	return bin
+}
+
+func TestRunMCPGit_LaunchesAdapterMCPMode(t *testing.T) {
+	bin := writeFakeAdapter(t, `printf 'subcommand=%s\n' "$1"
+printf 'ADAPTER_CONFIG=%s\n' "$ADAPTER_CONFIG"
+printf 'GITHUB_TOKEN=%s\n' "$GITHUB_TOKEN"`)
+
+	env := []string{
+		gitAdapterBinEnv + "=" + bin,
+		"ADAPTER_CONFIG=/etc/git-adapter.yaml",
+		"GITHUB_TOKEN=ghp_secret",
+	}
+	var out, errOut bytes.Buffer
+	if err := runMCPGit(context.Background(), &out, &errOut, strings.NewReader(""), env); err != nil {
+		t.Fatalf("unexpected error: %v\nstderr: %s", err, errOut.String())
+	}
+
+	got := out.String()
+	// The only argument passed to the adapter is the constant "mcp" subcommand —
+	// never the token (no-secrets-in-args).
+	if !strings.Contains(got, "subcommand=mcp") {
+		t.Errorf("expected adapter launched with 'mcp' subcommand, got:\n%s", got)
+	}
+	if !strings.Contains(got, "ADAPTER_CONFIG=/etc/git-adapter.yaml") {
+		t.Errorf("ADAPTER_CONFIG not passed through, got:\n%s", got)
+	}
+	if !strings.Contains(got, "GITHUB_TOKEN=ghp_secret") {
+		t.Errorf("token env not inherited by adapter, got:\n%s", got)
+	}
+}
+
+func TestRunMCPGit_PipesStdinThrough(t *testing.T) {
+	bin := writeFakeAdapter(t, `cat`)
+	env := []string{gitAdapterBinEnv + "=" + bin}
+
+	var out bytes.Buffer
+	in := strings.NewReader(`{"jsonrpc":"2.0","method":"ping"}`)
+	if err := runMCPGit(context.Background(), &out, &bytes.Buffer{}, in, env); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out.String(), `"method":"ping"`) {
+		t.Errorf("stdin not piped to adapter stdout, got:\n%s", out.String())
+	}
+}
+
+func TestRunMCPGit_BinaryNotFound(t *testing.T) {
+	env := []string{gitAdapterBinEnv + "=/nonexistent/git-adapter-xyz"}
+	err := runMCPGit(context.Background(), &bytes.Buffer{}, &bytes.Buffer{}, strings.NewReader(""), env)
+	if err == nil {
+		t.Fatal("expected error for missing binary")
+	}
+	if !strings.Contains(err.Error(), "mcp git: launch") {
+		t.Errorf("error not wrapped with context: %v", err)
+	}
+}
+
+func TestRunMCPGit_DefaultBinaryWhenEnvUnset(t *testing.T) {
+	// No GIT_ADAPTER_BIN in env → default "git-adapter" is used. We don't have
+	// the real binary on PATH in CI, so we only assert the error names the
+	// default binary (exercising the default-resolution branch).
+	err := runMCPGit(context.Background(), &bytes.Buffer{}, &bytes.Buffer{}, strings.NewReader(""), []string{"PATH=/nonexistent"})
+	if err == nil {
+		t.Skip("git-adapter unexpectedly present on PATH; default-branch still exercised")
+	}
+	if !strings.Contains(err.Error(), defaultGitAdapterBin) {
+		t.Errorf("expected error to name default binary %q, got: %v", defaultGitAdapterBin, err)
+	}
+}
+
+func TestMCPGitCmd_RunE_Registered(t *testing.T) {
+	if mcpCmd.Use != "mcp" {
+		t.Errorf("mcpCmd.Use = %q", mcpCmd.Use)
+	}
+	sub, _, err := rootCmd.Find([]string{"mcp", "git"})
+	if err != nil || sub.Use != "git" {
+		t.Fatalf("mcp git subcommand not registered: sub=%v err=%v", sub, err)
+	}
+	if sub.RunE == nil {
+		t.Error("mcp git RunE not set")
+	}
+}

--- a/docs/git-mcp/README.md
+++ b/docs/git-mcp/README.md
@@ -1,0 +1,95 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Git MCP server (`zynax mcp git`)
+
+`zynax mcp git` launches a Git **MCP server** so an authoring loop (Claude Code,
+or any MCP client) can perform Git operations — clone / branch / commit / PR /
+review — as MCP tools, using a **least-privilege, injected** token.
+
+It is a thin shim over the existing `git-adapter` (ADR-032): one Git
+implementation, two surfaces. The adapter remains the runtime gRPC capability
+path; MCP is an additional authoring surface. No Git logic is duplicated in the
+shim.
+
+## How it works
+
+`zynax mcp git` execs the `git-adapter` binary in its `mcp` mode and wires the
+adapter's stdio through, so it speaks the MCP stdio protocol to the MCP client.
+
+```
+MCP client  <--stdio-->  zynax mcp git  --exec-->  git-adapter mcp
+                                                     (1:1 tool ↔ capability)
+```
+
+## Configuration
+
+All configuration is injected into the process environment **at start** — never
+passed as a CLI flag and never read from prompt content:
+
+| Variable          | Required | Purpose |
+|-------------------|----------|---------|
+| `ADAPTER_CONFIG`  | yes      | Path to the git-adapter YAML config (declares provider, `git.auth_env`, and the per-capability `owner`/`repo`). |
+| `<auth_env>`      | yes      | The token env var named by `git.auth_env` in that config (e.g. `GITHUB_TOKEN`). |
+| `GIT_ADAPTER_BIN` | no       | Override the `git-adapter` binary path (default: `git-adapter`, resolved via `$PATH`). |
+
+## Least-privilege token (required)
+
+The token is read **once** from the environment by the git-adapter at startup.
+It is **never** accepted as a tool argument, **never** read from a prompt, and
+**never** written to any committed config (ADR-032).
+
+Use a **fine-grained Personal Access Token** scoped to exactly the `owner/repo`
+declared in `ADAPTER_CONFIG`, with the **minimum** permissions the authoring
+task needs:
+
+- **Repository access:** only the specific repo(s) in the config — not "all
+  repositories".
+- **Permissions:** `Contents: Read and write` (clone/commit/push) and
+  `Pull requests: Read and write` (open/review PRs). Grant nothing else.
+- Do **not** use a classic `repo`-scoped PAT — it is org-wide and over-broad.
+
+The token lifetime is the operator's responsibility. The git-adapter reads it
+once at startup and does not refresh it (see canvas EPIC G.7 for refreshable /
+GitHub App credentials).
+
+## Wiring into an MCP client
+
+Copy [`.mcp.json.example`](../../.mcp.json.example) to `.mcp.json` and adjust the
+config path. Reference the token **by env name only** — never inline a literal:
+
+```json
+{
+  "mcpServers": {
+    "zynax-git": {
+      "command": "zynax",
+      "args": ["mcp", "git"],
+      "env": {
+        "ADAPTER_CONFIG": "agents/adapters/git/config.yaml",
+        "GITHUB_TOKEN": "${GITHUB_TOKEN}"
+      }
+    }
+  }
+}
+```
+
+Export the token in the shell that launches the MCP client (or source it from a
+secret manager); `${GITHUB_TOKEN}` resolves from that environment:
+
+```bash
+export GITHUB_TOKEN="$(your-secret-fetch ...)"   # fine-grained PAT, least-privilege
+```
+
+## Run it directly
+
+```bash
+ADAPTER_CONFIG=agents/adapters/git/config.yaml \
+GITHUB_TOKEN="$GITHUB_TOKEN" \
+zynax mcp git
+```
+
+The server speaks the MCP stdio protocol on stdin/stdout. Press Ctrl+C to stop.
+
+## See also
+
+- [ADR-032 — Git MCP shim over git-adapter](../adr/ADR-032-git-mcp-shim.md)
+- Canvas: `docs/spdd/1169-git-mcp-shim/canvas.md` (EPIC G)


### PR DESCRIPTION
Closes #1200

## Why
EPIC G (#1169) step 4: expose the git MCP surface from the CLI so agents/experts can author against git via MCP.

## What you'll get
- `zynax mcp git` command (serves the git MCP surface over the git-adapter)
- `.mcp.json.example` for client wiring
- `docs/git-mcp/README.md` guide

## Test plan & acceptance
- `GOWORK=off go test ./...` in cmd/zynax — all packages green (incl. mcp_test.go).

## Note
Recovered by the orchestrator from a crashed subagent (implementation was complete + tests green; committed per the crash-recovery contract). SPDD: canvas G (#1169) Aligned.

Assisted-by: Claude/claude-opus-4-8

🤖 Generated with [Claude Code](https://claude.com/claude-code)