### PR TITLE
feat(agents/adapters): least-privilege token scope validation at startup

### DIFF
--- a/agents/adapters/git/cmd/git-adapter/main.go
+++ b/agents/adapters/git/cmd/git-adapter/main.go
@@ -6,15 +6,18 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
 	"net"
+	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
 
 	"github.com/zynax-io/zynax/agents/adapters/git/internal/adapter"
+	"github.com/zynax-io/zynax/agents/adapters/git/internal/auth"
 	"github.com/zynax-io/zynax/agents/adapters/git/internal/config"
 	"github.com/zynax-io/zynax/agents/adapters/git/internal/mcp"
 	"github.com/zynax-io/zynax/agents/adapters/git/internal/redact"
@@ -50,6 +53,17 @@ func run() error {
 		return fmt.Errorf("resolve token: %w", err)
 	}
 
+	// Least-privilege gate (G.5 / #1260): verify the token cannot reach repos
+	// beyond the configured owner/repo before it is ever used. The token value is
+	// never passed to the logger — only scope/class metadata.
+	probe, err := newScopeProbe(token)
+	if err != nil {
+		return fmt.Errorf("scope probe init: %w", err)
+	}
+	if err := validateTokenScope(context.Background(), probe, auth.ParseMode(os.Getenv("GIT_ADAPTER_SCOPE_MODE"))); err != nil {
+		return err
+	}
+
 	// `git-adapter mcp` runs the thin MCP stdio shim over the same handlers
 	// instead of the runtime gRPC server (ADR-032 — one implementation, two
 	// surfaces). It needs no registry and binds no port.
@@ -67,6 +81,48 @@ func run() error {
 	defer stop()
 
 	return serve(ctx, cfg, token, regClient)
+}
+
+// scopeValidator is the probe surface auth.Validate consumes at startup (enables
+// testing main's wiring with a fake probe without reaching the GitHub API).
+type scopeValidator interface {
+	Probe(ctx context.Context) (http.Header, error)
+}
+
+// newScopeProbe builds the startup scope probe. It is a package var so tests can
+// substitute a fake probe that never reaches the network; production resolves to
+// the public GitHub API.
+var newScopeProbe = func(token string) (scopeValidator, error) {
+	return auth.NewGitHubProbe(token, "")
+}
+
+// validateTokenScope runs the startup least-privilege check and applies the
+// configured mode. In enforce mode an over-broad token aborts startup; in warn
+// mode it emits a loud structured warning and continues. The token value is
+// never logged — only scope/class metadata from the Result.
+func validateTokenScope(ctx context.Context, p scopeValidator, mode auth.Mode) error {
+	res, err := auth.Validate(ctx, p, mode)
+	if err != nil {
+		if errors.Is(err, auth.ErrOverBroadScope) {
+			// Metadata only — no token, no secret material in the message.
+			return fmt.Errorf("token scope validation failed: %w", err)
+		}
+		// Probe transport error: surface but do not block startup on a probe that
+		// could not run (e.g. offline registry-only bring-up); warn and proceed.
+		//nolint:gosec // G706: scope/error metadata only, never the token value
+		slog.Warn("token scope probe could not run; skipping least-privilege check",
+			"err", err, "mode", mode.String())
+		return nil
+	}
+	if len(res.OverBroad) > 0 {
+		//nolint:gosec // G706: scope metadata only, never the token value
+		slog.Warn("git token grants scope beyond configured owner/repo (least-privilege)",
+			"token_class", res.TokenClass, "over_broad_scopes", res.OverBroad, "mode", mode.String())
+		return nil
+	}
+	//nolint:gosec // G706: scope/class metadata only, never the token value
+	slog.Info("git token scope validated", "token_class", res.TokenClass, "mode", mode.String())
+	return nil
 }
 
 // serveMCP runs the MCP stdio shim. The exposed tool set is an explicit

