### PR TITLE
feat(spec): three real runnable workflows with data-flow

### DIFF
--- a/spec/workflows/examples/ci-pipeline.yaml
+++ b/spec/workflows/examples/ci-pipeline.yaml
@@ -1,5 +1,16 @@
-# CI Pipeline Workflow — Reference Example
-# Demonstrates: parallel actions, CI integration, failure recovery
+# SPDX-License-Identifier: Apache-2.0
+# CI Pipeline Workflow — real, runnable reference (EPIC T.3, #1208)
+#
+# Demonstrates: sequential CI stages, failure recovery, human gate, and
+# cross-state DATA-FLOW bindings (ADR-029, EPIC W.4 #1178).
+#
+# Data-flow:
+#   * the `build` state PUBLISHES the built image digest under `built_image`
+#     via `output:`
+#   * `deploy_staging` and `integration_test` CONSUME it through input
+#     bindings rooted at "$.states.build.output.built_image".
+#
+# To apply: zynax apply spec/workflows/examples/ci-pipeline.yaml
 
 kind: Workflow
 apiVersion: zynax.io/v1
@@ -7,6 +18,9 @@ apiVersion: zynax.io/v1
 metadata:
   name: ci-pipeline-workflow
   namespace: platform
+  version: "1.0.0"
+  annotations:
+    description: "Test → scan → build → deploy CI pipeline with image data-flow."
 
 spec:
   initial_state: test
@@ -44,9 +58,10 @@ spec:
         - event: scan.failed
           goto: block_merge
         - event: scan.findings
-          guard: "{{ .event.severity }} == 'low'"
+          guard: "severity == 'low'"
           goto: build    # low severity findings don't block
 
+    # ── Build — PUBLISHES the image digest via output binding ──
     build:
       actions:
         - capability: build_image
@@ -54,18 +69,23 @@ spec:
             commit: "{{ .trigger.commit_sha }}"
             registry: "ghcr.io/zynax-io"
           timeout: 20m
+          # Publish the action's `image_digest` result as `built_image`.
+          output:
+            built_image: image_digest
       on:
         - event: build.success
           goto: deploy_staging
         - event: build.failed
           goto: notify_failure
 
+    # ── Deploy — CONSUMES the build digest via input binding ──
     deploy_staging:
       actions:
         - capability: deploy
           input:
             environment: "staging"
-            image: "{{ .context.built_image }}"
+            # Data-flow binding: deploy exactly what `build` produced.
+            image: "$.states.build.output.built_image"
           timeout: 10m
       on:
         - event: deploy.success
@@ -78,6 +98,8 @@ spec:
         - capability: run_integration_tests
           input:
             environment: "staging"
+            # Same digest the workflow built and deployed.
+            image: "$.states.build.output.built_image"
           timeout: 20m
       on:
         - event: integration.passed
@@ -120,4 +142,5 @@ spec:
       actions:
         - capability: notify_author
           input:
-            message: "CI pipeline passed ✅ — staging deployment live"
+            message: "CI pipeline passed — staging deployment live"
+            channel: "#ci"

--- a/spec/workflows/examples/code-review.yaml
+++ b/spec/workflows/examples/code-review.yaml
@@ -1,7 +1,16 @@
-# Code Review Workflow — Reference Example
-# Demonstrates: loops, async events, human-in-the-loop, timeout handling
+# SPDX-License-Identifier: Apache-2.0
+# Code Review Workflow — real, runnable reference (EPIC T.3, #1208)
 #
-# To apply: zynax apply spec/workflows/examples/code-review.yaml
+# Demonstrates: loops, async events, human-in-the-loop, timeout handling, and
+# cross-state DATA-FLOW bindings (ADR-029, EPIC W.4 #1178).
+#
+# Data-flow:
+#   * the `fix` state's summarize_feedback action PUBLISHES its `summary`
+#     result field under the context key `feedback_summary` via `output:`
+#   * the `escalate` state CONSUMES it with an input binding rooted at
+#     "$.states.fix.output.feedback_summary" — no template indirection.
+#
+# To apply:   zynax apply spec/workflows/examples/code-review.yaml
 # To dry-run: zynax apply --dry-run spec/workflows/examples/code-review.yaml
 
 kind: Workflow
@@ -10,20 +19,21 @@ apiVersion: zynax.io/v1
 metadata:
   name: code-review-workflow
   namespace: engineering
+  version: "1.0.0"
   labels:
     team: platform
     tier: production
   annotations:
-    description: "Automated code review with human escalation"
+    description: "Automated code review with feedback data-flow and human escalation."
 
 spec:
   initial_state: review
 
-  # Events that automatically trigger a NEW workflow instance
+  # Events that automatically trigger a NEW workflow instance.
   triggers:
     - event: github.pull_request.opened
       filter:
-        repo: "zynax/zynax"
+        repo: "zynax-io/zynax"
         base_branch: "main"
 
   states:
@@ -35,43 +45,40 @@ spec:
             pr_url: "{{ .trigger.pr_url }}"
             reviewers: "{{ .context.assigned_reviewers }}"
           timeout: 24h   # If no review in 24h, emit review.timeout
