### PR TITLE
feat(agents/adapters): git-adapter refreshable credential package

### DIFF
--- a/agents/adapters/git/internal/credential/github_app.go
+++ b/agents/adapters/git/internal/credential/github_app.go
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package credential
+
+import (
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/go-github/v67/github"
+)
+
+// appJWTTTL is the lifetime of the App JWT used to authenticate to the
+// installation-token endpoint. GitHub rejects App JWTs with an expiry more than
+// 10 minutes out; a conservative value also absorbs clock skew.
+const appJWTTTL = 9 * time.Minute
+
+// GitHubAppMinter mints installation tokens for a GitHub App. It signs a
+// short-lived RS256 App JWT with the App private key (held only in memory) and
+// exchanges it for an installation token via the GitHub API. The private key is
+// never logged, returned, or embedded in any error — only minting errors with
+// non-secret context are surfaced.
+type GitHubAppMinter struct {
+	appID          int64
+	installationID int64
+	key            *rsa.PrivateKey
+	now            func() time.Time
+
+	// newClient builds an App-JWT-authenticated client for one mint call. It is a
+	// field so tests can point it at an httptest server without real network.
+	newClient func(jwt string) *github.Client
+}
+
+// AppCredentials are the GitHub App identity inputs resolved at startup. PrivateKeyPEM
+// is the PKCS#1 or PKCS#8 RSA private key bytes; it is parsed once into memory and
+// never retained as a string field.
+type AppCredentials struct {
+	AppID          int64
+	InstallationID int64
+	PrivateKeyPEM  []byte
+	// BaseURL overrides the GitHub API endpoint (tests point this at httptest);
+	// empty uses the public api.github.com.
+	BaseURL string
+	// Now is the clock used for JWT timestamps; nil defaults to time.Now.
+	Now func() time.Time
+}
+
+// NewGitHubAppMinter parses the App private key and builds a Minter. It returns an
+// error for a missing/invalid key or non-positive identifiers; the error never
+// contains key material.
+func NewGitHubAppMinter(c AppCredentials) (*GitHubAppMinter, error) {
+	if c.AppID <= 0 {
+		return nil, errors.New("credential: app_id must be positive")
+	}
+	if c.InstallationID <= 0 {
+		return nil, errors.New("credential: installation_id must be positive")
+	}
+	key, err := parseRSAPrivateKey(c.PrivateKeyPEM)
+	if err != nil {
+		return nil, err
+	}
+	now := c.Now
+	if now == nil {
+		now = time.Now
+	}
+	baseURL := c.BaseURL
+	return &GitHubAppMinter{
+		appID:          c.AppID,
+		installationID: c.InstallationID,
+		key:            key,
+		now:            now,
+		newClient: func(jwt string) *github.Client {
+			client := github.NewClient(nil).WithAuthToken(jwt)
+			if baseURL != "" {
+				if parsed, perr := client.BaseURL.Parse(baseURL + "/"); perr == nil {
+					client.BaseURL = parsed
+				}
+			}
+			return client
+		},
+	}, nil
+}
+
+// Mint signs an App JWT and exchanges it for a fresh installation token. The
+// returned expiry is GitHub's, so AppSource can schedule the next refresh. Neither
+// the JWT nor the private key is logged or returned in an error.
+func (m *GitHubAppMinter) Mint(ctx context.Context) (string, time.Time, error) {
+	jwt, err := m.signAppJWT()
+	if err != nil {
+		return "", time.Time{}, err
+	}
+	client := m.newClient(jwt)
+	tok, _, err := client.Apps.CreateInstallationToken(ctx, m.installationID, nil)
+	if err != nil {
+		// go-github error strings do not embed the JWT or key, but keep context minimal.
+		return "", time.Time{}, fmt.Errorf("credential: mint installation token: %w", err)
+	}
+	expires := tok.GetExpiresAt().Time
+	if expires.IsZero() {
+		// Defensive: GitHub always sets expires_at (~1 h). If absent, assume a
+		// short TTL so the next request forces a refresh rather than trusting forever.
+		expires = m.now().Add(refreshSkew)
+	}
+	return tok.GetToken(), expires, nil
+}
+
+// signAppJWT builds and RS256-signs the GitHub App JWT (iss=app-id, ~9 min TTL).
+// The signature is computed with stdlib crypto only — no JWT dependency.
+func (m *GitHubAppMinter) signAppJWT() (string, error) {
+	now := m.now()
+	header := map[string]string{"alg": "RS256", "typ": "JWT"}
+	claims := map[string]any{
+		// iat backdated 30s to tolerate clock drift between the adapter and GitHub.
+		"iat": now.Add(-30 * time.Second).Unix(),
+		"exp": now.Add(appJWTTTL).Unix(),
+		"iss": m.appID,
+	}
+	hJSON, err := json.Marshal(header)
+	if err != nil {
+		return "", fmt.Errorf("credential: marshal jwt header: %w", err)
+	}
+	cJSON, err := json.Marshal(claims)
+	if err != nil {
+		return "", fmt.Errorf("credential: marshal jwt claims: %w", err)
+	}
+	signingInput := b64url(hJSON) + "." + b64url(cJSON)
+	digest := sha256.Sum256([]byte(signingInput))
+	sig, err := rsa.SignPKCS1v15(rand.Reader, m.key, crypto.SHA256, digest[:])
+	if err != nil {
+		return "", fmt.Errorf("credential: sign jwt: %w", err)
+	}
+	return signingInput + "." + b64url(sig), nil
+}
+
+func b64url(b []byte) string {
+	return base64.RawURLEncoding.EncodeToString(b)
+}
+
+// parseRSAPrivateKey decodes a PEM-encoded RSA private key in PKCS#1 or PKCS#8
+// form. Errors carry no key material.
+func parseRSAPrivateKey(pemBytes []byte) (*rsa.PrivateKey, error) {
+	if len(pemBytes) == 0 {
+		return nil, errors.New("credential: private key is empty")
+	}
+	block, _ := pem.Decode(pemBytes)
+	if block == nil {
+		return nil, errors.New("credential: private key is not valid PEM")
+	}
+	if key, err := x509.ParsePKCS1PrivateKey(block.Bytes); err == nil {
+		return key, nil
+	}
+	parsed, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, errors.New("credential: private key is not a valid PKCS#1 or PKCS#8 RSA key")
+	}
+	rsaKey, ok := parsed.(*rsa.PrivateKey)
+	if !ok {
+		return nil, errors.New("credential: private key is not RSA")
+	}
+	return rsaKey, nil
+}

