### PR TITLE
feat(ci): zynax-ci bump-runner over images.yaml SoT

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,14 +52,9 @@ build-tools: check-docker ## Build zynax/tools:local from source — use when ed
 	docker build -f infra/docker/Dockerfile.tools -t $(TOOLS_IMAGE) .
 	@echo "✅ Tools image: $(TOOLS_IMAGE)"
 
-bump-ci-runner: ## [DEPRECATED] Use: edit images/images.yaml then make sync-images
-	@echo "⚠️  bump-ci-runner is deprecated. Use the new flow instead:"
-	@echo "    1. Edit images/images.yaml — update ci-runner digest"
-	@echo "    2. make sync-images"
-	@echo "    3. Verify: make check-images"
-	@echo "    Proceeding with legacy script for backward compatibility..."
+bump-ci-runner: ## Pin a new ci-runner digest in images.yaml and re-stamp consumers
 	@[ -n "$(NEW_DIGEST)" ] || (echo "❌ Usage: make bump-ci-runner NEW_DIGEST=sha256:<64-hex>"; exit 1)
-	scripts/bump-ci-runner.sh $(NEW_DIGEST)
+	cd cmd/zynax-ci && GOWORK=off go run . bump-runner "$(NEW_DIGEST)" --root "$(CURDIR)"
 
 pull-tools: check-docker ## Pull tools image from GHCR (authenticates via `gh auth token`)
 	@echo "🔐 Authenticating to GHCR via gh..."