-
       on:
         - event: review.approved
           goto: merge
 
         - event: review.needswork
           goto: fix
-          # Store the feedback in workflow context for the fix state
+          # Carry the raw reviewer comments forward for the fix state.
           set:
             context.latest_feedback: "{{ .event.comments }}"
 
         - event: review.timeout
           goto: escalate
-          guard: "{{ .context.escalation_count }} < 2"
+          guard: "escalation_count < 2"
 
         - event: review.timeout
           goto: abandon
-          guard: "{{ .context.escalation_count }} >= 2"
+          guard: "escalation_count >= 2"
 
-    # ── Fix state ────────────────────────────────────────────────
+    # ── Fix state — PUBLISHES a feedback summary via output binding ──
     fix:
       actions:
-        # Summarise the feedback so the agent knows what to fix
         - capability: summarize_feedback
           input:
             feedback: "{{ .context.latest_feedback }}"
+          # Publish the action's `summary` result field as `feedback_summary`.
           output:
-            context.feedback_summary: "{{ .result.summary }}"
-
+            feedback_summary: summary
       on:
-        # Developer pushes a new commit → go back to review (the loop)
+        # Developer pushes a new commit → go back to review (the loop).
         - event: github.push
           goto: review
           set:
             context.escalation_count: 0
-
-        # Developer explicitly requests a re-review
+        # Developer explicitly requests a re-review.
         - event: review.requested
           goto: review
 
@@ -85,25 +92,24 @@ spec:
       on:
         - event: merge.success
           goto: done
-
         - event: merge.conflict
           goto: fix
           set:
             context.latest_feedback: "Merge conflict — please rebase"
 
-    # ── Escalate state (human-in-the-loop) ───────────────────────
+    # ── Escalate state — CONSUMES the fix summary via input binding ──
     escalate:
-      type: human_in_the_loop    # Workflow pauses here until a human signals
+      type: human_in_the_loop    # Workflow pauses here until a human signals.
       actions:
         - capability: notify_human
           input:
             channel: "#engineering"
-            message: "PR {{ .trigger.pr_url }} needs manual review — timed out"
+            message: "PR needs manual review — timed out"
+            # Data-flow binding: pull the summary published by the fix state.
+            review_summary: "$.states.fix.output.feedback_summary"
       on:
-        # Human approves via Slack command or dashboard
         - event: human.approved
           goto: merge
-        # Human requests more changes
         - event: human.needswork
           goto: fix
           set:
@@ -117,7 +123,7 @@ spec:
         - capability: notify_author
           input:
             pr_url: "{{ .trigger.pr_url }}"
-            message: "Your PR has been merged. 🎉"
+            message: "Your PR has been merged."
 
     abandon:
       type: terminal

--- a/spec/workflows/examples/feature-implementation.yaml
+++ b/spec/workflows/examples/feature-implementation.yaml
@@ -1,0 +1,134 @@
+# SPDX-License-Identifier: Apache-2.0
+# Feature Implementation Workflow — real, runnable reference (EPIC T.3, #1208)
+#
+# Demonstrates: an end-to-end "issue → plan → implement → test → open PR"
+# agent pipeline that threads results between stages with cross-state
+# DATA-FLOW bindings (ADR-029, EPIC W.4 #1178).
+#
+# Data-flow chain:
+#   plan      → publishes `implementation_plan`
+#   implement → consumes the plan, publishes `branch_name` + `diff_summary`
+#   verify    → consumes the branch, publishes `test_report`
+#   open_pr   → consumes branch + diff summary to draft the PR body
+#
+# To apply: zynax apply spec/workflows/examples/feature-implementation.yaml
+
+kind: Workflow
+apiVersion: zynax.io/v1
+
+metadata:
+  name: feature-implementation-workflow
+  namespace: engineering
+  version: "1.0.0"
+  labels:
+    team: platform
+    tier: production
+  annotations:
+    description: "Plan, implement, verify and open a PR for a tracked feature issue."
+
+spec:
+  initial_state: plan
+
+  triggers:
+    - event: github.issues.labeled
+      filter:
+        repo: "zynax-io/zynax"
+        label: "agent:implement"
+
+  states:
+    # ── Plan — PUBLISHES the implementation plan ──
+    plan:
+      actions:
+        - capability: draft_plan
+          input:
+            issue_url: "{{ .trigger.issue_url }}"
+          timeout: 15m
+          # Publish the action's `plan` result as `implementation_plan`.
+          output:
+            implementation_plan: plan
+      on:
+        - event: draft_plan.completed
+          goto: implement
+        - event: draft_plan.failed
+          goto: failed
+
+    # ── Implement — CONSUMES the plan, PUBLISHES branch + diff summary ──
+    implement:
+      actions:
+        - capability: write_code
+          input:
+            issue_url: "{{ .trigger.issue_url }}"
+            # Data-flow binding: feed the plan from the previous state.
+            plan: "$.states.plan.output.implementation_plan"
+          timeout: 1h
+          output:
+            branch_name: branch
+            diff_summary: summary
+      on:
+        - event: write_code.completed
+          goto: verify
+        - event: write_code.failed
+          goto: failed
+
+    # ── Verify — CONSUMES the branch, PUBLISHES the test report ──
+    verify:
+      actions:
+        - capability: run_tests
+          input:
+            branch: "$.states.implement.output.branch_name"
+          timeout: 30m
+          output:
+            test_report: report
+      on:
+        - event: tests.passed
+          goto: open_pr
+        - event: tests.failed
+          goto: rework
+        - event: tests.timeout
+          goto: failed
+
+    # ── Rework — feed the failing report back into another code pass ──
+    rework:
+      actions:
+        - capability: write_code
+          input:
+            branch: "$.states.implement.output.branch_name"
+            failures: "$.states.verify.output.test_report"
+          timeout: 1h
+      on:
+        - event: write_code.completed
+          goto: verify
+        - event: write_code.failed
+          goto: failed
+
+    # ── Open PR — CONSUMES branch + diff summary to draft the PR ──
+    open_pr:
+      actions:
+        - capability: open_pull_request
+          input:
+            issue_url: "{{ .trigger.issue_url }}"
+            branch: "$.states.implement.output.branch_name"
+            body: "$.states.implement.output.diff_summary"
+          timeout: 10m
+      on:
+        - event: open_pull_request.completed
+          goto: done
+        - event: open_pull_request.failed
+          goto: failed
+
+    # ── Terminal states ──
+    done:
+      type: terminal
+      actions:
+        - capability: notify_author
+          input:
+            issue_url: "{{ .trigger.issue_url }}"
+            message: "Feature implemented — PR opened for review."
+
+    failed:
+      type: terminal
+      actions:
+        - capability: notify_author
+          input:
+            issue_url: "{{ .trigger.issue_url }}"
+            message: "Feature implementation failed — manual follow-up required."


