### PR TITLE
feat(agents/adapters): Go llm-adapter scaffold + config

### DIFF
--- a/agents/adapters/llm/agent-def.yaml.example
+++ b/agents/adapters/llm/agent-def.yaml.example
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+# llm-adapter — example AgentDef YAML (Go re-implementation, ADR-035)
+#
+# Copy this file to agent-def.yaml and set the ZYNAX_LLM_CONFIG env var to its path.
+# The provider and model are always declared here — never in input_payload.
+# The API key is resolved at startup from the env var named in provider.api_key_env;
+# its value is never stored in config and never logged.
+
+agent_id: llm-adapter
+name: LLM Adapter
+description: Wraps OpenAI / Bedrock / Ollama chat completions as Zynax capabilities.
+endpoint: :50070
+registry_endpoint: agent-registry:50052
+
+provider:
+  name: openai            # one of: openai | bedrock | ollama
+  model: gpt-4o
+  api_key_env: OPENAI_API_KEY  # name of the env var holding the API key (openai/bedrock)
+  max_tokens: 4096
+  # ollama_base_url: http://localhost:11434  # required when name == ollama
+  # region: us-east-1                          # required when name == bedrock
+
+capabilities:
+  - name: chat_completion
+    timeout_seconds: 60
+    description: Stream a chat completion from the configured LLM provider.
+    input_schema_json: |
+      {
+        "type": "object",
+        "required": ["prompt"],
+        "properties": {
+          "prompt": { "type": "string", "minLength": 1 }
+        },
+        "additionalProperties": false
+      }
+    output_schema_json: |
+      {
+        "type": "object",
+        "properties": {
+          "completion": { "type": "string" }
+        }
+      }

--- a/agents/adapters/llm/cmd/llm-adapter/main.go
+++ b/agents/adapters/llm/cmd/llm-adapter/main.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package main is the entry point for the llm-adapter gRPC service. This
+// scaffold (M7.P.2) loads and validates configuration and resolves the API-key
+// secret from the environment; provider routing, the AgentService server, and
+// registry bootstrap are added in later EPIC P steps (P.3–P.5).
+package main
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/zynax-io/zynax/agents/adapters/llm/internal/config"
+)
+
+// configEnvVar names the env var holding the YAML config path (prefix ZYNAX_LLM_).
+const configEnvVar = "ZYNAX_LLM_CONFIG"
+
+func main() {
+	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stdout, nil)))
+	if err := run(); err != nil {
+		slog.Error("llm-adapter error", "err", err)
+		os.Exit(1)
+	}
+}
+
+// run loads config, resolves the credential, and logs readiness. The gRPC serve
+// loop is wired in a later P step; keeping run() pure makes it test-friendly.
+func run() error {
+	cfgPath := os.Getenv(configEnvVar)
+	if cfgPath == "" {
+		return fmt.Errorf("%s env var is required", configEnvVar)
+	}
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+	if _, err := cfg.ResolveSecret(); err != nil {
+		return fmt.Errorf("resolve secret: %w", err)
+	}
+	// Fields are operator-controlled config (not request input); the API-key
+	// Secret is never logged. //nolint:gosec — matches sibling git-adapter.
+	slog.Info("llm-adapter config loaded", //nolint:gosec
+		"agent_id", cfg.AgentID,
+		"provider", cfg.Provider.Name,
+		"endpoint", cfg.Endpoint,
+		"capabilities", len(cfg.Capabilities),
+	)
+	return nil
+}

