### PR TITLE
feat(ci): zynax-ci coverage-comment subcommand

### DIFF
--- a/.github/workflows/_test-go.yml
+++ b/.github/workflows/_test-go.yml
@@ -350,7 +350,7 @@ jobs:
           RUN_NUMBER: ${{ github.run_number }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           SHA: ${{ github.sha }}
-        run: bash .github/scripts/build-coverage-comment.sh
+        run: GOWORK=off go -C cmd/zynax-ci run . coverage-comment >/dev/null
 
       - name: Post coverage report on PR
         if: always() && inputs.event_name == 'pull_request'

--- a/cmd/zynax-ci/cmd/coverage_comment.go
+++ b/cmd/zynax-ci/cmd/coverage_comment.go
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/zynax-io/zynax/cmd/zynax-ci/coveragecomment"
+)
+
+var (
+	covResultsPath string
+	covOutPath     string
+)
+
+var coverageCommentCmd = &cobra.Command{
+	Use:   "coverage-comment",
+	Short: "Render the PR coverage markdown comment from a coverage-results file",
+	Long: `Read a coverage-results file (pipe-delimited type|name|pkg|pct rows) and
+render the PR coverage markdown comment.
+
+Replaces .github/scripts/build-coverage-comment.sh (ADR-036). Output is written
+to --out (default $OUT or /tmp/coverage-comment.md) and echoed to stdout.
+
+Inputs (flags override env, env overrides defaults):
+  --results  $RESULTS  (default /tmp/coverage-results.txt)
+  --out      $OUT      (default /tmp/coverage-comment.md)
+
+Footer env:  RUN_NUMBER, RUN_URL, SHA
+Gate env:    COVERAGE_DOMAIN_GATE, COVERAGE_ADAPTER_GATE,
+             COVERAGE_CLI_ZYNAX_GATE, COVERAGE_CLI_ZYNAX_CI_GATE,
+             COVERAGE_PYTHON_GATE`,
+	Args: cobra.NoArgs,
+	RunE: runCoverageComment,
+}
+
+func init() {
+	coverageCommentCmd.Flags().StringVar(&covResultsPath, "results", "", "coverage-results file ($RESULTS or /tmp/coverage-results.txt)")
+	coverageCommentCmd.Flags().StringVar(&covOutPath, "out", "", "output markdown file ($OUT or /tmp/coverage-comment.md)")
+	rootCmd.AddCommand(coverageCommentCmd)
+}
+
+func runCoverageComment(cmd *cobra.Command, _ []string) error {
+	results := pick(covResultsPath, os.Getenv("RESULTS"), "/tmp/coverage-results.txt")
+	out := pick(covOutPath, os.Getenv("OUT"), "/tmp/coverage-comment.md")
+
+	f, err := os.Open(results) //nolint:gosec // results path is CI-controlled (RESULTS env / flag)
+	if err != nil {
+		return fmt.Errorf("coverage-comment: open results: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	md, err := coveragecomment.Render(f, gatesFromEnv(), metaFromEnv())
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(out, []byte(md), 0o600); err != nil { //nolint:gosec // out path is CI-controlled (OUT env / flag)
+		return fmt.Errorf("coverage-comment: write %s: %w", out, err)
+	}
+	if _, err := fmt.Fprint(cmd.OutOrStdout(), md); err != nil {
+		return fmt.Errorf("coverage-comment: write stdout: %w", err)
+	}
+	return nil
+}
+
+func gatesFromEnv() coveragecomment.Gates {
+	return coveragecomment.Gates{
+		Domain:     os.Getenv("COVERAGE_DOMAIN_GATE"),
+		Adapter:    os.Getenv("COVERAGE_ADAPTER_GATE"),
+		CLIZynax:   os.Getenv("COVERAGE_CLI_ZYNAX_GATE"),
+		CLIZynaxCI: os.Getenv("COVERAGE_CLI_ZYNAX_CI_GATE"),
+		Python:     os.Getenv("COVERAGE_PYTHON_GATE"),
+	}
+}
+
+func metaFromEnv() coveragecomment.Meta {
+	return coveragecomment.Meta{
+		RunNumber: os.Getenv("RUN_NUMBER"),
+		RunURL:    os.Getenv("RUN_URL"),
+		SHA:       os.Getenv("SHA"),
+	}
+}
+
+// pick returns the first non-empty value among the candidates.
+func pick(vals ...string) string {
+	for _, v := range vals {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/cmd/zynax-ci/coveragecomment/coveragecomment.go
+++ b/cmd/zynax-ci/coveragecomment/coveragecomment.go
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package coveragecomment renders the PR coverage markdown comment from a
+// coverage results file. It is the tested Go replacement for
+// .github/scripts/build-coverage-comment.sh (ADR-036, M7 EPIC S step S.2).
+package coveragecomment
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+)
+
+// Gates holds the per-category coverage thresholds (percentages). Zero values
+// fall back to the documented defaults via gateOrDefault.
+type Gates struct {
+	Domain     string
+	Adapter    string
+	CLIZynax   string
+	CLIZynaxCI string
+	Python     string
+}
+
+// Meta holds the footer fields rendered at the bottom of the comment.
+type Meta struct {
+	RunNumber string
+	RunURL    string
+	SHA       string
+}
+
+// row is a single parsed coverage-results line: type|name|pkg|pct.
+type row struct {
+	kind string
+	name string
+	pct  string
+}
+
+// defaults mirror the bash fallbacks in build-coverage-comment.sh.
+var defaults = map[string]string{
+	"domain": "90", "adapter": "85", "zynax": "79", "zynax-ci": "80", "python": "90",
+}
+
+// Render parses the coverage-results stream and returns the markdown comment,
+// byte-identical to build-coverage-comment.sh on the same input.
+func Render(results io.Reader, gates Gates, meta Meta) (string, error) {
+	rows, err := parse(results)
+	if err != nil {
+		return "", err
+	}
+	var b strings.Builder
+	b.WriteString("<!-- zynax-coverage-report -->\n## Coverage Report\n\n")
+	renderServices(&b, rows, gateOrDefault(gates.Domain, "domain"))
+	renderAdapters(&b, rows, gateOrDefault(gates.Adapter, "adapter"))
+	renderCLI(&b, rows, gateOrDefault(gates.CLIZynax, "zynax"), gateOrDefault(gates.CLIZynaxCI, "zynax-ci"))
+	renderPython(&b, rows, gateOrDefault(gates.Python, "python"))
+	if len(rows) == 0 {
+		b.WriteString("_No coverage data collected — tests may have been skipped._\n\n")
+	}
+	fmt.Fprintf(&b, "<sub>Run [#%s](%s) · `%s`</sub>\n", orQuestion(meta.RunNumber), meta.RunURL, sha7(meta.SHA))
+	return b.String(), nil
+}
+
+// parse reads pipe-delimited rows, ignoring blank lines (parity with grep).
+func parse(r io.Reader) ([]row, error) {
+	var rows []row
+	sc := bufio.NewScanner(r)
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for sc.Scan() {
+		line := sc.Text()
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		f := strings.SplitN(line, "|", 4)
+		if len(f) < 4 {
+			continue
+		}
+		rows = append(rows, row{kind: f[0], name: f[1], pct: f[3]})
+	}
+	if err := sc.Err(); err != nil {
+		return nil, fmt.Errorf("read coverage results: %w", err)
+	}
+	return rows, nil
+}
+
+// gateIcon returns ✅ when pct ≥ gate, else ❌ (parity with the awk helper).
+func gateIcon(pct, gate string) string {
+	p, g := toFloat(pct), toFloat(gate)
+	if p >= g {
+		return "✅"
+	}
+	return "❌"
+}
+
+func toFloat(s string) float64 {
+	f, err := strconv.ParseFloat(strings.TrimSpace(s), 64)
+	if err != nil {
+		return 0
+	}
+	return f
+}
+
+func gateOrDefault(v, key string) string {
+	if v == "" {
+		return defaults[key]
+	}
+	return v
+}
+
+func orQuestion(s string) string {
+	if s == "" {
+		return "?"
+	}
+	return s
+}
+
+func sha7(s string) string {
+	if len(s) > 7 {
+		return s[:7]
+	}
+	return s
+}

--- a/cmd/zynax-ci/coveragecomment/coveragecomment_test.go
+++ b/cmd/zynax-ci/coveragecomment/coveragecomment_test.go
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package coveragecomment
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGateIcon(t *testing.T) {
+	tests := []struct {
+		name, pct, gate, want string
+	}{
+		{"above", "91.2", "90", "✅"},
+		{"equal", "90", "90", "✅"},
+		{"equal_decimal", "90.0", "90", "✅"},
+		{"below", "88.5", "90", "❌"},
+		{"empty_pct_defaults_zero", "", "90", "❌"},
+		{"empty_gate_defaults_zero", "0", "", "✅"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := gateIcon(tt.pct, tt.gate); got != tt.want {
+				t.Fatalf("gateIcon(%q,%q)=%q want %q", tt.pct, tt.gate, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRenderEmpty(t *testing.T) {
+	got, err := Render(strings.NewReader(""), Gates{}, Meta{SHA: "abcdef1234567", RunNumber: "42", RunURL: "u"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(got, "_No coverage data collected") {
+		t.Fatalf("expected no-data note, got:\n%s", got)
+	}
+	if !strings.Contains(got, "<sub>Run [#42](u) · `abcdef1`</sub>") {
+		t.Fatalf("footer mismatch:\n%s", got)
+	}
+}
+
+func TestRenderShortSHAAndMissingRunNumber(t *testing.T) {
+	got, err := Render(strings.NewReader(""), Gates{}, Meta{SHA: "abc"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(got, "<sub>Run [#?]() · `abc`</sub>") {
+		t.Fatalf("short-sha footer mismatch:\n%s", got)
+	}
+}
+
+func TestRenderDefaultGates(t *testing.T) {
+	in := "service|api-gateway||91.2\n"
+	got, err := Render(strings.NewReader(in), Gates{}, Meta{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(got, "gate ≥ 90%") {
+		t.Fatalf("expected default domain gate 90, got:\n%s", got)
+	}
+}
+
+func TestRenderBlankLinesIgnored(t *testing.T) {
+	in := "\nservice|api-gateway||91.2\n\n"
+	got, err := Render(strings.NewReader(in), Gates{}, Meta{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(got, "`services/api-gateway`") {
+		t.Fatalf("expected service row, got:\n%s", got)
+	}
+}
+
+// goldenInput / goldenOutput reproduce the exact bytes build-coverage-comment.sh
+// emits for a representative multi-category profile (parity check).
+const goldenInput = `service|api-gateway||91.2
+service|task-broker||90.0
+adapter|http||87.4
+cli|zynax||78.5
+cli|zynax-ci||80.0
+python|sdk||92.1
+`
+
+const goldenOutput = `<!-- zynax-coverage-report -->
+## Coverage Report
+
+### Go services — ` + "`internal/domain`" + ` (gate ≥ 90%)
+
+| Service | Coverage | Gate |
+|---------|----------|------|
+| ` + "`services/api-gateway`" + ` | **91.2%** | ✅ |
+| ` + "`services/task-broker`" + ` | **90.0%** | ✅ |
+
+### Go adapters (gate ≥ 85%)
+
+| Adapter | Coverage | Gate |
+|---------|----------|------|
+| ` + "`agents/adapters/http`" + ` | **87.4%** | ✅ |
+
+### CLI tools (gate ≥ 79% zynax / 80% zynax-ci)
+
+| Tool | Coverage | Gate |
+|------|----------|------|
+| ` + "`cmd/zynax`" + ` | **78.5%** | ❌ |
+| ` + "`cmd/zynax-ci`" + ` | **80.0%** | ✅ |
+
+### Python (gate ≥ 90%)
+
+| Module | Coverage | Gate |
+|--------|----------|------|
+| ` + "`agents/sdk`" + ` | **92.1%** | ✅ |
+
+<sub>Run [#7](https://example/run/1) · ` + "`abc1234`" + `</sub>
+`
+
+func TestRenderGoldenParity(t *testing.T) {
+	gates := Gates{Domain: "90", Adapter: "85", CLIZynax: "79", CLIZynaxCI: "80", Python: "90"}
+	meta := Meta{RunNumber: "7", RunURL: "https://example/run/1", SHA: "abc1234ffff"}
+	got, err := Render(strings.NewReader(goldenInput), gates, meta)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != goldenOutput {
+		t.Fatalf("golden mismatch.\n--- got ---\n%s\n--- want ---\n%s", got, goldenOutput)
+	}
+}

--- a/cmd/zynax-ci/coveragecomment/sections.go
+++ b/cmd/zynax-ci/coveragecomment/sections.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package coveragecomment
+
+import (
+	"fmt"
+	"strings"
+)
+
+// filter returns the rows of a given kind, preserving input order.
+func filter(rows []row, kind string) []row {
+	var out []row
+	for _, r := range rows {
+		if r.kind == kind {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+func renderServices(b *strings.Builder, rows []row, gate string) {
+	rs := filter(rows, "service")
+	if len(rs) == 0 {
+		return
+	}
+	fmt.Fprintf(b, "### Go services — `internal/domain` (gate ≥ %s%%)\n\n", gate)
+	b.WriteString("| Service | Coverage | Gate |\n|---------|----------|------|\n")
+	for _, r := range rs {
+		fmt.Fprintf(b, "| `services/%s` | **%s%%** | %s |\n", r.name, r.pct, gateIcon(r.pct, gate))
+	}
+	b.WriteString("\n")
+}
+
+func renderAdapters(b *strings.Builder, rows []row, gate string) {
+	rs := filter(rows, "adapter")
+	if len(rs) == 0 {
+		return
+	}
+	fmt.Fprintf(b, "### Go adapters (gate ≥ %s%%)\n\n", gate)
+	b.WriteString("| Adapter | Coverage | Gate |\n|---------|----------|------|\n")
+	for _, r := range rs {
+		fmt.Fprintf(b, "| `agents/adapters/%s` | **%s%%** | %s |\n", r.name, r.pct, gateIcon(r.pct, gate))
+	}
+	b.WriteString("\n")
+}
+
+func renderCLI(b *strings.Builder, rows []row, zynaxGate, zynaxCIGate string) {
+	rs := filter(rows, "cli")
+	if len(rs) == 0 {
+		return
+	}
+	fmt.Fprintf(b, "### CLI tools (gate ≥ %s%% zynax / %s%% zynax-ci)\n\n", zynaxGate, zynaxCIGate)
+	b.WriteString("| Tool | Coverage | Gate |\n|------|----------|------|\n")
+	for _, r := range rs {
+		g := zynaxCIGate
+		if r.name == "zynax" {
+			g = zynaxGate
+		}
+		fmt.Fprintf(b, "| `cmd/%s` | **%s%%** | %s |\n", r.name, r.pct, gateIcon(r.pct, g))
+	}
+	b.WriteString("\n")
+}
+
+func renderPython(b *strings.Builder, rows []row, gate string) {
+	rs := filter(rows, "python")
+	if len(rs) == 0 {
+		return
+	}
+	fmt.Fprintf(b, "### Python (gate ≥ %s%%)\n\n", gate)
+	b.WriteString("| Module | Coverage | Gate |\n|--------|----------|------|\n")
+	for _, r := range rs {
+		fmt.Fprintf(b, "| `agents/%s` | **%s%%** | %s |\n", r.name, r.pct, gateIcon(r.pct, gate))
+	}
+	b.WriteString("\n")
+}


### PR DESCRIPTION
## feat(ci): zynax-ci coverage-comment subcommand

Closes #1287
Part of #1285 (EPIC S — CI bash to Go, ADR-036)

### Why
The PR coverage comment was assembled by `build-coverage-comment.sh` (79 LOC) — untested,
untyped, outside `make lint` / `govulncheck`. ADR-036 EPIC S step S.2 moves this deterministic
rendering into a tested `zynax-ci` subcommand so the workflow step becomes a single call.

### What you'll get
- `zynax-ci coverage-comment` renders the PR coverage markdown from the coverage-results file ← `cmd/zynax-ci/cmd/coverage_comment.go`
- table-driven rendering + gate-icon logic with a golden byte-parity test ← `cmd/zynax-ci/coveragecomment/*.go`
- the workflow step reduced to one `zynax-ci coverage-comment` invocation ← `.github/workflows/_test-go.yml`

### Scope & boundaries
- **In scope:** the Go subcommand + unit tests; wiring the consuming `_test-go.yml` step; byte parity on populated and empty profiles.
- **Out of scope (deferred):** deleting `build-coverage-comment.sh` → S.7 (#1292), after parity is proven in CI.

### Test plan & acceptance
| Acceptance criterion | How verified (command) | Result |
|----------------------|------------------------|--------|
| `GOWORK=off go test ./...` green; tests cover rendering + threshold formatting | `GOWORK=off go -C cmd/zynax-ci test ./...` | ✅ ok (coveragecomment + cmd) |
| Output byte-identical vs the bash on a sample profile | `diff <(bash build-coverage-comment.sh)` vs Go on the same fixture | ✅ BYTE-IDENTICAL (populated + empty) |
| Workflow step reduced to one `zynax-ci coverage-comment` call | review `.github/workflows/_test-go.yml` | ✅ one `run:` line |
| SPDX header; functions ≤ 30 lines | review of new `.go` files | ✅ |

**Local gates:** `make lint` ✅ · `GOWORK=off go -C cmd/zynax-ci test ./...` ✅

### Evidence
- **CI:** required checks green (see run on this PR).
- **Local output:** `diff` of bash vs Go output prints `BYTE-IDENTICAL` for the multi-category profile and `EMPTY-IDENTICAL` for the empty profile; `make lint` → `All checks passed!`.
- **Artifacts / images:** none — no service source changed.
- **Post-merge digest sync → main:** N/A — no image rebuild.

### Risk & rollback
Low — additive subcommand; the workflow step builds-and-runs the verb from source with the same
`/tmp` defaults as the bash, so the downstream post step is unchanged. Revert this PR to restore the
bash invocation (the `.sh` is still present until S.7).

### Review aids
Start at `cmd/zynax-ci/coveragecomment/coveragecomment.go` (the renderer); `sections.go` holds the
per-category tables; the golden parity test in `coveragecomment_test.go` pins byte-for-byte fidelity
to the bash. The workflow change is a single `run:` line.

**SPDD:** Canvas `docs/spdd/1285-ci-bash-to-go/canvas.md` — Status: **Aligned** · `/spdd-security-review` **PASS**
**AI:** `Assisted-by: Claude/claude-opus-4-8`  (label: ai-assisted)
