### PR TITLE
feat(agents/sdk): agent handoff context contract + helpers

### DIFF
--- a/agents/sdk/AGENTS.md
+++ b/agents/sdk/AGENTS.md
@@ -32,7 +32,9 @@ What the SDK does **not** handle (M6+):
 ```
 agents/sdk/src/zynax_sdk/
 ├── agent.py       ← Agent base class, @capability decorator, report_* helpers
-└── __init__.py    ← Exports: Agent, capability, __version__
+├── handoff.py     ← HandoffContext contract + inbound_context / outbound_metadata
+├── telemetry.py   ← OTel traces + logs (off by default)
+└── __init__.py    ← Exports: Agent, capability, HandoffContext, …, __version__
 ```
 
 ---
@@ -101,6 +103,53 @@ Aborts with `INVALID_ARGUMENT` if `capability_name` or `task_id` is empty, or if
 
 gRPC handler. Returns basic schema metadata for a registered capability. Aborts with
 `NOT_FOUND` if the capability is not registered.
+
+---
+
+## Agent Handoff Context (canvas EPIC C, step C.4)
+
+When the broker dispatches a capability the agent is handed a **deterministic
+context** so the run stays traceable and data-scoped end to end. The contract is
+the frozen `HandoffContext` dataclass; two helpers honour it.
+
+The carrier keys mirror the Go gateway byte-for-byte (no bespoke formats — ADR-031):
+
+| `HandoffContext` field | gRPC metadata key | source of truth |
+|------------------------|-------------------|-----------------|
+| `request_id` | `request-id` | gateway correlation interceptor (C.2) |
+| `namespace` | `x-namespace` | gateway correlation interceptor (C.2) |
+| `traceparent` | `traceparent` (W3C) | tracing interceptor (C.2) |
+| `tracestate` | `tracestate` (W3C) | tracing interceptor (C.2) |
+| `workflow_id` | — (proto `workflow_id`) | run id; scopes the data-context (C.3) |
+| `task_id` | — (proto `task_id`) | per-task id |
+
+Correlation + trace are read from inbound gRPC metadata; `workflow_id` / `task_id`
+come from the proto request. The data-context (EPIC W / C.3) is scoped server-side
+by `namespace` + `workflow_id` — the agent receives the identifiers, never the
+store handle, so it cannot reach across runs.
+
+**Safeguard:** only correlation ids and W3C trace headers cross a handoff — never
+auth tokens, cookies, api keys, or secrets. `inbound_context` drops those keys.
+
+### `inbound_context(request, context=None) -> HandoffContext`
+
+Reads the deterministic context an agent **receives**. Metadata `request-id` is
+authoritative; the proto `request_id` is the fallback when metadata is absent.
+
+### `outbound_metadata(ctx: HandoffContext) -> list[tuple[str, str]]`
+
+Emits the context an agent **forwards** to its next Zynax hop, as ordered,
+unset-omitted gRPC metadata: `stub.Method(req, metadata=outbound_metadata(ctx))`.
+
+```python
+from zynax_sdk import inbound_context, outbound_metadata
+
+@capability("summarize")
+async def summarize(self, request, context):
+    hc = inbound_context(request, context)          # what I was handed
+    md = outbound_metadata(hc)                        # forward it downstream
+    yield self.report_completed(request.task_id, {"req": hc.request_id})
+```
 
 ---
 

--- a/agents/sdk/src/zynax_sdk/__init__.py
+++ b/agents/sdk/src/zynax_sdk/__init__.py
@@ -4,6 +4,11 @@
 __version__ = "0.1.0"
 
 from zynax_sdk.agent import Agent, capability