--- a/cmd/zynax-ci/bumprunner/bumprunner.go
+++ b/cmd/zynax-ci/bumprunner/bumprunner.go
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package bumprunner computes the next ci-runner digest pin and drives the
+// images/images.yaml source of truth so all consumer files re-stamp. It is the
+// tested Go replacement for scripts/bump-ci-runner.sh (ADR-036, M7 EPIC S step
+// S.4).
+//
+// The legacy script sed-replaced the ci-runner digest in each workflow file
+// directly. The images.yaml flow inverts that: the digest is updated once in the
+// SoT (ADR-024) and images.Sync re-stamps every consumer, so a single tested
+// path keeps every reference aligned. This package reuses the images internals
+// rather than re-parsing YAML by hand (issue #1289 scope).
+package bumprunner
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+
+	"github.com/zynax-io/zynax/cmd/zynax-ci/internal/images"
+)
+
+// RunnerImageName is the images.yaml entry whose digest this verb bumps.
+const RunnerImageName = "ci-runner"
+
+// digestRe matches a well-formed digest pin: sha256:<64 lowercase hex>.
+// Parity with the bash regex `^sha256:[0-9a-f]{64}$`.
+var digestRe = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
+
+// ValidateDigest reports an error when digest is not sha256:<64 lowercase hex>.
+func ValidateDigest(digest string) error {
+	if !digestRe.MatchString(digest) {
+		return fmt.Errorf("digest must match sha256:<64 lowercase hex chars>, got: %q", digest)
+	}
+	return nil
+}
+
+// Result reports the outcome of a bump: the digest before/after on the SoT entry
+// and the consumer files that were (or would be) re-stamped.
+type Result struct {
+	Image        string
+	Before       string
+	After        string
+	YAMLChanged  bool
+	ChangedFiles []string
+}
+
+// Bump validates digest, writes it onto the ci-runner entry in
+// images/images.yaml, and re-stamps every consumer via images.Sync. When dryRun
+// is true nothing is written; the Result still reflects what would change.
+func Bump(repoRoot, digest string, dryRun bool) (Result, error) {
+	if err := ValidateDigest(digest); err != nil {
+		return Result{}, err
+	}
+	before, err := currentDigest(repoRoot)
+	if err != nil {
+		return Result{}, err
+	}
+	res := Result{Image: RunnerImageName, Before: before, After: digest, YAMLChanged: before != digest}
+	if res.YAMLChanged && !dryRun {
+		if err := setDigest(repoRoot, digest); err != nil {
+			return res, err
+		}
+	}
+	if err := syncConsumers(&res, repoRoot, digest, dryRun); err != nil {
+		return res, err
+	}
+	return res, nil
+}
+
+// syncConsumers loads images.yaml (with digest applied in-memory so dry-run is
+// accurate) and records which consumer files change.
+func syncConsumers(res *Result, repoRoot, digest string, dryRun bool) error {
+	f, err := images.Load(repoRoot)
+	if err != nil {
+		return err
+	}
+	applyDigest(&f, digest)
+	results, err := images.Sync(f, repoRoot, dryRun)
+	if err != nil {
+		return err
+	}
+	for _, r := range results {
+		if r.Changed {
+			res.ChangedFiles = append(res.ChangedFiles, r.File)
+		}
+	}
+	return nil
+}
+
+// applyDigest overwrites the in-memory ci-runner digest so a dry-run Sync diffs
+// against the target value even before images.yaml is written.
+func applyDigest(f *images.File, digest string) {
+	for i := range f.Images {
+		if f.Images[i].Name == RunnerImageName {
+			f.Images[i].Digest = digest
+		}
+	}
+}
+
+// currentDigest returns the ci-runner digest recorded in images/images.yaml.
+func currentDigest(repoRoot string) (string, error) {
+	f, err := images.Load(repoRoot)
+	if err != nil {
+		return "", err
+	}
+	for _, e := range f.Images {
+		if e.Name == RunnerImageName {
+			return e.Digest, nil
+		}
+	}
+	return "", fmt.Errorf("bump-runner: %q not found in images/images.yaml", RunnerImageName)
+}
+
+// entryDigestRe matches the digest line of the ci-runner entry only: the entry
+// header followed by its ref and digest lines. The replacement preserves all
+// surrounding comments and formatting (a YAML re-marshal would strip them).
+var entryDigestRe = regexp.MustCompile(
+	`(?m)(^  - name: ` + RunnerImageName + `\n(?:    [^\n]*\n)*?    digest: )sha256:[0-9a-f]{64}`,
+)
+
+// setDigest rewrites only the ci-runner digest line in images/images.yaml,
+// leaving every other entry, comment, and consumer list untouched.
+func setDigest(repoRoot, digest string) error {
+	path := filepath.Join(repoRoot, "images", "images.yaml")
+	data, err := os.ReadFile(path) //nolint:gosec // path is the repo SoT
+	if err != nil {
+		return fmt.Errorf("bump-runner: read %s: %w", path, err)
+	}
+	if !entryDigestRe.Match(data) {
+		return fmt.Errorf("bump-runner: ci-runner digest line not found in %s", path)
+	}
+	out := entryDigestRe.ReplaceAll(data, []byte("${1}"+digest))
+	if err := os.WriteFile(path, out, 0o600); err != nil { //nolint:gosec // path is the repo SoT (images/images.yaml under repoRoot)
+		return fmt.Errorf("bump-runner: write %s: %w", path, err)
+	}
+	return nil
+}

