### PR TITLE
docs(agents/adapters): recommend fine-grained PAT + document no token refresh

### DIFF
--- a/agents/adapters/git/AGENTS.md
+++ b/agents/adapters/git/AGENTS.md
@@ -21,7 +21,7 @@ All three capabilities require `owner` and `repo` declared in config — never d
 | Variable | Required | Description |
 |----------|----------|-------------|
 | `ADAPTER_CONFIG` | ✓ | Path to the YAML config file (see `agent-def.yaml.example`). |
-| `GITHUB_TOKEN` | ✓ | GitHub PAT or App token. The name of the env var is declared via `git.auth_env` in the config YAML; the token value is read at startup from that env var. |
+| `GITHUB_TOKEN` | ✓ | GitHub token. The name of the env var is declared via `git.auth_env` in the config YAML; the token value is read at startup from that env var. Use a least-privilege **fine-grained PAT** (see [Credential — token scope and lifecycle](#credential--token-scope-and-lifecycle)), not a classic `repo`-scoped PAT. |
 
 ## Configuration
 
@@ -36,6 +36,44 @@ YAML file at the path given by `ADAPTER_CONFIG`. Key fields:
 | `git.auth_env` | Name of the env var holding the token (e.g. `GITHUB_TOKEN`). |
 | `capabilities[].owner` | Static GitHub org or user — never from `input_payload`. |
 | `capabilities[].repo` | Static repository name — never from `input_payload`. |
+
+## Credential — token scope and lifecycle
+
+### Recommended token: fine-grained PAT (least privilege)
+
+Use a GitHub **fine-grained personal access token** scoped to **only** the
+`owner/repo` declared in config — never a classic PAT with the broad `repo`
+scope (full read/write control across every repository the token owner can
+reach). The three capabilities only ever touch pull requests, so the token needs
+just one repository permission:
+
+| Capability | Required fine-grained permission |
+|------------|----------------------------------|
+| `open_pr` | Pull requests: **Read and write** |
+| `request_review` | Pull requests: **Read and write** |
+| `get_diff` | Pull requests: **Read** (Read and write also works) |
+
+Grant **Pull requests: Read and write** on the single configured repository and
+nothing else. No `Contents`, `Administration`, or org-wide access is required.
+
+### Lifecycle: read once at startup, no refresh
+
+The token is resolved **once at process start** from the env var named in
+`git.auth_env` (`config.ResolveToken`) and is **never refreshed** while the
+adapter runs. A short-lived credential — for example a GitHub App installation
+token (~1 h TTL) — will **expire mid-process** and subsequent Git calls will
+fail with no automatic re-resolution. Until refreshable credentials land
+(epic G, step G.7 / #1262 — App installation tokens minted and re-resolved
+before expiry), use a credential whose lifetime exceeds the process: a
+fine-grained PAT (no expiry, or a long expiry you rotate manually).
+
+### Defense-in-depth: static `owner/repo` pinning
+
+Token scope and `owner/repo` pinning are **distinct, complementary** controls.
+`capabilities[].owner` / `.repo` are declared in config and never derived from
+`input_payload` (SSRF prevention), so even a token broader than recommended
+cannot make the adapter reach a repository the config does not name. Pin the
+config narrowly **and** scope the token narrowly — neither replaces the other.
 
 ## gRPC Port
 

--- a/agents/adapters/git/agent-def.yaml.example
+++ b/agents/adapters/git/agent-def.yaml.example
@@ -2,9 +2,22 @@
 # git-adapter — example AgentDef YAML
 #
 # Copy this file to agent-def.yaml and set the ADAPTER_CONFIG env var to its path.
-# Set the env var named in git.auth_env to a GitHub PAT with repo scope.
+#
+# Token (least privilege): set the env var named in git.auth_env to a GitHub
+# fine-grained PAT scoped to ONLY the owner/repo configured below, granting just
+# "Pull requests: Read and write" — all three capabilities (open_pr,
+# request_review, get_diff) act on pull requests. Do NOT use a classic PAT with
+# the broad `repo` scope (full repo control across every repo the token owner can
+# reach). See agents/adapters/git/AGENTS.md for the per-capability scope table.
+#
+# Lifecycle: the token is read once at startup and never refreshed. A short-lived
+# credential (e.g. a GitHub App installation token, ~1 h TTL) will expire mid-run;
+# until refreshable credentials land (epic G, step G.7 / #1262) use a PAT or a
+# token whose lifetime exceeds the process.
 #
 # SSRF prevention: owner and repo are declared here — never in input_payload.
+# This static owner/repo pinning is defense-in-depth, separate from token scope:
+# even a broader token cannot reach a repo the config does not name.
 
 agent_id: git-adapter
 name: Git Adapter


### PR DESCRIPTION
## docs(agents/adapters): recommend fine-grained PAT + document no token refresh

Closes #1261
Part of #1169 (EPIC G — Git MCP shim · step G.6)

### Why
The git-adapter setup docs recommended a classic `repo`-scoped PAT (full repo
control across every repo the token owner can reach) and never stated the
credential lifecycle — so an operator could over-grant scope or feed a
short-lived token that silently expires mid-process. This is a docs-only
hardening of the credential substrate the MCP shim wraps.

### What you'll get
- least-privilege fine-grained PAT recommendation + per-capability scope table (Pull requests: Read/Write) ← `agents/adapters/git/AGENTS.md`
- documented "read once at startup, no refresh" lifecycle with forward-link to G.7 / #1262 ← `agents/adapters/git/AGENTS.md`
- example header steers operators to a repo-scoped fine-grained PAT and away from `repo` scope ← `agents/adapters/git/agent-def.yaml.example`
- `owner/repo` pinning called out as defense-in-depth, distinct from token scope ← both files

### Scope & boundaries
- **In scope:** doc/example text only — `AGENTS.md` + `agent-def.yaml.example`.
- **Out of scope (deferred):** startup scope validation → G.5 #1260; token refresh / App installation tokens → G.7 #1262.

### Test plan & acceptance
| Acceptance criterion | How verified | Result |
|----------------------|--------------|--------|
| example + AGENTS.md recommend a fine-grained PAT scoped to the configured repo (Pull requests: Read/Write) | review rendered docs: scope table in AGENTS.md, header in agent-def.yaml.example | ✅ both updated |
| document token read once at startup, no refresh (forward-link G.7) | review: "Lifecycle: read once at startup, no refresh" section links #1262 | ✅ present |
| note owner/repo pinning as defense-in-depth, distinct from token scope | review: "Defense-in-depth" section in AGENTS.md + example header note | ✅ present |

**Local gates:** secrets pre-commit hook ✅ (no hardcoded secrets); no code/spec changed — `make lint`/tests N/A.

### Evidence
- **CI:** awaiting required checks (markdown/PR-size; size-exempt under `docs/`-style exclusions for `AGENTS.md`).
- **Local output:** gitleaks PII/email scan over both files — no matches; links are repo-relative.
- **Artifacts / images:** none — no service source changed.
- **Post-merge digest sync → main:** N/A — no image rebuild.

### Risk & rollback
Low — documentation only, no behaviour change. Revert this PR to restore the prior text.

### Review aids
Start at `agents/adapters/git/AGENTS.md` — the new "Credential — token scope and lifecycle" section carries the scope table, the no-refresh lifecycle, and the defense-in-depth note; the example header is a condensed mirror for copy-paste setup.

**AI:** `Assisted-by: Claude/claude-opus-4-8`  (label: ai-assisted)