--- a/agents/adapters/git/internal/credential/github_app_test.go
+++ b/agents/adapters/git/internal/credential/github_app_test.go
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package credential
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// genKeyPEM returns a fresh PKCS#1 RSA private key in PEM form for tests.
+func genKeyPEM(t *testing.T) []byte {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	der := x509.MarshalPKCS1PrivateKey(key)
+	return pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: der})
+}
+
+// genKeyPEMPKCS8 returns a fresh PKCS#8 RSA private key in PEM form.
+func genKeyPEMPKCS8(t *testing.T) []byte {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		t.Fatalf("marshal pkcs8: %v", err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})
+}
+
+func TestNewGitHubAppMinter_Validation(t *testing.T) {
+	valid := genKeyPEM(t)
+	tests := []struct {
+		name string
+		c    AppCredentials
+	}{
+		{"zero app id", AppCredentials{AppID: 0, InstallationID: 1, PrivateKeyPEM: valid}},
+		{"zero installation id", AppCredentials{AppID: 1, InstallationID: 0, PrivateKeyPEM: valid}},
+		{"empty key", AppCredentials{AppID: 1, InstallationID: 1, PrivateKeyPEM: nil}},
+		{"garbage key", AppCredentials{AppID: 1, InstallationID: 1, PrivateKeyPEM: []byte("not pem")}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := NewGitHubAppMinter(tt.c); err == nil {
+				t.Fatal("expected validation error")
+			}
+		})
+	}
+}
+
+func TestParseRSAPrivateKey_PKCS8(t *testing.T) {
+	if _, err := parseRSAPrivateKey(genKeyPEMPKCS8(t)); err != nil {
+		t.Fatalf("PKCS#8 key should parse: %v", err)
+	}
+}
+
+func TestParseRSAPrivateKey_NonRSAPKCS8Rejected(t *testing.T) {
+	// A PEM block that decodes but is not an RSA key.
+	block := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: []byte("bogus")})
+	if _, err := parseRSAPrivateKey(block); err == nil {
+		t.Fatal("expected error for non-RSA PKCS#8 bytes")
+	}
+}
+
+// fakeInstallationServer serves the installation-token endpoint, asserting that a
+// Bearer App JWT is presented, and returns a token with the requested expiry.
+func fakeInstallationServer(t *testing.T, token string, exp time.Time) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := r.Header.Get("Authorization")
+		if !strings.HasPrefix(auth, "Bearer ") || len(auth) < len("Bearer ")+10 {
+			t.Errorf("expected a Bearer App JWT, got %q", auth)
+		}
+		if !strings.Contains(r.URL.Path, "/access_tokens") {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = fmt.Fprintf(w, `{"token":%q,"expires_at":%q}`, token, exp.UTC().Format(time.RFC3339))
+	}))
+}
+
+func TestGitHubAppMinter_MintAgainstFakeServer(t *testing.T) {
+	exp := time.Now().Add(time.Hour).Truncate(time.Second)
+	srv := fakeInstallationServer(t, "ghs_minted_token_abc", exp)
+	defer srv.Close()
+
+	m, err := NewGitHubAppMinter(AppCredentials{
+		AppID:          12345,
+		InstallationID: 67890,
+		PrivateKeyPEM:  genKeyPEM(t),
+		BaseURL:        srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("new minter: %v", err)
+	}
+
+	tok, gotExp, err := m.Mint(context.Background())
+	if err != nil {
+		t.Fatalf("mint: %v", err)
+	}
+	if tok != "ghs_minted_token_abc" {
+		t.Fatalf("token = %q, want minted value", tok)
+	}
+	if !gotExp.Equal(exp) {
+		t.Fatalf("expiry = %v, want %v", gotExp, exp)
+	}
+}
+
+func TestGitHubAppMinter_MintServerErrorSurfaced(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = fmt.Fprint(w, `{"message":"bad credentials"}`)
+	}))
+	defer srv.Close()
+
+	m, err := NewGitHubAppMinter(AppCredentials{
+		AppID:          1,
+		InstallationID: 1,
+		PrivateKeyPEM:  genKeyPEM(t),
+		BaseURL:        srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("new minter: %v", err)
+	}
+	if _, _, err := m.Mint(context.Background()); err == nil {
+		t.Fatal("expected error from a failing installation-token endpoint")
+	}
+}
+
+// AC: an App source wired to a minter survives past the original token TTL,
+// re-minting against the (fake) endpoint without a restart.
+func TestAppSource_WithRealMinter_RefreshAfterTTL(t *testing.T) {
+	base := time.Now()
+	cur := base
+	clock := func() time.Time { return cur }
+
+	// Server hands out a fresh token each call so we can observe the rotation.
+	var n int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		n++
+		w.WriteHeader(http.StatusCreated)
+		_, _ = fmt.Fprintf(w, `{"token":"ghs_v%d","expires_at":%q}`,
+			n, cur.Add(time.Hour).UTC().Format(time.RFC3339))
+	}))
+	defer srv.Close()
+
+	m, err := NewGitHubAppMinter(AppCredentials{
+		AppID: 1, InstallationID: 1, PrivateKeyPEM: genKeyPEM(t), BaseURL: srv.URL, Now: clock,
+	})
+	if err != nil {
+		t.Fatalf("new minter: %v", err)
+	}
+	s := NewAppSource(m, clock)
+
+	first, err := s.Token(context.Background())
+	if err != nil {
+		t.Fatalf("first token: %v", err)
+	}
+	cur = base.Add(2 * time.Hour) // past the original TTL
+	second, err := s.Token(context.Background())
+	if err != nil {
+		t.Fatalf("second token: %v", err)
+	}
+	if first == second {
+		t.Fatalf("expected token rotation after TTL, both were %q", first)
+	}
+}

