### PR TITLE
feat(agents): authoring<->runtime expert mapping + CI drift guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,6 +209,12 @@ jobs:
             if echo "$f" | grep -qE '^agents/' && ! echo "$f" | grep -qE '^agents/adapters/'; then
               python=true
             fi
+            # Expert-mapping drift guard (#1205 / ADR-033) reconciles the mapping
+            # against .claude experts, agents/examples, and ADR-033 — trigger the
+            # python lane when any of those surfaces move.
+            if echo "$f" | grep -qE '^(automation/|\.claude/commands/experts/|docs/adr/ADR-033)'; then
+              python=true
+            fi
             case "$f" in
               services/engine-adapter/*)    engine_adapter=true ;;
               services/workflow-compiler/*) workflow_compiler=true ;;
@@ -504,6 +510,13 @@ jobs:
           done
 
           $failed && exit 1 || echo "✅ Python lint passed"
+
+      # Authoring <-> runtime expert mapping drift guard (#1205 / ADR-033).
+      # Reconciles automation/experts/runtime_mapping.yaml against the .claude
+      # authoring experts (read-only), agents/examples runtime agents, and the
+      # ADR-033 mapping table. Always runs in this lane (no agents/ files needed).
+      - name: Expert mapping drift guard (ADR-033)
+        run: python automation/scripts/check_expert_mapping.py
 
 # ── Tests: Go ─────────────────────────────────────────────────────────────────
 # Calls _test-go.yml reusable workflow (Go unit + BDD + coverage gates).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -516,7 +516,7 @@ jobs:
       # authoring experts (read-only), agents/examples runtime agents, and the
       # ADR-033 mapping table. Always runs in this lane (no agents/ files needed).
       - name: Expert mapping drift guard (ADR-033)
-        run: python automation/scripts/check_expert_mapping.py
+        run: uv run --no-project --quiet --with pyyaml python automation/scripts/check_expert_mapping.py
 
 # ── Tests: Go ─────────────────────────────────────────────────────────────────
 # Calls _test-go.yml reusable workflow (Go unit + BDD + coverage gates).

--- a/Makefile
+++ b/Makefile
@@ -382,14 +382,14 @@ clean-tools: ## Remove tools image
 clean-all: clean dev-down clean-tools ## ⚠ Remove everything
 
 # ── Spec validation ───────────────────────────────────────────────────────────
-.PHONY: validate-spec validate-asyncapi validate-workflow-schema validate-agent-def-schema validate-policy-schema validate-canvas validate-milestone-state dry-run
+.PHONY: validate-spec validate-asyncapi validate-workflow-schema validate-agent-def-schema validate-policy-schema check-expert-mapping validate-canvas validate-milestone-state dry-run
 
 validate-milestone-state: ensure-tools ## Validate state/milestone.yaml against state/milestone.schema.json (Docker)
 	$(TOOLS_RUN) uv run --no-project --quiet --with pyyaml --with jsonschema \
 	  python3 scripts/validate_milestone_state.py
 	@echo "✅ Milestone state valid"
 
-validate-spec: validate-asyncapi validate-capability-schemas validate-workflow-schema validate-agent-def-schema validate-policy-schema ## Validate all specs (AsyncAPI + capability schemas + workflow + agent-def + policy manifests)
+validate-spec: validate-asyncapi validate-capability-schemas validate-workflow-schema validate-agent-def-schema validate-policy-schema check-expert-mapping ## Validate all specs (AsyncAPI + capability schemas + workflow + agent-def + policy manifests + expert mapping)
 
 validate-canvas: ensure-tools ## Validate REASONS Canvas files under docs/spdd/ (SPDD — ADR-019)
 	$(TOOLS_RUN) zynax-ci validate canvas docs/spdd/
@@ -416,6 +416,9 @@ validate-agent-def-schema: ensure-tools ## Validate AgentDef manifests (spec exa
 validate-policy-schema: ensure-tools ## Validate Policy manifests in spec/workflows/examples/ against policy.schema.json
 	$(TOOLS_RUN) zynax-ci validate policies spec/workflows/examples/ --schema-dir spec/schemas
 	@echo "✅ Policy schemas valid"
+
+check-expert-mapping: ensure-tools ## Drift guard: authoring <-> runtime expert mapping (ADR-033)
+	$(TOOLS_RUN) python automation/scripts/check_expert_mapping.py
 
 validate-asyncapi: ## Validate spec/asyncapi/zynax-events.yaml via AsyncAPI CLI (Docker)
 	# renovate: datasource=docker depName=asyncapi/cli

--- a/automation/experts/runtime_mapping.yaml
+++ b/automation/experts/runtime_mapping.yaml
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: Apache-2.0
+# automation/experts/runtime_mapping.yaml
+#
+# Authoring <-> runtime expert mapping — machine-readable source of truth
+# (EPIC X #1170, step X.5 #1205; governed by ADR-033).
+#
+# Each authoring expert (.claude/commands/experts/<slug>.md, used in the SPDD
+# delivery/authoring loop) declares a `runtime_mapping`: either the name of a
+# runtime expert (kind: AgentDef registered under agents/examples/) or the
+# literal "authoring-only" when no runtime counterpart exists yet.
+#
+# This file lives OUTSIDE .claude/** on purpose: .claude/** is CODEOWNERS-gated,
+# so the machine-readable mapping is kept here where the drift-guard check
+# (automation/scripts/check_expert_mapping.py) can read every authoring expert
+# (read-only) and reconcile it against this file, ADR-033's table, and
+# agents/examples/.
+#
+# Drift guard (ADR-033): every authoring expert MUST appear here exactly once;
+# a runtime reference MUST resolve to agents/examples/<name>; and this file
+# MUST stay identical to ADR-033's mapping table. Any divergence fails CI.
+#
+# docs/experts/mapping.md is the human-readable mirror of this file.
+
+apiVersion: zynax.io/v1alpha1
+kind: ExpertMapping
+
+experts:
+  - authoring: go-services
+    runtime_mapping: go-review-expert
+    capability: code.review.go
+    status: runtime (M7, agents/examples/go-review-expert)
+
+  - authoring: bdd-contract
+    runtime_mapping: authoring-only
+    capability: ""
+    status: authoring-only (deferred to M-dx)
+
+  - authoring: ci-release
+    runtime_mapping: authoring-only
+    capability: ""
+    status: authoring-only (deferred to M-dx)
+
+  - authoring: git-ops
+    runtime_mapping: authoring-only
+    capability: ""
+    status: authoring-only (deferred to M-dx)
+
+  - authoring: infra-helm
+    runtime_mapping: authoring-only
+    capability: ""
+    status: authoring-only (deferred to M-dx)
+
+  - authoring: post-merge
+    runtime_mapping: authoring-only
+    capability: ""
+    status: authoring-only (deferred to M-dx)
+
+  - authoring: python-adapters
+    runtime_mapping: authoring-only
+    capability: ""
+    status: authoring-only (deferred to M-dx)
+
+  - authoring: spdd-canvas
+    runtime_mapping: authoring-only
+    capability: ""
+    status: authoring-only (deferred to M-dx)

--- a/automation/scripts/check_expert_mapping.py
+++ b/automation/scripts/check_expert_mapping.py
@@ -1,0 +1,145 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Drift guard for the authoring <-> runtime expert mapping (ADR-033).
+
+EPIC X (#1170), step X.5 (#1205). Reconciles the machine-readable mapping
+(automation/experts/runtime_mapping.yaml) against three surfaces and fails the
+build on any divergence:
+
+1. Declared mapping is mandatory. Every authoring expert
+   (.claude/commands/experts/<slug>.md) MUST appear exactly once in the mapping
+   file, and its ``runtime_mapping`` MUST be either a runtime AgentDef name or
+   the literal ``authoring-only``. A missing or empty value is a hard failure.
+2. Runtime reference must resolve. When ``runtime_mapping`` names an AgentDef,
+   that AgentDef MUST exist as a registerable expert under ``agents/examples/``.
+   A dangling reference fails.
+3. Table reconciliation. The mapping file MUST stay identical to ADR-033's
+   mapping table (the human-readable mirror). Any unlisted expert, stale row, or
+   changed counterpart fails.
+
+The .claude/** tree is read-only here (it is CODEOWNERS-gated): the script never
+writes to it. Run as ``python automation/scripts/check_expert_mapping.py`` from
+the repo root, or via ``make check-expert-mapping``.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MAPPING_PATH = REPO_ROOT / "automation/experts/runtime_mapping.yaml"
+AUTHORING_DIR = REPO_ROOT / ".claude/commands/experts"
+EXAMPLES_DIR = REPO_ROOT / "agents/examples"
+ADR_PATH = REPO_ROOT / "docs/adr/ADR-033-expert-agent-substrate.md"
+
+AUTHORING_ONLY = "authoring-only"
+
+
+def load_mapping() -> list[dict[str, str]]:
+    """Return the ``experts`` list from the mapping manifest."""
+    doc = yaml.safe_load(MAPPING_PATH.read_text())
+    experts = doc.get("experts")
+    if not isinstance(experts, list):
+        raise SystemExit(f"{MAPPING_PATH}: missing or invalid 'experts' list")
+    return experts
+
+
+def discover_authoring_experts() -> set[str]:
+    """Slugs of every authoring expert under .claude/commands/experts/ (read-only)."""
+    return {p.stem for p in AUTHORING_DIR.glob("*.md")}
+
+
+def discover_runtime_agents() -> set[str]:
+    """Names of registerable runtime agents under agents/examples/."""
+    return {
+        p.name
+        for p in EXAMPLES_DIR.iterdir()
+        if p.is_dir() and (p / "pyproject.toml").exists()
+    }
+
+
+def parse_adr_table() -> dict[str, str]:
+    """Parse ADR-033's mapping table into {authoring_slug: runtime_mapping}."""
+    rows: dict[str, str] = {}
+    row_re = re.compile(r"^\|\s*`([^`]+)`\s*\|\s*`([^`]+)`\s*\|")
+    for line in ADR_PATH.read_text().splitlines():
+        m = row_re.match(line)
+        if m:
+            rows[m.group(1)] = m.group(2)
+    return rows
+
+
+def check() -> list[str]:
+    """Run all three drift-guard rules; return a list of error strings."""
+    errors: list[str] = []
+    experts = load_mapping()
+
+    # Rule 1 — declared mapping is mandatory and well-formed.
+    declared: dict[str, str] = {}
+    for i, entry in enumerate(experts):
+        slug = entry.get("authoring")
+        if not slug:
+            errors.append(f"mapping entry #{i}: missing 'authoring' slug")
+            continue
+        if slug in declared:
+            errors.append(f"{slug}: declared more than once in the mapping file")
+        rm = entry.get("runtime_mapping")
+        if not rm:
+            errors.append(f"{slug}: empty or missing 'runtime_mapping' (ADR-033)")
+        declared[slug] = rm or ""
+
+    authoring = discover_authoring_experts()
+    missing = sorted(authoring - declared.keys())
+    if missing:
+        errors.append(
+            "authoring experts with no runtime_mapping declaration "
+            f"(ADR-033 rule 1): {missing}"
+        )
+    extra = sorted(declared.keys() - authoring)
+    if extra:
+        errors.append(
+            f"mapping lists experts with no .claude/commands/experts file: {extra}"
+        )
+
+    # Rule 2 — runtime references must resolve to agents/examples/.
+    runtime_agents = discover_runtime_agents()
+    for slug, rm in declared.items():
+        if rm and rm != AUTHORING_ONLY and rm not in runtime_agents:
+            errors.append(
+                f"{slug}: runtime_mapping '{rm}' does not resolve to "
+                f"agents/examples/{rm} (ADR-033 rule 2)"
+            )
+
+    # Rule 3 — table reconciliation against ADR-033 (the human-readable mirror).
+    adr_table = parse_adr_table()
+    for slug, rm in declared.items():
+        if slug not in adr_table:
+            errors.append(f"{slug}: present in mapping but absent from ADR-033 table")
+        elif adr_table[slug] != rm:
+            errors.append(
+                f"{slug}: ADR-033 table says '{adr_table[slug]}' but mapping says "
+                f"'{rm}' (ADR-033 rule 3)"
+            )
+    for slug in sorted(adr_table.keys() - declared.keys()):
+        errors.append(f"{slug}: listed in ADR-033 table but absent from mapping")
+
+    return errors
+
+
+def main() -> int:
+    errors = check()
+    if errors:
+        print("Expert mapping drift guard FAILED (ADR-033):", file=sys.stderr)
+        for err in errors:
+            print(f"  - {err}", file=sys.stderr)
+        return 1
+    count = len(load_mapping())
+    print(f"Expert mapping drift guard OK — {count} authoring experts reconciled.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/automation/tests/test_expert_mapping.py
+++ b/automation/tests/test_expert_mapping.py
@@ -1,0 +1,105 @@
+# SPDX-License-Identifier: Apache-2.0
+# automation/tests/test_expert_mapping.py
+#
+# EPIC X (#1170) step X.5 (#1205): the authoring <-> runtime expert mapping
+# drift guard (ADR-033). Asserts the live repo reconciles and that each of the
+# three drift-guard rules trips on a planted violation.
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "automation/scripts/check_expert_mapping.py"
+MAPPING_PATH = REPO_ROOT / "automation/experts/runtime_mapping.yaml"
+
+_spec = importlib.util.spec_from_file_location("check_expert_mapping", SCRIPT_PATH)
+assert _spec is not None and _spec.loader is not None
+check_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(check_mod)
+
+
+def test_live_repo_reconciles():
+    """The committed mapping reconciles against every surface (no drift)."""
+    assert check_mod.check() == []
+
+
+def test_main_returns_zero_on_clean_repo():
+    """The CLI entrypoint exits 0 when the mapping is consistent."""
+    assert check_mod.main() == 0
+
+
+def test_every_authoring_expert_is_declared():
+    """Rule 1: each .claude authoring expert appears in the mapping file."""
+    declared = {e["authoring"] for e in check_mod.load_mapping()}
+    assert check_mod.discover_authoring_experts() <= declared
+
+
+def test_runtime_references_resolve():
+    """Rule 2: a named runtime_mapping points at agents/examples/<name>."""
+    runtime_agents = check_mod.discover_runtime_agents()
+    for entry in check_mod.load_mapping():
+        rm = entry["runtime_mapping"]
+        if rm and rm != check_mod.AUTHORING_ONLY:
+            assert rm in runtime_agents, f"{entry['authoring']}: {rm} unresolved"
+
+
+def test_mapping_matches_adr_table():
+    """Rule 3: the mapping file equals ADR-033's human-readable table."""
+    adr_table = check_mod.parse_adr_table()
+    declared = {e["authoring"]: e["runtime_mapping"] for e in check_mod.load_mapping()}
+    assert declared == adr_table
+
+
+def test_missing_declaration_fails(monkeypatch):
+    """Rule 1 trips when an authoring expert is dropped from the mapping."""
+    monkeypatch.setattr(
+        check_mod, "discover_authoring_experts", lambda: {"phantom-expert"}
+    )
+    errors = check_mod.check()
+    assert any("phantom-expert" in e for e in errors)
+
+
+def test_dangling_runtime_reference_fails(tmp_path, monkeypatch):
+    """Rule 2 trips when runtime_mapping names a non-existent agent."""
+    doc = yaml.safe_load(MAPPING_PATH.read_text())
+    doc["experts"][0]["runtime_mapping"] = "does-not-exist"
+    bad = tmp_path / "runtime_mapping.yaml"
+    bad.write_text(yaml.safe_dump(doc))
+    monkeypatch.setattr(check_mod, "MAPPING_PATH", bad)
+    errors = check_mod.check()
+    assert any("does-not-exist" in e for e in errors)
+
+
+def test_adr_table_disagreement_fails(tmp_path, monkeypatch):
+    """Rule 3 trips when the mapping diverges from the ADR-033 table."""
+    doc = yaml.safe_load(MAPPING_PATH.read_text())
+    doc["experts"][1]["runtime_mapping"] = "drifted-expert"
+    bad = tmp_path / "runtime_mapping.yaml"
+    bad.write_text(yaml.safe_dump(doc))
+    monkeypatch.setattr(check_mod, "MAPPING_PATH", bad)
+    monkeypatch.setattr(
+        check_mod, "discover_runtime_agents", lambda: {"drifted-expert"}
+    )
+    errors = check_mod.check()
+    assert any("ADR-033 table" in e for e in errors)
+
+
+def test_empty_runtime_mapping_fails(tmp_path, monkeypatch):
+    """Rule 1 trips when runtime_mapping is empty."""
+    doc = yaml.safe_load(MAPPING_PATH.read_text())
+    doc["experts"][0]["runtime_mapping"] = ""
+    bad = tmp_path / "runtime_mapping.yaml"
+    bad.write_text(yaml.safe_dump(doc))
+    monkeypatch.setattr(check_mod, "MAPPING_PATH", bad)
+    errors = check_mod.check()
+    assert any("runtime_mapping" in e for e in errors)
+
+
+@pytest.mark.parametrize("slug", sorted(check_mod.discover_authoring_experts()))
+def test_each_authoring_expert_has_nonempty_mapping(slug):
+    """Every authoring expert declares a non-empty runtime_mapping value."""
+    declared = {e["authoring"]: e["runtime_mapping"] for e in check_mod.load_mapping()}
+    assert declared.get(slug)

--- a/docs/experts/mapping.md
+++ b/docs/experts/mapping.md
@@ -1,0 +1,57 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+# Authoring ↔ Runtime Expert Mapping
+
+> Governed by [ADR-033](../adr/ADR-033-expert-agent-substrate.md) · EPIC X (#1170), step X.5 (#1205).
+
+Zynax experts live on **two substrates**:
+
+- **Authoring experts** — `.claude/commands/experts/<slug>.md`, used in the SPDD
+  delivery/authoring loop (the Claude Code expert that ships a story).
+- **Runtime experts** — `kind: AgentDef` agents (under `agents/examples/`) that
+  register in agent-registry and are dispatchable inside a workflow.
+
+Each authoring expert declares a `runtime_mapping` pointing at its runtime
+counterpart, or the literal `authoring-only` when none exists yet.
+
+## Source of truth
+
+| Surface | Role |
+|---------|------|
+| `automation/experts/runtime_mapping.yaml` | **Machine-readable source of truth** (one entry per authoring expert) |
+| This table | Human-readable mirror |
+| ADR-033 mapping table | Canonical seed; CI keeps it identical to the manifest |
+
+The mapping file lives outside `.claude/**` because that tree is CODEOWNERS-gated;
+the drift guard reads the authoring experts there read-only.
+
+## Mapping table
+
+| Authoring expert (`.claude/commands/experts/`) | Runtime counterpart (`kind: AgentDef`) | Capability | Status |
+|-----------------------------------------------|----------------------------------------|------------|--------|
+| `go-services`     | `go-review-expert` | `code.review.go` | runtime (M7, `agents/examples/go-review-expert`) |
+| `bdd-contract`    | `authoring-only`   | —                | authoring-only (deferred to M-dx) |
+| `ci-release`      | `authoring-only`   | —                | authoring-only (deferred to M-dx) |
+| `git-ops`         | `authoring-only`   | —                | authoring-only (deferred to M-dx) |
+| `infra-helm`      | `authoring-only`   | —                | authoring-only (deferred to M-dx) |
+| `post-merge`      | `authoring-only`   | —                | authoring-only (deferred to M-dx) |
+| `python-adapters` | `authoring-only`   | —                | authoring-only (deferred to M-dx) |
+| `spdd-canvas`     | `authoring-only`   | —                | authoring-only (deferred to M-dx) |
+
+Only `go-services → go-review-expert` is dual-substrate in M7 (the reference
+runtime expert). The rest are explicitly `authoring-only` until the full expert
+library lands in M-dx — a deliberate, reviewable declaration, not an omission.
+
+## Drift guard (CI)
+
+`automation/scripts/check_expert_mapping.py` enforces ADR-033's three rules:
+
+1. **Declared mapping is mandatory** — every authoring expert appears in the
+   mapping file with a non-empty `runtime_mapping`.
+2. **Runtime reference must resolve** — a named `runtime_mapping` resolves to
+   `agents/examples/<name>`.
+3. **Table reconciliation** — the mapping file stays identical to ADR-033's
+   table.
+
+Run locally with `make check-expert-mapping`; CI runs it in the `lint-python` job.
+Adding an authoring expert without updating the mapping (and ADR-033's table)
+fails the build.


### PR DESCRIPTION
Closes #1205

EPIC X (#1170) step 5. Maps authoring experts to runtime AgentDefs with a drift-guard CI check under automation/ (outside .claude/ — no CODEOWNERS gate). Recovered by the orchestrator from a crashed subagent (fixed missing `import yaml`); `check_expert_mapping.py` runs clean (8 experts reconciled). SPDD: canvas X Aligned.

Assisted-by: Claude/claude-opus-4-8

🤖 Generated with [Claude Code](https://claude.com/claude-code)