### PR TITLE
feat(ci): zynax-ci bench-gate + bdd-select

### DIFF
--- a/.github/workflows/_test-go.yml
+++ b/.github/workflows/_test-go.yml
@@ -189,7 +189,8 @@ jobs:
           else
             export BASE="HEAD~1" HEAD="HEAD"
           fi
-          pkgs=$(bash tools/ci/bdd-select-packages.sh)
+          # Build-from-source until the ci-runner image carries the bdd-select verb.
+          pkgs=$(GOWORK=off go -C cmd/zynax-ci run . bdd-select)
           cd protos/tests
           if [ "$pkgs" = "ALL" ]; then
             echo "── BDD: full suite"

--- a/cmd/zynax-ci/bddselect/bddselect.go
+++ b/cmd/zynax-ci/bddselect/bddselect.go
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package bddselect computes the godog BDD package/service matrix to run based
+// on changed proto / contract-test files. It is the tested Go replacement for
+// tools/ci/bdd-select-packages.sh (ADR-036, M7 EPIC S step S.3).
+//
+// Output parity with the bash:
+//   - "ALL"  → run the full suite
+//   - ""     → run nothing
+//   - else   → a space-separated, deduplicated, sorted list of packages
+package bddselect
+
+import (
+	"path"
+	"sort"
+	"strings"
+)
+
+// All is the sentinel selection that triggers the full BDD suite.
+const All = "ALL"
+
+// pkgMap maps a changed protos/zynax/v1/*.proto basename to its BDD package
+// (parity with the PKG_MAP associative array in bdd-select-packages.sh).
+var pkgMap = map[string]string{
+	"agent.proto":             "agent_service",
+	"agent_registry.proto":    "agent_registry_service",
+	"cloudevents.proto":       "cloudevents_envelope",
+	"engine_adapter.proto":    "engine_adapter_service",
+	"event_bus.proto":         "event_bus_service",
+	"memory.proto":            "memory_service",
+	"task_broker.proto":       "task_broker_service",
+	"workflow_compiler.proto": "workflow_compiler_service",
+}
+
+// Select returns the BDD selection for the given changed file paths (the
+// `git diff --name-only BASE..HEAD -- protos/` output, one path per element).
+// Blank entries are ignored, matching the bash `[ -z "$f" ] && continue`.
+func Select(changed []string) string {
+	pkgs := map[string]struct{}{}
+	for _, f := range changed {
+		f = strings.TrimSpace(f)
+		if f == "" {
+			continue
+		}
+		if forcesAll(f) {
+			return All
+		}
+		if pkg := pkgFor(f); pkg != "" {
+			pkgs[pkg] = struct{}{}
+		}
+	}
+	return join(pkgs)
+}
+
+// forcesAll reports whether a changed path triggers the full suite: shared test
+// infrastructure (go.mod/go.sum or testserver/) or any feature file.
+func forcesAll(f string) bool {
+	if strings.HasPrefix(f, "protos/tests/go.mod") ||
+		strings.HasPrefix(f, "protos/tests/go.sum") ||
+		strings.HasPrefix(f, "protos/tests/testserver/") {
+		return true
+	}
+	return strings.HasPrefix(f, "protos/tests/features/")
+}
+
+// pkgFor maps a single changed path to its BDD package, or "" if none.
+func pkgFor(f string) string {
+	switch {
+	case strings.HasPrefix(f, "protos/zynax/v1/") && strings.HasSuffix(f, ".proto"):
+		return pkgMap[path.Base(f)]
+	case strings.HasPrefix(f, "protos/tests/"):
+		// protos/tests/<pkg>/... — the third path segment is the package,
+		// excluding the "features" dir (handled by forcesAll).
+		parts := strings.Split(f, "/")
+		if len(parts) >= 4 && parts[2] != "features" {
+			return parts[2]
+		}
+	}
+	return ""
+}
+
+// join renders the package set as a sorted, space-separated string.
+func join(set map[string]struct{}) string {
+	if len(set) == 0 {
+		return ""
+	}
+	out := make([]string, 0, len(set))
+	for p := range set {
+		out = append(out, p)
+	}
+	sort.Strings(out)
+	return strings.Join(out, " ")
+}

