### PR TITLE
feat(ci): zynax-ci release helpers (matrix + notes)

### DIFF
--- a/cmd/zynax-ci/cmd/release.go
+++ b/cmd/zynax-ci/cmd/release.go
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/zynax-io/zynax/cmd/zynax-ci/internal/releasehelpers"
+)
+
+var (
+	matrixPrefix   string
+	matrixService  string
+	matrixVersion  string
+	matrixExisting string
+	matrixCandSHAs string
+
+	notesVersion  string
+	notesServices string
+)
+
+var releaseCmd = &cobra.Command{
+	Use:   "release",
+	Short: "Release-pipeline decision helpers (release.yml)",
+	Long: `Compute the release.yml decisions that feed the cosign/crane signing
+steps: which promoted main-<sha> image a release tag promotes (matrix) and the
+GitHub Release notes body (notes).
+
+Replaces the gh-api/jq + assembly run: blocks (ADR-036). git/gh/docker/cosign/
+crane stay the external primitives — this group only makes their decisions
+testable; no signing or attestation crypto moves into Go (ADR-025 unchanged).`,
+}
+
+var releaseMatrixCmd = &cobra.Command{
+	Use:   "matrix",
+	Short: "Resolve the source→target image refs a release tag promotes",
+	Long: `Pick the promoted source tag a release promotes for one service and
+print "<src>:<source-image> <tgt>:<target-image>" for the crane/cosign loop.
+
+Walk --candidate-shas (first-parent commit SHAs from git rev-list, newest-first)
+and select the first main-<sha> (or main-<sha[:8]>) present in --existing-tags
+(the GHCR tag list from gh api). On no match the service is excluded: nothing is
+printed and the command succeeds (parity with the retag-version src='' guard).`,
+	Args: cobra.NoArgs,
+	RunE: runReleaseMatrix,
+}
+
+var releaseNotesCmd = &cobra.Command{
+	Use:   "notes",
+	Short: "Assemble the GitHub Release notes body for a version",
+	Long: `Render the release-notes markdown (install + GHCR pull blocks) for
+--version and print it to stdout for the softprops release body. The service
+pull block is rendered from --services so it cannot drift from SERVICE_IMAGES.
+
+Replaces the static body block in release.yml (ADR-036); the softprops action
+still appends its generated changelog. Use $GITHUB_OUTPUT redirection in the
+workflow to capture the body.`,
+	Args: cobra.NoArgs,
+	RunE: runReleaseNotes,
+}
+
+func init() {
+	releaseMatrixCmd.Flags().StringVar(&matrixPrefix, "prefix", "ghcr.io/zynax-io/zynax", "image repository prefix")
+	releaseMatrixCmd.Flags().StringVar(&matrixService, "service", "", "service image name (e.g. api-gateway)")
+	releaseMatrixCmd.Flags().StringVar(&matrixVersion, "version", "", "release version tag (e.g. v0.6.0)")
+	releaseMatrixCmd.Flags().StringVar(&matrixExisting, "existing-tags", "", "newline/space-separated GHCR tag list (gh api)")
+	releaseMatrixCmd.Flags().StringVar(&matrixCandSHAs, "candidate-shas", "", "newline/space-separated first-parent SHAs, newest-first")
+
+	releaseNotesCmd.Flags().StringVar(&notesVersion, "version", "", "release version tag (e.g. v0.6.0)")
+	releaseNotesCmd.Flags().StringVar(&notesServices, "services", "", "space/newline-separated service image names")
+
+	releaseCmd.AddCommand(releaseMatrixCmd)
+	releaseCmd.AddCommand(releaseNotesCmd)
+	rootCmd.AddCommand(releaseCmd)
+}
+
+func runReleaseMatrix(cmd *cobra.Command, _ []string) error {
+	src := releasehelpers.SelectSourceTag(fields(matrixCandSHAs), fields(matrixExisting))
+	ref, ok, err := releasehelpers.PromoteRef(matrixPrefix, matrixService, src, matrixVersion)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "::notice::%s: no promoted main-<sha> source — excluded from %s\n", matrixService, matrixVersion)
+		return nil
+	}
+	if _, err := fmt.Fprintf(cmd.OutOrStdout(), "src=%s\ntgt=%s\n", ref.Source, ref.Target); err != nil {
+		return fmt.Errorf("release matrix: write refs: %w", err)
+	}
+	return nil
+}
+
+func runReleaseNotes(cmd *cobra.Command, _ []string) error {
+	body, err := releasehelpers.Body(releasehelpers.NotesInput{
+		Version:  notesVersion,
+		Services: fields(notesServices),
+	})
+	if err != nil {
+		return err
+	}
+	if _, err := fmt.Fprint(cmd.OutOrStdout(), body); err != nil {
+		return fmt.Errorf("release notes: write body: %w", err)
+	}
+	return nil
+}
+
+// fields splits a space/newline-separated flag value into non-empty tokens,
+// preserving order (the candidate-sha walk and SERVICE_IMAGES are order-sensitive).
+func fields(s string) []string {
+	return strings.Fields(s)
+}