--- a/agents/adapters/git/internal/credential/source.go
+++ b/agents/adapters/git/internal/credential/source.go
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package credential provides a refreshable token abstraction for the
+// git-adapter (EPIC G, story G.7 / #1262, ADR-032).
+//
+// Before G.7 the adapter read its token once at startup and the go-github client
+// held it for the whole process lifetime (see internal/config.ResolveToken). That
+// is correct for a classic or fine-grained personal-access token, which does not
+// expire — but a GitHub App installation token lives only ~1 h, so a long-running
+// adapter would start returning 401s mid-process and need a restart.
+//
+// A Source returns a currently-valid token on demand and transparently refreshes
+// it before expiry. Two implementations are provided:
+//
+//   - StaticSource wraps a never-expiring PAT — Token always returns the same
+//     value, so the classic / fine-grained path is unchanged (G.7 AC: PAT path
+//     unchanged).
+//   - AppSource mints and refreshes GitHub App installation tokens from an
+//     app-id + private-key + installation-id, minting a fresh token whenever the
+//     held one is within refreshSkew of expiry.
+//
+// The token value and the App private key are never logged, returned in an
+// error, or otherwise serialized — Source surfaces only the token to its single
+// consumer (the authenticated HTTP transport) and metadata to logs. Pair a Source
+// with redact.Redactor at every caller-visible egress (handler.sanitise, MCP tool
+// results) so a token that leaks into an upstream error string is still scrubbed.
+package credential
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// refreshSkew is how long before a minted token's expiry AppSource refreshes it.
+// A generous margin (relative to the ~1 h installation-token TTL) absorbs clock
+// skew and in-flight request latency so a token never expires mid-request.
+const refreshSkew = 5 * time.Minute
+
+// Source yields a currently-valid Git credential. Implementations must be safe
+// for concurrent use: the adapter calls Token once per outbound API request from
+// multiple goroutines. Token must never return the App private key or any secret
+// material other than the token the transport needs.
+type Source interface {
+	// Token returns a valid token, refreshing it first if the held one is near
+	// expiry. It returns an error only when a refresh is required and fails; a
+	// non-expiring source never errors.
+	Token(ctx context.Context) (string, error)
+}
+
+// StaticSource is a Source for a non-expiring credential (classic or fine-grained
+// PAT). Token always returns the injected value and never errors, preserving the
+// pre-G.7 read-once behaviour for the PAT path.
+type StaticSource struct {
+	token string
+}
+
+// NewStaticSource wraps a never-expiring token.
+func NewStaticSource(token string) *StaticSource {
+	return &StaticSource{token: token}
+}
+
+// Token returns the static token. ctx is accepted for interface symmetry and is
+// unused — there is nothing to refresh.
+func (s *StaticSource) Token(_ context.Context) (string, error) {
+	return s.token, nil
+}
+
+// installationToken is one minted GitHub App installation token and its expiry.
+// It carries no secret beyond the token value itself.
+type installationToken struct {
+	token   string
+	expires time.Time
+}
+
+// Minter mints a fresh GitHub App installation token. The production
+// implementation signs an App JWT with the private key and calls the GitHub
+// installation-token endpoint; tests substitute a fake that returns a token with
+// a controllable expiry and no network access. A Minter must never log or return
+// the private key — only the minted token and its expiry.
+type Minter interface {
+	Mint(ctx context.Context) (token string, expires time.Time, err error)
+}
+
+// AppSource is a Source backed by GitHub App installation tokens. It holds the
+// most recently minted token and re-mints through its Minter once the token is
+// within refreshSkew of expiry. It is safe for concurrent use.
+type AppSource struct {
+	minter Minter
+	now    func() time.Time // injectable clock; defaults to time.Now in tests via NewAppSource
+
+	mu  sync.Mutex
+	cur installationToken
+}
+
+// NewAppSource builds an AppSource over the given Minter. now is the clock used
+// for expiry decisions; pass nil for time.Now (tests inject a fake clock to drive
+// refresh deterministically without sleeping).
+func NewAppSource(minter Minter, now func() time.Time) *AppSource {
+	if now == nil {
+		now = time.Now
+	}
+	return &AppSource{minter: minter, now: now}
+}
+
+// Token returns a valid installation token, minting a fresh one when none is held
+// yet or the current one is within refreshSkew of expiry. On a refresh failure the
+// previously held (still-unexpired) token is returned if usable, so a transient
+// minting error does not break a request that an existing token can still serve.
+func (s *AppSource) Token(ctx context.Context) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.valid() {
+		return s.cur.token, nil
+	}
+
+	tok, exp, err := s.minter.Mint(ctx)
+	if err != nil {
+		// Fall back to the held token if it has not yet hard-expired — a refresh
+		// hiccup should not fail a request a valid token can still serve.
+		if s.cur.token != "" && s.now().Before(s.cur.expires) {
+			return s.cur.token, nil
+		}
+		return "", fmt.Errorf("mint installation token: %w", err)
+	}
+	s.cur = installationToken{token: tok, expires: exp}
+	return s.cur.token, nil
+}
+
+// valid reports whether the held token exists and is not yet within refreshSkew
+// of expiry. Caller must hold s.mu.
+func (s *AppSource) valid() bool {
+	if s.cur.token == "" {
+		return false
+	}
+	return s.now().Add(refreshSkew).Before(s.cur.expires)
+}