--- a/agents/adapters/git/cmd/git-adapter/scope_main_test.go
+++ b/agents/adapters/git/cmd/git-adapter/scope_main_test.go
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package main (whitebox) tests the startup least-privilege scope gate wiring
+// (G.5 / #1260). A package-wide TestMain installs a no-network fake probe so the
+// pre-existing run()/serve() tests never reach the real GitHub API; individual
+// tests below swap the probe to exercise enforce/warn/error branches.
+package main
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/zynax-io/zynax/agents/adapters/git/internal/auth"
+)
+
+// fakeProbe returns a fixed header/error and never touches the network.
+type fakeProbe struct {
+	hdr http.Header
+	err error
+}
+
+func (f fakeProbe) Probe(_ context.Context) (http.Header, error) { return f.hdr, f.err }
+
+func scopeHdr(scopes string, set bool) http.Header {
+	h := http.Header{}
+	if set {
+		h.Set("X-OAuth-Scopes", scopes)
+	}
+	return h
+}
+
+// TestMain defaults newScopeProbe to a passing fine-grained fake for the whole
+// package, then restores it. This keeps the legacy run() tests offline.
+func TestMain(m *testing.M) {
+	orig := newScopeProbe
+	newScopeProbe = func(string) (scopeValidator, error) {
+		return fakeProbe{hdr: scopeHdr("", false)}, nil
+	}
+	code := m.Run()
+	newScopeProbe = orig
+	os.Exit(code)
+}
+
+func TestValidateTokenScope_EnforceRejects(t *testing.T) {
+	p := fakeProbe{hdr: scopeHdr("repo", true)}
+	if err := validateTokenScope(context.Background(), p, auth.ModeEnforce); err == nil {
+		t.Fatal("enforce mode must reject an over-broad token")
+	} else if !errors.Is(err, auth.ErrOverBroadScope) {
+		t.Fatalf("expected ErrOverBroadScope, got %v", err)
+	}
+}
+
+func TestValidateTokenScope_WarnAllows(t *testing.T) {
+	p := fakeProbe{hdr: scopeHdr("repo", true)}
+	if err := validateTokenScope(context.Background(), p, auth.ModeWarn); err != nil {
+		t.Fatalf("warn mode must not fail startup: %v", err)
+	}
+}
+
+func TestValidateTokenScope_FineGrainedPasses(t *testing.T) {
+	p := fakeProbe{hdr: scopeHdr("", false)}
+	if err := validateTokenScope(context.Background(), p, auth.ModeEnforce); err != nil {
+		t.Fatalf("fine-grained token must pass: %v", err)
+	}
+}
+
+func TestValidateTokenScope_NarrowClassicPasses(t *testing.T) {
+	p := fakeProbe{hdr: scopeHdr("public_repo, read:user", true)}
+	if err := validateTokenScope(context.Background(), p, auth.ModeEnforce); err != nil {
+		t.Fatalf("narrow classic token must pass: %v", err)
+	}
+}
+
+func TestValidateTokenScope_ProbeErrorIsNonFatal(t *testing.T) {
+	// A probe transport failure must not block startup — it warns and proceeds.
+	p := fakeProbe{err: errors.New("network down")}
+	if err := validateTokenScope(context.Background(), p, auth.ModeEnforce); err != nil {
+		t.Fatalf("probe transport error must be non-fatal: %v", err)
+	}
+}
+
+// TestRun_OverBroadTokenFailsStartup wires the over-broad probe through run() to
+// confirm the gate aborts before any registry dial.
+func TestRun_OverBroadTokenFailsStartup(t *testing.T) {
+	orig := newScopeProbe
+	newScopeProbe = func(string) (scopeValidator, error) {
+		return fakeProbe{hdr: scopeHdr("repo", true)}, nil
+	}
+	defer func() { newScopeProbe = orig }()
+
+	dir := t.TempDir()
+	cfgPath := dir + "/git-adapter.yaml"
+	writeScopeCfg(t, cfgPath)
+	t.Setenv("ADAPTER_CONFIG", cfgPath)
+	t.Setenv("GIT_TOKEN_SCOPE_1260", "fake-token-value-1260")
+	t.Setenv("GIT_ADAPTER_SCOPE_MODE", "enforce")
+
+	if err := run(); err == nil {
+		t.Fatal("expected run() to fail for an over-broad token in enforce mode")
+	} else if !errors.Is(err, auth.ErrOverBroadScope) {
+		t.Fatalf("expected ErrOverBroadScope, got %v", err)
+	}
+}
+
+// TestNewScopeProbe_Default exercises the production factory (no network call is
+// made — only client construction).
+func TestNewScopeProbe_Default(t *testing.T) {
+	orig := newScopeProbe
+	newScopeProbe = orig // ensure default
+	p, err := orig("some-token-value-1260")
+	if err != nil {
+		t.Fatalf("default probe factory: %v", err)
+	}
+	if p == nil {
+		t.Fatal("default probe factory returned nil probe")
+	}
+}
+
+func writeScopeCfg(t *testing.T, path string) {
+	t.Helper()
+	const body = "agent_id: git-test\nname: Git Test\n" +
+		"endpoint: \"127.0.0.1:0\"\nregistry_endpoint: \"127.0.0.1:9090\"\n" +
+		"git:\n  provider: github\n  auth_env: GIT_TOKEN_SCOPE_1260\n" +
+		"capabilities:\n  - name: open_pr\n    owner: o\n    repo: r\n"
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/agents/adapters/git/internal/auth/github_probe.go
+++ b/agents/adapters/git/internal/auth/github_probe.go
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package auth
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/google/go-github/v67/github"
+)
+
+// GitHubProbe issues the scope probe through a go-github client. It performs one
+// authenticated GET to the API root and returns only the response headers; the
+// body is discarded and the token is never surfaced.
+type GitHubProbe struct {
+	client *github.Client
+}
+
+// NewGitHubProbe builds a probe for the given token. baseURL overrides the GitHub
+// API endpoint when non-empty (used by tests against an httptest server); the
+// production default is the public api.github.com.
+func NewGitHubProbe(token, baseURL string) (*GitHubProbe, error) {
+	client := github.NewClient(nil).WithAuthToken(token)
+	if baseURL != "" {
+		parsed, err := client.BaseURL.Parse(baseURL + "/")
+		if err != nil {
+			return nil, fmt.Errorf("auth: parse base URL: %w", err)
+		}
+		client.BaseURL = parsed
+	}
+	return &GitHubProbe{client: client}, nil
+}
+
+// Probe satisfies scopeProbe. The root API endpoint is authenticated and echoes
+// the token's X-OAuth-Scopes header for classic PATs while costing no rate-limit
+// quota beyond the request itself.
+func (g *GitHubProbe) Probe(ctx context.Context) (http.Header, error) {
+	req, err := g.client.NewRequest(http.MethodGet, "", nil)
+	if err != nil {
+		return nil, fmt.Errorf("auth: build probe request: %w", err)
+	}
+	resp, err := g.client.BareDo(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("auth: probe request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	return resp.Header, nil
+}

--- a/agents/adapters/git/internal/auth/github_probe_test.go
+++ b/agents/adapters/git/internal/auth/github_probe_test.go
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package auth
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+)
+
+// newProbeServer returns an httptest server that answers the API-root probe with
+// the given X-OAuth-Scopes header (omitted when emit is false) and records the
+// Authorization header it received so a test can assert the token was sent
+// without that token ever appearing in adapter logs.
+func newProbeServer(t *testing.T, scopes string, emit bool, gotAuth *string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		*gotAuth = r.Header.Get("Authorization")
+		if emit {
+			w.Header().Set("X-OAuth-Scopes", scopes)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestGitHubProbe_ClassicOverBroad(t *testing.T) {
+	var auth string
+	srv := newProbeServer(t, "repo, gist", true, &auth)
+
+	p, err := NewGitHubProbe("classic-token-value-1234", srv.URL)
+	if err != nil {
+		t.Fatalf("NewGitHubProbe: %v", err)
+	}
+	res, err := Validate(context.Background(), p, ModeEnforce)
+	if err == nil {
+		t.Fatal("expected over-broad classic token to be rejected")
+	}
+	if !reflect.DeepEqual(res.OverBroad, []string{"repo"}) {
+		t.Errorf("OverBroad = %v, want [repo]", res.OverBroad)
+	}
+	if auth == "" {
+		t.Error("probe must send the Authorization header")
+	}
+}
+
+func TestGitHubProbe_FineGrainedPasses(t *testing.T) {
+	var auth string
+	srv := newProbeServer(t, "", false, &auth)
+
+	p, err := NewGitHubProbe("github_pat_fine_grained_value", srv.URL)
+	if err != nil {
+		t.Fatalf("NewGitHubProbe: %v", err)
+	}
+	res, err := Validate(context.Background(), p, ModeEnforce)
+	if err != nil {
+		t.Fatalf("fine-grained token must pass: %v", err)
+	}
+	if res.TokenClass != "fine-grained-or-app" {
+		t.Errorf("TokenClass = %q", res.TokenClass)
+	}
+}
+
+func TestGitHubProbe_NarrowClassicPasses(t *testing.T) {
+	var auth string
+	srv := newProbeServer(t, "public_repo, read:user", true, &auth)
+
+	p, err := NewGitHubProbe("classic-narrow-token-value", srv.URL)
+	if err != nil {
+		t.Fatalf("NewGitHubProbe: %v", err)
+	}
+	if _, err := Validate(context.Background(), p, ModeEnforce); err != nil {
+		t.Fatalf("narrow classic token must pass: %v", err)
+	}
+}
+
+func TestGitHubProbe_TransportError(t *testing.T) {
+	// Point at an unroutable base URL so BareDo fails at transport level.
+	p, err := NewGitHubProbe("tok-value-abcdef", "http://127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("NewGitHubProbe: %v", err)
+	}
+	if _, err := p.Probe(context.Background()); err == nil {
+		t.Fatal("expected transport error from unroutable endpoint")
+	}
+}
+
+func TestNewGitHubProbe_BadBaseURL(t *testing.T) {
+	if _, err := NewGitHubProbe("tok-value-abcdef", "://bad url"); err == nil {
+		t.Fatal("expected error for malformed base URL")
+	}
+}

--- a/agents/adapters/git/internal/auth/scope.go
+++ b/agents/adapters/git/internal/auth/scope.go
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package auth validates, at startup, that the git-adapter's GitHub token grants
+// no more access than the configured owner/repo capability set requires
+// (least-privilege; EPIC G, story G.5 / #1260, ADR-032).
+//
+// The check is a single authenticated probe to the GitHub API root. GitHub
+// echoes the granted scopes of a classic personal-access token in the
+// `X-OAuth-Scopes` response header. A token carrying the broad `repo`
+// (or other account-wide admin/delete) scope can reach every repository the
+// account can, regardless of the adapter's static owner/repo pinning — so it is
+// rejected (or warned on, when configured) before the adapter ever uses it.
+//
+// Fine-grained PATs and GitHub App installation tokens carry no
+// `X-OAuth-Scopes` header (their access is bounded server-side to selected
+// repositories); they are treated as already least-privilege and pass.
+//
+// The token value is never logged, returned, or embedded in any error. Only
+// scope/visibility metadata is surfaced.
+package auth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+)
+
+// Token-class labels surfaced in the (non-secret) Result.
+const (
+	tokenClassClassic     = "classic"
+	tokenClassFineGrained = "fine-grained-or-app" //nolint:gosec // G101: a token-class label, not a credential
+)
+
+// scopesHeaderKey is the canonical (textproto-canonicalised) form of the
+// GitHub X-OAuth-Scopes response header. http.Header keys are stored canonical,
+// so the lookup must use this exact casing.
+const scopesHeaderKey = "X-Oauth-Scopes"
+
+// Mode selects what happens when a token's scope exceeds the configured set.
+type Mode int
+
+const (
+	// ModeEnforce fails startup (fail-fast) when the token is over-broad. Default.
+	ModeEnforce Mode = iota
+	// ModeWarn logs a loud structured warning but allows startup to continue.
+	ModeWarn
+)
+
+// ParseMode maps an operator-supplied string (e.g. the GIT_ADAPTER_SCOPE_MODE
+// env var) to a Mode. Empty or unrecognised values fall back to ModeEnforce so
+// the secure default holds when the setting is absent or mistyped.
+func ParseMode(s string) Mode {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "warn":
+		return ModeWarn
+	default:
+		return ModeEnforce
+	}
+}
+
+// String renders the Mode for structured log fields.
+func (m Mode) String() string {
+	if m == ModeWarn {
+		return "warn"
+	}
+	return "enforce"
+}
+
+// overBroadScopes are classic-PAT OAuth scopes that grant access beyond a single
+// configured repository: account-wide repository write/admin, repo deletion, and
+// organisation/user administration. Any of these on the token means it is not
+// least-privilege for an adapter pinned to one owner/repo.
+var overBroadScopes = map[string]struct{}{
+	"repo":             {}, // full control of all private repositories
+	"write:org":        {},
+	"admin:org":        {},
+	"delete_repo":      {},
+	"admin:repo_hook":  {},
+	"admin:org_hook":   {},
+	"admin:public_key": {},
+	"admin:gpg_key":    {},
+	"user":             {}, // full account profile write
+	"delete:packages":  {},
+	"site_admin":       {},
+}
+
+// Result is the non-secret outcome of a scope probe — safe to log in full.
+type Result struct {
+	// TokenClass is "classic" when the probe saw an X-OAuth-Scopes header,
+	// "fine-grained-or-app" otherwise.
+	TokenClass string
+	// Scopes are the granted classic-PAT scopes (empty for fine-grained/App).
+	Scopes []string
+	// OverBroad lists the granted scopes that exceed a single-repo least-privilege
+	// posture. Non-empty means the token is over-privileged.
+	OverBroad []string
+}
+
+// scopeProbe is the minimal surface the validator needs from a GitHub client —
+// a single GET to the API root whose response headers are inspected. Satisfied
+// by the production *github.Client wrapper (see GitHubProbe) and by test fakes.
+type scopeProbe interface {
+	// Probe issues an authenticated GET to the API root and returns the response
+	// headers (notably X-OAuth-Scopes). It must never return the token.
+	Probe(ctx context.Context) (http.Header, error)
+}
+
+// ErrOverBroadScope is returned by Validate in ModeEnforce when the token grants
+// access beyond the configured owner/repo set. It carries only scope metadata,
+// never the token value.
+var ErrOverBroadScope = errors.New("git token scope exceeds configured owner/repo (least-privilege)")
+
+// Inspect probes the token and classifies its scope without applying a policy.
+// It never logs or returns the token value.
+func Inspect(ctx context.Context, p scopeProbe) (Result, error) {
+	hdr, err := p.Probe(ctx)
+	if err != nil {
+		return Result{}, fmt.Errorf("auth: scope probe failed: %w", err)
+	}
+
+	raw, hasHeader := scopeHeader(hdr)
+	if !hasHeader {
+		// Fine-grained PAT or App installation token: access is bounded
+		// server-side to selected repositories; least-privilege by construction.
+		return Result{TokenClass: tokenClassFineGrained}, nil
+	}
+
+	scopes := parseScopes(raw)
+	over := make([]string, 0)
+	for _, s := range scopes {
+		if _, bad := overBroadScopes[s]; bad {
+			over = append(over, s)
+		}
+	}
+	sort.Strings(over)
+	return Result{TokenClass: tokenClassClassic, Scopes: scopes, OverBroad: over}, nil
+}
+
+// Validate inspects the token and applies the policy: in ModeEnforce an
+// over-broad token yields ErrOverBroadScope; in ModeWarn it returns the Result
+// with a non-nil error replaced by nil so the caller can log a warning and
+// continue. The returned Result is always safe to log.
+func Validate(ctx context.Context, p scopeProbe, mode Mode) (Result, error) {
+	res, err := Inspect(ctx, p)
+	if err != nil {
+		return Result{}, err
+	}
+	if len(res.OverBroad) > 0 && mode == ModeEnforce {
+		return res, fmt.Errorf("%w: granted [%s]", ErrOverBroadScope, strings.Join(res.OverBroad, ", "))
+	}
+	return res, nil
+}
+
+// scopeHeader returns the X-OAuth-Scopes header value and whether it was present.
+// A present-but-empty header (the token grants no classic scopes) still counts as
+// present — it tells us this is a classic token with an empty scope set.
+func scopeHeader(h http.Header) (string, bool) {
+	if h == nil {
+		return "", false
+	}
+	vals, ok := h[scopesHeaderKey]
+	if !ok {
+		return "", false
+	}
+	if len(vals) == 0 {
+		return "", true
+	}
+	return vals[0], true
+}
+
+// parseScopes splits the comma-separated X-OAuth-Scopes value into a normalised,
+// de-duplicated, sorted slice. Empty entries are dropped.
+func parseScopes(raw string) []string {
+	seen := make(map[string]struct{})
+	out := make([]string, 0)
+	for _, part := range strings.Split(raw, ",") {
+		s := strings.TrimSpace(part)
+		if s == "" {
+			continue
+		}
+		if _, dup := seen[s]; dup {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/agents/adapters/git/internal/auth/scope_test.go
+++ b/agents/adapters/git/internal/auth/scope_test.go
@@ -1,0 +1,206 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package auth
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// fakeProbe returns a fixed header (or error) and never touches the network or
+// any token — the scope policy is pure given the probe result.
+type fakeProbe struct {
+	hdr http.Header
+	err error
+}
+
+func (f fakeProbe) Probe(_ context.Context) (http.Header, error) { return f.hdr, f.err }
+
+func hdr(scopes string, set bool) http.Header {
+	h := http.Header{}
+	if set {
+		h.Set("X-OAuth-Scopes", scopes)
+	}
+	return h
+}
+
+func TestParseMode(t *testing.T) {
+	cases := []struct {
+		in   string
+		want Mode
+	}{
+		{"warn", ModeWarn},
+		{"WARN", ModeWarn},
+		{"  warn ", ModeWarn}, // surrounding whitespace is trimmed
+		{"enforce", ModeEnforce},
+		{"", ModeEnforce},
+		{"bogus", ModeEnforce},
+	}
+	for _, c := range cases {
+		if got := ParseMode(c.in); got != c.want {
+			t.Errorf("ParseMode(%q) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}
+
+func TestModeString(t *testing.T) {
+	const (
+		warn    = "warn"
+		enforce = "enforce"
+	)
+	if ModeWarn.String() != warn {
+		t.Errorf("ModeWarn.String() = %q", ModeWarn.String())
+	}
+	if ModeEnforce.String() != enforce {
+		t.Errorf("ModeEnforce.String() = %q", ModeEnforce.String())
+	}
+}
+
+func TestInspect(t *testing.T) {
+	tests := []struct {
+		name       string
+		probe      fakeProbe
+		wantClass  string
+		wantScopes []string
+		wantOver   []string
+		wantErr    bool
+	}{
+		{
+			name:      "fine-grained token has no scope header",
+			probe:     fakeProbe{hdr: hdr("", false)},
+			wantClass: "fine-grained-or-app",
+		},
+		{
+			name:       "classic over-broad repo scope",
+			probe:      fakeProbe{hdr: hdr("repo, read:org", true)},
+			wantClass:  "classic",
+			wantScopes: []string{"read:org", "repo"},
+			wantOver:   []string{"repo"},
+		},
+		{
+			name:       "classic narrow scope passes",
+			probe:      fakeProbe{hdr: hdr("read:user, public_repo", true)},
+			wantClass:  "classic",
+			wantScopes: []string{"public_repo", "read:user"},
+			wantOver:   []string{},
+		},
+		{
+			name:       "classic empty scope set present",
+			probe:      fakeProbe{hdr: hdr("", true)},
+			wantClass:  "classic",
+			wantScopes: []string{},
+			wantOver:   []string{},
+		},
+		{
+			name:       "multiple over-broad scopes sorted+deduped",
+			probe:      fakeProbe{hdr: hdr("admin:org, repo, repo, delete_repo", true)},
+			wantClass:  "classic",
+			wantScopes: []string{"admin:org", "delete_repo", "repo"},
+			wantOver:   []string{"admin:org", "delete_repo", "repo"},
+		},
+		{
+			name:    "probe error propagates",
+			probe:   fakeProbe{err: errors.New("boom")},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res, err := Inspect(context.Background(), tt.probe)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if res.TokenClass != tt.wantClass {
+				t.Errorf("TokenClass = %q, want %q", res.TokenClass, tt.wantClass)
+			}
+			if tt.wantScopes != nil && !reflect.DeepEqual(res.Scopes, tt.wantScopes) {
+				t.Errorf("Scopes = %v, want %v", res.Scopes, tt.wantScopes)
+			}
+			if tt.wantOver != nil && !reflect.DeepEqual(res.OverBroad, tt.wantOver) {
+				t.Errorf("OverBroad = %v, want %v", res.OverBroad, tt.wantOver)
+			}
+		})
+	}
+}
+
+func TestValidate_EnforceRejectsOverBroad(t *testing.T) {
+	p := fakeProbe{hdr: hdr("repo", true)}
+	res, err := Validate(context.Background(), p, ModeEnforce)
+	if !errors.Is(err, ErrOverBroadScope) {
+		t.Fatalf("expected ErrOverBroadScope, got %v", err)
+	}
+	// Result is still returned (safe to log) and lists the offending scope.
+	if !reflect.DeepEqual(res.OverBroad, []string{"repo"}) {
+		t.Errorf("OverBroad = %v, want [repo]", res.OverBroad)
+	}
+	// The error message must carry scope metadata, never a token value.
+	if !strings.Contains(err.Error(), "repo") {
+		t.Errorf("error should name the over-broad scope: %v", err)
+	}
+}
+
+func TestValidate_WarnAllowsOverBroad(t *testing.T) {
+	p := fakeProbe{hdr: hdr("repo", true)}
+	res, err := Validate(context.Background(), p, ModeWarn)
+	if err != nil {
+		t.Fatalf("warn mode must not error: %v", err)
+	}
+	if len(res.OverBroad) != 1 {
+		t.Errorf("warn mode should still report over-broad scopes: %v", res.OverBroad)
+	}
+}
+
+func TestValidate_FineGrainedPasses(t *testing.T) {
+	p := fakeProbe{hdr: hdr("", false)}
+	res, err := Validate(context.Background(), p, ModeEnforce)
+	if err != nil {
+		t.Fatalf("fine-grained token must pass: %v", err)
+	}
+	if res.TokenClass != "fine-grained-or-app" {
+		t.Errorf("TokenClass = %q", res.TokenClass)
+	}
+	if len(res.OverBroad) != 0 {
+		t.Errorf("fine-grained token has no over-broad scopes: %v", res.OverBroad)
+	}
+}
+
+func TestValidate_ProbeErrorPropagates(t *testing.T) {
+	p := fakeProbe{err: errors.New("net down")}
+	if _, err := Validate(context.Background(), p, ModeEnforce); err == nil {
+		t.Fatal("expected probe error to propagate")
+	}
+}
+
+func TestScopeHeaderAbsentVsEmpty(t *testing.T) {
+	// Nil header → absent.
+	if _, ok := scopeHeader(nil); ok {
+		t.Error("nil header should report absent")
+	}
+	// Present but empty → present.
+	h := http.Header{}
+	h.Set("X-OAuth-Scopes", "")
+	if v, ok := scopeHeader(h); !ok || v != "" {
+		t.Errorf("present-empty header: got (%q,%v)", v, ok)
+	}
+}
+
+func TestParseScopes(t *testing.T) {
+	got := parseScopes(" repo ,, read:org, repo ")
+	want := []string{"read:org", "repo"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("parseScopes = %v, want %v", got, want)
+	}
+	if len(parseScopes("")) != 0 {
+		t.Error("empty input should yield no scopes")
+	}
+}


### PR DESCRIPTION
## feat(agents/adapters): least-privilege token scope validation at startup

Closes #1260
Part of #1169 (EPIC G — Git MCP Shim · canvas step G.5)

### Why  (problem & intent)
The git-adapter uses whatever token `ResolveToken` returns and never validates its
scope. `owner`/`repo` are statically pinned (an adapter-level SSRF guard) but that is
not a credential restriction — an over-privileged classic `repo`-scoped PAT can still
reach every repository the account can. G.5 catches such a token at startup, before it
is ever used.

### What you'll get  (deliverables ↔ what changed)
- a startup scope probe that classifies the token and lists any over-broad scopes ← `agents/adapters/git/internal/auth/scope.go`
- the production probe over the GitHub API root (one authenticated GET, headers only) ← `agents/adapters/git/internal/auth/github_probe.go`
- fail-fast by default, loud structured warning when `GIT_ADAPTER_SCOPE_MODE=warn` ← `agents/adapters/git/cmd/git-adapter/main.go` (`validateTokenScope`)
- token value never logged — only `token_class` / `over_broad_scopes` metadata surfaced ← scope `Result` is the only logged value

### Scope & boundaries
- **In scope:** classic-PAT `X-OAuth-Scopes` probe at startup; over-broad detection (`repo`, `admin:*`, `delete_repo`, …); enforce/warn modes; fine-grained / App tokens (no scope header) treated as least-privilege.
- **Out of scope (deferred):** minting / refreshing tokens → G.7 (#1262); MCP wiring → G.2–G.4; fine-grained accessible-repos enumeration (header-absence is sufficient signal).

### Test plan & acceptance
| Acceptance criterion | How verified (command) | Result |
|----------------------|------------------------|--------|
| Probe effective token access (`X-OAuth-Scopes` / fine-grained / App) | `GOWORK=off go test ./internal/auth/... -race` (httptest probe + fakes) | ✅ ok, 96.7% pkg cov |
| Fail-fast or loud warning (configurable) when scope exceeds owner/repo | `TestValidate_EnforceRejectsOverBroad` / `TestValidate_WarnAllowsOverBroad` / `TestRun_OverBroadTokenFailsStartup` | ✅ pass |
| Token value never logged (metadata only) | review: only `Result` (class/scopes) logged; `redact` unchanged; no token in any slog arg | ✅ |
| Unit: over-broad → fail/warn; fine-grained → pass | `TestGitHubProbe_ClassicOverBroad` / `TestGitHubProbe_FineGrainedPasses` / `TestGitHubProbe_NarrowClassicPasses` | ✅ pass |

**Local gates:** `make lint-go-adapters` ✅ · `GOWORK=off go test ./... -race` ✅ (all packages) · `make security-go-adapters` ✅ (0 new findings)

### Evidence
- **CI:** pending — required checks to run on PR.
- **Local output:** module coverage `total: 89.3%`; new `internal/auth` pkg `96.7%`; full suite `ok` across all 7 packages.
- **Artifacts / images:** git-adapter source changed — image will rebuild on merge.
- **Post-merge digest sync → main:** _placeholder — post-merge verifier fills `chore(images): sync digests after main-<sha>`._

### Risk & rollback
Low — additive startup check. Default `enforce` mode fails fast only on a genuinely over-broad classic PAT; probe transport errors are non-fatal (warn + continue) so an offline bring-up is not blocked. Revert this PR to remove. No change to any existing capability path.

### Review aids
Start at `internal/auth/scope.go` (`Inspect`/`Validate` — the pure policy); `github_probe.go` is the thin go-github wrapper; `main.go` `validateTokenScope` is the startup wiring (overridable `newScopeProbe` var keeps `run()` tests offline). Header lookup uses the canonical key `X-Oauth-Scopes` (http.Header canonicalisation).

**SPDD:** Canvas `docs/spdd/1169-git-mcp-shim/canvas.md` — Status: **Aligned** · `/spdd-security-review` **PASS** (2026-06-16, G.5–G.7 in §4) · security story (Tier 2-sensitive substrate hardening)
**AI:** `Assisted-by: Claude/claude-opus-4-8`  (label: ai-assisted)
