### PR TITLE
feat(agents/adapters): refreshable git credentials via GitHub App tokens

### DIFF
--- a/agents/adapters/git/cmd/git-adapter/credential_main_test.go
+++ b/agents/adapters/git/cmd/git-adapter/credential_main_test.go
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Whitebox coverage for the G.7 (#1262) credential-source wiring in main: PAT vs
+// GitHub App mode selection, App credential resolution, and the scope gate over a
+// refreshable source. No real network — App minting is never triggered here.
+package main
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"testing"
+
+	"github.com/zynax-io/zynax/agents/adapters/git/internal/config"
+	"github.com/zynax-io/zynax/agents/adapters/git/internal/credential"
+)
+
+func appKeyPEM(t *testing.T) string {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	der := x509.MarshalPKCS1PrivateKey(key)
+	return string(pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: der}))
+}
+
+func TestResolveCredentialSource_PATMode(t *testing.T) {
+	t.Setenv("CRED_PAT_ENV", "ghp_test_pat_value")
+	cfg := &config.AdapterConfig{Git: config.GitConfig{Provider: "github", AuthEnv: "CRED_PAT_ENV"}}
+	src, seed, err := resolveCredentialSource(cfg)
+	if err != nil {
+		t.Fatalf("PAT mode: %v", err)
+	}
+	if seed != "ghp_test_pat_value" {
+		t.Fatalf("seed token mismatch: %q", seed)
+	}
+	tok, err := src.Token(context.Background())
+	if err != nil || tok != "ghp_test_pat_value" {
+		t.Fatalf("static source token = %q err=%v", tok, err)
+	}
+}
+
+func TestResolveCredentialSource_PATMissingEnv(t *testing.T) {
+	cfg := &config.AdapterConfig{Git: config.GitConfig{Provider: "github", AuthEnv: "CRED_PAT_UNSET_XYZ"}}
+	if _, _, err := resolveCredentialSource(cfg); err == nil {
+		t.Fatal("expected error when PAT env var is unset")
+	}
+}
+
+func TestResolveCredentialSource_AppMode(t *testing.T) {
+	t.Setenv("CRED_APP_ID", "12345")
+	t.Setenv("CRED_INSTALL_ID", "67890")
+	t.Setenv("CRED_APP_KEY", appKeyPEM(t))
+	cfg := &config.AdapterConfig{Git: config.GitConfig{Provider: "github", App: &config.GitHubAppConfig{
+		AppIDEnv: "CRED_APP_ID", InstallationIDEnv: "CRED_INSTALL_ID", PrivateKeyEnv: "CRED_APP_KEY",
+	}}}
+	src, seed, err := resolveCredentialSource(cfg)
+	if err != nil {
+		t.Fatalf("App mode: %v", err)
+	}
+	if seed != "" {
+		t.Fatalf("App-mode seed token should be empty, got %q", seed)
+	}
+	if _, ok := src.(*credential.AppSource); !ok {
+		t.Fatalf("expected *credential.AppSource, got %T", src)
+	}
+}
+
+func TestResolveCredentialSource_AppMode_BadKey(t *testing.T) {
+	t.Setenv("CRED_APP_ID", "1")
+	t.Setenv("CRED_INSTALL_ID", "1")
+	t.Setenv("CRED_APP_KEY", "not a pem key")
+	cfg := &config.AdapterConfig{Git: config.GitConfig{Provider: "github", App: &config.GitHubAppConfig{
+		AppIDEnv: "CRED_APP_ID", InstallationIDEnv: "CRED_INSTALL_ID", PrivateKeyEnv: "CRED_APP_KEY",
+	}}}
+	if _, _, err := resolveCredentialSource(cfg); err == nil {
+		t.Fatal("expected error for an invalid App private key")
+	}
+}
+
+func TestResolveCredentialSource_AppMode_MissingEnv(t *testing.T) {
+	cfg := &config.AdapterConfig{Git: config.GitConfig{Provider: "github", App: &config.GitHubAppConfig{
+		AppIDEnv: "CRED_APP_ID_UNSET", InstallationIDEnv: "CRED_INSTALL_ID_UNSET", PrivateKeyEnv: "CRED_APP_KEY_UNSET",
+	}}}
+	if _, _, err := resolveCredentialSource(cfg); err == nil {
+		t.Fatal("expected error when App env vars are unset")
+	}
+}
+
+func TestRunScopeGate_StaticSourcePasses(t *testing.T) {
+	// newScopeProbe defaults to a passing fine-grained fake (see scope_main_test.go TestMain).
+	if err := runScopeGate(context.Background(), credential.NewStaticSource("ghp_fine_grained")); err != nil {
+		t.Fatalf("scope gate over a static source should pass: %v", err)
+	}
+}

