### PR TITLE
feat(api-gateway): propagate correlation context across all hops

### DIFF
--- a/services/api-gateway/internal/api/handler.go
+++ b/services/api-gateway/internal/api/handler.go
@@ -60,6 +60,14 @@ func (h *Handler) handleApply(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, err.Error(), code)
 		return
 	}
+	// Attach the namespace to the request context so the downstream gRPC
+	// interceptors carry it as correlation metadata on every hop (canvas C.2).
+	// The X-Namespace header set by RequestIDMiddleware takes precedence; the
+	// ?namespace= query param only applies when no header value is present, and
+	// an empty param never clears an existing namespace.
+	if ns := r.URL.Query().Get("namespace"); ns != "" && domain.NamespaceFromContext(r.Context()) == "" {
+		r = r.WithContext(domain.WithNamespace(r.Context(), ns))
+	}
 	switch kind {
 	case domain.KindWorkflow:
 		h.applyWorkflow(w, r, body)

--- a/services/api-gateway/internal/api/namespace_propagation_test.go
+++ b/services/api-gateway/internal/api/namespace_propagation_test.go
@@ -26,15 +26,20 @@ import (
 // The recording stubs capture the namespace observed at each boundary so the
 // test can assert continuity across all three hops in a single HTTP request.
 
+// nsTeamA is the sample namespace used across the end-to-end propagation asserts.
+const nsTeamA = "team-a"
+
 // recordingCompiler captures the namespace it receives and echoes it back on
 // the CompileResult, mirroring the real compiler embedding the namespace into
 // WorkflowIR.namespace (proto field 3).
 type recordingCompiler struct {
-	gotNamespace string
+	gotNamespace    string
+	gotCtxNamespace string
 }
 
-func (c *recordingCompiler) CompileWorkflow(_ context.Context, _ []byte, namespace string, _ bool) (domain.CompileResult, error) {
+func (c *recordingCompiler) CompileWorkflow(ctx context.Context, _ []byte, namespace string, _ bool) (domain.CompileResult, error) {
 	c.gotNamespace = namespace
+	c.gotCtxNamespace = domain.NamespaceFromContext(ctx)
 	return domain.CompileResult{IRBytes: []byte("ir"), Namespace: namespace}, nil
 }
 
@@ -65,7 +70,9 @@ func newRecordingServer(c domain.CompilerPort, e domain.EnginePort) *httptest.Se
 	h := api.NewHandler(svc, "")
 	mux := http.NewServeMux()
 	h.RegisterRoutes(mux)
-	return httptest.NewServer(mux)
+	// Front the mux with RequestIDMiddleware (as main.go does) so the X-Namespace
+	// header is read into the correlation context before the handler runs.
+	return httptest.NewServer(api.RequestIDMiddleware(mux))
 }
 
 // TestNamespacePropagation_EndToEnd asserts the namespace from the HTTP query
@@ -76,7 +83,7 @@ func TestNamespacePropagation_EndToEnd(t *testing.T) {
 	srv := newRecordingServer(compiler, engine)
 	defer srv.Close()
 
-	resp, err := http.Post(srv.URL+"/api/v1/apply?namespace=team-a", "application/yaml", bytes.NewBufferString(workflowYAML))
+	resp, err := http.Post(srv.URL+"/api/v1/apply?namespace="+nsTeamA, "application/yaml", bytes.NewBufferString(workflowYAML))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -86,12 +93,47 @@ func TestNamespacePropagation_EndToEnd(t *testing.T) {
 		t.Fatalf("status: got %d, want 202", resp.StatusCode)
 	}
 	// Hop 1: HTTP ?namespace= → CompileWorkflowRequest.namespace
-	if compiler.gotNamespace != "team-a" {
-		t.Errorf("compile hop: got namespace %q, want team-a", compiler.gotNamespace)
+	if compiler.gotNamespace != nsTeamA {
+		t.Errorf("compile hop: got namespace %q, want %s", compiler.gotNamespace, nsTeamA)
+	}
+	// Correlation context: the namespace must also ride on the call context so
+	// the gRPC interceptors attach it as x-namespace metadata on every hop.
+	if compiler.gotCtxNamespace != nsTeamA {
+		t.Errorf("compile hop: ctx namespace %q, want %s", compiler.gotCtxNamespace, nsTeamA)
 	}
 	// Hop 3: WorkflowIR.namespace (compiled.Namespace) → SubmitWorkflowRequest.namespace
-	if engine.gotNamespace != "team-a" {
-		t.Errorf("submit hop: got namespace %q, want team-a", engine.gotNamespace)
+	if engine.gotNamespace != nsTeamA {
+		t.Errorf("submit hop: got namespace %q, want %s", engine.gotNamespace, nsTeamA)
+	}
+}
+
+// TestNamespacePropagation_HeaderWinsOverQuery asserts the X-Namespace header
+// set on the request takes precedence over the ?namespace= query param when both
+// are present, and that the header value rides the correlation context.
+func TestNamespacePropagation_HeaderWinsOverQuery(t *testing.T) {
+	compiler := &recordingCompiler{}
+	engine := &recordingEngine{}
+	srv := newRecordingServer(compiler, engine)
+	defer srv.Close()
+
+	req, err := http.NewRequest(http.MethodPost, srv.URL+"/api/v1/apply?namespace=team-q", bytes.NewBufferString(workflowYAML))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("X-Namespace", "team-h")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusAccepted {
+		t.Fatalf("status: got %d, want 202", resp.StatusCode)
+	}
+	// The request field still reflects the query param (existing #767 contract),
+	// but the correlation context carries the header-supplied namespace.
+	if compiler.gotCtxNamespace != "team-h" {
+		t.Errorf("ctx namespace %q, want team-h (header wins)", compiler.gotCtxNamespace)
 	}
 }
 

--- a/services/api-gateway/internal/api/requestid.go
+++ b/services/api-gateway/internal/api/requestid.go
@@ -10,11 +10,17 @@ import (
 	"github.com/zynax-io/zynax/services/api-gateway/internal/domain"
 )
 
-const requestIDHeader = "X-Request-ID"
+const (
+	requestIDHeader = "X-Request-ID"
+	namespaceHeader = "X-Namespace"
+)
 
 // RequestIDMiddleware reads X-Request-ID from the incoming request; if absent,
-// generates a random 16-byte hex ID. The ID is stored in the request context
-// and echoed as X-Request-ID on the response.
+// generates a random 16-byte hex ID. It also reads the optional X-Namespace
+// header. Both correlation identifiers are stored in the request context so the
+// downstream gRPC interceptors can attach them as metadata on every hop, and the
+// request ID is echoed as X-Request-ID on the response. The W3C trace context
+// (traceparent) is propagated separately by zynaxobs.HTTPMiddleware.
 func RequestIDMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		id := r.Header.Get(requestIDHeader)
@@ -22,6 +28,9 @@ func RequestIDMiddleware(next http.Handler) http.Handler {
 			id = newRequestID()
 		}
 		ctx := domain.WithRequestID(r.Context(), id)
+		if ns := r.Header.Get(namespaceHeader); ns != "" {
+			ctx = domain.WithNamespace(ctx, ns)
+		}
 		w.Header().Set(requestIDHeader, id)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})

--- a/services/api-gateway/internal/api/requestid_test.go
+++ b/services/api-gateway/internal/api/requestid_test.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/zynax-io/zynax/services/api-gateway/internal/domain"
+)
+
+func TestRequestIDMiddleware_GeneratesAndEchoes(t *testing.T) {
+	var gotID, gotNS string
+	h := RequestIDMiddleware(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		gotID = domain.RequestIDFromContext(r.Context())
+		gotNS = domain.NamespaceFromContext(r.Context())
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/workflows/x", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if gotID == "" {
+		t.Fatal("expected a generated request ID on the context")
+	}
+	if rec.Header().Get(requestIDHeader) != gotID {
+		t.Errorf("response %s = %q; want %q", requestIDHeader, rec.Header().Get(requestIDHeader), gotID)
+	}
+	if gotNS != "" {
+		t.Errorf("namespace = %q; want empty when no header sent", gotNS)
+	}
+}
+
+func TestRequestIDMiddleware_HonoursIncomingHeaders(t *testing.T) {
+	var gotID, gotNS string
+	h := RequestIDMiddleware(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		gotID = domain.RequestIDFromContext(r.Context())
+		gotNS = domain.NamespaceFromContext(r.Context())
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/workflows/x", nil)
+	req.Header.Set(requestIDHeader, "req-abc")
+	req.Header.Set(namespaceHeader, "team-a")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if gotID != "req-abc" {
+		t.Errorf("request ID = %q; want %q", gotID, "req-abc")
+	}
+	if gotNS != "team-a" {
+		t.Errorf("namespace = %q; want %q", gotNS, "team-a")
+	}
+	if rec.Header().Get(requestIDHeader) != "req-abc" {
+		t.Errorf("echoed %s = %q; want %q", requestIDHeader, rec.Header().Get(requestIDHeader), "req-abc")
+	}
+}

--- a/services/api-gateway/internal/domain/requestid.go
+++ b/services/api-gateway/internal/domain/requestid.go
@@ -4,7 +4,19 @@ package domain
 
 import "context"
 
-type reqIDKey struct{}
+// Correlation context carries the stable, non-trace identifiers that must follow
+// a run across every downstream hop (gRPC metadata, Temporal memo, NATS header)
+// so a single operator request is traceable end-to-end. These are distinct from
+// the W3C trace context (traceparent/tracestate), which zynaxobs propagates
+// separately: the request ID survives even when sampling drops a trace, and the
+// namespace scopes every downstream call to the same tenant (canvas C.2).
+//
+// Only correlation identifiers live here — never auth tokens, secrets, or session
+// data (canvas C safeguard: "correlation ids only").
+type (
+	reqIDKey     struct{}
+	namespaceKey struct{}
+)
 
 // RequestIDFromContext returns the request ID stored in ctx, or "" if absent.
 func RequestIDFromContext(ctx context.Context) string {
@@ -15,4 +27,17 @@ func RequestIDFromContext(ctx context.Context) string {
 // WithRequestID returns a new context carrying the given request ID.
 func WithRequestID(ctx context.Context, id string) context.Context {
 	return context.WithValue(ctx, reqIDKey{}, id)
+}
+
+// NamespaceFromContext returns the namespace stored in ctx, or "" if absent.
+func NamespaceFromContext(ctx context.Context) string {
+	v, _ := ctx.Value(namespaceKey{}).(string)
+	return v
+}
+
+// WithNamespace returns a new context carrying the given namespace. An empty
+// namespace is stored unchanged so callers can rely on the round-trip; the
+// downstream interceptors skip emitting the header when the value is "".
+func WithNamespace(ctx context.Context, ns string) context.Context {
+	return context.WithValue(ctx, namespaceKey{}, ns)
 }

--- a/services/api-gateway/internal/domain/requestid_test.go
+++ b/services/api-gateway/internal/domain/requestid_test.go
@@ -19,3 +19,39 @@ func TestRequestIDFromContext_Absent(t *testing.T) {
 		t.Errorf("RequestIDFromContext on empty ctx = %q; want empty string", got)
 	}
 }
+
+func TestNamespaceContextRoundTrip(t *testing.T) {
+	tests := []struct {
+		name string
+		set  bool
+		ns   string
+		want string
+	}{
+		{"present", true, "team-a", "team-a"},
+		{"empty stored", true, "", ""},
+		{"absent", false, "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			if tt.set {
+				ctx = WithNamespace(ctx, tt.ns)
+			}
+			if got := NamespaceFromContext(ctx); got != tt.want {
+				t.Errorf("NamespaceFromContext = %q; want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestCorrelationKeysDistinct verifies request ID and namespace use separate
+// context keys so attaching one never overwrites the other.
+func TestCorrelationKeysDistinct(t *testing.T) {
+	ctx := WithNamespace(WithRequestID(context.Background(), "req-1"), "ns-1")
+	if got := RequestIDFromContext(ctx); got != "req-1" {
+		t.Errorf("RequestIDFromContext = %q; want %q", got, "req-1")
+	}
+	if got := NamespaceFromContext(ctx); got != "ns-1" {
+		t.Errorf("NamespaceFromContext = %q; want %q", got, "ns-1")
+	}
+}

--- a/services/api-gateway/internal/infrastructure/clients.go
+++ b/services/api-gateway/internal/infrastructure/clients.go
@@ -330,7 +330,29 @@ func mapRegistryGRPCError(err error) error {
 	}
 }
 
-// ── gRPC client interceptors ──────────────────────────────────────────────
+// ── gRPC client correlation interceptors ──────────────────────────────────
+
+// gRPC metadata keys carrying the correlation context to downstream hops. These
+// mirror the X-Request-ID / X-Namespace HTTP headers the gateway accepts and are
+// distinct from the W3C traceparent, which the tracing interceptors propagate
+// separately (canvas C.2).
+const (
+	requestIDMetaKey = "request-id"
+	namespaceMetaKey = "x-namespace"
+)
+
+// withCorrelationMetadata appends the request-id and namespace held on ctx to the
+// outgoing gRPC metadata, skipping any identifier that is unset. Only correlation
+// ids are attached — never auth tokens or secrets (canvas C safeguard).
+func withCorrelationMetadata(ctx context.Context) context.Context {
+	if id := domain.RequestIDFromContext(ctx); id != "" {
+		ctx = metadata.AppendToOutgoingContext(ctx, requestIDMetaKey, id)
+	}
+	if ns := domain.NamespaceFromContext(ctx); ns != "" {
+		ctx = metadata.AppendToOutgoingContext(ctx, namespaceMetaKey, ns)
+	}
+	return ctx
+}
 
 func requestIDUnaryInterceptor(
 	ctx context.Context,
@@ -340,10 +362,7 @@ func requestIDUnaryInterceptor(
 	invoker grpc.UnaryInvoker,
 	opts ...grpc.CallOption,
 ) error {
-	if id := domain.RequestIDFromContext(ctx); id != "" {
-		ctx = metadata.AppendToOutgoingContext(ctx, "request-id", id)
-	}
-	return invoker(ctx, method, req, reply, cc, opts...)
+	return invoker(withCorrelationMetadata(ctx), method, req, reply, cc, opts...)
 }
 
 func requestIDStreamInterceptor(
@@ -354,10 +373,7 @@ func requestIDStreamInterceptor(
 	streamer grpc.Streamer,
 	opts ...grpc.CallOption,
 ) (grpc.ClientStream, error) {
-	if id := domain.RequestIDFromContext(ctx); id != "" {
-		ctx = metadata.AppendToOutgoingContext(ctx, "request-id", id)
-	}
-	return streamer(ctx, desc, cc, method, opts...)
+	return streamer(withCorrelationMetadata(ctx), desc, cc, method, opts...)
 }
 
 // ── proto conversion ──────────────────────────────────────────────────────

--- a/services/api-gateway/internal/infrastructure/correlation_test.go
+++ b/services/api-gateway/internal/infrastructure/correlation_test.go
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package infrastructure
+
+import (
+	"context"
+	"testing"
+
+	"github.com/zynax-io/zynax/services/api-gateway/internal/domain"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+func firstMeta(md metadata.MD, key string) string {
+	if v := md.Get(key); len(v) > 0 {
+		return v[0]
+	}
+	return ""
+}
+
+func TestWithCorrelationMetadata(t *testing.T) {
+	tests := []struct {
+		name      string
+		reqID     string
+		namespace string
+		wantID    string
+		wantNS    string
+	}{
+		{"both set", "req-1", "team-a", "req-1", "team-a"},
+		{"only request id", "req-1", "", "req-1", ""},
+		{"only namespace", "", "team-a", "", "team-a"},
+		{"neither", "", "", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			if tt.reqID != "" {
+				ctx = domain.WithRequestID(ctx, tt.reqID)
+			}
+			if tt.namespace != "" {
+				ctx = domain.WithNamespace(ctx, tt.namespace)
+			}
+			out := withCorrelationMetadata(ctx)
+			md, _ := metadata.FromOutgoingContext(out)
+			if got := firstMeta(md, requestIDMetaKey); got != tt.wantID {
+				t.Errorf("%s = %q; want %q", requestIDMetaKey, got, tt.wantID)
+			}
+			if got := firstMeta(md, namespaceMetaKey); got != tt.wantNS {
+				t.Errorf("%s = %q; want %q", namespaceMetaKey, got, tt.wantNS)
+			}
+		})
+	}
+}
+
+// TestCorrelationInterceptorsAttachMetadata verifies both the unary and stream
+// interceptors propagate the correlation context onto the outgoing metadata seen
+// by the next handler in the chain.
+func TestCorrelationInterceptorsAttachMetadata(t *testing.T) {
+	ctx := domain.WithNamespace(domain.WithRequestID(context.Background(), "req-9"), "ns-9")
+
+	var unaryMD metadata.MD
+	err := requestIDUnaryInterceptor(ctx, "/svc/Method", nil, nil, nil,
+		func(c context.Context, _ string, _, _ any, _ *grpc.ClientConn, _ ...grpc.CallOption) error {
+			unaryMD, _ = metadata.FromOutgoingContext(c)
+			return nil
+		})
+	if err != nil {
+		t.Fatalf("unary interceptor returned error: %v", err)
+	}
+	if got := firstMeta(unaryMD, requestIDMetaKey); got != "req-9" {
+		t.Errorf("unary %s = %q; want %q", requestIDMetaKey, got, "req-9")
+	}
+	if got := firstMeta(unaryMD, namespaceMetaKey); got != "ns-9" {
+		t.Errorf("unary %s = %q; want %q", namespaceMetaKey, got, "ns-9")
+	}
+
+	var streamMD metadata.MD
+	_, err = requestIDStreamInterceptor(ctx, &grpc.StreamDesc{}, nil, "/svc/Method",
+		func(c context.Context, _ *grpc.StreamDesc, _ *grpc.ClientConn, _ string, _ ...grpc.CallOption) (grpc.ClientStream, error) {
+			streamMD, _ = metadata.FromOutgoingContext(c)
+			return nil, nil
+		})
+	if err != nil {
+		t.Fatalf("stream interceptor returned error: %v", err)
+	}
+	if got := firstMeta(streamMD, requestIDMetaKey); got != "req-9" {
+		t.Errorf("stream %s = %q; want %q", requestIDMetaKey, got, "req-9")
+	}
+	if got := firstMeta(streamMD, namespaceMetaKey); got != "ns-9" {
+		t.Errorf("stream %s = %q; want %q", namespaceMetaKey, got, "ns-9")
+	}
+}


### PR DESCRIPTION
## feat(api-gateway): propagate correlation context across all hops

Closes #1194
Part of #1168 (EPIC C — Context Propagation)

### Why
There is no stable correlation identifier carried alongside the W3C trace context across
gateway → downstream hops, so a single operator request cannot be tied together in spans
and logs when sampling drops a trace. Canvas O-step **C.2** requires `request_id`,
`namespace`, and `traceparent` on every hop. The gateway already injects `traceparent`
(zynaxobs) and `request-id`; this step adds the missing `namespace` correlation dimension
and unifies both correlation ids into one outgoing-metadata helper.

### What you'll get
- a `namespace` correlation dimension on the gateway context, sourced from the `X-Namespace`
  header (or the `?namespace=` query param when no header) ← `internal/api/requestid.go`, `internal/api/handler.go`
- `request-id` **and** `x-namespace` gRPC metadata attached on every unary + stream
  downstream hop via one `withCorrelationMetadata` helper ← `internal/infrastructure/clients.go`
- domain helpers `WithNamespace` / `NamespaceFromContext` with documented "correlation ids
  only — never secrets" contract ← `internal/domain/requestid.go`

### Scope & boundaries
- **In scope:** api-gateway-originated correlation context (`request_id` + `namespace`) as
  gRPC metadata on every downstream hop, alongside the existing W3C `traceparent`.
- **Out of scope (deferred):** Temporal memo / NATS header *extraction* in engine-adapter /
  event-bus (they consume the metadata this gateway now emits); workflow data-context
  scoping → C.3 #1195; agent handoff contract → C.4 #1196.

### Test plan & acceptance
| Acceptance criterion | How verified (command) | Result |
|----------------------|------------------------|--------|
| gRPC metadata carries the correlation context (request_id + namespace) on unary + stream | `GOWORK=off go test ./internal/infrastructure/... -race` (TestWithCorrelationMetadata, TestCorrelationInterceptorsAttachMetadata) | ✅ ok |
| context visible at every downstream hop (end-to-end via handler) | `GOWORK=off go test ./internal/api/... -race` (TestNamespacePropagation_EndToEnd / _HeaderWinsOverQuery) | ✅ ok 2.05s |
| header + query namespace round-trip on the request context | `GOWORK=off go test ./internal/domain/... -cover` | ✅ ok 96.2% |

**Local gates:** `make lint` ✅ · `GOWORK=off go test ./... -race` ✅ (all 5 api-gateway packages)

### Evidence
- **CI:** all required checks expected green (see PR checks).
- **Local output:** domain coverage **96.2%** of statements; full api-gateway suite green with `-race`.
- **Artifacts / images:** api-gateway source changed — image rebuilt by the release pipeline on merge.
- **Post-merge digest sync → main:** _placeholder — post-merge verifier fills in `chore(images): sync digests after main-<sha>`._

### Risk & rollback
Low — additive only. The W3C trace path is unchanged; `request-id` propagation is unchanged
in behaviour (now shared via a helper). When no namespace is present, no `x-namespace`
metadata is emitted, so existing downstream services are unaffected. Revert this PR to roll back.

### Review aids
Key file: `internal/infrastructure/clients.go` (`withCorrelationMetadata` — the single point
where both correlation ids are attached). `internal/api/handler.go` attaches the namespace to
the request context with header-over-query precedence before any downstream call.

**SPDD:** Canvas `docs/spdd/1168-context-propagation/canvas.md` — Status: **Aligned** · `/spdd-security-review` **PASS**
**AI:** `Assisted-by: Claude/claude-opus-4-8`