--- a/agents/adapters/git/internal/credential/source_test.go
+++ b/agents/adapters/git/internal/credential/source_test.go
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package credential
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+// fakeMinter is a controllable Minter: it returns a token derived from a counter
+// and an expiry the test sets, never touching the network.
+type fakeMinter struct {
+	calls   int
+	ttl     time.Duration
+	now     func() time.Time
+	failNow bool
+	err     error
+}
+
+func (f *fakeMinter) Mint(_ context.Context) (string, time.Time, error) {
+	f.calls++
+	if f.failNow {
+		if f.err != nil {
+			return "", time.Time{}, f.err
+		}
+		return "", time.Time{}, errors.New("mint failed")
+	}
+	exp := f.now().Add(f.ttl)
+	return tokenFor(f.calls), exp, nil
+}
+
+func tokenFor(n int) string {
+	return "ghs_installation_token_v" + string(rune('0'+n)) //nolint:gosec // test helper: n is a small bounded loop index
+}
+
+func TestStaticSource_AlwaysReturnsSameTokenNoError(t *testing.T) {
+	s := NewStaticSource("ghp_classic_pat_value")
+	for i := 0; i < 3; i++ {
+		got, err := s.Token(context.Background())
+		if err != nil {
+			t.Fatalf("StaticSource.Token returned error: %v", err)
+		}
+		if got != "ghp_classic_pat_value" {
+			t.Fatalf("StaticSource.Token = %q, want the injected PAT", got)
+		}
+	}
+}
+
+func TestAppSource_MintsLazilyAndCaches(t *testing.T) {
+	now := time.Now()
+	clock := func() time.Time { return now }
+	m := &fakeMinter{ttl: time.Hour, now: clock}
+	s := NewAppSource(m, clock)
+
+	first, err := s.Token(context.Background())
+	if err != nil {
+		t.Fatalf("first Token: %v", err)
+	}
+	if m.calls != 1 {
+		t.Fatalf("expected lazy mint on first call, got calls=%d", m.calls)
+	}
+
+	// A second call well before expiry must reuse the cached token (no new mint).
+	second, err := s.Token(context.Background())
+	if err != nil {
+		t.Fatalf("second Token: %v", err)
+	}
+	if second != first {
+		t.Fatalf("expected cached token reuse, got %q then %q", first, second)
+	}
+	if m.calls != 1 {
+		t.Fatalf("expected no re-mint within TTL, got calls=%d", m.calls)
+	}
+}
+
+func TestAppSource_RefreshesBeforeExpiry(t *testing.T) {
+	base := time.Now()
+	cur := base
+	clock := func() time.Time { return cur }
+	m := &fakeMinter{ttl: time.Hour, now: clock}
+	s := NewAppSource(m, clock)
+
+	first, err := s.Token(context.Background())
+	if err != nil {
+		t.Fatalf("first Token: %v", err)
+	}
+
+	// Advance the clock to within refreshSkew of expiry — the next call must re-mint.
+	cur = base.Add(time.Hour - (refreshSkew / 2))
+	second, err := s.Token(context.Background())
+	if err != nil {
+		t.Fatalf("second Token: %v", err)
+	}
+	if second == first {
+		t.Fatalf("expected a refreshed token near expiry, got the same value %q", first)
+	}
+	if m.calls != 2 {
+		t.Fatalf("expected exactly one re-mint near expiry, got calls=%d", m.calls)
+	}
+}
+
+// AC: requests after the original token's TTL succeed without a restart.
+func TestAppSource_RequestAfterOriginalTTLSucceeds(t *testing.T) {
+	base := time.Now()
+	cur := base
+	clock := func() time.Time { return cur }
+	m := &fakeMinter{ttl: time.Hour, now: clock}
+	s := NewAppSource(m, clock)
+
+	if _, err := s.Token(context.Background()); err != nil {
+		t.Fatalf("initial Token: %v", err)
+	}
+	// Move the clock past the original token's full TTL — a static read-once PAT
+	// would now be expired; the App source must mint a fresh, valid one.
+	cur = base.Add(2 * time.Hour)
+	got, err := s.Token(context.Background())
+	if err != nil {
+		t.Fatalf("Token after original TTL: %v", err)
+	}
+	if got == "" {
+		t.Fatal("expected a valid refreshed token after the original TTL")
+	}
+	if m.calls != 2 {
+		t.Fatalf("expected a refresh after TTL, got calls=%d", m.calls)
+	}
+}
+
+func TestAppSource_MintFailureWithNoHeldTokenErrors(t *testing.T) {
+	now := time.Now()
+	clock := func() time.Time { return now }
+	m := &fakeMinter{ttl: time.Hour, now: clock, failNow: true}
+	s := NewAppSource(m, clock)
+
+	_, err := s.Token(context.Background())
+	if err == nil {
+		t.Fatal("expected error when first mint fails and no token is held")
+	}
+}
+
+func TestAppSource_MintFailureFallsBackToUnexpiredToken(t *testing.T) {
+	base := time.Now()
+	cur := base
+	clock := func() time.Time { return cur }
+	m := &fakeMinter{ttl: time.Hour, now: clock}
+	s := NewAppSource(m, clock)
+
+	first, err := s.Token(context.Background())
+	if err != nil {
+		t.Fatalf("first Token: %v", err)
+	}
+
+	// Near expiry the source tries to refresh; make minting fail. The held token
+	// is still before hard expiry, so it should be returned rather than erroring.
+	cur = base.Add(time.Hour - (refreshSkew / 2))
+	m.failNow = true
+	got, err := s.Token(context.Background())
+	if err != nil {
+		t.Fatalf("expected fallback to held token, got error: %v", err)
+	}
+	if got != first {
+		t.Fatalf("expected the still-valid held token %q, got %q", first, got)
+	}
+}
+
+func TestAppSource_MintFailureAfterHardExpiryErrors(t *testing.T) {
+	base := time.Now()
+	cur := base
+	clock := func() time.Time { return cur }
+	m := &fakeMinter{ttl: time.Hour, now: clock}
+	s := NewAppSource(m, clock)
+
+	if _, err := s.Token(context.Background()); err != nil {
+		t.Fatalf("first Token: %v", err)
+	}
+	// Past hard expiry with minting down: no usable token remains.
+	cur = base.Add(2 * time.Hour)
+	m.failNow = true
+	if _, err := s.Token(context.Background()); err == nil {
+		t.Fatal("expected error when held token is hard-expired and mint fails")
+	}
+}
+
+func TestNewAppSource_NilClockDefaultsToTimeNow(t *testing.T) {
+	m := &fakeMinter{ttl: time.Hour, now: time.Now}
+	s := NewAppSource(m, nil)
+	if s.now == nil {
+		t.Fatal("expected a default clock when nil is passed")
+	}
+	if _, err := s.Token(context.Background()); err != nil {
+		t.Fatalf("Token with default clock: %v", err)
+	}
+}