--- a/agents/adapters/git/cmd/git-adapter/main.go
+++ b/agents/adapters/git/cmd/git-adapter/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/zynax-io/zynax/agents/adapters/git/internal/adapter"
 	"github.com/zynax-io/zynax/agents/adapters/git/internal/auth"
 	"github.com/zynax-io/zynax/agents/adapters/git/internal/config"
+	"github.com/zynax-io/zynax/agents/adapters/git/internal/credential"
 	"github.com/zynax-io/zynax/agents/adapters/git/internal/mcp"
 	"github.com/zynax-io/zynax/agents/adapters/git/internal/redact"
 	"github.com/zynax-io/zynax/agents/adapters/git/internal/registry"
@@ -48,19 +49,23 @@ func run() error {
 	}
 	slog.Info("config loaded", "agent_id", cfg.AgentID, "endpoint", cfg.Endpoint) //nolint:gosec
 
-	token, err := config.ResolveToken(cfg)
+	// Build the credential source. App mode (G.7 / #1262) mints a short-lived
+	// installation token and refreshes it before expiry; PAT mode wraps the
+	// non-expiring token read once from the environment. seedToken is the initial
+	// token used to seed the egress redactor (empty for App mode — its token is
+	// minted lazily and never reaches a payload thanks to per-request Bearer
+	// isolation). No secret value is logged at any point.
+	src, seedToken, err := resolveCredentialSource(cfg)
 	if err != nil {
-		return fmt.Errorf("resolve token: %w", err)
+		return err
 	}
 