--- a/agents/adapters/llm/cmd/llm-adapter/main_test.go
+++ b/agents/adapters/llm/cmd/llm-adapter/main_test.go
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const validConfig = `
+agent_id: llm-adapter-test
+endpoint: :50070
+registry_endpoint: localhost:50052
+capabilities:
+  - name: chat_completion
+provider:
+  name: openai
+  model: gpt-4o
+  api_key_env: OPENAI_API_KEY
+`
+
+func writeConfig(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return path
+}
+
+func TestRun_MissingEnv(t *testing.T) {
+	t.Setenv(configEnvVar, "")
+	if err := run(); err == nil {
+		t.Fatal("expected error when config env var unset")
+	}
+}
+
+func TestRun_BadConfigPath(t *testing.T) {
+	t.Setenv(configEnvVar, "/nonexistent/config.yaml")
+	if err := run(); err == nil {
+		t.Fatal("expected error for missing config file")
+	}
+}
+
+func TestRun_UnsetSecret(t *testing.T) {
+	t.Setenv(configEnvVar, writeConfig(t, validConfig))
+	t.Setenv("OPENAI_API_KEY", "")
+	if err := run(); err == nil {
+		t.Fatal("expected error when api key env unset")
+	}
+}
+
+func TestRun_Success(t *testing.T) {
+	t.Setenv(configEnvVar, writeConfig(t, validConfig))
+	t.Setenv("OPENAI_API_KEY", "sk-test-value")
+	if err := run(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/agents/adapters/llm/go.mod
+++ b/agents/adapters/llm/go.mod
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+module github.com/zynax-io/zynax/agents/adapters/llm
+
+go 1.26.4
+
+require gopkg.in/yaml.v3 v3.0.1

--- a/agents/adapters/llm/go.sum
+++ b/agents/adapters/llm/go.sum
@@ -1,0 +1,4 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/agents/adapters/llm/internal/config/config.go
+++ b/agents/adapters/llm/internal/config/config.go
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Supported provider names — the closed set per ADR-035.
+const (
+	providerOpenAI  = "openai"
+	providerBedrock = "bedrock"
+	providerOllama  = "ollama"
+)
+
+// validProviders is the closed set of supported LLM providers (ADR-035).
+var validProviders = map[string]struct{}{
+	providerOpenAI:  {},
+	providerBedrock: {},
+	providerOllama:  {},
+}
+
+// AdapterConfig is the top-level YAML struct parsed from the file at startup.
+// The path is read from the ZYNAX_LLM_CONFIG env var by the bootstrap layer.
+// Fields mirror the Python AdapterConfig for behavioural parity.
+type AdapterConfig struct {
+	AgentID          string             `yaml:"agent_id"`
+	Name             string             `yaml:"name"`
+	Description      string             `yaml:"description"`
+	Endpoint         string             `yaml:"endpoint"`
+	RegistryEndpoint string             `yaml:"registry_endpoint"`
+	Capabilities     []CapabilityConfig `yaml:"capabilities"`
+	Provider         ProviderConfig     `yaml:"provider"`
+}
+
+// CapabilityConfig declares one capability the adapter exposes, with its JSON
+// Schemas. Schemas are validated against input_payload at request time (P.4).
+type CapabilityConfig struct {
+	Name             string `yaml:"name"`
+	Description      string `yaml:"description"`
+	TimeoutSeconds   int    `yaml:"timeout_seconds"`
+	InputSchemaJSON  string `yaml:"input_schema_json"`
+	OutputSchemaJSON string `yaml:"output_schema_json"`
+}
+
+// ProviderConfig holds per-provider settings. Name selects the active provider;
+// ApiKeyEnv names the environment variable holding the credential — the value
+// is never a config field. Mirrors the Python ProviderConfig fields.
+type ProviderConfig struct {
+	Name          string `yaml:"name"`
+	Model         string `yaml:"model"`
+	OllamaBaseURL string `yaml:"ollama_base_url"`
+	APIKeyEnv     string `yaml:"api_key_env"`
+	MaxTokens     int    `yaml:"max_tokens"`
+	Region        string `yaml:"region"`
+}
+
+// Load reads, parses, and validates the YAML config at path. It returns a
+// descriptive error for a missing file, malformed YAML, or any invalid field.
+func Load(path string) (*AdapterConfig, error) {
+	data, err := os.ReadFile(path) //nolint:gosec // path sourced from ZYNAX_LLM_CONFIG env var (operator-controlled)
+	if err != nil {
+		return nil, fmt.Errorf("config: read %s: %w", path, err)
+	}
+
+	var cfg AdapterConfig
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("config: parse %s: %w", path, err)
+	}
+
+	if err := cfg.validate(); err != nil {
+		return nil, err
+	}
+
+	return &cfg, nil
+}
+
+// validate fails fast on any missing or invalid required field.
+func (c *AdapterConfig) validate() error {
+	if err := c.validateIdentity(); err != nil {
+		return err
+	}
+	if len(c.Capabilities) == 0 {
+		return fmt.Errorf("config: at least one capability is required")
+	}
+	for i, cap := range c.Capabilities {
+		if cap.Name == "" {
+			return fmt.Errorf("config: capabilities[%d].name is required", i)
+		}
+	}
+	return c.Provider.validate()
+}
+
+// validateIdentity checks the adapter identity and endpoint fields.
+func (c *AdapterConfig) validateIdentity() error {
+	if c.AgentID == "" {
+		return fmt.Errorf("config: agent_id is required")
+	}
+	if c.Endpoint == "" {
+		return fmt.Errorf("config: endpoint is required")
+	}
+	if c.RegistryEndpoint == "" {
+		return fmt.Errorf("config: registry_endpoint is required")
+	}
+	return nil
+}
+
+// validate checks the provider selection and its required fields.
+func (p *ProviderConfig) validate() error {
+	if _, ok := validProviders[p.Name]; !ok {
+		return fmt.Errorf("config: provider.name %q is not one of openai|bedrock|ollama", p.Name)
+	}
+	if p.Model == "" {
+		return fmt.Errorf("config: provider.model is required")
+	}
+	return p.validateRequiredByProvider()
+}
+
+// validateRequiredByProvider enforces the per-provider required fields.
+func (p *ProviderConfig) validateRequiredByProvider() error {
+	switch p.Name {
+	case providerOpenAI, providerBedrock:
+		if p.APIKeyEnv == "" {
+			return fmt.Errorf("config: provider.api_key_env is required for %s", p.Name)
+		}
+	case providerOllama:
+		if p.OllamaBaseURL == "" {
+			return fmt.Errorf("config: provider.ollama_base_url is required for ollama")
+		}
+	}
+	if p.Name == providerBedrock && p.Region == "" {
+		return fmt.Errorf("config: provider.region is required for bedrock")
+	}
+	return nil
+}
+
+// ResolveSecret reads the API key from the env var named in provider.api_key_env
+// and returns it wrapped in a redacting Secret. Returns an error if the named
+// env var is unset or empty. Returns a zero Secret when no key env is declared
+// (e.g. the ollama provider, which needs no credential).
+func (c *AdapterConfig) ResolveSecret() (Secret, error) {
+	if c.Provider.APIKeyEnv == "" {
+		return Secret{}, nil
+	}
+	value := os.Getenv(c.Provider.APIKeyEnv)
+	if value == "" {
+		return Secret{}, fmt.Errorf("config: env var %s is required but not set", c.Provider.APIKeyEnv)
+	}
+	return NewSecret(value), nil
+}

--- a/agents/adapters/llm/internal/config/config_test.go
+++ b/agents/adapters/llm/internal/config/config_test.go
@@ -1,0 +1,246 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package config_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/zynax-io/zynax/agents/adapters/llm/internal/config"
+)
+
+func writeYAML(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write temp config: %v", err)
+	}
+	return path
+}
+
+const validOpenAI = `
+agent_id: llm-adapter-test
+name: LLM Adapter Test
+description: test
+endpoint: :50070
+registry_endpoint: localhost:50052
+capabilities:
+  - name: chat_completion
+    timeout_seconds: 60
+provider:
+  name: openai
+  model: gpt-4o
+  api_key_env: OPENAI_API_KEY
+  max_tokens: 4096
+`
+
+func TestLoad_Valid(t *testing.T) {
+	t.Parallel()
+	cfg, err := config.Load(writeYAML(t, validOpenAI))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.AgentID != "llm-adapter-test" {
+		t.Errorf("agent_id mismatch: got %q", cfg.AgentID)
+	}
+	if cfg.Provider.Name != "openai" {
+		t.Errorf("provider.name mismatch: got %q", cfg.Provider.Name)
+	}
+	if cfg.Provider.Model != "gpt-4o" {
+		t.Errorf("provider.model mismatch: got %q", cfg.Provider.Model)
+	}
+	if cfg.Provider.APIKeyEnv != "OPENAI_API_KEY" {
+		t.Errorf("provider.api_key_env mismatch: got %q", cfg.Provider.APIKeyEnv)
+	}
+	if len(cfg.Capabilities) != 1 || cfg.Capabilities[0].Name != "chat_completion" {
+		t.Fatalf("capabilities mismatch: %+v", cfg.Capabilities)
+	}
+}
+
+func TestLoad_ValidOllama(t *testing.T) {
+	t.Parallel()
+	body := `
+agent_id: llm-ollama
+endpoint: :50070
+registry_endpoint: localhost:50052
+capabilities:
+  - name: chat_completion
+provider:
+  name: ollama
+  model: llama3.2
+  ollama_base_url: http://localhost:11434
+`
+	cfg, err := config.Load(writeYAML(t, body))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Provider.OllamaBaseURL != "http://localhost:11434" {
+		t.Errorf("ollama_base_url mismatch: got %q", cfg.Provider.OllamaBaseURL)
+	}
+}
+
+func TestLoad_MissingFile(t *testing.T) {
+	t.Parallel()
+	if _, err := config.Load("/nonexistent/path.yaml"); err == nil {
+		t.Fatal("expected error for missing file")
+	}
+}
+
+func TestLoad_MalformedYAML(t *testing.T) {
+	t.Parallel()
+	if _, err := config.Load(writeYAML(t, "agent_id: [unterminated")); err == nil {
+		t.Fatal("expected error for malformed YAML")
+	}
+}
+
+func TestLoad_MissingField(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{"no agent_id", strings.Replace(validOpenAI, "agent_id: llm-adapter-test", "", 1), "agent_id"},
+		{"no endpoint", strings.Replace(validOpenAI, "endpoint: :50070", "", 1), "endpoint"},
+		{"no registry", strings.Replace(validOpenAI, "registry_endpoint: localhost:50052", "", 1), "registry_endpoint"},
+		{"no capabilities", strings.Split(validOpenAI, "capabilities:")[0] + "provider:\n  name: openai\n  model: gpt-4o\n  api_key_env: OPENAI_API_KEY\n", "capability"},
+		{"no model", strings.Replace(validOpenAI, "model: gpt-4o", "", 1), "model"},
+		{"no api_key_env openai", strings.Replace(validOpenAI, "api_key_env: OPENAI_API_KEY", "", 1), "api_key_env"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := config.Load(writeYAML(t, tt.body))
+			if err == nil {
+				t.Fatalf("expected error mentioning %q", tt.want)
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Errorf("error %q does not mention %q", err.Error(), tt.want)
+			}
+		})
+	}
+}
+
+func TestLoad_UnknownProvider(t *testing.T) {
+	t.Parallel()
+	body := strings.Replace(validOpenAI, "name: openai", "name: anthropic", 1)
+	_, err := config.Load(writeYAML(t, body))
+	if err == nil {
+		t.Fatal("expected error for unknown provider")
+	}
+	if !strings.Contains(err.Error(), "openai|bedrock|ollama") {
+		t.Errorf("error %q should list valid providers", err.Error())
+	}
+}
+
+func TestLoad_BedrockRequiresRegion(t *testing.T) {
+	t.Parallel()
+	body := `
+agent_id: llm-bedrock
+endpoint: :50070
+registry_endpoint: localhost:50052
+capabilities:
+  - name: chat_completion
+provider:
+  name: bedrock
+  model: anthropic.claude-3-5-sonnet
+  api_key_env: AWS_KEY
+`
+	_, err := config.Load(writeYAML(t, body))
+	if err == nil || !strings.Contains(err.Error(), "region") {
+		t.Fatalf("expected region-required error, got: %v", err)
+	}
+}
+
+func TestResolveSecret(t *testing.T) {
+	cfg, err := config.Load(writeYAML(t, validOpenAI))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	t.Setenv("OPENAI_API_KEY", "sk-supersecretvalue123")
+	secret, err := cfg.ResolveSecret()
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if secret.Reveal() != "sk-supersecretvalue123" {
+		t.Errorf("reveal mismatch: got %q", secret.Reveal())
+	}
+}
+
+func TestResolveSecret_Unset(t *testing.T) {
+	cfg, err := config.Load(writeYAML(t, validOpenAI))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	t.Setenv("OPENAI_API_KEY", "")
+	if _, err := cfg.ResolveSecret(); err == nil {
+		t.Fatal("expected error for unset env var")
+	}
+}
+
+func TestResolveSecret_NoEnvDeclared(t *testing.T) {
+	cfg, err := config.Load(writeYAML(t, `
+agent_id: llm-ollama
+endpoint: :50070
+registry_endpoint: localhost:50052
+capabilities:
+  - name: chat_completion
+provider:
+  name: ollama
+  model: llama3.2
+  ollama_base_url: http://localhost:11434
+`))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	secret, err := cfg.ResolveSecret()
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if !secret.IsZero() {
+		t.Error("expected zero secret when no api_key_env declared")
+	}
+}
+
+func TestSecret_NeverLeaks(t *testing.T) {
+	t.Parallel()
+	const raw = "sk-this-must-never-appear"
+	s := config.NewSecret(raw)
+
+	// Render the Secret through every verb a log line or error might use.
+	// A struct wrapper forces the %v/%s family through Secret's Stringer
+	// rather than tripping the staticcheck S1025 single-arg shortcut.
+	wrap := struct{ S config.Secret }{S: s}
+	renderings := []string{
+		s.String(),
+		s.GoString(),
+		fmt.Sprintf("%v", wrap),
+		fmt.Sprintf("%s", wrap),
+		fmt.Sprintf("%#v", wrap),
+		fmt.Sprintf("%+v", wrap),
+	}
+	for _, r := range renderings {
+		if strings.Contains(r, raw) {
+			t.Errorf("secret value leaked in rendering: %q", r)
+		}
+		if !strings.Contains(r, "[REDACTED]") {
+			t.Errorf("expected [REDACTED] marker, got %q", r)
+		}
+	}
+	if s.String() != "[REDACTED]" || s.GoString() != "[REDACTED]" {
+		t.Errorf("direct redaction mismatch: String=%q GoString=%q", s.String(), s.GoString())
+	}
+
+	text, err := s.MarshalText()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(text), raw) {
+		t.Errorf("secret leaked via MarshalText: %q", text)
+	}
+}

