### PR TITLE
feat(engine-adapter): workflow data-context read/write scoping

### DIFF
--- a/services/engine-adapter/internal/domain/datacontext.go
+++ b/services/engine-adapter/internal/domain/datacontext.go
@@ -14,6 +14,49 @@ import (
 // workflow-scoped data context rather than a literal value (ADR-029 §1).
 const dataRefPrefix = "$."
 
+// DataContextScope identifies the single workflow run that owns a
+// WorkflowDataContext (canvas C.3). A data context is bound to exactly one
+// scope at construction; every read and write must present a scope that equals
+// the owning scope, so one run can never read or write another run's data even
+// if it somehow obtains a reference to the instance.
+//
+// RunID is the per-run identity (the workflow run / envelope workflow_id).
+// Namespace is the run's namespace (ADR-008 — never share state across
+// namespaces); it may be empty for single-namespace deployments.
+type DataContextScope struct {
+	RunID     string
+	Namespace string
+}
+
+// equals reports whether two scopes denote the same run in the same namespace.
+func (s DataContextScope) equals(other DataContextScope) bool {
+	return s.RunID == other.RunID && s.Namespace == other.Namespace
+}
+
+// String renders the scope for diagnostics as "<namespace>/<run-id>".
+func (s DataContextScope) String() string {
+	return s.Namespace + "/" + s.RunID
+}
+
+// ScopeError is returned when a read or write presents a scope that does not
+// match the data context's owning scope (canvas C.3 — cross-run access denied).
+// It fails the access loudly rather than silently returning or dropping data.
+type ScopeError struct {
+	// Owner is the scope the data context is bound to.
+	Owner DataContextScope
+	// Requester is the scope that attempted the access.
+	Requester DataContextScope
+	// Op is the attempted operation ("read" or "write").
+	Op string
+}
+
+func (e *ScopeError) Error() string {
+	return fmt.Sprintf(
+		"engine-adapter: cross-run data-context %s denied: context owned by %s, requested by %s",
+		e.Op, e.Owner, e.Requester,
+	)
+}
+
 // DataReferenceError is a structured error returned when an input binding
 // reference cannot be resolved against the workflow-scoped data context, or
 // when a referenced/extracted value is not a coercible scalar (a typed
@@ -45,13 +88,42 @@ func (e *DataReferenceError) Error() string {
 // Keys are canonical dotted paths of the form "states.<stateID>.output.<key>";
 // values are the scalar string form of the extracted output. The interpreter
 // owns exactly one instance per Run (behind the WorkflowEngine interface).
+//
+// The context is bound to a single DataContextScope at construction. Every read
+// (ResolveInputs) and write (WriteOutputs) must present a matching scope, so a
+// run can never leak data into or out of another run (canvas C.3).
 type WorkflowDataContext struct {
+	scope DataContextScope
 	store map[string]string
 }
 
-// NewWorkflowDataContext returns an empty run-scoped data context.
+// NewWorkflowDataContext returns an empty data context bound to the zero scope.
+// It is retained for back-compat with callers that do not yet thread a run
+// scope; reads and writes must present the same (zero) scope. Prefer
+// NewScopedWorkflowDataContext so cross-run access is denied (canvas C.3).
 func NewWorkflowDataContext() *WorkflowDataContext {
-	return &WorkflowDataContext{store: make(map[string]string)}
+	return NewScopedWorkflowDataContext(DataContextScope{})
+}
+
+// NewScopedWorkflowDataContext returns an empty data context owned by scope.
+// Every subsequent read/write must present a scope equal to this one, so the
+// context cannot serve another run's data (canvas C.3 — cross-run denied).
+func NewScopedWorkflowDataContext(scope DataContextScope) *WorkflowDataContext {
+	return &WorkflowDataContext{scope: scope, store: make(map[string]string)}
+}
+
+// Scope returns the run scope that owns this data context.
+func (c *WorkflowDataContext) Scope() DataContextScope {
+	return c.scope
+}
+
+// assertScope returns a ScopeError when requester does not match the owning
+// scope, enforcing strict run+namespace isolation on every read and write.
+func (c *WorkflowDataContext) assertScope(requester DataContextScope, op string) error {
+	if !c.scope.equals(requester) {
+		return &ScopeError{Owner: c.scope, Requester: requester, Op: op}
+	}
+	return nil
 }
 
 // WriteOutputs extracts each declared output from the action's result payload
@@ -62,7 +134,13 @@ func NewWorkflowDataContext() *WorkflowDataContext {
 // does not resolve to a scalar value is reported as a typed mismatch so the
 // run fails loudly rather than storing an unusable value. A nil/empty bindings
 // map is a no-op (actions that publish nothing).
-func (c *WorkflowDataContext) WriteOutputs(stateID string, bindings map[string]string, payload []byte) error {
+//
+// requester is the scope of the run performing the write; it must equal the
+// context's owning scope or the write is denied with a ScopeError (canvas C.3).
+func (c *WorkflowDataContext) WriteOutputs(requester DataContextScope, stateID string, bindings map[string]string, payload []byte) error {
+	if err := c.assertScope(requester, "write"); err != nil {
+		return err
+	}
 	if len(bindings) == 0 {
 		return nil
 	}
@@ -96,7 +174,13 @@ func (c *WorkflowDataContext) WriteOutputs(stateID string, bindings map[string]s
 // reference resolved against the store. A reference that does not resolve is a
 // DataReferenceError — the run fails rather than substituting an empty value.
 // A nil/empty bindings map yields a nil result (actions that consume nothing).
-func (c *WorkflowDataContext) ResolveInputs(bindings map[string]string) (map[string]string, error) {
+//
+// requester is the scope of the run performing the read; it must equal the
+// context's owning scope or the read is denied with a ScopeError (canvas C.3).
+func (c *WorkflowDataContext) ResolveInputs(requester DataContextScope, bindings map[string]string) (map[string]string, error) {
+	if err := c.assertScope(requester, "read"); err != nil {
+		return nil, err
+	}
 	if len(bindings) == 0 {
 		return nil, nil
 	}

--- a/services/engine-adapter/internal/domain/datacontext_test.go
+++ b/services/engine-adapter/internal/domain/datacontext_test.go
@@ -31,7 +31,7 @@ func TestWorkflowDataContext_WriteOutputs(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			dc := NewWorkflowDataContext()
-			if err := dc.WriteOutputs(tc.stateID, tc.bindings, []byte(tc.payload)); err != nil {
+			if err := dc.WriteOutputs(DataContextScope{}, tc.stateID, tc.bindings, []byte(tc.payload)); err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
 			if got := dc.store[tc.wantKey]; got != tc.wantVal {
@@ -58,7 +58,7 @@ func TestWorkflowDataContext_WriteOutputs_Errors(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			dc := NewWorkflowDataContext()
-			err := dc.WriteOutputs("search", tc.bindings, []byte(tc.payload))
+			err := dc.WriteOutputs(DataContextScope{}, "search", tc.bindings, []byte(tc.payload))
 			if err == nil {
 				t.Fatal("expected error, got nil")
 			}
@@ -72,7 +72,7 @@ func TestWorkflowDataContext_WriteOutputs_Errors(t *testing.T) {
 
 func TestWorkflowDataContext_WriteOutputs_NoBindings(t *testing.T) {
 	dc := NewWorkflowDataContext()
-	if err := dc.WriteOutputs("s", nil, []byte(`{"x":"y"}`)); err != nil {
+	if err := dc.WriteOutputs(DataContextScope{}, "s", nil, []byte(`{"x":"y"}`)); err != nil {
 		t.Fatalf("nil bindings should be a no-op, got: %v", err)
 	}
 	if len(dc.store) != 0 {
@@ -82,7 +82,7 @@ func TestWorkflowDataContext_WriteOutputs_NoBindings(t *testing.T) {
 
 func TestWorkflowDataContext_WriteOutputs_EmptyPayload(t *testing.T) {
 	dc := NewWorkflowDataContext()
-	err := dc.WriteOutputs("s", map[string]string{"k": "v"}, nil)
+	err := dc.WriteOutputs(DataContextScope{}, "s", map[string]string{"k": "v"}, nil)
 	if err == nil {
 		t.Fatal("expected error extracting from empty payload")
 	}
@@ -90,7 +90,7 @@ func TestWorkflowDataContext_WriteOutputs_EmptyPayload(t *testing.T) {
 
 func TestWorkflowDataContext_ResolveInputs(t *testing.T) {
 	dc := NewWorkflowDataContext()
-	if err := dc.WriteOutputs("search", map[string]string{"results": "results"}, []byte(`{"results":"data"}`)); err != nil {
+	if err := dc.WriteOutputs(DataContextScope{}, "search", map[string]string{"results": "results"}, []byte(`{"results":"data"}`)); err != nil {
 		t.Fatalf("seed write failed: %v", err)
 	}
 
@@ -136,7 +136,7 @@ func TestWorkflowDataContext_ResolveInputs(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := dc.ResolveInputs(tc.bindings)
+			got, err := dc.ResolveInputs(DataContextScope{}, tc.bindings)
 			if tc.wantErr {
 				if err == nil {
 					t.Fatalf("expected error, got nil (resolved=%v)", got)
@@ -159,7 +159,7 @@ func TestWorkflowDataContext_ResolveInputs(t *testing.T) {
 
 func TestWorkflowDataContext_ResolveInputs_NoBindings(t *testing.T) {
 	dc := NewWorkflowDataContext()
-	got, err := dc.ResolveInputs(nil)
+	got, err := dc.ResolveInputs(DataContextScope{}, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -293,6 +293,112 @@ func TestIRInterpreter_DataFlowTypeMismatchFailsRun(t *testing.T) {
 	var dre *DataReferenceError
 	if !errors.As(err, &dre) {
 		t.Fatalf("expected *DataReferenceError, got %T: %v", err, err)
+	}
+}
+
+// TestDataContextScope_Accessors proves equals/String behave on the value type.
+func TestDataContextScope_Accessors(t *testing.T) {
+	a := DataContextScope{RunID: "run-1", Namespace: "ns"}
+	if !a.equals(DataContextScope{RunID: "run-1", Namespace: "ns"}) {
+		t.Error("identical scopes should be equal")
+	}
+	if a.equals(DataContextScope{RunID: "run-2", Namespace: "ns"}) {
+		t.Error("different run ids must not be equal")
+	}
+	if a.equals(DataContextScope{RunID: "run-1", Namespace: "other"}) {
+		t.Error("different namespaces must not be equal")
+	}
+	if got := a.String(); got != "ns/run-1" {
+		t.Errorf("String() = %q; want ns/run-1", got)
+	}
+}
+
+// TestWorkflowDataContext_Scope proves the constructor binds the owning scope.
+func TestWorkflowDataContext_Scope(t *testing.T) {
+	owner := DataContextScope{RunID: "run-A", Namespace: "team"}
+	dc := NewScopedWorkflowDataContext(owner)
+	if got := dc.Scope(); !got.equals(owner) {
+		t.Errorf("Scope() = %v; want %v", got, owner)
+	}
+}
+
+// TestWorkflowDataContext_CrossRunWriteDenied proves a write presenting another
+// run's scope is denied with a ScopeError (canvas C.3 acceptance criterion 2).
+func TestWorkflowDataContext_CrossRunWriteDenied(t *testing.T) {
+	dc := NewScopedWorkflowDataContext(DataContextScope{RunID: "run-A", Namespace: "ns"})
+	other := DataContextScope{RunID: "run-B", Namespace: "ns"}
+	err := dc.WriteOutputs(other, "search", map[string]string{"results": "results"}, []byte(`{"results":"x"}`))
+	var se *ScopeError
+	if !errors.As(err, &se) {
+		t.Fatalf("expected *ScopeError, got %T: %v", err, err)
+	}
+	if se.Op != "write" {
+		t.Errorf("ScopeError.Op = %q; want write", se.Op)
+	}
+	if len(dc.store) != 0 {
+		t.Errorf("denied write must not mutate store, got %d entries", len(dc.store))
+	}
+}
+
+// TestWorkflowDataContext_CrossRunReadDenied proves a read presenting another
+// run's scope is denied even when the key exists (canvas C.3, criterion 2).
+func TestWorkflowDataContext_CrossRunReadDenied(t *testing.T) {
+	owner := DataContextScope{RunID: "run-A", Namespace: "ns"}
+	dc := NewScopedWorkflowDataContext(owner)
+	if err := dc.WriteOutputs(owner, "search", map[string]string{"results": "results"}, []byte(`{"results":"secret"}`)); err != nil {
+		t.Fatalf("seed write failed: %v", err)
+	}
+	// A different run that knows the exact key still cannot read it.
+	other := DataContextScope{RunID: "run-B", Namespace: "ns"}
+	got, err := dc.ResolveInputs(other, map[string]string{"q": "$.states.search.output.results"})
+	var se *ScopeError
+	if !errors.As(err, &se) {
+		t.Fatalf("expected *ScopeError, got %T: %v (resolved=%v)", err, err, got)
+	}
+	if se.Op != "read" {
+		t.Errorf("ScopeError.Op = %q; want read", se.Op)
+	}
+}
+
+// TestWorkflowDataContext_CrossNamespaceDenied proves the same run id in a
+// different namespace is a distinct scope and is denied (ADR-008).
+func TestWorkflowDataContext_CrossNamespaceDenied(t *testing.T) {
+	dc := NewScopedWorkflowDataContext(DataContextScope{RunID: "run-A", Namespace: "ns-1"})
+	other := DataContextScope{RunID: "run-A", Namespace: "ns-2"}
+	err := dc.WriteOutputs(other, "search", map[string]string{"results": "results"}, []byte(`{"results":"x"}`))
+	var se *ScopeError
+	if !errors.As(err, &se) {
+		t.Fatalf("expected *ScopeError across namespaces, got %T: %v", err, err)
+	}
+}
+
+// TestWorkflowDataContext_SameScopeAllowed proves the owning run reads/writes
+// its own data context normally (canvas C.3 acceptance criterion 1).
+func TestWorkflowDataContext_SameScopeAllowed(t *testing.T) {
+	owner := DataContextScope{RunID: "run-A", Namespace: "ns"}
+	dc := NewScopedWorkflowDataContext(owner)
+	if err := dc.WriteOutputs(owner, "search", map[string]string{"results": "results"}, []byte(`{"results":"data"}`)); err != nil {
+		t.Fatalf("same-scope write failed: %v", err)
+	}
+	got, err := dc.ResolveInputs(owner, map[string]string{"q": "$.states.search.output.results"})
+	if err != nil {
+		t.Fatalf("same-scope read failed: %v", err)
+	}
+	if got["q"] != "data" {
+		t.Errorf("resolved[q] = %q; want data", got["q"])
+	}
+}
+
+// TestScopeError_Error proves the diagnostic message names both scopes and op.
+func TestScopeError_Error(t *testing.T) {
+	e := &ScopeError{
+		Owner:     DataContextScope{RunID: "run-A", Namespace: "ns"},
+		Requester: DataContextScope{RunID: "run-B", Namespace: "ns"},
+		Op:        "read",
+	}
+	want := "engine-adapter: cross-run data-context read denied: context owned by ns/run-A, requested by ns/run-B"
+	if got := e.Error(); got != want {
+		t.Errorf("Error() = %q; want %q", got, want)
 	}
 }
 

--- a/services/engine-adapter/internal/domain/interpreter.go
+++ b/services/engine-adapter/internal/domain/interpreter.go
@@ -59,7 +59,11 @@ func (i *IRInterpreter) Run(
 	}
 	// data is the run-scoped data context (ADR-029): written by output_bindings,
 	// read by input_bindings. It lives for this Run only and is never persisted.
-	data := NewWorkflowDataContext()
+	// It is bound to this run's scope (run id + namespace); reads/writes that
+	// present any other scope are denied so data never leaks across runs
+	// (canvas C.3).
+	scope := DataContextScope{RunID: ir.GetWorkflowId(), Namespace: ir.GetNamespace()}
+	data := NewScopedWorkflowDataContext(scope)
 	for {
 		state := findState(ir, ec.CurrentState)
 		if state == nil {
@@ -74,7 +78,7 @@ func (i *IRInterpreter) Run(
 		if err := pub.Publish(ctx, "zynax.workflow.state.entered", ec.WorkflowID, ec.CurrentState); err != nil {
 			return fmt.Errorf("engine-adapter: publish state.entered: %w", err)
 		}
-		result, err := executeActions(ctx, state, ec, exec, data)
+		result, err := executeActions(ctx, state, ec, exec, data, scope)
 		if err != nil {
 			if perr := pub.Publish(ctx, "zynax.workflow.failed", ec.WorkflowID, ec.CurrentState); perr != nil {
 				slog.Warn("lifecycle event publish failed", "event", "zynax.workflow.failed", "workflow_id", ec.WorkflowID, "err", perr)
@@ -106,6 +110,7 @@ func executeActions(
 	ec *ExecutionContext,
 	exec ActivityExecutor,
 	data *WorkflowDataContext,
+	scope DataContextScope,
 ) (*ActivityResult, error) {
 	var last *ActivityResult
 	for _, action := range state.GetActions() {
@@ -123,7 +128,7 @@ func executeActions(
 		// Resolve input_bindings from the run-scoped data context (ADR-029) and
 		// merge them into the template context. A missing or typed-mismatch
 		// reference fails the run with a structured DataReferenceError.
-		inputs, err := data.ResolveInputs(action.GetInputBindings())
+		inputs, err := data.ResolveInputs(scope, action.GetInputBindings())
 		if err != nil {
 			return nil, err
 		}
@@ -144,7 +149,7 @@ func executeActions(
 		}
 		// Publish this action's declared output_bindings into the data context
 		// so downstream states can consume them (ADR-029).
-		if err := data.WriteOutputs(state.GetId(), action.GetOutputBindings(), result.Payload); err != nil {
+		if err := data.WriteOutputs(scope, state.GetId(), action.GetOutputBindings(), result.Payload); err != nil {
 			return nil, err
 		}
 		last = result


### PR DESCRIPTION
## feat(engine-adapter): workflow data-context read/write scoping

Closes #1195
Part of #1168 (EPIC C — Context Propagation)

### Why
The run-scoped data context (W.4 #1178) was isolated only by being a fresh
instance per `Run` — nothing bound it to its owning run, so any holder of the
instance could read or write it regardless of which run/namespace it belonged
to. Canvas C.3 step 3 requires explicit read/write scoping so states can't leak
data across runs.

### What you'll get
- a `DataContextScope{RunID, Namespace}` bound to each context at construction ← `services/engine-adapter/internal/domain/datacontext.go`
- every read (`ResolveInputs`) and write (`WriteOutputs`) now requires a matching scope, else a `ScopeError` ← `services/engine-adapter/internal/domain/datacontext.go`
- the interpreter builds the context's scope from the run's `workflow_id` + `namespace` and presents it on every access ← `services/engine-adapter/internal/domain/interpreter.go`

### Scope & boundaries
- **In scope:** scope binding + enforcement on the EPIC-W data context; cross-run and cross-namespace access denied; tests.
- **Out of scope (deferred):** agent handoff contract → C.4 #1196.

### Test plan & acceptance
| Acceptance criterion | How verified (command) | Result |
|----------------------|------------------------|--------|
| read/write scoping enforced on the EPIC-W data context | `GOWORK=off go test ./internal/domain/...` (SameScopeAllowed, Scope, assertScope) | ✅ ok |
| cross-run access denied | `GOWORK=off go test ./internal/domain/...` (CrossRunWriteDenied, CrossRunReadDenied, CrossNamespaceDenied) | ✅ ok — `*ScopeError`, store unmutated |
| tested | `GOWORK=off go test ./... -race` | ✅ all packages ok |

**Local gates:** `make lint` ✅ · `GOWORK=off go test ./... -race` ✅ · domain coverage 93.4% (gate ≥90%) ✅

### Evidence
- **CI:** required checks pending → green.
- **Local output:** domain `coverage: 93.4% of statements`; all new scope funcs at 100% (`equals`, `String`, `assertScope`, `NewScopedWorkflowDataContext`, `Scope`, `WriteOutputs`, `ResolveInputs`).
- **Artifacts / images:** engine-adapter image rebuilt on merge (domain source changed).
- **Post-merge digest sync → main:** _placeholder — filled by post-merge verifier._

### Risk & rollback
Low — additive value type + a required scope parameter on two domain methods,
all callers updated in the same PR; no behaviour change for a run accessing its
own context. Revert this PR to remove.

### Review aids
Start at `services/engine-adapter/internal/domain/datacontext.go` (the
`DataContextScope`/`ScopeError`/`assertScope` block); `interpreter.go` is just
the wiring that constructs the scope from the IR and threads it through.

**SPDD:** Canvas `docs/spdd/1168-context-propagation/canvas.md` — Status: **Aligned** · `/spdd-security-review` **PASS**
**AI:** `Assisted-by: Claude/claude-opus-4-8`  (label: ai-assisted)