-	// Least-privilege gate (G.5 / #1260): verify the token cannot reach repos
-	// beyond the configured owner/repo before it is ever used. The token value is
-	// never passed to the logger — only scope/class metadata.
-	probe, err := newScopeProbe(token)
-	if err != nil {
-		return fmt.Errorf("scope probe init: %w", err)
-	}
-	if err := validateTokenScope(context.Background(), probe, auth.ParseMode(os.Getenv("GIT_ADAPTER_SCOPE_MODE"))); err != nil {
+	// Least-privilege gate (G.5 / #1260): verify the credential cannot reach repos
+	// beyond the configured owner/repo before it is ever used. App installation
+	// tokens carry no X-OAuth-Scopes header and are least-privilege by construction;
+	// the probe classifies them as such. The token value is never logged — only
+	// scope/class metadata.
+	if err := runScopeGate(context.Background(), src); err != nil {
 		return err
 	}
 
@@ -68,7 +73,7 @@ func run() error {
 	// instead of the runtime gRPC server (ADR-032 — one implementation, two
 	// surfaces). It needs no registry and binds no port.
 	if len(os.Args) > 1 && os.Args[1] == "mcp" {
-		return serveMCP(cfg, token, os.Stdin, os.Stdout)
+		return serveMCP(cfg, src, seedToken, os.Stdin, os.Stdout)
 	}
 
 	regClient, cleanup, err := dialRegistry(cfg.RegistryEndpoint)
@@ -80,7 +85,50 @@ func run() error {
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 	defer stop()
 
-	return serve(ctx, cfg, token, regClient)
+	return serve(ctx, cfg, src, seedToken, regClient)
+}
+
+// resolveCredentialSource builds the credential.Source for the configured mode.
+// PAT mode returns a StaticSource and the token (for redactor seeding). App mode
+// resolves the App identity, builds the minter, and returns an AppSource minting
+// installation tokens on demand; its seed token is empty. No secret is logged.
+func resolveCredentialSource(cfg *config.AdapterConfig) (credential.Source, string, error) {
+	if cfg.UsesApp() {
+		inputs, err := config.ResolveAppCredentials(cfg)
+		if err != nil {
+			return nil, "", fmt.Errorf("resolve app credentials: %w", err)
+		}
+		minter, err := credential.NewGitHubAppMinter(credential.AppCredentials{
+			AppID:          inputs.AppID,
+			InstallationID: inputs.InstallationID,
+			PrivateKeyPEM:  inputs.PrivateKeyPEM,
+		})
+		if err != nil {
+			return nil, "", fmt.Errorf("init app minter: %w", err)
+		}
+		slog.Info("git-adapter using GitHub App installation-token credentials (refreshable)") //nolint:gosec
+		return credential.NewAppSource(minter, nil), "", nil
+	}
+	token, err := config.ResolveToken(cfg)
+	if err != nil {
+		return nil, "", fmt.Errorf("resolve token: %w", err)
+	}
+	return credential.NewStaticSource(token), token, nil
+}
+
+// runScopeGate resolves the current token from the source and runs the
+// least-privilege probe (G.5). A source resolution failure (e.g. App minting
+// down at startup) surfaces as a startup error.
+func runScopeGate(ctx context.Context, src credential.Source) error {
+	token, err := src.Token(ctx)
+	if err != nil {
+		return fmt.Errorf("resolve credential for scope gate: %w", err)
+	}
+	probe, err := newScopeProbe(token)
+	if err != nil {
+		return fmt.Errorf("scope probe init: %w", err)
+	}
+	return validateTokenScope(ctx, probe, auth.ParseMode(os.Getenv("GIT_ADAPTER_SCOPE_MODE")))
 }
 
 // scopeValidator is the probe surface auth.Validate consumes at startup (enables
@@ -127,15 +175,17 @@ func validateTokenScope(ctx context.Context, p scopeValidator, mode auth.Mode) e
 
 // serveMCP runs the MCP stdio shim. The exposed tool set is an explicit
 // allow-list built from the configured capability names — not "every handler".
-func serveMCP(cfg *config.AdapterConfig, token string, in io.Reader, out io.Writer) error {
-	srv := adapter.NewAgentServer(cfg, token)
+// The credential source is shared with the runtime path, so App-token refresh
+// applies equally to the MCP surface (ADR-032 — one implementation, two surfaces).
+func serveMCP(cfg *config.AdapterConfig, src credential.Source, seedToken string, in io.Reader, out io.Writer) error {
+	srv := adapter.NewAgentServerWithSource(cfg, src, seedToken)
 	tools := make([]string, 0, len(cfg.Capabilities))
 	for _, c := range cfg.Capabilities {
 		tools = append(tools, c.Name)
 	}
 	// The injected token is scrubbed from every tool result at the prompt
 	// boundary (G.3 / #1199); the token value itself is never logged here.
-	red := redact.New(token)
+	red := redact.New(seedToken)
 	slog.Info("git-adapter mcp serving over stdio", "tools", tools) //nolint:gosec
 	if err := mcp.NewServerWithRedactor(srv, tools, red).Serve(context.Background(), in, out); err != nil {
 		return fmt.Errorf("mcp serve: %w", err)
@@ -151,14 +201,14 @@ func dialRegistry(endpoint string) (zynaxv1.AgentRegistryServiceClient, func(), 
 	return zynaxv1.NewAgentRegistryServiceClient(conn), func() { _ = conn.Close() }, nil
 }
 
-func serve(ctx context.Context, cfg *config.AdapterConfig, token string, regClient zynaxv1.AgentRegistryServiceClient) error {
+func serve(ctx context.Context, cfg *config.AdapterConfig, src credential.Source, seedToken string, regClient zynaxv1.AgentRegistryServiceClient) error {
 	lis, err := net.Listen("tcp", cfg.Endpoint)
 	if err != nil {
 		return fmt.Errorf("listen %s: %w", cfg.Endpoint, err)
 	}
 
 	grpcSrv := grpc.NewServer()
-	zynaxv1.RegisterAgentServiceServer(grpcSrv, adapter.NewAgentServer(cfg, token))
+	zynaxv1.RegisterAgentServiceServer(grpcSrv, adapter.NewAgentServerWithSource(cfg, src, seedToken))
 	healthSrv := health.NewServer()
 	grpc_health_v1.RegisterHealthServer(grpcSrv, healthSrv)
 

--- a/agents/adapters/git/cmd/git-adapter/main_test.go
+++ b/agents/adapters/git/cmd/git-adapter/main_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/zynax-io/zynax/agents/adapters/git/internal/config"
+	"github.com/zynax-io/zynax/agents/adapters/git/internal/credential"
 	zynaxv1 "github.com/zynax-io/zynax/protos/generated/go/zynax/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -210,7 +211,7 @@ func TestServe_GracefulShutdown(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		done <- serve(ctx, cfg, "fake-token", client)
+		done <- serve(ctx, cfg, credential.NewStaticSource("fake-token"), "fake-token", client)
 	}()
 
 	// Give serve() time to start up (register + begin listening).

--- a/agents/adapters/git/cmd/git-adapter/mcp_main_test.go
+++ b/agents/adapters/git/cmd/git-adapter/mcp_main_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/zynax-io/zynax/agents/adapters/git/internal/config"
+	"github.com/zynax-io/zynax/agents/adapters/git/internal/credential"
 )
 
 // TestServeMCP_ClosedTransportReturnsNil covers serveMCP: it builds the tool
@@ -18,7 +19,8 @@ func TestServeMCP_ClosedTransportReturnsNil(t *testing.T) {
 	cfg := &config.AdapterConfig{
 		Capabilities: []config.GitCapabilityConfig{{Name: "open_pr"}, {Name: "get_diff"}},
 	}
-	if err := serveMCP(cfg, "token", strings.NewReader(""), io.Discard); err != nil {
+	src := credential.NewStaticSource("token")
+	if err := serveMCP(cfg, src, "token", strings.NewReader(""), io.Discard); err != nil {
 		t.Fatalf("serveMCP over a closed transport should return nil, got %v", err)
 	}
 }

--- a/agents/adapters/git/internal/adapter/handler.go
+++ b/agents/adapters/git/internal/adapter/handler.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/google/go-github/v67/github"
 	"github.com/zynax-io/zynax/agents/adapters/git/internal/config"
+	"github.com/zynax-io/zynax/agents/adapters/git/internal/credential"
 	"github.com/zynax-io/zynax/agents/adapters/git/internal/redact"
 	zynaxv1 "github.com/zynax-io/zynax/protos/generated/go/zynax/v1"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -38,6 +39,27 @@ type gitHandler struct {
 
 func newGitHandler(token string) *gitHandler {
 	return &gitHandler{gh: newGitHubClient(token), red: redact.New(token)}
+}
+
+// newGitHandlerWithSource builds a handler whose client resolves its token per
+// request from a refreshable credential.Source (G.7 / #1262). redactSeed seeds
+// the egress redactor with the initial token value when known; minted-on-demand
+// tokens are still scrubbed by the same Bearer-header isolation in the transport
+// (the token never reaches a payload or error string in the first place).
+func newGitHandlerWithSource(src credential.Source, redactSeed string) *gitHandler {
+	return &gitHandler{gh: newGitHubClientFromSource(src), red: redact.New(redactSeed)}
+}
+
+// newGitHandlerFromSourceWithURL creates a source-backed handler pointed at a
+// custom base URL (for tests against httptest).
+func newGitHandlerFromSourceWithURL(src credential.Source, baseURL string) *gitHandler {
+	client := newGitHubClientFromSource(src)
+	if baseURL != "" {
+		if parsed, err := client.BaseURL.Parse(baseURL + "/"); err == nil {
+			client.BaseURL = parsed
+		}
+	}
+	return &gitHandler{gh: client, red: redact.New()}
 }
 
 // newGitHandlerWithURL creates a handler pointed at a custom base URL (for tests).

--- a/agents/adapters/git/internal/adapter/server.go
+++ b/agents/adapters/git/internal/adapter/server.go
@@ -7,10 +7,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/google/go-github/v67/github"
 	"github.com/zynax-io/zynax/agents/adapters/git/internal/config"
+	"github.com/zynax-io/zynax/agents/adapters/git/internal/credential"
 	zynaxv1 "github.com/zynax-io/zynax/protos/generated/go/zynax/v1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -24,16 +26,34 @@ type AgentServer struct {
 	handler *gitHandler
 }
 
-// NewAgentServer builds an AgentServer from a validated AdapterConfig and a GitHub token.
-// The token is redacted from every caller-visible error and payload (G.3 / #1199).
+// NewAgentServer builds an AgentServer from a validated AdapterConfig and a static
+// GitHub token (classic / fine-grained PAT). The token is redacted from every
+// caller-visible error and payload (G.3 / #1199). For refreshable App credentials
+// use NewAgentServerWithSource (G.7 / #1262).
 func NewAgentServer(cfg *config.AdapterConfig, token string) *AgentServer {
 	return newAgentServer(cfg, newGitHandler(token))
+}
+
+// NewAgentServerWithSource builds an AgentServer backed by a refreshable
+// credential.Source — used for GitHub App installation tokens that expire (~1 h)
+// and must refresh without a process restart (G.7 / #1262). redactSeed is the
+// initial token value (if known) used to seed the egress redactor; pass "" when
+// the first token is minted lazily. The PAT path uses NewAgentServer unchanged.
+func NewAgentServerWithSource(cfg *config.AdapterConfig, src credential.Source, redactSeed string) *AgentServer {
+	return newAgentServer(cfg, newGitHandlerWithSource(src, redactSeed))
 }
 
 // NewAgentServerWithURL builds an AgentServer using a custom GitHub API base URL.
 // Intended for testing against httptest.Server.
 func NewAgentServerWithURL(cfg *config.AdapterConfig, token, baseURL string) *AgentServer {
 	return newAgentServer(cfg, newGitHandlerWithURL(token, baseURL))
+}
+
+// NewAgentServerWithSourceURL builds a source-backed AgentServer against a custom
+// GitHub API base URL. Intended for testing the refreshable-credential path
+// against an httptest.Server.
+func NewAgentServerWithSourceURL(cfg *config.AdapterConfig, src credential.Source, baseURL string) *AgentServer {
+	return newAgentServer(cfg, newGitHandlerFromSourceWithURL(src, baseURL))
 }
 
 func newAgentServer(cfg *config.AdapterConfig, h *gitHandler) *AgentServer {
@@ -86,9 +106,18 @@ func (s *AgentServer) GetCapabilitySchema(_ context.Context, req *zynaxv1.GetCap
 	}, nil
 }
 
-// newGitHubClient builds an authenticated GitHub client.
+// newGitHubClient builds a GitHub client authenticated by a static token.
 func newGitHubClient(token string) *github.Client {
 	return github.NewClient(nil).WithAuthToken(token)
+}
+
+// newGitHubClientFromSource builds a GitHub client whose Authorization header is
+// resolved per request from a refreshable credential.Source (G.7 / #1262). When
+// the source re-mints a token, subsequent requests carry the new value with no
+// client rebuild.
+func newGitHubClientFromSource(src credential.Source) *github.Client {
+	httpClient := &http.Client{Transport: credential.NewTransport(src, nil)}
+	return github.NewClient(httpClient)
 }
 
 // marshalPayload marshals v to JSON, returning an "UPSTREAM_ERROR" terminal event on failure.

--- a/agents/adapters/git/internal/adapter/source_test.go
+++ b/agents/adapters/git/internal/adapter/source_test.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package adapter_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/zynax-io/zynax/agents/adapters/git/internal/adapter"
+	"github.com/zynax-io/zynax/agents/adapters/git/internal/config"
+	"github.com/zynax-io/zynax/agents/adapters/git/internal/credential"
+	zynaxv1 "github.com/zynax-io/zynax/protos/generated/go/zynax/v1"
+)
+
+// rotatingSource hands out a fresh token on each call, modelling an App source
+// that has re-minted between requests.
+type rotatingSource struct{ n int }
+
+func (r *rotatingSource) Token(context.Context) (string, error) {
+	r.n++
+	return tokenN(r.n), nil
+}
+
+func tokenN(n int) string { return "ghs_rotated_v" + string(rune('0'+n)) } //nolint:gosec // test helper: n is a small bounded loop index
+
+func sourceTestCfg() *config.AdapterConfig {
+	return &config.AdapterConfig{
+		AgentID:          "git-test",
+		Endpoint:         ":50060",
+		RegistryEndpoint: "localhost:50052",
+		Git:              config.GitConfig{Provider: "github"},
+		Capabilities: []config.GitCapabilityConfig{
+			{Name: "open_pr", Owner: "test-owner", Repo: "test-repo", TimeoutSeconds: 5},
+		},
+	}
+}
+
+// TestSourceBackedServer_UsesRefreshedToken proves the source-backed server sends
+// the credential.Source's current token as a Bearer header — and that a rotated
+// token (App refresh) is picked up on the next request without a rebuild.
+func TestSourceBackedServer_UsesRefreshedToken(t *testing.T) {
+	var auths []string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/test-owner/test-repo/pulls", func(w http.ResponseWriter, r *http.Request) {
+		auths = append(auths, r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"number": 7, "html_url": "https://github.com/test-owner/test-repo/pull/7",
+		})
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	srv := adapter.NewAgentServerWithSourceURL(sourceTestCfg(), &rotatingSource{}, ts.URL)
+	payload, _ := json.Marshal(map[string]string{"title": "T", "head": "h", "base": "main"})
+
+	for i := 0; i < 2; i++ {
+		stream := &stubStream{ctx: context.Background()}
+		req := &zynaxv1.ExecuteCapabilityRequest{TaskId: "t", CapabilityName: "open_pr", InputPayload: payload}
+		if err := srv.ExecuteCapability(req, stream); err != nil {
+			t.Fatalf("request %d: %v", i, err)
+		}
+	}
+	if len(auths) != 2 {
+		t.Fatalf("expected 2 upstream requests, got %d", len(auths))
+	}
+	if auths[0] == auths[1] {
+		t.Fatalf("expected a rotated Bearer token between requests, both were %q", auths[0])
+	}
+	if auths[0] != "Bearer "+tokenN(1) {
+		t.Fatalf("first request Authorization = %q, want Bearer + first token", auths[0])
+	}
+}
+
+// TestNewAgentServerWithSource_Constructs covers the production constructor path.
+func TestNewAgentServerWithSource_Constructs(t *testing.T) {
+	srv := adapter.NewAgentServerWithSource(sourceTestCfg(), credential.NewStaticSource("ghp_seed_value"), "ghp_seed_value")
+	if srv == nil {
+		t.Fatal("expected a non-nil server")
+	}
+}

--- a/agents/adapters/git/internal/config/app_config_test.go
+++ b/agents/adapters/git/internal/config/app_config_test.go
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package config_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/zynax-io/zynax/agents/adapters/git/internal/config"
+)
+
+// writeAppYAML writes a config file for the App-mode tests (its own helper so it
+// does not depend on declaration order with the existing config_test.go helper).
+func writeAppYAML(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("writeAppYAML: %v", err)
+	}
+	return path
+}
+
+const appModeYAML = `
+agent_id: git-adapter
+endpoint: :50060
+registry_endpoint: localhost:50052
+git:
+  provider: github
+  app:
+    app_id_env: GH_APP_ID
+    installation_id_env: GH_INSTALL_ID
+    private_key_env: GH_APP_KEY
+capabilities:
+  - name: open_pr
+    owner: zynax-io
+    repo: zynax
+`
+
+func TestLoad_AppMode_NoAuthEnvRequired(t *testing.T) {
+	t.Parallel()
+	cfg, err := config.Load(writeAppYAML(t, appModeYAML))
+	if err != nil {
+		t.Fatalf("App-mode config should load without auth_env: %v", err)
+	}
+	if !cfg.UsesApp() {
+		t.Fatal("UsesApp should be true when git.app is set")
+	}
+	if cfg.Git.App.AppIDEnv != "GH_APP_ID" {
+		t.Errorf("app_id_env mismatch: got %q", cfg.Git.App.AppIDEnv)
+	}
+}
+
+func TestLoad_AppMode_MissingFieldRejected(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		yaml string
+	}{
+		{"missing app_id_env", `
+agent_id: a
+endpoint: :1
+registry_endpoint: r:1
+git:
+  provider: github
+  app:
+    installation_id_env: I
+    private_key_env: K
+capabilities:
+  - {name: open_pr, owner: o, repo: r}
+`},
+		{"missing installation_id_env", `
+agent_id: a
+endpoint: :1
+registry_endpoint: r:1
+git:
+  provider: github
+  app:
+    app_id_env: A
+    private_key_env: K
+capabilities:
+  - {name: open_pr, owner: o, repo: r}
+`},
+		{"missing private_key_env", `
+agent_id: a
+endpoint: :1
+registry_endpoint: r:1
+git:
+  provider: github
+  app:
+    app_id_env: A
+    installation_id_env: I
+capabilities:
+  - {name: open_pr, owner: o, repo: r}
+`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := config.Load(writeAppYAML(t, tt.yaml)); err == nil {
+				t.Fatal("expected validation error for incomplete App config")
+			}
+		})
+	}
+}
+
+func TestUsesApp_FalseForPATMode(t *testing.T) {
+	t.Parallel()
+	cfg := &config.AdapterConfig{Git: config.GitConfig{AuthEnv: "X"}}
+	if cfg.UsesApp() {
+		t.Fatal("UsesApp should be false in PAT mode")
+	}
+}
+
+func TestResolveAppCredentials_Set(t *testing.T) {
+	t.Setenv("GH_APP_ID", "12345")
+	t.Setenv("GH_INSTALL_ID", "67890")
+	t.Setenv("GH_APP_KEY", "test-private-key-placeholder") // not a real key; ResolveAppCredentials only passes the env value through
+	cfg := &config.AdapterConfig{Git: config.GitConfig{App: &config.GitHubAppConfig{
+		AppIDEnv: "GH_APP_ID", InstallationIDEnv: "GH_INSTALL_ID", PrivateKeyEnv: "GH_APP_KEY",
+	}}}
+	got, err := config.ResolveAppCredentials(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.AppID != 12345 || got.InstallationID != 67890 {
+		t.Fatalf("ids mismatch: %+v", got)
+	}
+	if len(got.PrivateKeyPEM) == 0 {
+		t.Fatal("expected private key bytes to be resolved")
+	}
+}
+
+func TestResolveAppCredentials_NotConfigured(t *testing.T) {
+	t.Parallel()
+	cfg := &config.AdapterConfig{Git: config.GitConfig{AuthEnv: "X"}}
+	if _, err := config.ResolveAppCredentials(cfg); err == nil {
+		t.Fatal("expected error when git.app is not configured")
+	}
+}
+
+func TestResolveAppCredentials_BadValues(t *testing.T) {
+	base := &config.GitHubAppConfig{
+		AppIDEnv: "BAD_APP_ID", InstallationIDEnv: "BAD_INSTALL_ID", PrivateKeyEnv: "BAD_KEY",
+	}
+	tests := []struct {
+		name               string
+		appID, instID, key string
+	}{
+		{"app id unset", "", "1", "k"},
+		{"app id non-numeric", "abc", "1", "k"},
+		{"app id non-positive", "0", "1", "k"},
+		{"installation id unset", "1", "", "k"},
+		{"installation id non-numeric", "1", "xyz", "k"},
+		{"key unset", "1", "1", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("BAD_APP_ID", tt.appID)
+			t.Setenv("BAD_INSTALL_ID", tt.instID)
+			t.Setenv("BAD_KEY", tt.key)
+			cfg := &config.AdapterConfig{Git: config.GitConfig{App: base}}
+			if _, err := config.ResolveAppCredentials(cfg); err == nil {
+				t.Fatalf("expected error for %s", tt.name)
+			}
+		})
+	}
+}

