### PR TITLE
feat(infra): ship logs to Uptrace via OTLP + naming conventions

### DIFF
--- a/docs/observability/naming-conventions.md
+++ b/docs/observability/naming-conventions.md
@@ -1,0 +1,101 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+# Telemetry Naming Conventions
+
+> EPIC O (#467), step O.9. Governs span, metric, and log naming across every
+> Zynax service and adapter so traces, metrics, and logs join up in the Uptrace
+> UI. Telemetry is **off by default** — these conventions apply only when
+> `ZYNAX_OTEL_EXPORTER_OTLP_ENDPOINT` is set.
+
+All telemetry follows the [OpenTelemetry semantic conventions][semconv]; the
+rules below are the Zynax-specific bindings on top of them. They exist so a
+single workflow run produces a connected trace, RED metrics, and correlated logs
+that a developer can pivot between from one place.
+
+## Resource attributes
+
+Every signal (trace, metric, log) carries the same resource attributes, set once
+in `libs/zynaxobs` and the Python SDK:
+
+| Attribute | Source | Example |
+|-----------|--------|---------|
+| `service.name` | per service | `api-gateway`, `engine-adapter` |
+| `service.version` | build version | `0.6.0` |
+| `service.namespace` | deployment | `zynax` |
+| `deployment.environment` | env-gated | `local`, `staging`, `prod` |
+
+These come from `semconv` constants — never hand-rolled string keys.
+
+## Span names
+
+Spans use a lowercase, dot-delimited `<producer>.<operation>` form. Never embed
+high-cardinality values (IDs, payloads) in the **span name** — put those in span
+attributes instead.
+
+| Producer | Pattern | Example |
+|----------|---------|---------|
+| gRPC server/client hop | `<service>.<rpc>` | `engine-adapter.DispatchCapability` |
+| api-gateway HTTP route | `<service>.<method> <route>` | `api-gateway.POST /v1/workflows` |
+| Python capability handler | `capability.<name>` | `capability.git.clone` |
+| Temporal workflow/activity | `<workflow>.<activity>` | `IRInterpreter.DispatchCapability` |
+
+## Metric names
+
+Metrics use the `zynax_` prefix and OpenTelemetry unit suffixes. **Labels stay
+low-cardinality — only `service`, `method`, `status`.** Never label with workflow
+IDs, request IDs, or any unbounded value (canvas O.4 Safeguard).
+
+| Metric | Type | Labels |
+|--------|------|--------|
+| `zynax_grpc_requests_total` | counter | `service`, `method`, `status` |
+| `zynax_grpc_request_duration_seconds` | histogram | `service`, `method` |
+| `zynax_eventbus_publish_failed_total` | counter | `event_type` |
+
+Histograms carry **exemplars** that link to a `trace_id`, so a dashboard spike
+jumps straight to the offending trace.
+
+## Log correlation (trace_id / span_id)
+
+Logs are shipped to Uptrace as **OTLP log records** through the OpenTelemetry
+Collector (`logs` pipeline), not scraped from stdout. The single most important
+rule:
+
+> **Every log line emitted inside an active span MUST carry `trace_id` and
+> `span_id`.**
+
+How this is guaranteed end-to-end:
+
+1. **Emit** — services log through the `libs/zynaxobs` log bridge (and the Python
+   SDK through the OTEL logging handler), which stamps the current span context
+   onto each `LogRecord`'s `trace_id` / `span_id` fields from the OTLP log data
+   model. These are first-class fields, not free-text attributes.
+2. **Transport** — the OpenTelemetry Collector `logs` pipeline (`otlp` receiver →
+   `memory_limiter` → `batch` → `otlp/uptrace` exporter) forwards records
+   verbatim. No processor rewrites or strips the trace/span identifiers.
+3. **Display** — Uptrace joins logs to traces on `trace_id`, so a log line in the
+   UI links to its span and vice versa.
+
+Conventions for log records:
+
+- Use structured key/value fields, never string interpolation of IDs into the
+  message body.
+- Reuse the resource attributes above; do not duplicate `service.name` into the
+  message.
+- **Never** log secrets, credentials, tokens, or raw request payloads — redact by
+  default (canvas O.9 Safeguard).
+- Severity uses the OTLP severity model (`DEBUG`/`INFO`/`WARN`/`ERROR`); the
+  collector preserves it.
+
+## Context propagation
+
+The only context propagated across gRPC, Temporal, and NATS is the W3C
+`traceparent` header — never auth tokens or session data (canvas O.5 Safeguard).
+This is what keeps `trace_id` stable across async hops so logs from different
+services correlate to one run.
+
+## See also
+
+- `infra/docker-compose/docker-compose.observability.yml` — local Uptrace + collector stack (O.7)
+- `helm/charts/uptrace/` — in-cluster Uptrace + collector chart (O.8)
+- ADR-030 — OTEL + Uptrace backend decision
+
+[semconv]: https://opentelemetry.io/docs/specs/semconv/

--- a/helm/charts/uptrace/templates/otel-collector-config.yaml
+++ b/helm/charts/uptrace/templates/otel-collector-config.yaml
@@ -18,6 +18,10 @@ data:
           http:
             endpoint: 0.0.0.0:{{ .Values.collector.ports.http }}
     processors:
+      memory_limiter:
+        check_interval: 1s
+        limit_percentage: 80
+        spike_limit_percentage: 25
       batch:
         timeout: 5s
     exporters:
@@ -31,14 +35,16 @@ data:
       pipelines:
         traces:
           receivers: [otlp]
-          processors: [batch]
+          processors: [memory_limiter, batch]
           exporters: [otlp/uptrace]
         metrics:
           receivers: [otlp]
-          processors: [batch]
+          processors: [memory_limiter, batch]
           exporters: [otlp/uptrace]
+        # Logs forwarded verbatim — trace_id/span_id preserved end-to-end
+        # (docs/observability/naming-conventions.md).
         logs:
           receivers: [otlp]
-          processors: [batch]
+          processors: [memory_limiter, batch]
           exporters: [otlp/uptrace]
 {{- end }}

--- a/infra/docker-compose/README.md
+++ b/infra/docker-compose/README.md
@@ -74,6 +74,10 @@ export ZYNAX_OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:7017
 All observability host ports bind to `127.0.0.1` only — OTLP ingest is never publicly
 exposed (canvas O.7 Safeguards). ClickHouse and Postgres have no host ports.
 
+Logs ship to Uptrace as OTLP log records through the collector `logs` pipeline,
+correlated to traces by `trace_id`/`span_id`. Span, metric, and log naming rules
+live in [docs/observability/naming-conventions.md](../../docs/observability/naming-conventions.md).
+
 ## Not included
 
 The following services are unimplemented stubs awaiting M5 and are intentionally

--- a/infra/docker-compose/observability/otel-collector.yaml
+++ b/infra/docker-compose/observability/otel-collector.yaml
@@ -14,6 +14,11 @@ receivers:
         endpoint: 0.0.0.0:4318
 
 processors:
+  # Guard the collector against OOM under log/trace bursts before batching.
+  memory_limiter:
+    check_interval: 1s
+    limit_percentage: 80
+    spike_limit_percentage: 25
   # Batch async so service request paths never block on export.
   batch:
     timeout: 5s
@@ -36,13 +41,16 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      processors: [batch]
+      processors: [memory_limiter, batch]
       exporters: [otlp/uptrace]
     metrics:
       receivers: [otlp]
-      processors: [batch]
+      processors: [memory_limiter, batch]
       exporters: [otlp/uptrace]
+    # Logs are forwarded verbatim — no processor rewrites or strips the OTLP
+    # LogRecord trace_id/span_id, so log↔trace correlation survives transport
+    # (docs/observability/naming-conventions.md).
     logs:
       receivers: [otlp]
-      processors: [batch]
+      processors: [memory_limiter, batch]
       exporters: [otlp/uptrace]


### PR DESCRIPTION
Closes #1192

EPIC O (#467) step 9. otel-collector logs pipeline → Uptrace in compose + Helm, plus naming conventions. Recovered by the orchestrator from a crashed subagent (full scope this attempt). SPDD: canvas O Aligned.

Assisted-by: Claude/claude-opus-4-8

🤖 Generated with [Claude Code](https://claude.com/claude-code)