### PR TITLE
feat(ci): zynax-ci images meta/cleanup/retag

### DIFF
--- a/cmd/zynax-ci/cmd/images_report.go
+++ b/cmd/zynax-ci/cmd/images_report.go
@@ -1,0 +1,203 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/zynax-io/zynax/cmd/zynax-ci/internal/imagesreport"
+)
+
+var (
+	metaLabel   string
+	metaDigest  string
+	metaExtra   string
+	metaIndex   string
+	metaSummary string
+
+	cleanupTag     string
+	cleanupVerJSON string
+	cleanupKeep    int
+	cleanupPrune   bool
+
+	retagRef    string
+	retagSHA    string
+	retagGitRef string
+)
+
+var imagesMetaCmd = &cobra.Command{
+	Use:   "meta",
+	Short: "Report OCI image metadata + size budget from an index manifest",
+	Long: `Read a GHCR index manifest (JSON, from stdin or --index) and report the
+OCI annotations, attestation count, and platform rows. Fails when the index
+resolved but carries no description annotation; warns on a missing title.
+
+Replaces .github/actions/report-image-meta (ADR-036). The workflow still fetches
+the manifest with curl (the external primitive); this verb makes the
+annotation/budget decisions testable. Writes the markdown report to
+$GITHUB_STEP_SUMMARY (or --summary) and echoes it.`,
+	Args: cobra.NoArgs,
+	RunE: runImagesMeta,
+}
+
+var imagesCleanupCmd = &cobra.Command{
+	Use:   "cleanup",
+	Short: "Select GHCR package version ids to delete (PR-image or prune)",
+	Long: `Read a GitHub packages-API versions list (JSON, from stdin or --versions)
+and print the version ids to delete, one per line, for the shell DELETE loop.
+
+Default mode selects versions tagged exactly --tag (the pr-image-cleanup
+selection). With --prune it selects stale per-commit (main-<sha>) builds that
+carry no latest/main/v* tag, newest-first, keeping --keep (the tools-image
+prune). Replaces the gh/jq selection blocks (ADR-036); gh stays the API client.`,
+	Args: cobra.NoArgs,
+	RunE: runImagesCleanup,
+}
+
+var imagesRetagCmd = &cobra.Command{
+	Use:   "retag",
+	Short: "Compute the release tags to apply when promoting a manifest",
+	Long: `Print the fully-qualified tags to apply when promoting a multi-arch
+manifest: always <ref>:main-<sha> and <ref>:latest, plus <ref>:<version> when
+--git-ref is a refs/tags/v* ref. One tag per line for the crane/imagetools loop.
+
+Replaces the FINAL_TAGS bash in tools-image.yml (ADR-036); crane/imagetools
+stays the copy primitive. zynax-ci only computes which tags to apply.`,
+	Args: cobra.NoArgs,
+	RunE: runImagesRetag,
+}
+
+func init() {
+	imagesMetaCmd.Flags().StringVar(&metaLabel, "label", "", "human-readable image label for the summary")
+	imagesMetaCmd.Flags().StringVar(&metaDigest, "digest", "", "index digest (sha256:...)")
+	imagesMetaCmd.Flags().StringVar(&metaExtra, "extra", "", "extra markdown appended after the digest line")
+	imagesMetaCmd.Flags().StringVar(&metaIndex, "index", "", "index manifest JSON file (default stdin)")
+	imagesMetaCmd.Flags().StringVar(&metaSummary, "summary", "", "summary output file ($GITHUB_STEP_SUMMARY)")
+
+	imagesCleanupCmd.Flags().StringVar(&cleanupTag, "tag", "", "exact tag to select (pr-<sha>)")
+	imagesCleanupCmd.Flags().StringVar(&cleanupVerJSON, "versions", "", "versions-list JSON file (default stdin)")
+	imagesCleanupCmd.Flags().BoolVar(&cleanupPrune, "prune", false, "prune mode: select stale main-<sha> builds")
+	imagesCleanupCmd.Flags().IntVar(&cleanupKeep, "keep", 0, "prune mode: number of newest builds to keep")
+
+	imagesRetagCmd.Flags().StringVar(&retagRef, "ref", "", "image repository without tag (ghcr.io/...)")
+	imagesRetagCmd.Flags().StringVar(&retagSHA, "sha", "", "commit sha being published (github.sha)")
+	imagesRetagCmd.Flags().StringVar(&retagGitRef, "git-ref", "", "triggering git ref (github.ref)")
+
+	imagesCmd.AddCommand(imagesMetaCmd)
+	imagesCmd.AddCommand(imagesCleanupCmd)
+	imagesCmd.AddCommand(imagesRetagCmd)
+}
+
+func runImagesMeta(cmd *cobra.Command, _ []string) error {
+	r, closeFn, err := openOrStdin(metaIndex, cmd)
+	if err != nil {
+		return err
+	}
+	defer closeFn()
+	meta, err := imagesreport.ParseMeta(r)
+	if err != nil {
+		return err
+	}
+	if err := emitMetaSummary(cmd, meta); err != nil {
+		return err
+	}
+	return metaDiagnostics(cmd, meta)
+}
+
+// emitMetaSummary renders and writes the step-summary markdown.
+func emitMetaSummary(cmd *cobra.Command, meta imagesreport.Meta) error {
+	md := meta.Summary(metaLabel, metaDigest, metaExtra)
+	dest := pick(metaSummary, os.Getenv("GITHUB_STEP_SUMMARY"))
+	if dest != "" {
+		if err := appendFile(dest, md); err != nil {
+			return err
+		}
+	}
+	if _, err := fmt.Fprint(cmd.OutOrStdout(), md); err != nil {
+		return fmt.Errorf("images meta: write stdout: %w", err)
+	}
+	return nil
+}
+
+// metaDiagnostics emits warnings/notices and fails on a missing description.
+func metaDiagnostics(cmd *cobra.Command, meta imagesreport.Meta) error {
+	if meta.MissingDescription() {
+		return fmt.Errorf("images meta: %s@%s is missing the org.opencontainers.image.description annotation", metaLabel, metaDigest)
+	}
+	errOut := cmd.ErrOrStderr()
+	if meta.IndexResolved && meta.Title == "" {
+		_, _ = fmt.Fprintf(errOut, "::warning::%s@%s is missing the org.opencontainers.image.title annotation\n", metaLabel, metaDigest)
+	}
+	if meta.IndexResolved && meta.Attestations != imagesreport.ExpectedAttestations {
+		_, _ = fmt.Fprintf(errOut, "::notice::%s attestation manifests: %d (expected %d, ADR-025)\n", metaLabel, meta.Attestations, imagesreport.ExpectedAttestations)
+	}
+	return nil
+}
+
+func runImagesCleanup(cmd *cobra.Command, _ []string) error {
+	r, closeFn, err := openOrStdin(cleanupVerJSON, cmd)
+	if err != nil {
+		return err
+	}
+	defer closeFn()
+	ids, err := selectCleanupIDs(r)
+	if err != nil {
+		return err
+	}
+	if _, err := fmt.Fprint(cmd.OutOrStdout(), imagesreport.FormatIDs(ids)); err != nil {
+		return fmt.Errorf("images cleanup: write ids: %w", err)
+	}
+	return nil
+}
+
+// selectCleanupIDs dispatches to prune or exact-tag selection.
+func selectCleanupIDs(r io.Reader) ([]int64, error) {
+	if cleanupPrune {
+		return imagesreport.SelectPrunable(r, cleanupKeep)
+	}
+	if cleanupTag == "" {
+		return nil, fmt.Errorf("images cleanup: --tag is required unless --prune is set")
+	}
+	return imagesreport.SelectByTag(r, cleanupTag)
+}
+
+func runImagesRetag(cmd *cobra.Command, _ []string) error {
+	tags, err := imagesreport.FinalTags(imagesreport.RetagInput{Ref: retagRef, SHA: retagSHA, GitRef: retagGitRef})
+	if err != nil {
+		return err
+	}
+	for _, t := range tags {
+		if _, err := fmt.Fprintln(cmd.OutOrStdout(), t); err != nil {
+			return fmt.Errorf("images retag: write tag: %w", err)
+		}
+	}
+	return nil
+}
+
+// openOrStdin opens path, or returns the command's stdin when path is empty.
+func openOrStdin(path string, cmd *cobra.Command) (io.Reader, func(), error) {
+	if path == "" {
+		return cmd.InOrStdin(), func() {}, nil
+	}
+	f, err := os.Open(path) //nolint:gosec // path is CI-controlled (flag)
+	if err != nil {
+		return nil, nil, fmt.Errorf("images: open %s: %w", path, err)
+	}
+	return f, func() { _ = f.Close() }, nil
+}
+
+// appendFile appends s to the file at path (created if absent).
+func appendFile(path, s string) error {
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600) //nolint:gosec // CI-controlled
+	if err != nil {
+		return fmt.Errorf("images meta: open %s: %w", path, err)
+	}
+	defer func() { _ = f.Close() }()
+	if _, err := f.WriteString(s); err != nil {
+		return fmt.Errorf("images meta: append %s: %w", path, err)
+	}
+	return nil
+}