--- a/cmd/zynax-ci/cmd/release_cmd_test.go
+++ b/cmd/zynax-ci/cmd/release_cmd_test.go
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+const (
+	testSvc = "api-gateway"
+	testVer = "v0.6.0"
+)
+
+func resetMatrixFlags() {
+	matrixPrefix = "ghcr.io/zynax-io/zynax"
+	matrixService, matrixVersion, matrixExisting, matrixCandSHAs = "", "", "", ""
+}
+
+func TestRunReleaseMatrix_Match(t *testing.T) {
+	resetMatrixFlags()
+	defer resetMatrixFlags()
+	matrixService, matrixVersion = testSvc, testVer
+	matrixCandSHAs = "deadbeef00 cafef00d11"
+	matrixExisting = "latest\nmain\nmain-cafef00d11"
+	c, out := cmdWithIO(t, "")
+	if err := runReleaseMatrix(c, nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := out.String()
+	for _, want := range []string{
+		"src=ghcr.io/zynax-io/zynax/api-gateway:main-cafef00d11",
+		"tgt=ghcr.io/zynax-io/zynax/api-gateway:v0.6.0",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("want %q, got:\n%s", want, got)
+		}
+	}
+}
+
+func TestRunReleaseMatrix_NoMatchExcludes(t *testing.T) {
+	resetMatrixFlags()
+	defer resetMatrixFlags()
+	matrixService, matrixVersion = testSvc, testVer
+	matrixCandSHAs = "deadbeef00"
+	matrixExisting = "latest\nv0.5.0"
+	c, out := cmdWithIO(t, "")
+	if err := runReleaseMatrix(c, nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.TrimSpace(out.String()) != "" {
+		t.Errorf("want empty stdout for excluded service, got:\n%s", out.String())
+	}
+}
+
+func TestRunReleaseMatrix_MissingVersion(t *testing.T) {
+	resetMatrixFlags()
+	defer resetMatrixFlags()
+	matrixService = testSvc
+	matrixCandSHAs, matrixExisting = "abc", "main-abc"
+	c, _ := cmdWithIO(t, "")
+	if err := runReleaseMatrix(c, nil); err == nil {
+		t.Error("want error for missing --version")
+	}
+}
+
+func resetNotesFlags() {
+	notesVersion, notesServices = "", ""
+}
+
+func TestRunReleaseNotes_OK(t *testing.T) {
+	resetNotesFlags()
+	defer resetNotesFlags()
+	notesVersion = testVer
+	notesServices = "api-gateway\nengine-adapter"
+	c, out := cmdWithIO(t, "")
+	if err := runReleaseNotes(c, nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "## Zynax v0.6.0") {
+		t.Errorf("want notes header, got:\n%s", got)
+	}
+	if !strings.Contains(got, "docker pull ghcr.io/zynax-io/zynax/engine-adapter:v0.6.0") {
+		t.Errorf("want engine-adapter pull line, got:\n%s", got)
+	}
+}
+
+func TestRunReleaseNotes_MissingVersion(t *testing.T) {
+	resetNotesFlags()
+	defer resetNotesFlags()
+	c, _ := cmdWithIO(t, "")
+	if err := runReleaseNotes(c, nil); err == nil {
+		t.Error("want error for missing --version")
+	}
+}

--- a/cmd/zynax-ci/internal/releasehelpers/matrix.go
+++ b/cmd/zynax-ci/internal/releasehelpers/matrix.go
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package releasehelpers holds the deterministic decision logic ported from the
+// release.yml gh-api/jq + assembly run: blocks (ADR-036). It computes which
+// promoted main-<sha> image a release tag promotes (the per-service matrix that
+// feeds cosign/crane) and assembles the GitHub Release notes. The external
+// primitives — git, gh, docker, cosign, crane, syft — stay in the workflow
+// shell; this package only makes their decisions testable.
+package releasehelpers
+
+import (
+	"fmt"
+	"strings"
+)
+
+// shortSHALen is the length of the short commit SHA used in the main-<sha:0:8>
+// fallback tag (parity with the bash ${sha:0:8}).
+const shortSHALen = 8
+
+// mainTagPrefix is the per-commit promoted-image tag prefix (main-<sha>).
+const mainTagPrefix = "main-"
+
+// SelectSourceTag picks the source image tag a release promotes, parity with the
+// release.yml retag-version "Resolve version and source image" block: walk the
+// first-parent commit SHAs newest-first and return the first main-<sha> (or its
+// main-<sha[:8]> short form) that exists in the promoted tag set. An empty
+// result (no match within the candidate window) is the caller's signal to
+// exclude the service from the release — it is not an error.
+func SelectSourceTag(candidateSHAs, existingTags []string) string {
+	promoted := promotedSet(existingTags)
+	if len(promoted) == 0 {
+		return ""
+	}
+	for _, sha := range candidateSHAs {
+		if sha == "" {
+			continue
+		}
+		if full := mainTagPrefix + sha; promoted[full] {
+			return full
+		}
+		if len(sha) >= shortSHALen {
+			if short := mainTagPrefix + sha[:shortSHALen]; promoted[short] {
+				return short
+			}
+		}
+	}
+	return ""
+}
+
+// promotedSet collects the main-<...> tags from a GHCR tag list into a lookup
+// set (parity with the bash `grep '^main-'` filter over the existing tags).
+func promotedSet(existingTags []string) map[string]bool {
+	set := make(map[string]bool, len(existingTags))
+	for _, t := range existingTags {
+		t = strings.TrimSpace(t)
+		if strings.HasPrefix(t, mainTagPrefix) {
+			set[t] = true
+		}
+	}
+	return set
+}
+
+// VersionRef is the fully-qualified promote source/target pair for one service.
+type VersionRef struct {
+	Service string // service image name, e.g. api-gateway
+	Source  string // <prefix>/<service>:main-<sha>
+	Target  string // <prefix>/<service>:<version>
+}
+
+// PromoteRef builds the source→target image references a service promote applies,
+// given the image prefix (ghcr.io/zynax-io/zynax), the service name, the matched
+// source tag (from SelectSourceTag), and the release version. It returns ok=false
+// when srcTag is empty so the caller skips the service (parity with the bash
+// `if [ -z "${SRC_TAG}" ]` early-exit guard).
+func PromoteRef(prefix, service, srcTag, version string) (VersionRef, bool, error) {
+	if prefix == "" {
+		return VersionRef{}, false, fmt.Errorf("releasehelpers: matrix: prefix is required")
+	}
+	if service == "" {
+		return VersionRef{}, false, fmt.Errorf("releasehelpers: matrix: service is required")
+	}
+	if version == "" {
+		return VersionRef{}, false, fmt.Errorf("releasehelpers: matrix: version is required")
+	}
+	if srcTag == "" {
+		return VersionRef{}, false, nil
+	}
+	base := prefix + "/" + service
+	return VersionRef{
+		Service: service,
+		Source:  base + ":" + srcTag,
+		Target:  base + ":" + version,
+	}, true, nil
+}

--- a/cmd/zynax-ci/internal/releasehelpers/notes.go
+++ b/cmd/zynax-ci/internal/releasehelpers/notes.go
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package releasehelpers
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Version is the resolved release version and its pre-release classification,
+// parity with the release.yml "Resolve version" block: a tag containing a hyphen
+// (e.g. v0.6.0-rc.1) is a pre-release.
+type Version struct {
+	Tag        string
+	Prerelease bool
+}
+
+// Resolve classifies a release tag. A hyphen in the tag marks a pre-release
+// (parity with the bash `if [[ "${TAG}" == *-* ]]`).
+func Resolve(tag string) (Version, error) {
+	if tag == "" {
+		return Version{}, fmt.Errorf("releasehelpers: notes: tag is required")
+	}
+	return Version{Tag: tag, Prerelease: strings.Contains(tag, "-")}, nil
+}
+
+// repoURL is the canonical download/clone URL base used throughout the notes.
+const repoURL = "https://github.com/zynax-io/zynax"
+
+// NotesInput holds the inputs to the release-notes body assembly.
+type NotesInput struct {
+	// Version is the release tag (e.g. v0.6.0).
+	Version string
+	// Services is the ordered list of service image names whose GHCR pull
+	// lines are rendered in the notes (parity with the SERVICE_IMAGES env).
+	Services []string
+}
+
+// Body assembles the GitHub Release notes markdown, parity with the static body
+// block in the release.yml "Create GitHub Release" step. The version is
+// substituted into every download URL; the GHCR pull block is rendered from the
+// service list rather than hand-maintained, so it can never drift from
+// SERVICE_IMAGES. The softprops generate_release_notes changelog is appended by
+// the action itself — this is the prepended body only.
+func Body(in NotesInput) (string, error) {
+	v, err := Resolve(in.Version)
+	if err != nil {
+		return "", err
+	}
+	var b strings.Builder
+	writeHeader(&b, v.Tag)
+	writeCLIInstall(&b, v.Tag)
+	writeCIInstall(&b, v.Tag)
+	writeServiceImages(&b, v.Tag, in.Services)
+	return b.String(), nil
+}
+
+func writeHeader(b *strings.Builder, version string) {
+	fmt.Fprintf(b, "## Zynax %s\n\n", version)
+	b.WriteString("Declarative AI-workflow control plane — CLI, CI toolchain, and service images.\n\n")
+	b.WriteString("All service images are retag-promoted from the pre-merge security ")
+	b.WriteString("gate (ADR-027): the digests below are the exact binaries that ")
+	b.WriteString("passed Trivy before merge.\n\n")
+}
+
+// cliTarget is one zynax CLI download row in the install section.
+type cliTarget struct{ label, artifact string }
+
+func writeCLIInstall(b *strings.Builder, version string) {
+	b.WriteString("### Install zynax CLI\n\n")
+	rows := []cliTarget{
+		{"macOS (Apple Silicon)", "zynax_%s_darwin_arm64.tar.gz"},
+		{"macOS (Intel)", "zynax_%s_darwin_amd64.tar.gz"},
+		{"Linux (amd64)", "zynax_%s_linux_amd64.tar.gz"},
+		{"Linux (arm64)", "zynax_%s_linux_arm64.tar.gz"},
+	}
+	for _, r := range rows {
+		artifact := fmt.Sprintf(r.artifact, version)
+		fmt.Fprintf(b, "**%s:**\n```bash\n", r.label)
+		fmt.Fprintf(b, "curl -L %s/releases/download/%s/%s | tar xz && sudo mv zynax /usr/local/bin/\n```\n\n", repoURL, version, artifact)
+	}
+	fmt.Fprintf(b, "**Windows (amd64):** download `zynax_%s_windows_amd64.zip`\n\n", version)
+	b.WriteString("**Verify checksums:**\n```bash\nsha256sum -c checksums-cli.txt\n```\n\n")
+}
+
+func writeCIInstall(b *strings.Builder, version string) {
+	b.WriteString("### Install zynax-ci\n\n```bash\n# Linux (amd64)\n")
+	fmt.Fprintf(b, "curl -fsSL %s/releases/download/%s/zynax-ci-linux-amd64 -o ~/bin/zynax-ci && chmod +x ~/bin/zynax-ci\n", repoURL, version)
+	b.WriteString("# macOS (Apple Silicon)\n")
+	fmt.Fprintf(b, "curl -fsSL %s/releases/download/%s/zynax-ci-darwin-arm64 -o ~/bin/zynax-ci && chmod +x ~/bin/zynax-ci\n```\n\n", repoURL, version)
+}
+
+func writeServiceImages(b *strings.Builder, version string, services []string) {
+	b.WriteString("### Service images (GHCR)\n\n```bash\n")
+	for _, svc := range services {
+		fmt.Fprintf(b, "docker pull ghcr.io/zynax-io/zynax/%s:%s\n", svc, version)
+	}
+	b.WriteString("```\n\n")
+	b.WriteString("SPDX SBOMs for all service and adapter images are attached to this ")
+	b.WriteString("release. Verify image signatures with ")
+	b.WriteString("`cosign verify ghcr.io/zynax-io/zynax/<service>:<version>`.\n")
+}

--- a/cmd/zynax-ci/internal/releasehelpers/releasehelpers_test.go
+++ b/cmd/zynax-ci/internal/releasehelpers/releasehelpers_test.go
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package releasehelpers
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSelectSourceTag(t *testing.T) {
+	tests := []struct {
+		name      string
+		candidate []string
+		existing  []string
+		want      string
+	}{
+		{
+			name:      "full sha match newest-first",
+			candidate: []string{"aaaa1111", "bbbb2222"},
+			existing:  []string{"latest", "main", "main-bbbb2222"},
+			want:      "main-bbbb2222",
+		},
+		{
+			name:      "first matching candidate wins",
+			candidate: []string{"cccc3333", "bbbb2222"},
+			existing:  []string{"main-cccc3333", "main-bbbb2222"},
+			want:      "main-cccc3333",
+		},
+		{
+			name:      "short-sha fallback",
+			candidate: []string{"abcdef0123456789"},
+			existing:  []string{"main-abcdef01"},
+			want:      "main-abcdef01",
+		},
+		{
+			name:      "no promoted tags",
+			candidate: []string{"aaaa1111"},
+			existing:  []string{"latest", "v1.0.0"},
+			want:      "",
+		},
+		{
+			name:      "no candidate match",
+			candidate: []string{"zzzz9999"},
+			existing:  []string{"main-aaaa1111"},
+			want:      "",
+		},
+		{
+			name:      "empty candidate skipped",
+			candidate: []string{"", "aaaa1111"},
+			existing:  []string{"main-aaaa1111"},
+			want:      "main-aaaa1111",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := SelectSourceTag(tt.candidate, tt.existing); got != tt.want {
+				t.Errorf("SelectSourceTag = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPromoteRef(t *testing.T) {
+	ref, ok, err := PromoteRef("ghcr.io/zynax-io/zynax", "api-gateway", "main-abc123", "v0.6.0")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ok {
+		t.Fatal("want ok=true for a matched source tag")
+	}
+	if ref.Source != "ghcr.io/zynax-io/zynax/api-gateway:main-abc123" {
+		t.Errorf("Source = %q", ref.Source)
+	}
+	if ref.Target != "ghcr.io/zynax-io/zynax/api-gateway:v0.6.0" {
+		t.Errorf("Target = %q", ref.Target)
+	}
+	if ref.Service != "api-gateway" {
+		t.Errorf("Service = %q", ref.Service)
+	}
+}
+
+func TestPromoteRef_EmptySourceExcludes(t *testing.T) {
+	_, ok, err := PromoteRef("ghcr.io/zynax-io/zynax", "api-gateway", "", "v0.6.0")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ok {
+		t.Error("want ok=false (service excluded) when source tag is empty")
+	}
+}
+
+func TestPromoteRef_Validation(t *testing.T) {
+	cases := []struct{ prefix, service, version string }{
+		{"", "svc", "v1"},
+		{"p", "", "v1"},
+		{"p", "svc", ""},
+	}
+	for _, c := range cases {
+		if _, _, err := PromoteRef(c.prefix, c.service, "main-x", c.version); err == nil {
+			t.Errorf("want error for prefix=%q service=%q version=%q", c.prefix, c.service, c.version)
+		}
+	}
+}
+
+func TestResolve(t *testing.T) {
+	tests := []struct {
+		tag        string
+		prerelease bool
+	}{
+		{"v0.6.0", false},
+		{"v0.6.0-rc.1", true},
+		{"v1.2.3-beta", true},
+	}
+	for _, tt := range tests {
+		got, err := Resolve(tt.tag)
+		if err != nil {
+			t.Fatalf("Resolve(%q): unexpected error: %v", tt.tag, err)
+		}
+		if got.Tag != tt.tag {
+			t.Errorf("Tag = %q, want %q", got.Tag, tt.tag)
+		}
+		if got.Prerelease != tt.prerelease {
+			t.Errorf("Resolve(%q).Prerelease = %v, want %v", tt.tag, got.Prerelease, tt.prerelease)
+		}
+	}
+}
+
+func TestResolve_EmptyTag(t *testing.T) {
+	if _, err := Resolve(""); err == nil {
+		t.Error("want error for empty tag")
+	}
+}
+
+func TestBody(t *testing.T) {
+	body, err := Body(NotesInput{
+		Version:  "v0.6.0",
+		Services: []string{"api-gateway", "git-adapter"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	wants := []string{
+		"## Zynax v0.6.0",
+		"zynax_v0.6.0_darwin_arm64.tar.gz",
+		"zynax_v0.6.0_linux_amd64.tar.gz",
+		"zynax-ci-linux-amd64",
+		"docker pull ghcr.io/zynax-io/zynax/api-gateway:v0.6.0",
+		"docker pull ghcr.io/zynax-io/zynax/git-adapter:v0.6.0",
+		"cosign verify",
+	}
+	for _, w := range wants {
+		if !strings.Contains(body, w) {
+			t.Errorf("body missing %q\n--- body ---\n%s", w, body)
+		}
+	}
+}
+
+func TestBody_EmptyVersion(t *testing.T) {
+	if _, err := Body(NotesInput{Version: ""}); err == nil {
+		t.Error("want error for empty version")
+	}
+}


### PR DESCRIPTION
Closes #1291

EPIC S (#1285) step 6. `zynax-ci release matrix` (source-tag SHA walk) + `release notes` (prerelease + body assembly) subcommands, parity with release.yml bash; cosign/crane stay shell consumers. Recovered by the orchestrator from a subagent blocked by an ENOSPC /tmp-full (work complete; orchestrator fixed 2 goconst findings + committed). SPDD: canvas S Aligned, ADR-036.

Assisted-by: Claude/claude-opus-4-8

🤖 Generated with [Claude Code](https://claude.com/claude-code)