--- a/cmd/zynax-ci/bumprunner/bumprunner_test.go
+++ b/cmd/zynax-ci/bumprunner/bumprunner_test.go
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package bumprunner_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/zynax-io/zynax/cmd/zynax-ci/bumprunner"
+)
+
+const (
+	oldDigest = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	newDigest = "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+)
+
+// imagesYAML mirrors the real file's comment-preceded, multi-entry shape so the
+// scoped digest replacement is exercised against realistic content.
+const imagesYAML = `# SPDX-License-Identifier: Apache-2.0
+# Single source of truth.
+
+images:
+
+  - name: ci-runner
+    ref: ghcr.io/zynax-io/zynax/ci-runner
+    digest: ` + oldDigest + `
+    consumers:
+      - ci.yml
+      - digest.txt
+
+  - name: golang-alpine
+    ref: golang
+    tag: "1.26.4-alpine"
+    digest: ` + golangDigest + `
+    consumers:
+      - other.yml
+`
+
+const golangDigest = "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+const ciWorkflow = "container:\n  image: ghcr.io/zynax-io/zynax/ci-runner@" + oldDigest + "\n"
+const digestTxt = oldDigest + "\n"
+const otherWorkflow = "FROM golang:1.26.4-alpine@" + golangDigest + "\n"
+
+func writeFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func setupRepo(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	writeFile(t, root, "images/images.yaml", imagesYAML)
+	writeFile(t, root, "ci.yml", ciWorkflow)
+	writeFile(t, root, "digest.txt", digestTxt)
+	writeFile(t, root, "other.yml", otherWorkflow)
+	return root
+}
+
+func read(t *testing.T, root, name string) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(root, name)) //nolint:gosec
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}
+
+func TestValidateDigest(t *testing.T) {
+	cases := []struct {
+		name   string
+		digest string
+		ok     bool
+	}{
+		{"valid", newDigest, true},
+		{"missing prefix", strings.TrimPrefix(newDigest, "sha256:"), false},
+		{"too short", "sha256:abc", false},
+		{"uppercase hex", "sha256:" + strings.Repeat("A", 64), false},
+		{"empty", "", false},
+		{"trailing space", newDigest + " ", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := bumprunner.ValidateDigest(tc.digest)
+			if tc.ok && err != nil {
+				t.Fatalf("want valid, got error: %v", err)
+			}
+			if !tc.ok && err == nil {
+				t.Fatalf("want error for %q", tc.digest)
+			}
+		})
+	}
+}
+
+func TestBump_UpdatesYAMLAndConsumers(t *testing.T) {
+	root := setupRepo(t)
+	res, err := bumprunner.Bump(root, newDigest, false)
+	if err != nil {
+		t.Fatalf("Bump: %v", err)
+	}
+	if !res.YAMLChanged {
+		t.Error("expected YAMLChanged=true")
+	}
+	if res.Before != oldDigest || res.After != newDigest {
+		t.Errorf("before/after mismatch: %s -> %s", res.Before, res.After)
+	}
+	if len(res.ChangedFiles) != 2 {
+		t.Fatalf("expected 2 changed consumers, got %d: %v", len(res.ChangedFiles), res.ChangedFiles)
+	}
+	// SoT updated, scoped to ci-runner only.
+	yaml := read(t, root, "images/images.yaml")
+	if !strings.Contains(yaml, "digest: "+newDigest) {
+		t.Errorf("images.yaml ci-runner digest not bumped:\n%s", yaml)
+	}
+	// golang-alpine digest must be untouched by the scoped replacement.
+	if !strings.Contains(yaml, golangDigest) {
+		t.Errorf("golang-alpine digest was corrupted:\n%s", yaml)
+	}
+	if !strings.Contains(read(t, root, "ci.yml"), newDigest) {
+		t.Error("ci.yml not re-stamped")
+	}
+	if !strings.Contains(read(t, root, "digest.txt"), newDigest) {
+		t.Error("digest.txt not re-stamped")
+	}
+	// Unrelated image's consumer must stay put.
+	if strings.Contains(read(t, root, "other.yml"), newDigest) {
+		t.Error("other.yml (golang-alpine consumer) was wrongly re-stamped")
+	}
+}
+
+func TestBump_Idempotent(t *testing.T) {
+	root := setupRepo(t)
+	res, err := bumprunner.Bump(root, oldDigest, false)
+	if err != nil {
+		t.Fatalf("Bump: %v", err)
+	}
+	if res.YAMLChanged {
+		t.Error("expected YAMLChanged=false for a no-op bump")
+	}
+	if len(res.ChangedFiles) != 0 {
+		t.Errorf("expected 0 changed files, got %v", res.ChangedFiles)
+	}
+}
+
+func TestBump_DryRun_NoWrites(t *testing.T) {
+	root := setupRepo(t)
+	res, err := bumprunner.Bump(root, newDigest, true)
+	if err != nil {
+		t.Fatalf("Bump: %v", err)
+	}
+	if !res.YAMLChanged || len(res.ChangedFiles) != 2 {
+		t.Fatalf("dry-run should report the would-be changes, got changed=%v files=%v", res.YAMLChanged, res.ChangedFiles)
+	}
+	// Nothing on disk may change in dry-run.
+	if strings.Contains(read(t, root, "images/images.yaml"), newDigest) {
+		t.Error("dry-run modified images.yaml")
+	}
+	if strings.Contains(read(t, root, "ci.yml"), newDigest) {
+		t.Error("dry-run modified ci.yml")
+	}
+}
+
+func TestBump_InvalidDigest(t *testing.T) {
+	root := setupRepo(t)
+	if _, err := bumprunner.Bump(root, "sha256:nothex", false); err == nil {
+		t.Fatal("want error for invalid digest")
+	}
+}
+
+func TestBump_MissingImagesYAML(t *testing.T) {
+	root := t.TempDir()
+	if _, err := bumprunner.Bump(root, newDigest, false); err == nil {
+		t.Fatal("want error when images.yaml is absent")
+	}
+}
+
+func TestBump_RunnerEntryAbsent(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "images/images.yaml", "images:\n  - name: other\n    ref: r\n    digest: "+oldDigest+"\n")
+	if _, err := bumprunner.Bump(root, newDigest, false); err == nil {
+		t.Fatal("want error when ci-runner entry is missing")
+	}
+}