--- a/cmd/zynax-ci/cmd/images_report_cmd_test.go
+++ b/cmd/zynax-ci/cmd/images_report_cmd_test.go
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const metaIndexJSON = `{"annotations":{"org.opencontainers.image.description":"d","org.opencontainers.image.title":"tools"},"manifests":[{"digest":"sha256:a","platform":{"os":"linux","architecture":"amd64"}}]}`
+
+const (
+	testDigest = "sha256:idx"
+	testLabel  = "tools"
+)
+
+func resetMetaFlags() {
+	metaLabel, metaDigest, metaExtra, metaIndex, metaSummary = "", "", "", "", ""
+}
+
+func TestRunImagesMeta_OK(t *testing.T) {
+	resetMetaFlags()
+	defer resetMetaFlags()
+	metaLabel, metaDigest, metaExtra = testLabel, testDigest, "synced to images.yaml"
+	c, out := cmdWithIO(t, metaIndexJSON)
+	if err := runImagesMeta(c, nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out.String(), "## tools") {
+		t.Errorf("want summary header, got:\n%s", out.String())
+	}
+}
+
+func TestRunImagesMeta_MissingDescriptionFails(t *testing.T) {
+	resetMetaFlags()
+	defer resetMetaFlags()
+	metaLabel, metaDigest = testLabel, testDigest
+	c, _ := cmdWithIO(t, `{"annotations":{},"manifests":[]}`)
+	if err := runImagesMeta(c, nil); err == nil {
+		t.Fatal("want error for missing description annotation")
+	}
+}
+
+func TestRunImagesMeta_WritesSummaryFile(t *testing.T) {
+	resetMetaFlags()
+	defer resetMetaFlags()
+	dir := t.TempDir()
+	summary := filepath.Join(dir, "summary.md")
+	metaLabel, metaDigest, metaSummary = testLabel, testDigest, summary
+	c, _ := cmdWithIO(t, metaIndexJSON)
+	if err := runImagesMeta(c, nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	data, _ := os.ReadFile(summary) //nolint:gosec
+	if !strings.Contains(string(data), "## tools") {
+		t.Errorf("summary file not written:\n%s", data)
+	}
+}
+
+func TestRunImagesMeta_BadFile(t *testing.T) {
+	resetMetaFlags()
+	defer resetMetaFlags()
+	metaIndex = filepath.Join(t.TempDir(), "missing.json")
+	c, _ := cmdWithIO(t, "")
+	if err := runImagesMeta(c, nil); err == nil {
+		t.Error("want error opening missing index file")
+	}
+}
+
+const cleanupVersionsJSON = `[{"id":101,"updated_at":"2026-06-01T00:00:00Z","metadata":{"container":{"tags":["pr-abc","main-abc"]}}},{"id":102,"updated_at":"2026-06-02T00:00:00Z","metadata":{"container":{"tags":["main-def"]}}}]`
+
+func resetCleanupFlags() {
+	cleanupTag, cleanupVerJSON, cleanupKeep, cleanupPrune = "", "", 0, false
+}
+
+func TestRunImagesCleanup_ByTag(t *testing.T) {
+	resetCleanupFlags()
+	defer resetCleanupFlags()
+	cleanupTag = "pr-abc"
+	c, out := cmdWithIO(t, cleanupVersionsJSON)
+	if err := runImagesCleanup(c, nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.TrimSpace(out.String()) != "101" {
+		t.Errorf("want id 101, got %q", out.String())
+	}
+}
+
+func TestRunImagesCleanup_Prune(t *testing.T) {
+	resetCleanupFlags()
+	defer resetCleanupFlags()
+	cleanupPrune, cleanupKeep = true, 1
+	c, out := cmdWithIO(t, cleanupVersionsJSON)
+	if err := runImagesCleanup(c, nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Newest-first: 102, 101; keep=1 → prune 101.
+	if strings.TrimSpace(out.String()) != "101" {
+		t.Errorf("want pruned id 101, got %q", out.String())
+	}
+}
+
+func TestRunImagesCleanup_TagRequired(t *testing.T) {
+	resetCleanupFlags()
+	defer resetCleanupFlags()
+	c, _ := cmdWithIO(t, cleanupVersionsJSON)
+	if err := runImagesCleanup(c, nil); err == nil {
+		t.Error("want error when neither --tag nor --prune set")
+	}
+}
+
+func TestRunImagesRetag(t *testing.T) {
+	retagRef, retagSHA, retagGitRef = "ghcr.io/z/tools", "abc123", "refs/tags/v1.2.3"
+	defer func() { retagRef, retagSHA, retagGitRef = "", "", "" }()
+	c, out := cmdWithIO(t, "")
+	if err := runImagesRetag(c, nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := out.String()
+	for _, want := range []string{"ghcr.io/z/tools:main-abc123", "ghcr.io/z/tools:v1.2.3", "ghcr.io/z/tools:latest"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("want tag %q, got:\n%s", want, got)
+		}
+	}
+	retagRef = ""
+	if err := runImagesRetag(c, nil); err == nil {
+		t.Error("want error for missing ref")
+	}
+}

--- a/cmd/zynax-ci/internal/imagesreport/cleanup.go
+++ b/cmd/zynax-ci/internal/imagesreport/cleanup.go
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package imagesreport
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"regexp"
+	"strconv"
+)
+
+// version is one entry of the GitHub packages-API versions list.
+type version struct {
+	ID       int64 `json:"id"`
+	Metadata struct {
+		Container struct {
+			Tags []string `json:"tags"`
+		} `json:"container"`
+	} `json:"metadata"`
+	UpdatedAt string `json:"updated_at"`
+}
+
+// numericID guards the DELETE call (parity with the bash `^[0-9]+$` check). The
+// API id is already an int64, so any decoded value is numeric; this stays as a
+// defensive boundary mirroring the original.
+func numericID(id int64) bool { return id >= 0 }
+
+// mainShaRe matches the per-commit tag `main-<hex>` (parity with the prune
+// jq `test("^main-[a-f0-9]")`).
+var mainShaRe = regexp.MustCompile(`^main-[a-f0-9]`)
+
+// versionTagRe matches a release tag `v<digit>...` (parity with `test("^v[0-9]")`).
+var versionTagRe = regexp.MustCompile(`^v[0-9]`)
+
+// decodeVersions parses a packages-API versions JSON array.
+func decodeVersions(r io.Reader) ([]version, error) {
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return nil, fmt.Errorf("imagesreport: read versions: %w", err)
+	}
+	var vs []version
+	if err := json.Unmarshal(data, &vs); err != nil {
+		return nil, fmt.Errorf("imagesreport: parse versions: %w", err)
+	}
+	return vs, nil
+}
+
+// SelectByTag returns the version ids whose tag set contains exactTag — the
+// pr-image-cleanup selection (parity with `select(.tags[]? == "pr-<sha>")`).
+// A missing package or empty list yields no ids (a quiet no-op upstream).
+func SelectByTag(versionsJSON io.Reader, exactTag string) ([]int64, error) {
+	vs, err := decodeVersions(versionsJSON)
+	if err != nil {
+		return nil, err
+	}
+	var ids []int64
+	for _, v := range vs {
+		if !numericID(v.ID) {
+			continue
+		}
+		for _, t := range v.Metadata.Container.Tags {
+			if t == exactTag {
+				ids = append(ids, v.ID)
+				break
+			}
+		}
+	}
+	return ids, nil
+}
+
+// SelectPrunable returns the version ids of stale per-commit builds to delete:
+// versions whose tags include a main-<sha> tag and whose tags never include
+// latest/main or any v<digit> release tag, sorted newest-first, keeping the
+// first `keep` (parity with the tools-image prune jq pipeline).
+func SelectPrunable(versionsJSON io.Reader, keep int) ([]int64, error) {
+	vs, err := decodeVersions(versionsJSON)
+	if err != nil {
+		return nil, err
+	}
+	candidates := filterPrunable(vs)
+	sortNewestFirst(candidates)
+	if keep < 0 {
+		keep = 0
+	}
+	if keep >= len(candidates) {
+		return nil, nil
+	}
+	ids := make([]int64, 0, len(candidates)-keep)
+	for _, v := range candidates[keep:] {
+		ids = append(ids, v.ID)
+	}
+	return ids, nil
+}
+
+// filterPrunable keeps versions that are a per-commit build and carry no
+// protected (latest/main/v*) tag.
+func filterPrunable(vs []version) []version {
+	var out []version
+	for _, v := range vs {
+		if isPerCommitBuild(v) && !hasProtectedTag(v) {
+			out = append(out, v)
+		}
+	}
+	return out
+}
+
+// isPerCommitBuild reports whether any tag matches main-<sha>.
+func isPerCommitBuild(v version) bool {
+	for _, t := range v.Metadata.Container.Tags {
+		if mainShaRe.MatchString(t) {
+			return true
+		}
+	}
+	return false
+}
+
+// hasProtectedTag reports whether any tag is latest, main, or a v* release tag.
+func hasProtectedTag(v version) bool {
+	for _, t := range v.Metadata.Container.Tags {
+		if t == "latest" || t == "main" || versionTagRe.MatchString(t) {
+			return true
+		}
+	}
+	return false
+}
+
+// sortNewestFirst orders versions by UpdatedAt descending (RFC3339 strings sort
+// lexicographically, matching the jq `sort_by(.ts) | reverse`).
+func sortNewestFirst(vs []version) {
+	for i := 1; i < len(vs); i++ {
+		for j := i; j > 0 && vs[j].UpdatedAt > vs[j-1].UpdatedAt; j-- {
+			vs[j], vs[j-1] = vs[j-1], vs[j]
+		}
+	}
+}
+
+// FormatIDs renders ids one-per-line for the shell DELETE loop to consume.
+func FormatIDs(ids []int64) string {
+	var b []byte
+	for _, id := range ids {
+		b = append(b, []byte(strconv.FormatInt(id, 10))...)
+		b = append(b, '\n')
+	}
+	return string(b)
+}

--- a/cmd/zynax-ci/internal/imagesreport/cleanup_retag_test.go
+++ b/cmd/zynax-ci/internal/imagesreport/cleanup_retag_test.go
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package imagesreport
+
+import (
+	"strings"
+	"testing"
+)
+
+const versionsJSON = `[
+  {"id": 101, "updated_at": "2026-06-01T00:00:00Z", "metadata": {"container": {"tags": ["pr-abc123", "main-abc123"]}}},
+  {"id": 102, "updated_at": "2026-06-02T00:00:00Z", "metadata": {"container": {"tags": ["main-def456"]}}},
+  {"id": 103, "updated_at": "2026-06-03T00:00:00Z", "metadata": {"container": {"tags": ["main-aaa789"]}}},
+  {"id": 104, "updated_at": "2026-06-04T00:00:00Z", "metadata": {"container": {"tags": ["latest", "main"]}}},
+  {"id": 105, "updated_at": "2026-06-05T00:00:00Z", "metadata": {"container": {"tags": ["main-bbb012", "v1.2.3"]}}},
+  {"id": 106, "updated_at": "2026-06-06T00:00:00Z", "metadata": {"container": {"tags": ["pr-only-tag"]}}}
+]`
+
+const testRef = "ghcr.io/z/tools"
+
+func TestSelectByTag(t *testing.T) {
+	ids, err := SelectByTag(strings.NewReader(versionsJSON), "pr-abc123")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(ids) != 1 || ids[0] != 101 {
+		t.Errorf("SelectByTag = %v, want [101]", ids)
+	}
+}
+
+func TestSelectByTag_NoMatch(t *testing.T) {
+	ids, err := SelectByTag(strings.NewReader(versionsJSON), "pr-nonexistent")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(ids) != 0 {
+		t.Errorf("SelectByTag no-match = %v, want empty", ids)
+	}
+}
+
+func TestSelectPrunable_KeepsNewest(t *testing.T) {
+	// Prunable per-commit builds: 101,102,103 (105 has v-tag → protected;
+	// 104 has latest/main → protected; 106 has no main-<sha> → not a build).
+	// Newest-first: 103, 102, 101. keep=1 → prune 102, 101.
+	ids, err := SelectPrunable(strings.NewReader(versionsJSON), 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(ids) != 2 || ids[0] != 102 || ids[1] != 101 {
+		t.Errorf("SelectPrunable keep=1 = %v, want [102 101]", ids)
+	}
+}
+
+func TestSelectPrunable_KeepAll(t *testing.T) {
+	ids, err := SelectPrunable(strings.NewReader(versionsJSON), 10)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(ids) != 0 {
+		t.Errorf("keep>=candidates should prune nothing, got %v", ids)
+	}
+}
+
+func TestSelectPrunable_NegativeKeepAndProtected(t *testing.T) {
+	// keep<0 is treated as 0 → all three prunable builds (101,102,103) selected;
+	// 104 (latest/main), 105 (v-tag), 106 (no main-<sha>) are excluded.
+	ids, err := SelectPrunable(strings.NewReader(versionsJSON), -5)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(ids) != 3 {
+		t.Fatalf("negative keep treated as 0, want 3 prunable, got %v", ids)
+	}
+	for _, id := range ids {
+		if id == 104 || id == 105 || id == 106 {
+			t.Errorf("id %d must not be prunable (protected/non-build)", id)
+		}
+	}
+}
+
+func TestFormatIDs(t *testing.T) {
+	got := FormatIDs([]int64{101, 102})
+	if got != "101\n102\n" {
+		t.Errorf("FormatIDs = %q, want \"101\\n102\\n\"", got)
+	}
+	if FormatIDs(nil) != "" {
+		t.Error("FormatIDs(nil) should be empty")
+	}
+}
+
+func TestDecodeVersions_Invalid(t *testing.T) {
+	if _, err := SelectByTag(strings.NewReader("{not json}"), "x"); err == nil {
+		t.Error("expected parse error for invalid JSON")
+	}
+}
+
+func TestFinalTags_MainBranch(t *testing.T) {
+	tags, err := FinalTags(RetagInput{Ref: testRef, SHA: "abc123", GitRef: "refs/heads/main"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"ghcr.io/z/tools:main-abc123", "ghcr.io/z/tools:latest"}
+	if len(tags) != 2 || tags[0] != want[0] || tags[1] != want[1] {
+		t.Errorf("FinalTags main = %v, want %v", tags, want)
+	}
+	// A non-v refs/tags ref must not add a version tag either.
+	nv, _ := FinalTags(RetagInput{Ref: testRef, SHA: "abc", GitRef: "refs/tags/nightly"})
+	if len(nv) != 2 {
+		t.Errorf("non-v tag must not add a version tag, got %v", nv)
+	}
+}
+
+func TestFinalTags_VersionTag(t *testing.T) {
+	tags, err := FinalTags(RetagInput{Ref: testRef, SHA: "abc123", GitRef: "refs/tags/v1.2.3"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"ghcr.io/z/tools:main-abc123", "ghcr.io/z/tools:v1.2.3", "ghcr.io/z/tools:latest"}
+	if len(tags) != 3 || tags[1] != want[1] {
+		t.Errorf("FinalTags version = %v, want %v", tags, want)
+	}
+}
+
+func TestFinalTags_Validation(t *testing.T) {
+	if _, err := FinalTags(RetagInput{SHA: "abc"}); err == nil {
+		t.Error("expected error for missing ref")
+	}
+	if _, err := FinalTags(RetagInput{Ref: testRef}); err == nil {
+		t.Error("expected error for missing sha")
+	}
+}

--- a/cmd/zynax-ci/internal/imagesreport/imagesreport_test.go
+++ b/cmd/zynax-ci/internal/imagesreport/imagesreport_test.go
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package imagesreport
+
+import (
+	"strings"
+	"testing"
+)
+
+const sampleIndex = `{
+  "annotations": {
+    "org.opencontainers.image.description": "Zynax tools image",
+    "org.opencontainers.image.title": "tools"
+  },
+  "manifests": [
+    {"platform": {"os": "linux"}},
+    {"platform": {"os": "linux"}},
+    {"platform": {"os": "unknown"}},
+    {"platform": {"os": "unknown"}}
+  ]
+}`
+
+func TestParseMeta_AnnotationsAndAttestations(t *testing.T) {
+	m, err := ParseMeta(strings.NewReader(sampleIndex))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !m.IndexResolved || m.Description != "Zynax tools image" || m.Title != "tools" {
+		t.Errorf("annotations not parsed: resolved=%v desc=%q title=%q", m.IndexResolved, m.Description, m.Title)
+	}
+	if m.Attestations != ExpectedAttestations {
+		t.Errorf("attestations = %d, want %d", m.Attestations, ExpectedAttestations)
+	}
+}
+
+func TestParseMeta_EmptyIndexNonFatal(t *testing.T) {
+	m, err := ParseMeta(strings.NewReader("  \n"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if m.IndexResolved || m.MissingDescription() {
+		t.Error("empty index must be unresolved and not fail the description check")
+	}
+	if !strings.Contains(m.Summary("tools", "sha256:x", ""), "report skipped") {
+		t.Error("unresolved index should render the skipped block")
+	}
+}
+
+func TestParseMeta_Invalid(t *testing.T) {
+	if _, err := ParseMeta(strings.NewReader("{not json}")); err == nil {
+		t.Error("expected parse error for invalid index JSON")
+	}
+}
+
+func TestMeta_MissingDescriptionFails(t *testing.T) {
+	m, _ := ParseMeta(strings.NewReader(`{"annotations":{},"manifests":[]}`))
+	if !m.MissingDescription() {
+		t.Error("expected MissingDescription when description annotation absent")
+	}
+}
+
+func TestMeta_SummaryParity(t *testing.T) {
+	m, _ := ParseMeta(strings.NewReader(sampleIndex))
+	s := m.Summary("tools", "sha256:idx", "extra line")
+	for _, want := range []string{"## tools", "**Digest:** `sha256:idx`", "extra line"} {
+		if !strings.Contains(s, want) {
+			t.Errorf("summary missing %q:\n%s", want, s)
+		}
+	}
+}

--- a/cmd/zynax-ci/internal/imagesreport/meta.go
+++ b/cmd/zynax-ci/internal/imagesreport/meta.go
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package imagesreport holds the deterministic, tested logic behind the
+// `zynax-ci images meta|cleanup|retag` verbs. It is the Go replacement for the
+// report-image-meta composite action, the pr-image-cleanup gh/jq blocks, and
+// the tools-image retag/prune blocks (ADR-036, M7 EPIC S step S.5).
+//
+// The external primitives stay in the shell: the workflow pipes the GHCR index
+// manifest JSON (curl), the packages-API versions list (gh api), and runs
+// crane/imagetools for the actual copy/delete. This package only computes the
+// decisions — annotation checks, version-id selection, and the release-tag
+// list — so they get unit tests and govulncheck instead of living untested in
+// YAML. Per-platform size budgeting stays in the workflow's curl loop.
+package imagesreport
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// ExpectedAttestations is the dual-arch SLSA provenance count (ADR-025).
+const ExpectedAttestations = 2
+
+// index is the parsed OCI image index (manifest list).
+type index struct {
+	Annotations map[string]string `json:"annotations"`
+	Manifests   []struct {
+		Platform struct {
+			OS string `json:"os"`
+		} `json:"platform"`
+	} `json:"manifests"`
+}
+
+// Meta is the result of inspecting an index manifest.
+type Meta struct {
+	Description   string
+	Title         string
+	Attestations  int
+	IndexResolved bool
+}
+
+// ParseMeta reads the index manifest JSON and returns the annotation report. An
+// empty or whitespace-only body is non-fatal (IndexResolved stays false), parity
+// with the bash retry-then-skip path when GHCR lags after a push.
+func ParseMeta(indexJSON io.Reader) (Meta, error) {
+	data, err := io.ReadAll(indexJSON)
+	if err != nil {
+		return Meta{}, fmt.Errorf("imagesreport: read index: %w", err)
+	}
+	if len(strings.TrimSpace(string(data))) == 0 {
+		return Meta{}, nil
+	}
+	var idx index
+	if err := json.Unmarshal(data, &idx); err != nil {
+		return Meta{}, fmt.Errorf("imagesreport: parse index: %w", err)
+	}
+	m := Meta{
+		IndexResolved: true,
+		Description:   idx.Annotations["org.opencontainers.image.description"],
+		Title:         idx.Annotations["org.opencontainers.image.title"],
+		Attestations:  countAttestations(idx),
+	}
+	return m, nil
+}
+
+// countAttestations counts the unknown-OS (SLSA provenance) descriptors.
+func countAttestations(idx index) int {
+	n := 0
+	for _, d := range idx.Manifests {
+		if d.Platform.OS == "unknown" {
+			n++
+		}
+	}
+	return n
+}

--- a/cmd/zynax-ci/internal/imagesreport/retag.go
+++ b/cmd/zynax-ci/internal/imagesreport/retag.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package imagesreport
+
+import (
+	"fmt"
+	"strings"
+)
+
+// RetagInput holds the inputs to the release-tag computation.
+type RetagInput struct {
+	// Ref is the image repository without a tag, e.g.
+	// ghcr.io/zynax-io/zynax/tools.
+	Ref string
+	// SHA is the commit being published (github.sha).
+	SHA string
+	// GitRef is the triggering git ref (github.ref), e.g. refs/heads/main or
+	// refs/tags/v1.2.3.
+	GitRef string
+}
+
+// refNamePrefix is the prefix stripped from a refs/tags/<name> git ref.
+const refNamePrefix = "refs/tags/"
+
+// FinalTags computes the fully-qualified tags to apply when promoting a
+// multi-arch manifest, parity with the tools-image create-*-manifest blocks:
+// always main-<sha> and latest; plus the version tag when GitRef is refs/tags/v*.
+// The order matches the bash: main-<sha>, [version], latest.
+func FinalTags(in RetagInput) ([]string, error) {
+	if in.Ref == "" {
+		return nil, fmt.Errorf("imagesreport: retag: ref is required")
+	}
+	if in.SHA == "" {
+		return nil, fmt.Errorf("imagesreport: retag: sha is required")
+	}
+	tags := []string{in.Ref + ":main-" + in.SHA}
+	if v := versionTag(in.GitRef); v != "" {
+		tags = append(tags, in.Ref+":"+v)
+	}
+	tags = append(tags, in.Ref+":latest")
+	return tags, nil
+}
+
+// versionTag returns the v* tag name when gitRef is a refs/tags/v* ref, else "".
+// Parity with the bash `grep -q '^refs/tags/v'` test plus ${github.ref_name}.
+func versionTag(gitRef string) string {
+	if !strings.HasPrefix(gitRef, refNamePrefix) {
+		return ""
+	}
+	name := strings.TrimPrefix(gitRef, refNamePrefix)
+	if strings.HasPrefix(name, "v") {
+		return name
+	}
+	return ""
+}

--- a/cmd/zynax-ci/internal/imagesreport/summary.go
+++ b/cmd/zynax-ci/internal/imagesreport/summary.go
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package imagesreport
+
+import (
+	"fmt"
+	"strings"
+)
+
+// MissingDescription reports whether the FAIL condition fired: the index was
+// resolved but carries no description annotation (parity with the bash hard
+// exit 1). When the index never resolved the check is skipped (non-fatal).
+func (m Meta) MissingDescription() bool {
+	return m.IndexResolved && m.Description == ""
+}
+
+// Summary renders the GITHUB_STEP_SUMMARY markdown block for an image, parity
+// with report-image-meta's header. When the index was not resolved it emits the
+// skipped-report block instead (non-fatal GHCR read lag).
+func (m Meta) Summary(label, digest, extra string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "## %s\n", label)
+	fmt.Fprintf(&b, "**Digest:** `%s`\n", digest)
+	if !m.IndexResolved {
+		b.WriteString("\n_Metadata report skipped: GHCR index manifest unavailable after retries (non-fatal)._\n")
+		return b.String()
+	}
+	if extra != "" {
+		fmt.Fprintf(&b, "\n%s\n", extra)
+	}
+	return b.String()
+}


### PR DESCRIPTION
## feat(ci): zynax-ci images meta/cleanup/retag

Closes #1290
Part of #1285 (EPIC S — CI bash → zynax-ci)

### Why  (problem & intent)
Image metadata reporting, PR-image cleanup, and release retag decisions live as
untested inline workflow bash (the `report-image-meta` composite action, the
`pr-image-cleanup` gh/jq blocks, and the `tools-image` FINAL_TAGS/prune blocks).
EPIC S step S.5 moves those deterministic decisions into tested `zynax-ci`
subcommands so they get unit tests, type checking, and govulncheck.

### What you'll get  (deliverables ↔ what changed)
- `zynax-ci images meta` — OCI annotation report from an index manifest: FAIL on a missing description, WARN on a missing title, attestation-count notice (ADR-025), step-summary markdown ← `cmd/zynax-ci/cmd/images_report.go`, `internal/imagesreport/meta.go`, `summary.go`
- `zynax-ci images cleanup` — GHCR version-id selection: exact `--tag` (pr-image-cleanup) and `--prune --keep N` (tools-image prune) ← `internal/imagesreport/cleanup.go`
- `zynax-ci images retag` — release-tag computation (always `main-<sha>` + `latest`, plus `v*` on a tag ref) for the imagetools/crane loop ← `internal/imagesreport/retag.go`
- table-driven unit tests + cmd-level RunE tests proving parity with the bash selection/annotation logic ← `*_test.go`

### Scope & boundaries
- **In scope:** the three new `images` subcommands + tests; the deterministic decisions only.
- **Out of scope (deferred):** wiring the workflows + removing the composite action → S.7 cutover (#1292); cosign signing/attestation → S.6 (#1291). The external primitives (curl fetch, `gh api` DELETE, crane/imagetools copy, per-platform size loop) intentionally stay in the workflow shell (ADR-036).

### Test plan & acceptance
| Acceptance criterion | How verified (command) | Result |
|----------------------|------------------------|--------|
| `GOWORK=off go test ./...` green; unit tests on ref/digest parsing + cleanup selection | `GOWORK=off go -C cmd/zynax-ci test ./...` | ✅ all packages ok |
| meta: description/title annotation checks + attestation count | `internal/imagesreport` tests (ParseMeta/MissingDescription/Summary) | ✅ pass |
| cleanup: exact-tag + prune selection parity (protected tags excluded, newest-first keep N) | `TestSelectByTag*`, `TestSelectPrunable*` | ✅ pass |
| retag: FINAL_TAGS parity (main-<sha>/latest, +v* on tag ref) | `TestFinalTags_*`, `TestRunImagesRetag` | ✅ pass |
| No change to which images are produced/deleted (parity on a dry-run) | logic ports only; workflows unchanged this PR (S.7) | ✅ N/A — verbs not yet wired |

**Local gates:** `make lint` ✅ · `GOWORK=off go test ./...` ✅ · module coverage 84.5% (≥80% gate) ✅ · pre-commit golangci-lint ✅

### Evidence
- **CI:** required checks pending on this PR (link in the run).
- **Local output:** `total: (statements) 84.5%`; `internal/imagesreport` 95.7%; all zynax-ci packages `ok`.
- **Artifacts / images:** none — no service source changed (CLI module only).
- **Post-merge digest sync → main:** N/A — no image rebuild.

### Risk & rollback
Low — purely additive. Three new subcommands + one internal package; no existing
verb, workflow, or image behaviour is touched (workflows are wired in S.7). Revert
this PR to remove the verbs.

### Review aids
Key file: `cmd/zynax-ci/internal/imagesreport/cleanup.go` — the version-id
selection that mirrors the pr-image-cleanup and tools-image prune jq. Each Go
function cites the bash predicate it reproduces. `meta` deliberately reports
annotations only; the per-platform size loop stays in the workflow's curl loop
(documented in the package doc) and is a candidate follow-up.

**SPDD:** Canvas `docs/spdd/1285-ci-bash-to-go/canvas.md` — Status: **Aligned** · `/spdd-security-review` **PASS** · ADR-036
**AI:** `Assisted-by: Claude/claude-opus-4-8`   (set the `ai-assisted` label)
