### PR TITLE
feat(cli): zynax init workflow|expert scaffolder

### DIFF
--- a/cmd/zynax/AGENTS.md
+++ b/cmd/zynax/AGENTS.md
@@ -27,6 +27,7 @@ cmd/zynax/
     logs.go         zynax logs <run-id> [--follow|-f] [--format text|json]
     mcp.go          zynax mcp git   (launch Git MCP server — execs `git-adapter mcp`, ADR-032)
     validate.go      zynax validate <file> [--schema-dir] [--format]  (local: schema + data-flow)
+    init.go          zynax init workflow|expert [name] [-o file]  (scaffold from spec/templates)
   validate/
     manifest.go     JSON Schema validation (validate.Manifest) + combined pipeline (validate.File)
     dataflow.go     Workflow state-machine checks (initial_state + transition goto targets)

--- a/cmd/zynax/cmd/cmd_test.go
+++ b/cmd/zynax/cmd/cmd_test.go
@@ -162,6 +162,133 @@ func TestRunValidate_DataFlowError(t *testing.T) {
 	}
 }
 
+// ── init subcommand ───────────────────────────────────────────────────────────
+
+func TestRunInit_Workflow_EmitsValidManifest(t *testing.T) {
+	root := repoRoot(t)
+	initTemplateDir = filepath.Join(root, "spec/templates")
+	initOutput = ""
+
+	cmd := fakeCmd(t)
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	if err := runInit(cmd, "workflow", nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out.String(), "kind: Workflow") {
+		t.Errorf("expected Workflow manifest, got:\n%s", out.String())
+	}
+	// AC: emits a *versioned* manifest.
+	if !strings.Contains(out.String(), "version:") {
+		t.Errorf("expected version field in scaffolded manifest, got:\n%s", out.String())
+	}
+
+	// AC: the scaffolded manifest must be *valid* — round-trip through validate.
+	dir := t.TempDir()
+	f := filepath.Join(dir, "wf.yaml")
+	if err := os.WriteFile(f, out.Bytes(), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	validateSchemaDir = filepath.Join(root, "spec/schemas")
+	validateFormat = formatText
+	if err := runValidate(fakeCmd(t), []string{f}); err != nil {
+		t.Errorf("scaffolded workflow failed validation: %v", err)
+	}
+}
+
+func TestRunInit_Expert_EmitsValidManifest(t *testing.T) {
+	root := repoRoot(t)
+	initTemplateDir = filepath.Join(root, "spec/templates")
+	initOutput = ""
+
+	cmd := fakeCmd(t)
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	if err := runInit(cmd, "expert", nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out.String(), "kind: AgentDef") {
+		t.Errorf("expected AgentDef manifest, got:\n%s", out.String())
+	}
+
+	dir := t.TempDir()
+	f := filepath.Join(dir, "expert.yaml")
+	if err := os.WriteFile(f, out.Bytes(), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	validateSchemaDir = filepath.Join(root, "spec/schemas")
+	validateFormat = formatText
+	if err := runValidate(fakeCmd(t), []string{f}); err != nil {
+		t.Errorf("scaffolded expert failed validation: %v", err)
+	}
+}
+
+func TestRunInit_NameOverride(t *testing.T) {
+	root := repoRoot(t)
+	initTemplateDir = filepath.Join(root, "spec/templates")
+	initOutput = ""
+
+	cmd := fakeCmd(t)
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	if err := runInit(cmd, "workflow", []string{"my-pipeline"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out.String(), "name: my-pipeline") {
+		t.Errorf("expected overridden name, got:\n%s", out.String())
+	}
+}
+
+func TestRunInit_OutputFile(t *testing.T) {
+	root := repoRoot(t)
+	initTemplateDir = filepath.Join(root, "spec/templates")
+	dir := t.TempDir()
+	initOutput = filepath.Join(dir, "wf.yaml")
+	defer func() { initOutput = "" }()
+
+	cmd := fakeCmd(t)
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	if err := runInit(cmd, "workflow", nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out.String(), initOutput) {
+		t.Errorf("expected confirmation message, got:\n%s", out.String())
+	}
+	b, err := os.ReadFile(initOutput) //nolint:gosec // test reads the file it just scaffolded into a temp dir
+	if err != nil {
+		t.Fatalf("output file not written: %v", err)
+	}
+	if !strings.Contains(string(b), "kind: Workflow") {
+		t.Errorf("output file missing manifest, got:\n%s", b)
+	}
+}
+
+func TestRunInit_TemplateNotFound(t *testing.T) {
+	initTemplateDir = t.TempDir()
+	initOutput = ""
+
+	cmd := fakeCmd(t)
+	if err := runInit(cmd, "workflow", nil); err == nil {
+		t.Error("expected error for missing template")
+	}
+}
+
+func TestScaffold_NoMetadataName(t *testing.T) {
+	dir := t.TempDir()
+	kindDir := filepath.Join(dir, "workflow")
+	if err := os.Mkdir(kindDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(kindDir, "workflow.template.yaml"),
+		[]byte("kind: Workflow\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := scaffold(dir, "workflow", "x"); err == nil {
+		t.Error("expected error when template has no metadata.name")
+	}
+}
+
 // ── apply subcommand ──────────────────────────────────────────────────────────
 
 func TestRunApply_Workflow_202(t *testing.T) {

--- a/cmd/zynax/cmd/init.go
+++ b/cmd/zynax/cmd/init.go
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+
+	"github.com/spf13/cobra"
+)
+
+// initTemplateDir is the directory holding <kind>/<kind>.template.yaml files.
+var (
+	initTemplateDir string
+	initOutput      string
+)
+
+var initCmd = &cobra.Command{
+	Use:   "init",
+	Short: "Scaffold a new manifest from a reusable template",
+	Long: `Scaffold a new, valid, versioned manifest from a reusable template.
+
+Templates ship under <template-dir>/<kind>/<kind>.template.yaml (EPIC T.1).
+The scaffolded manifest is written to stdout by default, or to --output.
+
+If [name] is given it replaces the metadata.name field in the emitted manifest;
+otherwise the template's baseline name is kept.
+
+Runs entirely locally — no api-gateway connection required.`,
+}
+
+var initWorkflowCmd = &cobra.Command{
+	Use:   "workflow [name]",
+	Short: "Scaffold a new Workflow manifest",
+	Args:  cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runInit(cmd, "workflow", args)
+	},
+}
+
+var initExpertCmd = &cobra.Command{
+	Use:   "expert [name]",
+	Short: "Scaffold a new expert (AgentDef) manifest",
+	Args:  cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runInit(cmd, "expert", args)
+	},
+}
+
+func init() {
+	initCmd.PersistentFlags().StringVar(&initTemplateDir, "template-dir", "spec/templates",
+		"directory containing <kind>/<kind>.template.yaml files")
+	initCmd.PersistentFlags().StringVarP(&initOutput, "output", "o", "",
+		"write the manifest to this file instead of stdout")
+	initCmd.AddCommand(initWorkflowCmd)
+	initCmd.AddCommand(initExpertCmd)
+	rootCmd.AddCommand(initCmd)
+}
+
+// runInit reads the template for kind, applies the optional name override, and
+// writes the result to --output or stdout.
+func runInit(cmd *cobra.Command, kind string, args []string) error {
+	manifest, err := scaffold(initTemplateDir, kind, optionalName(args))
+	if err != nil {
+		return err
+	}
+	if initOutput != "" {
+		if err := os.WriteFile(initOutput, manifest, 0o600); err != nil {
+			return fmt.Errorf("write %s: %w", initOutput, err)
+		}
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "wrote %s manifest to %s\n", kind, initOutput)
+		return nil
+	}
+	_, _ = cmd.OutOrStdout().Write(manifest)
+	return nil
+}
+
+// optionalName returns the first positional arg, or "" when none is given.
+func optionalName(args []string) string {
+	if len(args) == 1 {
+		return args[0]
+	}
+	return ""
+}
+
+// metadataName matches the first metadata-level "  name: <value>" line.
+var metadataName = regexp.MustCompile(`(?m)^(\s{2}name:).*$`)
+
+// scaffold reads the template for kind from templateDir and returns the manifest
+// bytes with the metadata.name overridden by name when name is non-empty.
+func scaffold(templateDir, kind, name string) ([]byte, error) {
+	path := filepath.Join(templateDir, kind, kind+".template.yaml")
+	body, err := os.ReadFile(path) //nolint:gosec // path built from a fixed flag + kind constant
+	if err != nil {
+		return nil, fmt.Errorf("read template %s: %w", path, err)
+	}
+	if name == "" {
+		return body, nil
+	}
+	if !metadataName.Match(body) {
+		return nil, fmt.Errorf("template %s has no metadata.name field to override", path)
+	}
+	return metadataName.ReplaceAll(body, []byte("${1} "+name)), nil
+}

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -24,6 +24,23 @@ cd cmd/zynax && GOWORK=off go build -o ~/bin/zynax .
 
 ---
 
+## Scaffold a new manifest
+
+Start a new workflow or expert from a reusable, versioned template instead of from
+scratch. The manifest prints to stdout by default, or to `--output`/`-o`:
+
+```bash
+zynax init workflow                       # print a starting Workflow manifest
+zynax init workflow my-pipeline -o wf.yaml  # override metadata.name, write to file
+zynax init expert                         # print a starting expert (AgentDef) manifest
+```
+
+Templates live under `spec/templates/<kind>/<kind>.template.yaml`. Override the source
+directory with `--template-dir`. The emitted manifest is valid and versioned — run
+`zynax validate <file>` to confirm before `zynax apply`.
+
+---
+
 ## One-time setup
 
 ```bash


### PR DESCRIPTION
Closes #1209

EPIC T (#1171) step 4. `zynax init workflow|expert [name]` scaffolds a manifest from spec/templates. Recovered by the orchestrator from a crashed subagent (go test green; fixed a gosec G304 nolint in the test). SPDD: canvas T Aligned.

Assisted-by: Claude/claude-opus-4-8

🤖 Generated with [Claude Code](https://claude.com/claude-code)