--- a/agents/adapters/llm/internal/config/secret.go
+++ b/agents/adapters/llm/internal/config/secret.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package config parses and validates the llm-adapter YAML configuration at
+// startup. API-key values are never stored in config — only the name of the
+// environment variable holding the key is kept; the value is resolved at
+// startup into a redacting Secret type that never appears in logs, errors, or
+// String()/repr output (ADR-035, canvas M7.P norms).
+package config
+
+// redactedPlaceholder is the only thing a Secret ever renders as.
+const redactedPlaceholder = "[REDACTED]"
+
+// Secret holds a credential value resolved from an environment variable at
+// startup. It deliberately exposes no exported field and overrides String() and
+// GoString() so the value never leaks into %s, %v, %#v, structured logs, or a
+// CapabilityError.message. Retrieve the raw value only via Reveal at the
+// provider call site.
+type Secret struct {
+	value string
+}
+
+// NewSecret wraps a raw credential value in a redacting Secret.
+func NewSecret(value string) Secret {
+	return Secret{value: value}
+}
+
+// Reveal returns the underlying credential value. Call this only at the point
+// of use (the provider client constructor); never log or format the result.
+func (s Secret) Reveal() string {
+	return s.value
+}
+
+// IsZero reports whether the Secret holds no value.
+func (s Secret) IsZero() bool {
+	return s.value == ""
+}
+
+// String renders the redacted placeholder so a Secret is safe in any %s/%v.
+func (s Secret) String() string {
+	return redactedPlaceholder
+}
+
+// GoString renders the redacted placeholder so a Secret is safe in any %#v.
+func (s Secret) GoString() string {
+	return redactedPlaceholder
+}
+
+// MarshalText keeps the value out of any text encoder (JSON, YAML).
+func (s Secret) MarshalText() ([]byte, error) {
+	return []byte(redactedPlaceholder), nil
+}