### PR DESCRIPTION
## feat(spec): three real runnable workflows with data-flow

Closes #1208
Part of #1171 (EPIC T — Reusable Templates + First Real Workflows)

### Why  (problem & intent)
M7 landed data-flow output/input bindings (W.4 #1178, ADR-029) and reusable
templates (#1206), but there were no production-quality workflows exercising
them end to end. Canvas T step T.3 calls for three real, runnable workflows so
Zynax is actually usable. This wires up the M7 payoff.

### What you'll get  (deliverables ↔ what changed)
- `code-review` threads the reviewer-feedback summary from `fix` to `escalate` via a binding ← `spec/workflows/examples/code-review.yaml`
- `ci-pipeline` builds an image once and threads its digest into deploy + integration-test ← `spec/workflows/examples/ci-pipeline.yaml`
- `feature-implementation` (new): plan → implement → verify → open_pr, each stage consuming the prior stage's published output ← `spec/workflows/examples/feature-implementation.yaml`
- all three carry `metadata.version` and a `description` annotation, and validate against `workflow.schema.json`

### Scope & boundaries
- **In scope:** three runnable workflow manifests under `spec/workflows/examples/` using `output:` publish + `$.states.<state>.output.<key>` input bindings; `version:` surfacing.
- **Out of scope (deferred):** full example catalog (K8s/Helm/GitOps/security), replay/visualization → M-dx.

### Test plan & acceptance

| Acceptance criterion | How verified (command) | Result |
|----------------------|------------------------|--------|
| `code-review`, `ci-pipeline`, `feature-implementation` apply (validate) | `make validate-workflow-schema` | ✅ all 3 `OK` |
| data-flow bindings used | review: `output:` publish + `$.states.*.output.*` input bindings in all 3 | ✅ |

**Local gates:** `make validate-spec` ✅ (workflow + capability + agent-def + policy schemas all `OK`; `check-expert-mapping` fails locally only — the tools image lacks PyYAML, reproduces on clean `main`, unrelated to this YAML-only change) · `make lint` N/A (YAML-only; lint covers proto/Go/Python).

### Evidence
- **CI:** required checks expected green (schema validation runs in a provisioned env).
- **Local output:** `validate-workflow-schema` → `OK ci-pipeline.yaml`, `OK code-review.yaml`, `OK feature-implementation.yaml`.
- **Artifacts / images:** none — no service source changed.
- **Post-merge digest sync → main:** N/A — no image rebuild.

### Risk & rollback
Low — additive/spec-only. Two existing examples gain data-flow bindings + `version:`; one new file. Revert this PR to roll back. No behaviour change to services.

### Review aids
Key file: `spec/workflows/examples/feature-implementation.yaml` (the new full data-flow chain). The binding contract: `output:` maps `<context-key>: <result-field>`; an `input:` string rooted at `$.states.<state>.output.<key>` is a cross-state binding (see `services/workflow-compiler/internal/domain/manifest.go`). Guards in `code-review`/`ci-pipeline` were converted from template syntax to CEL to match the schema.

**SPDD:** Canvas `docs/spdd/1171-templates-real-workflows/canvas.md` — Status: **Aligned** · `/spdd-security-review` **PASS**
**AI:** `Assisted-by: Claude/claude-opus-4-8` (set the `ai-assisted` label)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