--- a/agents/adapters/git/internal/config/config.go
+++ b/agents/adapters/git/internal/config/config.go
@@ -8,6 +8,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"strconv"
 
 	"gopkg.in/yaml.v3"
 )
@@ -25,12 +26,37 @@ type AdapterConfig struct {
 }
 
 // GitConfig holds provider-level settings shared across all capabilities.
+//
+// Two credential modes are supported (G.7 / #1262):
+//   - PAT mode (default): AuthEnv names an env var holding a classic / fine-grained
+//     personal-access token. The token does not expire and is read once at startup.
+//   - GitHub App mode: App.* fields name the env vars holding the App id,
+//     installation id, and private key. The adapter mints a short-lived (~1 h)
+//     installation token and refreshes it before expiry, with no process restart.
+//
+// No secret value is ever stored in config — only the names of the env vars that
+// hold them. App mode takes precedence when App is configured.
 type GitConfig struct {
 	// Provider is the Git hosting provider: "github" or "gitlab" (stub only in M5).
 	Provider string `yaml:"provider"`
 	// AuthEnv is the name of the environment variable that holds the PAT or app token.
 	// The token value is never stored in config — it is resolved from the environment.
 	AuthEnv string `yaml:"auth_env"`
+	// App configures GitHub App installation-token mode. When set, it takes
+	// precedence over AuthEnv and credentials refresh automatically before expiry.
+	App *GitHubAppConfig `yaml:"app,omitempty"`
+}
+
+// GitHubAppConfig names the environment variables that hold GitHub App identity
+// inputs. As with AuthEnv, only env-var names live in config — never the App id,
+// installation id, or private key themselves.
+type GitHubAppConfig struct {
+	// AppIDEnv names the env var holding the numeric GitHub App id.
+	AppIDEnv string `yaml:"app_id_env"`
+	// InstallationIDEnv names the env var holding the numeric installation id.
+	InstallationIDEnv string `yaml:"installation_id_env"`
+	// PrivateKeyEnv names the env var holding the PEM-encoded RSA private key.
+	PrivateKeyEnv string `yaml:"private_key_env"`
 }
 
 // GitCapabilityConfig maps one capability name to a static repository target.