--- a/cmd/zynax-ci/bddselect/bddselect_test.go
+++ b/cmd/zynax-ci/bddselect/bddselect_test.go
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package bddselect
+
+import "testing"
+
+func TestSelect(t *testing.T) {
+	tests := []struct {
+		name    string
+		changed []string
+		want    string
+	}{
+		{"empty_no_change", nil, ""},
+		{"blank_lines_ignored", []string{"", "  "}, ""},
+		{
+			"single_proto_maps",
+			[]string{"protos/zynax/v1/agent.proto"},
+			"agent_service",
+		},
+		{
+			"unknown_proto_ignored",
+			[]string{"protos/zynax/v1/unknown.proto"},
+			"",
+		},
+		{
+			"two_protos_sorted_unique",
+			[]string{"protos/zynax/v1/memory.proto", "protos/zynax/v1/agent.proto", "protos/zynax/v1/agent.proto"},
+			"agent_service memory_service",
+		},
+		{
+			"go_mod_forces_all",
+			[]string{"protos/tests/go.mod", "protos/zynax/v1/agent.proto"},
+			All,
+		},
+		{
+			"go_sum_forces_all",
+			[]string{"protos/tests/go.sum"},
+			All,
+		},
+		{
+			"testserver_forces_all",
+			[]string{"protos/tests/testserver/server.go"},
+			All,
+		},
+		{
+			"features_forces_all",
+			[]string{"protos/tests/features/agent.feature"},
+			All,
+		},
+		{
+			"tests_pkg_dir_selects",
+			[]string{"protos/tests/agent_service/steps_test.go"},
+			"agent_service",
+		},
+		{
+			"tests_features_dir_not_treated_as_pkg",
+			[]string{"protos/tests/features/x.feature", "protos/zynax/v1/memory.proto"},
+			All,
+		},
+		{
+			"mixed_proto_and_tests_dir",
+			[]string{"protos/zynax/v1/agent.proto", "protos/tests/memory_service/foo_test.go"},
+			"agent_service memory_service",
+		},
+		{
+			"tests_single_segment_ignored",
+			[]string{"protos/tests/README.md"},
+			"",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Select(tt.changed); got != tt.want {
+				t.Fatalf("Select(%v)=%q want %q", tt.changed, got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/zynax-ci/benchgate/benchgate.go
+++ b/cmd/zynax-ci/benchgate/benchgate.go
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package benchgate parses benchstat output and applies the benchmark
+// regression threshold. It is the tested Go replacement for
+// tools/ci/bench-regression.sh (ADR-036, M7 EPIC S step S.3).
+//
+// benchstat prints a "vs base" percentage like "+24.10%" on rows whose metric
+// changed; "~" means no statistically significant change. A positive delta on a
+// time/op (sec/op) row is a regression. The gate flags any positive delta whose
+// magnitude exceeds the threshold percent.
+package benchgate
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// DefaultThresholdPct mirrors THRESHOLD_PCT's default in bench-regression.sh.
+const DefaultThresholdPct = 20.0
+
+// pctRe matches a signed percentage token, e.g. +24.10% or -5.00% (parity with
+// the `grep -oE '[+-][0-9]+(\.[0-9]+)?%'` extraction in the bash).
+var pctRe = regexp.MustCompile(`[+-][0-9]+(\.[0-9]+)?%`)
+
+// Regression is a single benchstat row flagged as a regression.
+type Regression struct {
+	Line string  // the full benchstat line that regressed
+	Pct  float64 // the positive delta magnitude (percent)
+}
+
+// Result holds the outcome of evaluating a benchstat report.
+type Result struct {
+	Threshold   float64
+	Regressions []Regression
+}
+
+// Regressed reports whether any row regressed beyond the threshold.
+func (r Result) Regressed() bool { return len(r.Regressions) > 0 }
+
+// Evaluate parses a benchstat report and returns the regressions that exceed
+// thresholdPct. Decisions are identical to the bash: for each line, take the
+// first signed percentage token; only positive deltas count; flag when the
+// magnitude is strictly greater than the threshold.
+func Evaluate(report io.Reader, thresholdPct float64) (Result, error) {
+	res := Result{Threshold: thresholdPct}
+	sc := bufio.NewScanner(report)
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for sc.Scan() {
+		line := sc.Text()
+		pct, ok := positiveDelta(line)
+		if !ok {
+			continue
+		}
+		if pct > thresholdPct {
+			res.Regressions = append(res.Regressions, Regression{Line: line, Pct: pct})
+		}
+	}
+	if err := sc.Err(); err != nil {
+		return Result{}, fmt.Errorf("read benchstat report: %w", err)
+	}
+	return res, nil
+}
+
+// positiveDelta returns the magnitude of the first signed percentage token on
+// the line and whether it is a positive (slower = regression) delta.
+func positiveDelta(line string) (float64, bool) {
+	tok := pctRe.FindString(line)
+	if tok == "" {
+		return 0, false
+	}
+	num := strings.TrimSuffix(tok, "%")
+	if !strings.HasPrefix(num, "+") {
+		return 0, false // only positive deltas are regressions
+	}
+	mag, err := strconv.ParseFloat(strings.TrimPrefix(num, "+"), 64)
+	if err != nil {
+		return 0, false
+	}
+	return mag, true
+}
+
+// Summary renders the human-readable gate summary, parity with the bash echoes.
+// enforce selects the fail-closed wording; the caller decides the exit code.
+func Summary(res Result, enforce bool) string {
+	var b strings.Builder
+	if !res.Regressed() {
+		fmt.Fprintf(&b, "✅ No benchmark regressed beyond %s%%.\n", trimPct(res.Threshold))
+		return b.String()
+	}
+	for _, r := range res.Regressions {
+		fmt.Fprintf(&b, "⚠️  REGRESSION: %s  (>%s%%)\n", r.Line, trimPct(res.Threshold))
+	}
+	if enforce {
+		b.WriteString("❌ Benchmark regression gate ENFORCED — failing build.\n")
+		return b.String()
+	}
+	b.WriteString("⚠️  Benchmark regression detected, but gate is in fail-open mode\n")
+	b.WriteString("    (baseline not yet stabilised over 3 runs). Set BENCH_GATE_ENFORCE=true to block.\n")
+	return b.String()
+}
+
+// trimPct renders a threshold without a trailing ".0" so "20" stays "20".
+func trimPct(f float64) string {
+	return strconv.FormatFloat(f, 'f', -1, 64)
+}

--- a/cmd/zynax-ci/benchgate/benchgate_test.go
+++ b/cmd/zynax-ci/benchgate/benchgate_test.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package benchgate
+
+import (
+	"strings"
+	"testing"
+)
+
+// noRegression is a benchstat table where every delta is within threshold or "~".
+const noRegression = `goos: linux
+goarch: amd64
+                  │  baseline   │           new            │
+                  │   sec/op    │   sec/op     vs base     │
+Compile-8            1.20µ ± 2%   1.18µ ± 3%        ~ (p=0.31)
+Interpret-8          3.00µ ± 1%   3.45µ ± 2%   +15.00% (p=0.00)
+`
+
+// regression has one row over the 20% threshold.
+const regression = `                  │  baseline   │           new            │
+                  │   sec/op    │   sec/op     vs base     │
+Compile-8            1.20µ ± 2%   1.49µ ± 3%   +24.10% (p=0.00)
+Interpret-8          3.00µ ± 1%   2.85µ ± 2%    -5.00% (p=0.00)
+`
+
+func TestEvaluate(t *testing.T) {
+	tests := []struct {
+		name      string
+		report    string
+		threshold float64
+		want      int     // expected regression count
+		wantPct   float64 // expected first regression magnitude (0 if none)
+	}{
+		{"no_regression_default", noRegression, DefaultThresholdPct, 0, 0},
+		{"regression_default", regression, DefaultThresholdPct, 1, 24.10},
+		{"boundary_equal_not_flagged", "Foo-8  +20.00% (p=0.00)\n", 20, 0, 0},
+		{"boundary_above_flagged", "Foo-8  +20.01% (p=0.00)\n", 20, 1, 20.01},
+		{"negative_delta_ignored", "Foo-8  -99.00% (p=0.00)\n", 20, 0, 0},
+		{"tilde_ignored", "Foo-8  ~ (p=0.31)\n", 20, 0, 0},
+		{"lower_threshold_catches_15pct", noRegression, 10, 1, 15.0},
+		{"empty_report", "", DefaultThresholdPct, 0, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res, err := Evaluate(strings.NewReader(tt.report), tt.threshold)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := len(res.Regressions); got != tt.want {
+				t.Fatalf("regressions=%d want %d (%+v)", got, tt.want, res.Regressions)
+			}
+			if tt.want > 0 && res.Regressions[0].Pct != tt.wantPct {
+				t.Fatalf("first pct=%v want %v", res.Regressions[0].Pct, tt.wantPct)
+			}
+			if res.Regressed() != (tt.want > 0) {
+				t.Fatalf("Regressed()=%v want %v", res.Regressed(), tt.want > 0)
+			}
+		})
+	}
+}
+
+func TestSummary(t *testing.T) {
+	pass, _ := Evaluate(strings.NewReader(noRegression), DefaultThresholdPct)
+	if s := Summary(pass, false); !strings.Contains(s, "✅ No benchmark regressed beyond 20%.") {
+		t.Fatalf("pass summary mismatch:\n%s", s)
+	}
+
+	fail, _ := Evaluate(strings.NewReader(regression), DefaultThresholdPct)
+	warn := Summary(fail, false)
+	if !strings.Contains(warn, "⚠️  REGRESSION:") || !strings.Contains(warn, "fail-open mode") {
+		t.Fatalf("warn summary mismatch:\n%s", warn)
+	}
+	if strings.Contains(warn, "ENFORCED") {
+		t.Fatalf("warn summary must not mention ENFORCED:\n%s", warn)
+	}
+
+	enforced := Summary(fail, true)
+	if !strings.Contains(enforced, "❌ Benchmark regression gate ENFORCED — failing build.") {
+		t.Fatalf("enforced summary mismatch:\n%s", enforced)
+	}
+	if strings.Contains(enforced, "fail-open mode") {
+		t.Fatalf("enforced summary must not mention fail-open:\n%s", enforced)
+	}
+}

--- a/cmd/zynax-ci/cmd/bdd_select.go
+++ b/cmd/zynax-ci/cmd/bdd_select.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/zynax-io/zynax/cmd/zynax-ci/bddselect"
+)
+
+var (
+	bddBase string
+	bddHead string
+)
+
+var bddSelectCmd = &cobra.Command{
+	Use:   "bdd-select",
+	Short: "Emit the godog BDD package selection from changed proto files",
+	Long: `Print the BDD packages to run based on the proto / contract-test files changed
+between BASE and HEAD:
+
+  ALL  → run the full suite          (empty) → run nothing
+  else → a sorted, deduplicated, space-separated package list
+
+Replaces tools/ci/bdd-select-packages.sh (ADR-036). Fail-open: if the git diff
+fails, "ALL" is printed and the verb exits 0 (parity with the bash).
+
+Inputs (flags override env):
+  --base  $BASE    base commit SHA / ref
+  --head  $HEAD    head commit SHA / ref`,
+	Args: cobra.NoArgs,
+	RunE: runBDDSelect,
+}
+
+func init() {
+	bddSelectCmd.Flags().StringVar(&bddBase, "base", "", "base commit SHA/ref ($BASE)")
+	bddSelectCmd.Flags().StringVar(&bddHead, "head", "", "head commit SHA/ref ($HEAD)")
+	rootCmd.AddCommand(bddSelectCmd)
+}
+
+func runBDDSelect(cmd *cobra.Command, _ []string) error {
+	base := pick(bddBase, os.Getenv("BASE"))
+	head := pick(bddHead, os.Getenv("HEAD"))
+
+	changed, err := gitDiffProtos(base, head)
+	if err != nil {
+		// Fail-open: a diff failure runs the full suite (parity with the bash).
+		_, _ = fmt.Fprintln(cmd.ErrOrStderr(), err)
+		return writeLine(cmd, bddselect.All)
+	}
+	return writeLine(cmd, bddselect.Select(changed))
+}
+
+// writeLine writes s and a newline to the command's stdout.
+func writeLine(cmd *cobra.Command, s string) error {
+	if _, err := fmt.Fprintln(cmd.OutOrStdout(), s); err != nil {
+		return fmt.Errorf("bdd-select: write stdout: %w", err)
+	}
+	return nil
+}
+
+// gitDiffProtos returns the protos/ files changed between base and head.
+func gitDiffProtos(base, head string) ([]string, error) {
+	out, err := exec.Command("git", "diff", "--name-only", base+".."+head, "--", "protos/").Output() //nolint:gosec // base/head are CI refs (BASE/HEAD env)
+	if err != nil {
+		return nil, fmt.Errorf("git diff %s..%s: %w", base, head, err)
+	}
+	return strings.Split(strings.TrimRight(string(out), "\n"), "\n"), nil
+}

--- a/cmd/zynax-ci/cmd/bench_bdd_cmd_test.go
+++ b/cmd/zynax-ci/cmd/bench_bdd_cmd_test.go
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// cmdWithIO builds a command with buffered stdin/stdout/stderr for assertions.
+func cmdWithIO(t *testing.T, stdin string) (*cobra.Command, *bytes.Buffer) {
+	t.Helper()
+	c := &cobra.Command{}
+	var out bytes.Buffer
+	c.SetOut(&out)
+	c.SetErr(&bytes.Buffer{})
+	c.SetIn(strings.NewReader(stdin))
+	c.SetContext(context.Background())
+	return c, &out
+}
+
+func writeReport(t *testing.T, body string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "report.txt")
+	if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func TestRunBenchGate_NoRegression_Stdin(t *testing.T) {
+	benchReportPath, benchThreshold, benchEnforce = "", 0, false
+	t.Setenv("BENCH_REPORT", "")
+	t.Setenv("THRESHOLD_PCT", "")
+	t.Setenv("BENCH_GATE_ENFORCE", "")
+	c, out := cmdWithIO(t, "Compile-8  +5.00% (p=0.00)\n")
+	if err := runBenchGate(c, nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out.String(), "✅ No benchmark regressed beyond 20%.") {
+		t.Fatalf("want pass summary, got:\n%s", out.String())
+	}
+}
+
+func TestRunBenchGate_Regression_FailOpen_File(t *testing.T) {
+	benchReportPath = writeReport(t, "Compile-8  +24.10% (p=0.00)\n")
+	benchThreshold, benchEnforce = 0, false
+	t.Setenv("BENCH_REPORT", "")
+	t.Setenv("THRESHOLD_PCT", "")
+	t.Setenv("BENCH_GATE_ENFORCE", "")
+	defer func() { benchReportPath = "" }()
+	c, out := cmdWithIO(t, "")
+	if err := runBenchGate(c, nil); err != nil {
+		t.Fatalf("fail-open must not error: %v", err)
+	}
+	if !strings.Contains(out.String(), "fail-open mode") {
+		t.Fatalf("want fail-open note, got:\n%s", out.String())
+	}
+}
+
+func TestRunBenchGate_Regression_Enforce_Errors(t *testing.T) {
+	benchReportPath, benchThreshold, benchEnforce = "", 0, true
+	t.Setenv("BENCH_REPORT", "")
+	t.Setenv("THRESHOLD_PCT", "")
+	t.Setenv("BENCH_GATE_ENFORCE", "")
+	defer func() { benchEnforce = false }()
+	c, _ := cmdWithIO(t, "Compile-8  +24.10% (p=0.00)\n")
+	if err := runBenchGate(c, nil); err == nil {
+		t.Fatal("enforce must return an error on regression")
+	}
+}
+
+func TestRunBenchGate_ThresholdFromEnv(t *testing.T) {
+	benchReportPath, benchThreshold, benchEnforce = "", 0, false
+	t.Setenv("BENCH_REPORT", "")
+	t.Setenv("THRESHOLD_PCT", "10")
+	t.Setenv("BENCH_GATE_ENFORCE", "")
+	c, out := cmdWithIO(t, "Compile-8  +15.00% (p=0.00)\n")
+	if err := runBenchGate(c, nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out.String(), "REGRESSION") || !strings.Contains(out.String(), "10%") {
+		t.Fatalf("env threshold not applied, got:\n%s", out.String())
+	}
+}
+
+func TestRunBenchGate_OpenError(t *testing.T) {
+	benchReportPath = filepath.Join(t.TempDir(), "missing.txt")
+	benchThreshold, benchEnforce = 0, false
+	t.Setenv("BENCH_REPORT", "")
+	defer func() { benchReportPath = "" }()
+	c, _ := cmdWithIO(t, "")
+	if err := runBenchGate(c, nil); err == nil {
+		t.Fatal("want error opening a missing report file")
+	}
+}
+
+func TestRunBDDSelect_FailOpen_BadRef(t *testing.T) {
+	bddBase, bddHead = "", ""
+	t.Setenv("BASE", "zzz-no-such-ref")
+	t.Setenv("HEAD", "also-missing")
+	c, out := cmdWithIO(t, "")
+	// A bogus diff range makes git fail → fail-open prints ALL, exits nil.
+	if err := runBDDSelect(c, nil); err != nil {
+		t.Fatalf("fail-open must not error: %v", err)
+	}
+	if strings.TrimSpace(out.String()) != "ALL" {
+		t.Fatalf("want ALL on diff failure, got: %q", out.String())
+	}
+}
+
+func TestRunBDDSelect_EmptyRange(t *testing.T) {
+	// HEAD..HEAD is a valid, empty diff → no proto changes → empty selection.
+	bddBase, bddHead = "HEAD", "HEAD"
+	t.Setenv("BASE", "")
+	t.Setenv("HEAD", "")
+	defer func() { bddBase, bddHead = "", "" }()
+	c, out := cmdWithIO(t, "")
+	if err := runBDDSelect(c, nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.TrimSpace(out.String()) != "" {
+		t.Fatalf("want empty selection for HEAD..HEAD, got: %q", out.String())
+	}
+}

--- a/cmd/zynax-ci/cmd/bench_gate.go
+++ b/cmd/zynax-ci/cmd/bench_gate.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	"github.com/zynax-io/zynax/cmd/zynax-ci/benchgate"
+)
+
+var (
+	benchReportPath string
+	benchThreshold  float64
+	benchEnforce    bool
+)
+
+var benchGateCmd = &cobra.Command{
+	Use:   "bench-gate",
+	Short: "Gate on benchmark regression from a benchstat report",
+	Long: `Parse a benchstat report (baseline → new) and fail/pass on the regression
+threshold. A positive "vs base" delta on a benchmark row whose magnitude exceeds
+the threshold percent is a regression.
+
+Replaces the parsing/gating half of tools/ci/bench-regression.sh (ADR-036). The
+benchmarks themselves are still run by the workflow / Makefile; this verb reads
+the benchstat output it produces and applies the decision.
+
+Fail-open by default (EPIC R safeguard): a regression WARNS but exits 0. Set
+--enforce (or BENCH_GATE_ENFORCE=true) to fail the build on a regression.
+
+Inputs (flags override env, env overrides defaults):
+  --report     $BENCH_REPORT   (default: stdin)
+  --threshold  $THRESHOLD_PCT  (default: 20)
+  --enforce    $BENCH_GATE_ENFORCE=true`,
+	Args: cobra.NoArgs,
+	RunE: runBenchGate,
+}
+
+func init() {
+	benchGateCmd.Flags().StringVar(&benchReportPath, "report", "", "benchstat report file ($BENCH_REPORT; default stdin)")
+	benchGateCmd.Flags().Float64Var(&benchThreshold, "threshold", 0, "regression threshold percent ($THRESHOLD_PCT; default 20)")
+	benchGateCmd.Flags().BoolVar(&benchEnforce, "enforce", false, "fail the build on regression ($BENCH_GATE_ENFORCE=true)")
+	rootCmd.AddCommand(benchGateCmd)
+}
+
+func runBenchGate(cmd *cobra.Command, _ []string) error {
+	r, closeFn, err := benchReport(benchReportPath, cmd)
+	if err != nil {
+		return err
+	}
+	defer closeFn()
+
+	res, err := benchgate.Evaluate(r, benchThresholdPct())
+	if err != nil {
+		return err
+	}
+	enforce := benchEnforce || os.Getenv("BENCH_GATE_ENFORCE") == "true"
+	if _, err := fmt.Fprint(cmd.OutOrStdout(), benchgate.Summary(res, enforce)); err != nil {
+		return fmt.Errorf("bench-gate: write summary: %w", err)
+	}
+	if res.Regressed() && enforce {
+		return fmt.Errorf("bench-gate: %d benchmark(s) regressed beyond %g%%", len(res.Regressions), res.Threshold)
+	}
+	return nil
+}
+
+// benchReport opens the report file, or returns stdin when none is given.
+func benchReport(p string, cmd *cobra.Command) (io.Reader, func(), error) {
+	path := pick(p, os.Getenv("BENCH_REPORT"))
+	if path == "" {
+		return cmd.InOrStdin(), func() {}, nil
+	}
+	f, err := os.Open(path) //nolint:gosec // report path is CI-controlled (BENCH_REPORT env / flag)
+	if err != nil {
+		return nil, nil, fmt.Errorf("bench-gate: open report: %w", err)
+	}
+	return f, func() { _ = f.Close() }, nil
+}
+
+// benchThresholdPct resolves the threshold from flag, env, then default.
+func benchThresholdPct() float64 {
+	if benchThreshold > 0 {
+		return benchThreshold
+	}
+	if v := os.Getenv("THRESHOLD_PCT"); v != "" {
+		if f, err := strconv.ParseFloat(v, 64); err == nil {
+			return f
+		}
+	}
+	return benchgate.DefaultThresholdPct
+}


### PR DESCRIPTION
## feat(ci): zynax-ci bench-gate + bdd-select

Closes #1288
Part of #1285 (EPIC S — CI bash → zynax-ci)

### Why
Two deterministic CI decisions — the benchmark-regression gate and the godog BDD
package selection — lived in untested bash (`tools/ci/bench-regression.sh`,
`tools/ci/bdd-select-packages.sh`). ADR-036 step S.3 moves them into the `zynax-ci`
CLI so they get unit tests, type checking, and `make lint` coverage. This is the
canvas O-step S.3 (`docs/spdd/1285-ci-bash-to-go/canvas.md`, Aligned).

### What you'll get
- `zynax-ci bench-gate` — parse a `benchstat` report, apply the regression threshold, fail-open warn (or `--enforce`/`BENCH_GATE_ENFORCE=true` to block) ← `cmd/zynax-ci/benchgate/benchgate.go`, `cmd/zynax-ci/cmd/bench_gate.go`
- `zynax-ci bdd-select` — emit the BDD package matrix (`ALL` / empty / sorted-unique list) from changed proto/contract files ← `cmd/zynax-ci/bddselect/bddselect.go`, `cmd/zynax-ci/cmd/bdd_select.go`
- the `_test-go.yml` BDD step reduced to a single verb call ← `.github/workflows/_test-go.yml`

### Scope & boundaries
- **In scope:** the two new subcommands + table-driven unit tests; wire the BDD workflow step (build-from-source until the ci-runner image carries the verb). Behaviour parity only.
- **Out of scope (deferred):** changing the threshold or selection policy; deleting the `.sh` files (the S.7 cutover → #1292). `bench-gate` has no workflow consumer today (the script was never wired into a workflow); the verb is ready for S.7.

### Test plan & acceptance
| Acceptance criterion | How verified (command) | Result |
|----------------------|------------------------|--------|
| `GOWORK=off go test ./...` green; unit tests for threshold + matrix | `GOWORK=off go -C cmd/zynax-ci test ./...` | ✅ ok benchgate, bddselect, cmd |
| Identical pass/fail vs bash (regression + no-regression) | `printf '...+24.10%...' \| zynax-ci bench-gate` (warn, exit 0) and `BENCH_GATE_ENFORCE=true` (exit 1) | ✅ same wording + exit codes as `bench-regression.sh` |
| Identical BDD selection vs bash | `BASE=06e5bea~1 HEAD=06e5bea` → both bash and `zynax-ci bdd-select` print `ALL`; empty range → both empty | ✅ parity |
| Both workflow steps single `zynax-ci` calls | BDD step now `GOWORK=off go -C cmd/zynax-ci run . bdd-select` | ✅ (bench-gate has no workflow consumer yet) |

**Local gates:** `make lint` ✅ (pre-existing goconst warnings in `agents/adapters/ci`, untouched here) · `GOWORK=off go -C cmd/zynax-ci test ./...` ✅

### Evidence
- **CI:** required checks pending — see the run on this PR.
- **Local output:** `bench-gate` fail-open prints `⚠️  REGRESSION: … (>20%)` then the fail-open note (exit 0); `--enforce` prints `❌ … ENFORCED` (exit 1) — byte-parity with `bench-regression.sh`. `bdd-select` returns `ALL` on a feature-file commit, empty on a non-proto range.
- **Artifacts / images:** none — no service source changed (CLI-only).
- **Post-merge digest sync → main:** N/A — no image rebuild.

### Risk & rollback
Low — additive subcommands plus one workflow line. The BDD step swap preserves the
exact `ALL` / empty / list contract the downstream `go test` branching depends on.
Revert this PR to restore the bash call.

### Review aids
Key files: `cmd/zynax-ci/benchgate/benchgate.go` (the `positiveDelta` + threshold logic
mirrors the bash `grep -oE` + awk compare) and `cmd/zynax-ci/bddselect/bddselect.go`
(`pkgMap` and the `protos/tests/*` selection mirror the bash `case`). The `cmd/` files
are thin Cobra wrappers reading env/flags.

**SPDD:** Canvas `docs/spdd/1285-ci-bash-to-go/canvas.md` — Status: **Aligned** · `/spdd-security-review` **PASS** · ADR-036
**AI:** `Assisted-by: Claude/claude-opus-4-8`