--- a/agents/adapters/git/internal/credential/transport.go
+++ b/agents/adapters/git/internal/credential/transport.go
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package credential
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// Transport is an http.RoundTripper that injects the current token from a Source
+// as a Bearer Authorization header on every outbound request. Resolving the token
+// per request (rather than baking it into the client once) is what makes refresh
+// transparent: when an AppSource re-mints, the next request automatically carries
+// the new token with no client rebuild.
+//
+// The token is set on a shallow clone of the request so the caller's Header map is
+// never mutated, and it is written only to the Authorization header — never logged.
+type Transport struct {
+	src  Source
+	base http.RoundTripper
+}
+
+// NewTransport wraps base (or http.DefaultTransport when nil) so each request is
+// authenticated with src's current token.
+func NewTransport(src Source, base http.RoundTripper) *Transport {
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	return &Transport{src: src, base: base}
+}
+
+// RoundTrip resolves the current token and attaches it as a Bearer header. A token
+// resolution failure aborts the request with a non-secret error.
+func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	token, err := t.src.Token(req.Context())
+	if err != nil {
+		return nil, fmt.Errorf("credential: resolve token for request: %w", err)
+	}
+	clone := req.Clone(req.Context())
+	clone.Header.Set("Authorization", "Bearer "+token)
+	return t.base.RoundTrip(clone) //nolint:wrapcheck // transport error surfaced as-is to the http client
+}