--- a/go.work
+++ b/go.work
@@ -8,6 +8,7 @@ use (
 	./agents/adapters/ci
 	./agents/adapters/git
 	./agents/adapters/http
+	./agents/adapters/llm
 	./libs/zynaxconfig
 	./libs/zynaxobs
 	./protos/generated/go


### PR DESCRIPTION
## feat(agents/adapters): Go llm-adapter scaffold + config

Closes #1278
Part of #1276 (EPIC P — Port llm-adapter to Go)

### Why  (problem & intent)
ADR-035 moves the `llm-adapter` from Python to Go because it is a stateless
provider proxy that drags the `openai`/`aiobotocore`/`aiohttp` CVE tree into the
supply chain for no Python-specific need. Canvas O-step **P.2** lays the first
implementation course: the Go module plus the config layer that loads provider
routing and credentials the same config-only way as the Python adapter, with no
wire-contract change. Providers (P.3), server RPCs (P.4), and bootstrap/registry
(P.5) follow.

### What you'll get  (deliverables ↔ what changed)
- a new Go module `github.com/zynax-io/zynax/agents/adapters/llm` (in `go.work` like the ci/git/http adapters; `GOWORK=off` for go commands per ADR-017) ← `agents/adapters/llm/go.mod`, `go.work`
- `AdapterConfig`/`ProviderConfig` parsed from YAML with fail-fast validation (missing field, unknown provider, per-provider required fields) ← `agents/adapters/llm/internal/config/config.go`
- a redacting `Secret` type — API keys resolved from env-var **references** at startup, never logged, never serialized (`String`/`GoString`/`MarshalText` all render `[REDACTED]`) ← `agents/adapters/llm/internal/config/secret.go`
- a minimal `cmd/llm-adapter` bootstrap that loads config + resolves the secret (serve loop wired in a later P step) ← `agents/adapters/llm/cmd/llm-adapter/main.go`
- an operator-facing `agent-def.yaml.example` mirroring the sibling adapters ← `agents/adapters/llm/agent-def.yaml.example`

### Scope & boundaries
- **In scope:** Go module scaffold + `internal/config` (load, validate, secret) + minimal bootstrap + unit tests.
- **Out of scope (deferred):** `Provider` interface + providers → #1279 · server RPCs → #1280 · registry/bootstrap/health → #1281 · Dockerfile/cutover → #1282 · retire Python tree → #1283.

### Test plan & acceptance
| Acceptance criterion | How verified (command) | Result |
|----------------------|------------------------|--------|
| `GOWORK=off go test ./...` green | `GOWORK=off go test ./... -race -timeout 60s -cover` | ✅ both packages `ok` |
| unit tests: valid config | `TestLoad_Valid`, `TestLoad_ValidOllama` | ✅ pass |
| unit tests: missing field | `TestLoad_MissingField` (agent_id/endpoint/registry/capabilities/model/api_key_env) | ✅ pass |
| unit tests: unknown provider | `TestLoad_UnknownProvider` | ✅ pass |
| unit tests: secret not exposed in String()/logs | `TestSecret_NeverLeaks` (String/GoString/%v/%s/%#v/%+v/MarshalText) | ✅ pass |
| No credential value read from `input_payload` | review: keys resolved only via `ResolveSecret` from `api_key_env` | ✅ |
| Config struct mirrors Python `AdapterConfig`/`ProviderConfig` | review vs `agents/adapters/llm/src/llm_adapter/config.py` | ✅ |
| SPDX header on every `.go`; functions ≤ 30 lines | review + `golangci-lint` | ✅ |

**Local gates:** `GOWORK=off go build ./...` ✅ · `GOWORK=off go test ./... -race` ✅ · `make lint-go-adapters` ✅ (exit 0)

### Evidence
- **CI:** required checks pending on this PR.
- **Local output:** `internal/config` coverage **95.9%** (> 90% domain gate); `cmd/llm-adapter` 71.4%; `make lint-go-adapters` exit 0.
- **Artifacts / images:** none — no image built this step (Dockerfile/cutover is P.6).
- **Post-merge digest sync → main:** N/A — no image rebuild.

### Risk & rollback
Low — purely additive. A new isolated module + one `go.work` entry; no existing
service or adapter code path changes. Revert = revert this PR (drops the new
directory and the go.work line).

### Review aids
Key file: `internal/config/config.go` (validation rules + per-provider required
fields). `secret.go` is the redaction backstop — note it exposes no exported
field and overrides every formatting verb. The `cmd/llm-adapter/main.go` `run()`
is intentionally serve-loop-free so it is unit-testable now; the gRPC serve +
registry dial arrive in P.4/P.5. Line count is ~608 (excl. `go.sum`), most of it
table-driven tests (~290 lines); production code is well under 400.

**SPDD:** Canvas `docs/spdd/1276-llm-adapter-go/canvas.md` — Status: **Aligned** · `/spdd-security-review` **PASS** · ADR-035 (Accepted)
**AI:** `Assisted-by: Claude/claude-opus-4-8`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