@@ -78,8 +104,8 @@ func validate(cfg *AdapterConfig) error {
 	if cfg.Git.Provider == "" {
 		return fmt.Errorf("config: git.provider is required")
 	}
-	if cfg.Git.AuthEnv == "" {
-		return fmt.Errorf("config: git.auth_env is required")
+	if err := validateAuth(&cfg.Git); err != nil {
+		return err
 	}
 	if len(cfg.Capabilities) == 0 {
 		return fmt.Errorf("config: at least one capability is required")
@@ -98,12 +124,93 @@ func validate(cfg *AdapterConfig) error {
 	return nil
 }
 
+// validateAuth checks that exactly one credential mode is fully configured.
+// App mode requires all three env-var names; otherwise AuthEnv (PAT mode) is
+// required. Only env-var names are validated here — secret values are resolved
+// later from the environment, never stored.
+func validateAuth(g *GitConfig) error {
+	if g.App != nil {
+		if g.App.AppIDEnv == "" {
+			return fmt.Errorf("config: git.app.app_id_env is required in App mode")
+		}
+		if g.App.InstallationIDEnv == "" {
+			return fmt.Errorf("config: git.app.installation_id_env is required in App mode")
+		}
+		if g.App.PrivateKeyEnv == "" {
+			return fmt.Errorf("config: git.app.private_key_env is required in App mode")
+		}
+		return nil
+	}
+	if g.AuthEnv == "" {
+		return fmt.Errorf("config: git.auth_env is required (or configure git.app)")
+	}
+	return nil
+}
+
+// UsesApp reports whether the config selects GitHub App installation-token mode.
+func (c *AdapterConfig) UsesApp() bool {
+	return c.Git.App != nil
+}
+
 // ResolveToken reads the auth token from the env var named in cfg.Git.AuthEnv.
-// Returns an error if the env var is unset or empty.
+// Returns an error if the env var is unset or empty. This is the PAT (non-expiring)
+// path; App mode resolves credentials via ResolveAppCredentials instead.
 func ResolveToken(cfg *AdapterConfig) (string, error) {
 	token := os.Getenv(cfg.Git.AuthEnv)
 	if token == "" {
 		return "", fmt.Errorf("config: env var %s is required but not set", cfg.Git.AuthEnv)
 	}
 	return token, nil
+}
+
+// AppCredentialInputs are the resolved GitHub App identity values, read from the
+// env vars named in GitHubAppConfig. The private key bytes are held only in
+// memory and never re-stored in config.
+type AppCredentialInputs struct {
+	AppID          int64
+	InstallationID int64
+	PrivateKeyPEM  []byte
+}
+
+// ResolveAppCredentials reads the GitHub App identity values from the env vars
+// named in cfg.Git.App. It returns a descriptive error (without any secret value)
+// for a missing var or a non-numeric id.
+func ResolveAppCredentials(cfg *AdapterConfig) (AppCredentialInputs, error) {
+	app := cfg.Git.App
+	if app == nil {
+		return AppCredentialInputs{}, fmt.Errorf("config: git.app is not configured")
+	}
+	appID, err := envInt64(app.AppIDEnv)
+	if err != nil {
+		return AppCredentialInputs{}, err
+	}
+	instID, err := envInt64(app.InstallationIDEnv)
+	if err != nil {
+		return AppCredentialInputs{}, err
+	}
+	keyPEM := os.Getenv(app.PrivateKeyEnv)
+	if keyPEM == "" {
+		return AppCredentialInputs{}, fmt.Errorf("config: env var %s is required but not set", app.PrivateKeyEnv)
+	}
+	return AppCredentialInputs{
+		AppID:          appID,
+		InstallationID: instID,
+		PrivateKeyPEM:  []byte(keyPEM),
+	}, nil
+}
+
+// envInt64 reads a positive int64 from the named env var.
+func envInt64(name string) (int64, error) {
+	raw := os.Getenv(name)
+	if raw == "" {
+		return 0, fmt.Errorf("config: env var %s is required but not set", name)
+	}
+	v, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("config: env var %s must be an integer", name)
+	}
+	if v <= 0 {
+		return 0, fmt.Errorf("config: env var %s must be positive", name)
+	}
+	return v, nil
 }


### PR DESCRIPTION
Closes #1262

EPIC G (#1169) step 7 (LAST G story → finishes EPIC G). GitHub App installation-token support for the git-adapter: mint-on-demand + refresh-before-expiry via a RoundTripper credential.Source; static-PAT path preserved; token/key never logged. Recovered by the orchestrator from a subagent blocked by an ENOSPC /tmp-full (work complete; orchestrator fixed pre-commit lint + a gitleaks placeholder-PEM finding). SPDD: canvas G Aligned, security story.

Assisted-by: Claude/claude-opus-4-8

🤖 Generated with [Claude Code](https://claude.com/claude-code)