--- a/cmd/zynax-ci/cmd/bump_runner.go
+++ b/cmd/zynax-ci/cmd/bump_runner.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/zynax-io/zynax/cmd/zynax-ci/bumprunner"
+)
+
+var (
+	bumpRunnerRoot   string
+	bumpRunnerDryRun bool
+)
+
+var bumpRunnerCmd = &cobra.Command{
+	Use:   "bump-runner <sha256:digest>",
+	Short: "Pin a new ci-runner digest in images.yaml and re-stamp consumers",
+	Long: `Update the ci-runner digest in images/images.yaml (the image-reference
+source of truth, ADR-024) and re-stamp every consumer file via the images sync
+internals so all references stay aligned.
+
+Replaces scripts/bump-ci-runner.sh (ADR-036). The legacy script sed-replaced the
+digest in each workflow file directly; this verb updates the SoT once and lets
+images sync drive the consumers, keeping a single tested path. It is idempotent:
+re-running with the current digest is a no-op.
+
+Pass --dry-run to preview the digest change and the consumer files that would be
+re-stamped without writing anything (parity with the script's --check mode).`,
+	Args: cobra.ExactArgs(1),
+	RunE: runBumpRunner,
+}
+
+func init() {
+	bumpRunnerCmd.Flags().StringVar(&bumpRunnerRoot, "root", ".", "repository root directory")
+	bumpRunnerCmd.Flags().BoolVar(&bumpRunnerDryRun, "dry-run", false, "preview changes; do not write files")
+	rootCmd.AddCommand(bumpRunnerCmd)
+}
+
+func runBumpRunner(cmd *cobra.Command, args []string) error {
+	root, err := resolveRoot(bumpRunnerRoot)
+	if err != nil {
+		return fmt.Errorf("bump-runner: %w", err)
+	}
+	res, err := bumprunner.Bump(root, args[0], bumpRunnerDryRun)
+	if err != nil {
+		return err
+	}
+	return printBumpResult(cmd, res)
+}
+
+// printBumpResult renders the human-readable summary of a bump.
+func printBumpResult(cmd *cobra.Command, res bumprunner.Result) error {
+	out := cmd.OutOrStdout()
+	if !res.YAMLChanged && len(res.ChangedFiles) == 0 {
+		_, err := fmt.Fprintf(out, "✅  ci-runner already pinned to %s — nothing to do.\n", res.After)
+		return wrapWrite(err)
+	}
+	verb := "Updated"
+	if bumpRunnerDryRun {
+		verb = "Would update"
+	}
+	if _, err := fmt.Fprintf(out, "🔄 %s ci-runner digest %s → %s\n", verb, res.Before, res.After); err != nil {
+		return wrapWrite(err)
+	}
+	for _, f := range res.ChangedFiles {
+		if _, err := fmt.Fprintf(out, "   ✓ %s\n", f); err != nil {
+			return wrapWrite(err)
+		}
+	}
+	_, err := fmt.Fprintf(out, "✅  %s images.yaml + %d consumer file(s).\n", verb, len(res.ChangedFiles))
+	return wrapWrite(err)
+}
+
+// wrapWrite annotates a stdout write error for the wrapcheck linter.
+func wrapWrite(err error) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("bump-runner: write summary: %w", err)
+}