+from zynax_sdk.handoff import (
+    HandoffContext,
+    inbound_context,
+    outbound_metadata,
+)
 from zynax_sdk.telemetry import (
     capability_span,
     extract_context,
@@ -13,10 +18,13 @@ from zynax_sdk.telemetry import (
 
 __all__ = [
     "Agent",
+    "HandoffContext",
     "capability",
     "capability_span",
     "extract_context",
+    "inbound_context",
     "init_telemetry",
     "is_enabled",
+    "outbound_metadata",
     "__version__",
 ]

--- a/agents/sdk/src/zynax_sdk/handoff.py
+++ b/agents/sdk/src/zynax_sdk/handoff.py
@@ -1,0 +1,198 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Agent handoff context contract + helpers (canvas EPIC C, step C.4).
+
+When the broker dispatches a capability to an agent it hands off a deterministic
+**context** so the run stays traceable and data-scoped end to end. This module
+defines that contract — :class:`HandoffContext` — and the two helpers an agent
+author uses to honour it:
+
+* :func:`inbound_context` — read the context an agent **receives** from the
+  ``ExecuteCapabilityRequest`` proto fields and the inbound gRPC metadata.
+* :func:`outbound_metadata` — emit the context an agent **returns / forwards**
+  when it itself calls another Zynax hop, so correlation and trace survive the
+  next handoff.
+
+The carrier keys mirror the Go gateway exactly (``services/api-gateway`` and
+``libs/zynaxobs``) so a request-id set at the gateway is the same value an agent
+observes — no bespoke header formats (canvas Norms / ADR-031):
+
+================  ============================  =================================
+field             gRPC metadata key             source of truth
+================  ============================  =================================
+request_id        ``request-id``                api-gateway correlation interceptor
+namespace         ``x-namespace``               api-gateway correlation interceptor
+traceparent       ``traceparent`` (W3C)         tracing interceptor (C.2)
+tracestate        ``tracestate`` (W3C)          tracing interceptor (C.2)
+================  ============================  =================================
+
+The data-context (EPIC W / C.3) is scoped server-side by ``namespace`` +
+``workflow_id`` (the run id); the agent receives those identifiers — never the
+data store handle itself — so it cannot reach across runs (canvas Safeguards).
+
+**Safeguard:** only correlation ids and W3C trace headers cross the handoff —
+never auth tokens, session data, secrets, or credentials (canvas C Safeguards).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any
+
+# gRPC metadata keys carrying the correlation context. These mirror
+# ``requestIDMetaKey`` / ``namespaceMetaKey`` in
+# ``services/api-gateway/internal/infrastructure/clients.go`` and the W3C trace
+# headers propagated by the tracing interceptors — keep them byte-for-byte equal.
+_REQUEST_ID_KEY = "request-id"
+_NAMESPACE_KEY = "x-namespace"
+_TRACEPARENT_KEY = "traceparent"
+_TRACESTATE_KEY = "tracestate"
+
+# Keys an agent must never read out of inbound metadata into a handoff context —
+# documented here so the safeguard is explicit and testable.
+_FORBIDDEN_KEYS = frozenset(
+    {"authorization", "cookie", "x-api-key", "set-cookie", "proxy-authorization"}
+)
+
+
+@dataclass(frozen=True)
+class HandoffContext:
+    """The deterministic context an agent receives on, and returns from, a handoff.
+
+    Immutable by design: a handler reads it but never mutates it, so the same
+    correlation and trace identifiers flow unchanged to the next hop. Construct
+    it from a request with :func:`inbound_context`; turn it back into gRPC
+    metadata for a downstream call with :func:`outbound_metadata`.
+
+    Attributes:
+        request_id: Stable correlation id set at the gateway; appears in every
+            downstream span and log line for the run (canvas C.2). Empty when the
+            call did not originate behind the gateway.
+        namespace: Tenant / routing namespace; also half of the data-context
+            scope key (canvas C.3). Empty when unset.
+        workflow_id: The workflow run id; with ``namespace`` it scopes the
+            data-context so a state cannot read another run's data.
+        task_id: The opaque per-task identifier from the originating request.
+        traceparent: W3C ``traceparent`` carrying the remote span, or empty.
+        tracestate: W3C ``tracestate`` vendor data, or empty.
+    """
+
+    request_id: str = ""
+    namespace: str = ""
+    workflow_id: str = ""
+    task_id: str = ""
+    traceparent: str = ""
+    tracestate: str = ""
+
+    def is_traced(self) -> bool:
+        """Return ``True`` when a W3C ``traceparent`` was carried on the handoff."""
+        return bool(self.traceparent)
+
+
+def _carrier_from_metadata(
+    metadata: Sequence[tuple[str, Any]] | None,
+) -> dict[str, str]:
+    """Build a lower-cased carrier dict from gRPC invocation metadata.
+
+    Only the correlation and W3C trace keys are read; forbidden keys (auth,
+    cookies, api keys) are dropped so they can never leak into a handoff context.
+    """
+    carrier: dict[str, str] = {}
+    if not metadata:
+        return carrier
+    allowed = {
+        _REQUEST_ID_KEY,
+        _NAMESPACE_KEY,
+        _TRACEPARENT_KEY,
+        _TRACESTATE_KEY,
+    }
+    for key, value in metadata:
+        lower = key.lower()
+        if lower in _FORBIDDEN_KEYS:
+            continue
+        if lower in allowed:
+            carrier[lower] = value.decode() if isinstance(value, bytes) else str(value)
+    return carrier
+
+
+def _invocation_metadata(context: Any) -> Sequence[tuple[str, Any]] | None:
+    """Return ``context.invocation_metadata()`` if the context exposes it."""
+    getter = getattr(context, "invocation_metadata", None)
+    if getter is None:
+        return None
+    try:
+        metadata: Sequence[tuple[str, Any]] = getter()
+    except Exception:  # pragma: no cover - defensive: never fail a handler here
+        return None
+    return metadata
+
+
+def inbound_context(request: Any, context: Any = None) -> HandoffContext:
+    """Read the deterministic handoff context an agent receives.
+
+    Correlation (``request_id``, ``namespace``) and W3C trace headers are read
+    from the inbound gRPC metadata when ``context`` is supplied; ``request_id``,
+    ``workflow_id`` and ``task_id`` fall back to the proto request fields so the
+    context is populated even outside a transport (e.g. in unit tests). The proto
+    ``request_id`` wins only when the metadata did not carry one, keeping the
+    gateway-set value authoritative.
+
+    Args:
+        request: The ``ExecuteCapabilityRequest`` proto message (or any object
+            exposing ``request_id`` / ``workflow_id`` / ``task_id``).
+        context: The gRPC ``ServicerContext`` (or any object exposing
+            ``invocation_metadata()``); optional.
+
+    Returns:
+        A frozen :class:`HandoffContext`. Never raises on missing fields — absent
+        identifiers are returned as empty strings.
+    """
+    carrier = _carrier_from_metadata(_invocation_metadata(context))
+
+    request_id = carrier.get(_REQUEST_ID_KEY, "") or _attr(request, "request_id")
+    namespace = carrier.get(_NAMESPACE_KEY, "") or _attr(request, "namespace")
+
+    return HandoffContext(
+        request_id=request_id,
+        namespace=namespace,
+        workflow_id=_attr(request, "workflow_id"),
+        task_id=_attr(request, "task_id"),
+        traceparent=carrier.get(_TRACEPARENT_KEY, ""),
+        tracestate=carrier.get(_TRACESTATE_KEY, ""),
+    )
+
+
+def outbound_metadata(ctx: HandoffContext) -> list[tuple[str, str]]:
+    """Emit gRPC metadata that forwards the handoff context to the next hop.
+
+    Returns the correlation and W3C trace headers as an ordered metadata list
+    suitable for ``stub.Method(req, metadata=outbound_metadata(ctx))``. Unset
+    fields are omitted so an absent identifier is never sent as an empty header,
+    and the ordering is deterministic (request-id, namespace, traceparent,
+    tracestate) so two equal contexts always produce identical metadata.
+
+    Only correlation ids and trace headers are emitted — never auth tokens or
+    secrets (canvas C Safeguards).
+
+    Args:
+        ctx: The :class:`HandoffContext` to forward.
+
+    Returns:
+        An ordered list of ``(key, value)`` metadata pairs; possibly empty.
+    """
+    md: list[tuple[str, str]] = []
+    if ctx.request_id:
+        md.append((_REQUEST_ID_KEY, ctx.request_id))
+    if ctx.namespace:
+        md.append((_NAMESPACE_KEY, ctx.namespace))
+    if ctx.traceparent:
+        md.append((_TRACEPARENT_KEY, ctx.traceparent))
+    if ctx.tracestate:
+        md.append((_TRACESTATE_KEY, ctx.tracestate))
+    return md
+
+
+def _attr(obj: Any, name: str) -> str:
+    """Return ``str(obj.<name>)`` or ``""`` when the attribute is missing/falsy."""
+    value = getattr(obj, name, "")
+    return str(value) if value else ""

--- a/agents/sdk/tests/test_handoff.py
+++ b/agents/sdk/tests/test_handoff.py
@@ -1,0 +1,180 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit + example tests for the agent handoff context contract (canvas C.4)."""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import Any
+
+sys.path.insert(
+    0, os.path.join(os.path.dirname(__file__), "../../../protos/generated/python")
+)
+from zynax.v1 import agent_pb2  # noqa: E402
+
+from zynax_sdk import (  # noqa: E402
+    HandoffContext,
+    inbound_context,
+    outbound_metadata,
+)
+
+# A valid W3C traceparent (version-traceid-spanid-flags).
+_TRACEPARENT = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
+_TRACESTATE = "vendor=opaque"
+
+
+class _MockContext:
+    """gRPC ServicerContext mock exposing invocation_metadata()."""
+
+    def __init__(self, metadata: list[tuple[str, Any]] | None = None) -> None:
+        self._metadata = metadata or []
+
+    def invocation_metadata(self) -> list[tuple[str, Any]]:
+        return self._metadata
+
+
+def _request(**kwargs: Any) -> agent_pb2.ExecuteCapabilityRequest:
+    return agent_pb2.ExecuteCapabilityRequest(
+        capability_name=kwargs.pop("capability_name", "summarize"),
+        task_id=kwargs.pop("task_id", "task-1"),
+        request_id=kwargs.pop("request_id", ""),
+        workflow_id=kwargs.pop("workflow_id", ""),
+    )
+
+
+def test_inbound_reads_correlation_and_trace_from_metadata() -> None:
+    ctx_obj = _MockContext(
+        [
+            ("request-id", "req-abc"),
+            ("x-namespace", "team-a"),
+            ("traceparent", _TRACEPARENT),
+            ("tracestate", _TRACESTATE),
+        ]
+    )
+    hc = inbound_context(_request(workflow_id="wf-9", task_id="t-2"), ctx_obj)
+
+    assert hc == HandoffContext(
+        request_id="req-abc",
+        namespace="team-a",
+        workflow_id="wf-9",
+        task_id="t-2",
+        traceparent=_TRACEPARENT,
+        tracestate=_TRACESTATE,
+    )
+    assert hc.is_traced() is True
+
+
+def test_inbound_falls_back_to_proto_request_id_when_metadata_absent() -> None:
+    # No transport context: request_id/workflow_id come from the proto fields.
+    hc = inbound_context(_request(request_id="req-proto", workflow_id="wf-1"))
+
+    assert hc.request_id == "req-proto"
+    assert hc.workflow_id == "wf-1"
+    assert hc.namespace == ""
+    assert hc.is_traced() is False
+
+
+def test_metadata_request_id_wins_over_proto_field() -> None:
+    ctx_obj = _MockContext([("request-id", "req-meta")])
+    hc = inbound_context(_request(request_id="req-proto"), ctx_obj)
+
+    assert hc.request_id == "req-meta"
+
+
+def test_inbound_drops_forbidden_auth_keys() -> None:
+    # Safeguard: auth tokens/cookies must never enter a handoff context.
+    ctx_obj = _MockContext(
+        [
+            ("request-id", "req-x"),
+            ("authorization", "Bearer super-secret"),
+            ("cookie", "session=abc"),
+            ("x-api-key", "key-123"),
+        ]
+    )
+    hc = inbound_context(_request(), ctx_obj)
+
+    assert hc.request_id == "req-x"
+    for value in vars(hc).values():
+        assert "secret" not in value and "session" not in value
+        assert "key-123" not in value
+
+
+def test_outbound_metadata_round_trips_and_is_ordered() -> None:
+    hc = HandoffContext(
+        request_id="req-abc",
+        namespace="team-a",
+        traceparent=_TRACEPARENT,
+        tracestate=_TRACESTATE,
+    )
+    md = outbound_metadata(hc)
+
+    assert md == [
+        ("request-id", "req-abc"),
+        ("x-namespace", "team-a"),
+        ("traceparent", _TRACEPARENT),
+        ("tracestate", _TRACESTATE),
+    ]
+    # Re-extracting the emitted metadata reproduces the correlation + trace.
+    again = inbound_context(_request(), _MockContext(md))
+    assert again.request_id == hc.request_id
+    assert again.namespace == hc.namespace
+    assert again.traceparent == hc.traceparent
+
+
+def test_outbound_metadata_omits_unset_fields() -> None:
+    assert outbound_metadata(HandoffContext()) == []
+    assert outbound_metadata(HandoffContext(request_id="r")) == [("request-id", "r")]
+
+
+def test_outbound_metadata_is_deterministic() -> None:
+    hc = HandoffContext(request_id="r", namespace="n", traceparent=_TRACEPARENT)
+    assert outbound_metadata(hc) == outbound_metadata(hc)
+
+
+def test_bytes_metadata_values_are_decoded() -> None:
+    ctx_obj = _MockContext([("request-id", b"req-bytes")])
+    hc = inbound_context(_request(), ctx_obj)
+    assert hc.request_id == "req-bytes"
+
+
+def test_inbound_tolerates_context_without_metadata() -> None:
+    # A context object that does not expose invocation_metadata() is handled.
+    hc = inbound_context(_request(request_id="r"), object())
+    assert hc.request_id == "r"
+
+
+def test_frozen_context_is_immutable() -> None:
+    hc = HandoffContext(request_id="r")
+    try:
+        hc.request_id = "mutated"  # type: ignore[misc]
+    except Exception as exc:  # FrozenInstanceError
+        assert "request_id" in str(exc) or "cannot assign" in str(exc).lower()
+    else:  # pragma: no cover - frozen dataclass must reject assignment
+        raise AssertionError("HandoffContext should be immutable")
+
+
+def test_example_agent_reads_and_forwards_context() -> None:
+    """End-to-end: an agent reads its inbound context and forwards it downstream.
+
+    This is the canvas C.4 example — an agent author receives a deterministic
+    context and passes it to the next Zynax hop unchanged.
+    """
+    inbound = _MockContext(
+        [
+            ("request-id", "req-e2e"),
+            ("x-namespace", "prod"),
+            ("traceparent", _TRACEPARENT),
+        ]
+    )
+    request = _request(workflow_id="run-42", task_id="task-7")
+
+    # 1. Agent reads the deterministic context it was handed.
+    hc = inbound_context(request, inbound)
+    assert hc.request_id == "req-e2e"
+    assert hc.workflow_id == "run-42"
+
+    # 2. Agent forwards it on its own downstream call — correlation survives.
+    forwarded = outbound_metadata(hc)
+    assert ("request-id", "req-e2e") in forwarded
+    assert ("x-namespace", "prod") in forwarded
+    assert ("traceparent", _TRACEPARENT) in forwarded


### PR DESCRIPTION
## feat(agents/sdk): agent handoff context contract + helpers

Closes #1196
Part of #1168

### Why  (problem & intent)
Agents had no documented, deterministic context to read on a capability handoff,
so correlation and trace identifiers set at the gateway were not reliably carried
into agent logic nor forwarded to the next hop. This adds the SDK-side handoff
contract for canvas EPIC C, step C.4, building on C.2 (correlation) and C.3
(data-context scoping).

### What you'll get  (deliverables ↔ what changed)
- A documented, frozen `HandoffContext` (request_id, namespace, workflow_id, task_id, traceparent, tracestate) ← `agents/sdk/src/zynax_sdk/handoff.py`
- `inbound_context(request, context)` — reads correlation + W3C trace from gRPC metadata, workflow/task ids from the proto ← `agents/sdk/src/zynax_sdk/handoff.py`
- `outbound_metadata(ctx)` — emits ordered, unset-omitted metadata to forward the context downstream ← `agents/sdk/src/zynax_sdk/handoff.py`
- Public exports + documented contract (carrier-key table + example) ← `agents/sdk/src/zynax_sdk/__init__.py`, `agents/sdk/AGENTS.md`
- Example test exercising read → forward + the auth-key safeguard ← `agents/sdk/tests/test_handoff.py`

### Scope & boundaries
- **In scope:** SDK contract + helpers + example test for the agent handoff context (correlation ids + W3C trace + data-scope identifiers).
- **Out of scope (deferred):** long-term memory / RAG → M-dx; server-side data-context enforcement already delivered in C.3 (#1195).

### Test plan & acceptance

| Acceptance criterion | How verified (command) | Result |
|----------------------|------------------------|--------|
| contract documented | `agents/sdk/AGENTS.md` carrier-key table + module docstring | ✅ documented |
| SDK helper to read inbound + emit outbound context | `make test-unit-agents` (test_handoff.py) | ✅ 11/11 pass |
| example test | `test_example_agent_reads_and_forwards_context` | ✅ pass |

**Local gates:** `make lint-agents` ✅ (ruff + mypy clean) · `make test-unit-agents` ✅ (87 passed)

### Evidence
- **CI:** all required checks green (see run on this PR).
- **Local output:** `handoff.py` 100% coverage; full SDK suite 99.13% total, 87 passed.
- **Artifacts / images:** none — no service source changed.
- **Post-merge digest sync → main:** N/A — no image rebuild.

### Risk & rollback
Low — additive only. New module + exports; no behaviour change to existing
handlers. Revert this PR to remove. Only correlation ids and W3C trace headers
cross the handoff; auth tokens, cookies and api keys are dropped (no secret-leak path).

### Review aids
Key file: `agents/sdk/src/zynax_sdk/handoff.py`. Carrier keys mirror
`services/api-gateway/internal/infrastructure/clients.go` byte-for-byte
(`request-id`, `x-namespace`) plus the W3C `traceparent`/`tracestate`. Note
`inbound_context` lets metadata `request-id` win over the proto field to keep
the gateway-set value authoritative.

**SPDD:** Canvas `docs/spdd/1168-context-propagation/canvas.md` — Status: **Aligned** · `/spdd-security-review` **clean**
**AI:** `Assisted-by: Claude/claude-opus-4-8`