--- a/agents/adapters/git/internal/credential/transport_test.go
+++ b/agents/adapters/git/internal/credential/transport_test.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package credential
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// erroringSource always fails to resolve a token.
+type erroringSource struct{}
+
+func (erroringSource) Token(context.Context) (string, error) {
+	return "", errors.New("no token")
+}
+
+// rotatingSource returns a different token on each call to prove the transport
+// resolves per request rather than caching a value.
+type rotatingSource struct{ n int }
+
+func (r *rotatingSource) Token(context.Context) (string, error) {
+	r.n++
+	return tokenFor(r.n), nil
+}
+
+func TestTransport_InjectsBearerPerRequest(t *testing.T) {
+	var seen []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen = append(seen, r.Header.Get("Authorization"))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	client := &http.Client{Transport: NewTransport(&rotatingSource{}, nil)}
+	for i := 0; i < 2; i++ {
+		req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatalf("request %d: %v", i, err)
+		}
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}
+	if len(seen) != 2 {
+		t.Fatalf("expected 2 requests, got %d", len(seen))
+	}
+	if seen[0] == seen[1] {
+		t.Fatalf("expected a fresh token per request, both were %q", seen[0])
+	}
+	if seen[0] != "Bearer "+tokenFor(1) {
+		t.Fatalf("first header = %q, want Bearer + first token", seen[0])
+	}
+}
+
+func TestTransport_DoesNotMutateCallerHeader(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+	client := &http.Client{Transport: NewTransport(NewStaticSource("ghp_static_token_value"), nil)}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	_ = resp.Body.Close()
+	if req.Header.Get("Authorization") != "" {
+		t.Fatal("transport must not mutate the caller's request header")
+	}
+}
+
+func TestTransport_TokenResolutionFailureAborts(t *testing.T) {
+	client := &http.Client{Transport: NewTransport(erroringSource{}, nil)}
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://example.invalid", nil)
+	if _, err := client.Do(req); err == nil {
+		t.Fatal("expected the request to fail when token resolution errors")
+	}
+}
+
+func TestNewTransport_NilBaseDefaultsToDefaultTransport(t *testing.T) {
+	tr := NewTransport(NewStaticSource("x"), nil)
+	if tr.base == nil {
+		t.Fatal("expected a non-nil base RoundTripper")
+	}
+}


### PR DESCRIPTION
Part of #1262 (EPIC G step 7). The standalone `internal/credential` package (Source/StaticSource/AppSource + GitHubAppMinter + RoundTripper). Split from the config/adapter/cmd wiring for PR-size; the follow-up wiring PR Closes #1262. Builds + tests standalone (credential pkg green, no new deps). SPDD: canvas G Aligned, security story.

Assisted-by: Claude/claude-opus-4-8

🤖 Generated with [Claude Code](https://claude.com/claude-code)