--- a/cmd/zynax-ci/cmd/bump_runner_cmd_test.go
+++ b/cmd/zynax-ci/cmd/bump_runner_cmd_test.go
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const bumpOldDigest = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+const bumpNewDigest = "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+const bumpImagesYAML = `# SPDX-License-Identifier: Apache-2.0
+
+images:
+
+  - name: ci-runner
+    ref: ghcr.io/zynax-io/zynax/ci-runner
+    digest: ` + bumpOldDigest + `
+    consumers:
+      - ci.yml
+`
+
+func bumpRepo(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "images", "images.yaml"), bumpImagesYAML)
+	mustWrite(t, filepath.Join(root, "ci.yml"),
+		"image: ghcr.io/zynax-io/zynax/ci-runner@"+bumpOldDigest+"\n")
+	return root
+}
+
+func mustWrite(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRunBumpRunner_Updates(t *testing.T) {
+	root := bumpRepo(t)
+	bumpRunnerRoot, bumpRunnerDryRun = root, false
+	defer func() { bumpRunnerRoot, bumpRunnerDryRun = ".", false }()
+	c, out := cmdWithIO(t, "")
+	if err := runBumpRunner(c, []string{bumpNewDigest}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out.String(), "Updated ci-runner digest") {
+		t.Fatalf("want update summary, got:\n%s", out.String())
+	}
+	data, _ := os.ReadFile(filepath.Join(root, "ci.yml")) //nolint:gosec
+	if !strings.Contains(string(data), bumpNewDigest) {
+		t.Errorf("ci.yml not re-stamped:\n%s", data)
+	}
+}
+
+func TestRunBumpRunner_DryRun(t *testing.T) {
+	root := bumpRepo(t)
+	bumpRunnerRoot, bumpRunnerDryRun = root, true
+	defer func() { bumpRunnerRoot, bumpRunnerDryRun = ".", false }()
+	c, out := cmdWithIO(t, "")
+	if err := runBumpRunner(c, []string{bumpNewDigest}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out.String(), "Would update") {
+		t.Fatalf("want dry-run wording, got:\n%s", out.String())
+	}
+	data, _ := os.ReadFile(filepath.Join(root, "ci.yml")) //nolint:gosec
+	if strings.Contains(string(data), bumpNewDigest) {
+		t.Error("dry-run must not write ci.yml")
+	}
+}
+
+func TestRunBumpRunner_NoOp(t *testing.T) {
+	root := bumpRepo(t)
+	bumpRunnerRoot, bumpRunnerDryRun = root, false
+	defer func() { bumpRunnerRoot, bumpRunnerDryRun = ".", false }()
+	c, out := cmdWithIO(t, "")
+	if err := runBumpRunner(c, []string{bumpOldDigest}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out.String(), "nothing to do") {
+		t.Fatalf("want no-op summary, got:\n%s", out.String())
+	}
+}
+
+func TestRunBumpRunner_InvalidDigest(t *testing.T) {
+	root := bumpRepo(t)
+	bumpRunnerRoot, bumpRunnerDryRun = root, false
+	defer func() { bumpRunnerRoot, bumpRunnerDryRun = ".", false }()
+	c, _ := cmdWithIO(t, "")
+	if err := runBumpRunner(c, []string{"sha256:nothex"}); err == nil {
+		t.Fatal("want error for invalid digest")
+	}
+}


### PR DESCRIPTION
Closes #1289

EPIC S (#1285) step 4. `zynax-ci bump-runner` Go subcommand (over images.yaml SoT) replacing the ci-runner-bump bash. Recovered by the orchestrator from a subagent that committed+pushed but hit an API-529 before opening the PR. SPDD: canvas S Aligned, ADR-036.

Assisted-by: Claude/claude-opus-4-8

🤖 Generated with [Claude Code](https://claude.com/claude-code)