### PR TITLE
feat(infra): wire ZYNAX_GW_EVENT_BUS_ADDR into api-gateway chart

### DIFF
--- a/helm/zynax-api-gateway/templates/configmap.yaml
+++ b/helm/zynax-api-gateway/templates/configmap.yaml
@@ -10,6 +10,7 @@ data:
   compiler-addr: {{ .Values.env.compilerAddr | quote }}
   engine-addr: {{ .Values.env.engineAddr | quote }}
   registry-addr: {{ .Values.env.registryAddr | quote }}
+  event-bus-addr: {{ .Values.env.eventBusAddr | quote }}
   log-level: {{ .Values.env.logLevel | quote }}
   grpc-call-timeout-s: {{ .Values.env.grpcCallTimeoutS | quote }}
   liveness-threshold-s: {{ .Values.env.livenessThresholdS | quote }}

--- a/helm/zynax-api-gateway/templates/deployment.yaml
+++ b/helm/zynax-api-gateway/templates/deployment.yaml
@@ -63,6 +63,11 @@ spec:
                 configMapKeyRef:
                   name: {{ include "zynax.fullname" . }}
                   key: registry-addr
+            - name: ZYNAX_GW_EVENT_BUS_ADDR
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "zynax.fullname" . }}
+                  key: event-bus-addr
             - name: ZYNAX_GW_LOG_LEVEL
               valueFrom:
                 configMapKeyRef:

--- a/helm/zynax-api-gateway/values.yaml
+++ b/helm/zynax-api-gateway/values.yaml
@@ -28,6 +28,11 @@ env:
   compilerAddr: "zynax-workflow-compiler:50054"
   engineAddr: "zynax-engine-adapter:50055"
   registryAddr: "zynax-agent-registry:50052"
+  # EventBusService gRPC address consumed by the /logs SSE merge (#1182) to
+  # stream per-workflow capability CloudEvents (ADR-022). The gRPC client is
+  # lazy and the subscription is best-effort, so an unreachable address falls
+  # back to engine-history-only logs (e.g. when zynax-event-bus is disabled).
+  eventBusAddr: "zynax-event-bus:50056"
   logLevel: "info"
   grpcCallTimeoutS: 30
   livenessThresholdS: 60


### PR DESCRIPTION
## feat(infra): wire ZYNAX_GW_EVENT_BUS_ADDR into api-gateway chart

Closes #1313

### Why  (problem & intent)
The api-gateway `/logs` SSE merge (#1182) subscribes to per-workflow EventBus
capability CloudEvents when `ZYNAX_GW_EVENT_BUS_ADDR` is set, but the Helm chart
never surfaced it — so in-cluster deployments silently fell back to
engine-history-only logs. This wires the in-cluster event-bus address through.

### What you'll get  (deliverables ↔ what changed)
- api-gateway Deployment exports `ZYNAX_GW_EVENT_BUS_ADDR` ← `helm/zynax-api-gateway/templates/deployment.yaml`
- ConfigMap carries the `event-bus-addr` key ← `helm/zynax-api-gateway/templates/configmap.yaml`
- Overridable `env.eventBusAddr` default (`zynax-event-bus:50056`) ← `helm/zynax-api-gateway/values.yaml`

### Scope & boundaries
- **In scope:** api-gateway Helm chart env wiring for the event-bus address.
- **Out of scope (deferred):** event-bus service implementation (EPIC I #772, placeholder chart); no Go service changes.

### Test plan & acceptance

| Acceptance criterion | How verified (command) | Result |
|----------------------|------------------------|--------|
| `helm template` renders the Deployment with `ZYNAX_GW_EVENT_BUS_ADDR` set to the in-cluster event-bus address | `helm template gw helm/zynax-api-gateway/ \| grep -A2 ZYNAX_GW_EVENT_BUS_ADDR` | ✅ env wired via `configMapKeyRef` → key `event-bus-addr` → `zynax-event-bus:50056` |
| Chart still lints | `helm lint helm/zynax-api-gateway/` | ✅ 0 charts failed |

**Local gates:** `helm lint` ✅ · `helm template` ✅ (no Go/Python/proto touched → make lint N/A)

### Evidence
- **CI:** pending — all required checks expected green.
- **Local output:** `helm lint` → `1 chart(s) linted, 0 chart(s) failed`; render → ConfigMap `event-bus-addr: "zynax-event-bus:50056"`, Deployment env `ZYNAX_GW_EVENT_BUS_ADDR` via `configMapKeyRef`.
- **Artifacts / images:** none — no service source changed.
- **Post-merge digest sync → main:** N/A — no image rebuild.

### Risk & rollback
Low — additive Helm-only change. The api-gateway event-bus gRPC client is lazy
and the subscription is best-effort, so an unreachable address falls back to
engine-history-only logs. Revert this PR to remove the env wiring.

### Review aids
Mirrors the existing `zynax-engine-adapter` `eventBusAddr` pattern (values →
configmap key → env via `configMapKeyRef`). Key file: `templates/deployment.yaml`.

**SPDD:** EPIC L (#468) — execution log/event streaming (infra follow-up; no canvas required for `feat(infra)` Helm wiring).
**AI:** `Assisted-by: Claude/claude-opus-4-8`
