### PR TITLE
docs(observability): OpenTelemetry + Uptrace operator guides

### DIFF
--- a/docs/observability/naming-conventions.md
+++ b/docs/observability/naming-conventions.md
@@ -94,6 +94,10 @@ services correlate to one run.
 
 ## See also
 
+- [opentelemetry.md](opentelemetry.md) — what is emitted and how to enable telemetry
+- [uptrace.md](uptrace.md) — run the Uptrace backend (compose + Helm, login UI)
+- [sampling.md](sampling.md) — sampling and retention tuning
+- [troubleshooting.md](troubleshooting.md) — when signals do not show up
 - `infra/docker-compose/docker-compose.observability.yml` — local Uptrace + collector stack (O.7)
 - `helm/charts/uptrace/` — in-cluster Uptrace + collector chart (O.8)
 - ADR-030 — OTEL + Uptrace backend decision

--- a/docs/observability/opentelemetry.md
+++ b/docs/observability/opentelemetry.md
@@ -1,0 +1,117 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+# OpenTelemetry in Zynax
+
+> EPIC O (#467) · D.4 (#1220). How Zynax services and adapters emit traces,
+> metrics, and logs over OTLP, and how to turn telemetry on.
+
+Zynax instruments every Go service and Python adapter with OpenTelemetry. All
+three signals — traces, metrics, logs — leave a process as **OTLP** and are
+forwarded by an OpenTelemetry Collector to [Uptrace](uptrace.md). Naming rules
+that make those signals join up live in
+[naming-conventions.md](naming-conventions.md).
+
+## Telemetry is off by default
+
+A service runs with **zero exporter overhead and no collector required** until
+you point it at one. The single switch is one environment variable:
+
+```bash
+export ZYNAX_OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:7017
+```
+
+- **Unset** — every provider is a no-op. No OTLP connections are opened, the
+  request path is untouched. This is the default for `make run-local`.
+- **Set** — the shared OTel package wires real OTLP/gRPC tracer, meter, and
+  logger providers, installs them as the OTel globals, and registers the W3C
+  trace-context propagator.
+
+This is the *only* variable required to enable telemetry. It is consumed
+identically by the Go services (via `libs/zynaxobs`) and the Python SDK, so the
+same value works for the whole stack.
+
+| Variable | Purpose | Example |
+|----------|---------|---------|
+| `ZYNAX_OTEL_EXPORTER_OTLP_ENDPOINT` | OTLP/gRPC collector endpoint. Unset ⇒ telemetry off. | `http://localhost:7017` (compose) · `http://zynax-uptrace-otel-collector.<namespace>.svc.cluster.local:4317` (Helm) <!-- gitleaks:allow --> |
+
+> The endpoint must point at an **OTLP/gRPC collector**, not at Uptrace
+> directly. The collector batches and memory-limits the export so a service
+> request path never blocks on the backend.
+
+## What is emitted
+
+The shared OTel wiring (`libs/zynaxobs` for Go, the Python SDK for adapters)
+produces all three signals from a single resource, so they share `service.name`,
+`service.version`, and the other resource attributes from
+[naming-conventions.md](naming-conventions.md#resource-attributes).
+
+### Traces
+
+- gRPC server/client hops between services (e.g. `engine-adapter.DispatchCapability`).
+- api-gateway HTTP routes (e.g. `api-gateway.POST /v1/workflows`).
+- Temporal workflow + activity spans (e.g. `IRInterpreter.DispatchCapability`).
+- Python capability handler spans (e.g. `capability.git.clone`).
+
+The W3C `traceparent` header is propagated across gRPC, Temporal, and NATS, so
+one workflow run is a single connected trace end-to-end. Only `traceparent` is
+propagated — never auth tokens or session data.
+
+### Metrics
+
+RED-style metrics with the `zynax_` prefix and low-cardinality labels
+(`service`, `method`, `status` only):
+
+- `zynax_grpc_requests_total` — counter.
+- `zynax_grpc_request_duration_seconds` — histogram, carries **exemplars**
+  linking a latency bucket to a `trace_id`.
+- `zynax_eventbus_publish_failed_total` — counter.
+
+Never label a metric with workflow IDs, request IDs, or any unbounded value.
+
+### Logs
+
+Logs are emitted as **OTLP log records** (not scraped from stdout). Every log
+line written inside an active span carries `trace_id` and `span_id` as
+first-class OTLP fields, so Uptrace joins a log to its trace and back. Secrets,
+credentials, tokens, and raw request payloads are never logged — redact by
+default.
+
+## How the wiring works (Go)
+
+`libs/zynaxobs` owns the wiring. `InitProviders` reads
+`ZYNAX_OTEL_EXPORTER_OTLP_ENDPOINT`; if it is empty it installs no-op providers
+and a no-op shutdown, otherwise it builds OTLP/gRPC exporters for all three
+signals, batches them, installs the globals, and returns a `shutdown` func the
+caller defers to flush on exit.
+
+```go
+providers, shutdown, err := zynaxobs.InitProviders(ctx, "api-gateway", version)
+if err != nil { /* ... */ }
+defer shutdown(ctx)
+```
+
+Resource attributes (`service.name`, `service.version`) come from `semconv`
+constants — never hand-rolled string keys — so they stay identical across
+services. The Python SDK mirrors this contract for adapters.
+
+## Verifying telemetry is flowing
+
+1. Start the [Uptrace stack](uptrace.md) (`make obs-up`).
+2. Export the endpoint and (re)start the platform services:
+
+   ```bash
+   export ZYNAX_OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:7017
+   make run-local
+   ```
+3. Drive a request (e.g. `zynax apply spec/workflows/examples/code-review.yaml`).
+4. Open the Uptrace UI at <http://localhost:7020> and confirm a trace with
+   correlated logs appears.
+
+If nothing shows up, see [troubleshooting.md](troubleshooting.md).
+
+## See also
+
+- [uptrace.md](uptrace.md) — run the Uptrace backend (compose + Helm).
+- [sampling.md](sampling.md) — sampling and retention tuning.
+- [naming-conventions.md](naming-conventions.md) — span/metric/log naming.
+- ADR-030 — OTEL + Uptrace backend decision.
+- `libs/zynaxobs/providers.go` — the Go provider wiring.

--- a/docs/observability/sampling.md
+++ b/docs/observability/sampling.md
@@ -1,0 +1,91 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+# Sampling and Retention
+
+> EPIC O (#467) · D.4 (#1220). How to tune how much telemetry Zynax keeps —
+> trace sampling, collector batching, and storage retention (TTL).
+
+There are three levers between a service and the bytes stored in ClickHouse:
+**trace sampling** (what a service exports), **collector batching/limiting**
+(how it is transported), and **retention TTL** (how long Uptrace keeps it).
+
+## Trace sampling (at the service)
+
+Zynax ships with **parent-based, always-sample** behaviour: the tracer provider
+in `libs/zynaxobs` is configured with a batch span processor and no head sampler
+override, so a service records every span when telemetry is enabled and honours
+the upstream sampling decision carried in the W3C `traceparent` header.
+
+- Because the sampling decision rides on `traceparent`, a single workflow run is
+  sampled **consistently** across every gRPC, Temporal, and NATS hop — you never
+  get a half-sampled trace.
+- For local development this default is what you want: keep everything, debug
+  with full fidelity.
+- For higher-volume environments, reduce head sampling at the entry service
+  (api-gateway) so the decision propagates downstream. Reducing volume at the
+  root keeps traces *whole* — sampling independently per service would shred them.
+
+> Telemetry is off entirely until `ZYNAX_OTEL_EXPORTER_OTLP_ENDPOINT` is set
+> ([opentelemetry.md](opentelemetry.md)). "No sampling" is the cheapest setting:
+> unset the variable.
+
+## Collector batching and memory limiting
+
+The OpenTelemetry Collector (`infra/docker-compose/observability/otel-collector.yaml`
+locally; the Helm `otel-collector-config` in-cluster) protects both the service
+request path and the collector itself:
+
+| Processor | Setting | Why |
+|-----------|---------|-----|
+| `memory_limiter` | `limit_percentage: 80`, `spike_limit_percentage: 25` | Drops data before OOM under trace/log bursts. |
+| `batch` | `timeout: 5s`, `send_batch_size: 10000` | Batches async so a service never blocks on export. |
+
+This is the canvas Safeguard "never block the request path on the exporter".
+Raise `send_batch_size` for higher throughput; lower `timeout` for fresher data
+in the UI at the cost of more, smaller export requests. Logs are forwarded
+**verbatim** — no processor rewrites or strips the OTLP `trace_id`/`span_id`, so
+log↔trace correlation survives transport.
+
+## Retention (TTL) in Uptrace
+
+Uptrace stores spans, metrics, and logs in ClickHouse, each with its own TTL.
+
+### Local (compose)
+
+`infra/docker-compose/observability/uptrace.yml` pins a **one-week** TTL on every
+signal:
+
+```yaml
+ch_schema:
+  ttl: 168h     # 7 days
+spans:   { ttl: 168h }
+metrics: { ttl: 168h }
+logs:    { ttl: 168h }
+```
+
+This is deliberately short — local telemetry is for debugging, not long-term
+analysis. Long-term retention is deferred to M8. To keep data longer locally,
+raise these TTLs and re-run `make obs-up` (a TTL change applies to newly
+ingested data).
+
+### In-cluster (Helm)
+
+The Helm `uptrace-config` ConfigMap does **not** pin TTLs, so Uptrace applies its
+own defaults. To enforce a retention policy in a cluster, add `spans`/`metrics`/
+`logs` TTL blocks to the chart's Uptrace config and size ClickHouse persistence
+(`clickhouse.persistence.size`) to match the retained volume.
+
+## Choosing values
+
+| Goal | Lever |
+|------|-------|
+| Cheapest / off | Unset `ZYNAX_OTEL_EXPORTER_OTLP_ENDPOINT`. |
+| Full fidelity locally | Default (keep all spans), 168h TTL. |
+| Lower volume, whole traces | Reduce head sampling at api-gateway; let `traceparent` propagate. |
+| Longer history | Raise TTLs; grow ClickHouse persistence. |
+| Burst resilience | Tune collector `memory_limiter` / `batch`. |
+
+## See also
+
+- [opentelemetry.md](opentelemetry.md) · [uptrace.md](uptrace.md) ·
+  [troubleshooting.md](troubleshooting.md) · [naming-conventions.md](naming-conventions.md)
+- ADR-030 — OTEL + Uptrace backend decision.

--- a/docs/observability/troubleshooting.md
+++ b/docs/observability/troubleshooting.md
@@ -1,0 +1,108 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+# Observability Troubleshooting
+
+> EPIC O (#467) · D.4 (#1220). When traces, metrics, or logs do not show up in
+> Uptrace, work down this list. Most issues are the endpoint variable, the
+> project token, or the collector connection.
+
+Start from the signal flow — a problem is always at one of these hops:
+
+```
+service/adapter ──OTLP/gRPC──▶ OTel Collector ──OTLP──▶ Uptrace (ClickHouse + Postgres) ──▶ login UI
+```
+
+## Nothing appears in the UI at all
+
+1. **Is telemetry enabled?** Telemetry is off until the endpoint is set:
+
+   ```bash
+   echo "$ZYNAX_OTEL_EXPORTER_OTLP_ENDPOINT"
+   ```
+
+   Empty ⇒ every provider is a no-op and nothing is exported. Set it
+   (`http://localhost:7017` for compose) and **restart the service** — the
+   variable is read once at startup.
+
+2. **Is the stack up and healthy?**
+
+   ```bash
+   make obs-logs        # look for collector/uptrace/clickhouse/postgres errors
+   ```
+
+   Uptrace depends on ClickHouse and Postgres being healthy first; the collector
+   depends on Uptrace being healthy. A collector that started before Uptrace will
+   reconnect, but a crash-looping ClickHouse blocks everything.
+
+3. **Did you point at the collector, not Uptrace?** The endpoint must be the
+   **collector** OTLP/gRPC port (`7017` locally / `:4317` in-cluster), not the
+   Uptrace UI port. Exporting straight to Uptrace bypasses batching and will not
+   work.
+
+## Stack will not start
+
+- **`make obs-up` errors about a missing env file** — copy the example:
+
+  ```bash
+  cp infra/docker-compose/observability/.env.observability.example \
+     infra/docker-compose/observability/.env.observability
+  ```
+
+- **A container exits citing `set <VAR> in .env.observability`** — a required
+  credential (`PG_PASSWORD`, `UPTRACE_ADMIN_*`, `UPTRACE_PROJECT_TOKEN`,
+  `UPTRACE_DSN`) is unset. There are no committed defaults; fill them all in.
+
+- **Helm: pods stuck / Uptrace `CreateContainerConfigError`** — the credentials
+  Secret is missing. Create `zynax-uptrace-credentials` (see
+  [uptrace.md](uptrace.md#1-create-the-credentials-secret-prerequisite)).
+
+## Traces arrive but logs/metrics do not (or token mismatch)
+
+- **Token mismatch** — the collector's `UPTRACE_DSN` token must equal
+  `UPTRACE_PROJECT_TOKEN`. If they differ, Uptrace silently rejects forwarded
+  data. Make them identical and restart the stack.
+
+- **Metrics missing** — metrics are exported on a periodic reader, so allow one
+  export interval before they appear. Confirm the service actually records
+  instruments (`zynax_grpc_requests_total`, etc.).
+
+## Logs are not correlated to traces
+
+Every log line inside a span should carry `trace_id`/`span_id`. If logs appear
+unlinked:
+
+- Confirm the log was emitted **inside an active span** — a log written before a
+  span starts (or after it ends) has no context to stamp.
+- Confirm the service logs through the `libs/zynaxobs` log bridge (Go) or the
+  OTEL logging handler (Python) — stdout `print`/`fmt.Println` is not OTLP and is
+  never correlated.
+- The collector forwards log records verbatim; it never strips identifiers, so a
+  missing `trace_id` is an emit-side issue, not transport.
+
+See [naming-conventions.md](naming-conventions.md#log-correlation-trace_id--span_id).
+
+## Traces are broken across services
+
+A trace that splits into disconnected pieces means context propagation broke:
+
+- Only the W3C `traceparent` header is propagated across gRPC, Temporal, and
+  NATS. If a custom client drops headers, the downstream span starts a new trace.
+- Independent per-service sampling shreds traces — sample at the root
+  (api-gateway) and let the decision propagate. See [sampling.md](sampling.md).
+
+## Cannot reach the login UI
+
+- **Compose** — the UI binds `127.0.0.1:7020` only (never public). Browse from
+  the host, or set up an SSH tunnel; it is not reachable from another machine by
+  design.
+- **Helm** — Ingress is off by default; port-forward `svc/zynax-uptrace` (see
+  [uptrace.md](uptrace.md#4-reach-the-login-ui)).
+- **Login rejected** — the user is created on first start from
+  `UPTRACE_ADMIN_EMAIL`/`UPTRACE_ADMIN_PASSWORD`. If you changed them after first
+  boot, the original Postgres metadata still holds the old user; recreate the
+  metadata volume or update the user in the UI.
+
+## See also
+
+- [opentelemetry.md](opentelemetry.md) · [uptrace.md](uptrace.md) ·
+  [sampling.md](sampling.md) · [naming-conventions.md](naming-conventions.md)
+- ADR-030 — OTEL + Uptrace backend decision.

--- a/docs/observability/uptrace.md
+++ b/docs/observability/uptrace.md
@@ -1,0 +1,138 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+# Running Uptrace
+
+> EPIC O (#467) · D.4 (#1220). Run the Uptrace observability backend locally
+> (Docker Compose, step O.7) and in-cluster (Helm, step O.8). Uptrace gives you
+> traces, metrics, logs, APM, and a service map behind a single login UI.
+
+Uptrace is the single backend for all three signals. Services and adapters never
+talk to it directly — they export OTLP to an OpenTelemetry Collector, which
+forwards traces, metrics, and logs to Uptrace. See
+[opentelemetry.md](opentelemetry.md) for how signals are produced.
+
+The stack is the same shape in both environments: **single-binary Uptrace +
+ClickHouse (span/metric/log storage) + Postgres (metadata) + OTel Collector**.
+
+## Credentials are never committed
+
+The login user, project token, and Postgres password come **only** from
+environment / a Secret — there are no committed default credentials. Each runner
+fails fast (`${VAR:?...}` guards in compose, a required Secret in Helm) if a
+value is missing.
+
+## Local — Docker Compose (step O.7)
+
+### 1. Create the env file
+
+```bash
+cp infra/docker-compose/observability/.env.observability.example \
+   infra/docker-compose/observability/.env.observability
+# edit infra/docker-compose/observability/.env.observability and fill in:
+#   UPTRACE_ADMIN_EMAIL     — login UI user (any valid email)
+#   UPTRACE_ADMIN_PASSWORD  — login UI password
+#   UPTRACE_PROJECT_TOKEN   — opaque random string
+#   PG_PASSWORD             — Uptrace metadata Postgres password
+#   UPTRACE_DSN             — must embed the SAME token as UPTRACE_PROJECT_TOKEN
+```
+
+The real `.env.observability` is gitignored. The collector's `UPTRACE_DSN` token
+**must equal** `UPTRACE_PROJECT_TOKEN`, or Uptrace rejects the forwarded data.
+
+### 2. Bring it up
+
+```bash
+make obs-up        # Uptrace UI → http://localhost:7020
+make obs-logs      # tail the observability stack
+make obs-down      # stop and remove the stack
+```
+
+`make obs-up` refuses to start until `.env.observability` exists.
+
+### 3. Point services at the collector
+
+```bash
+export ZYNAX_OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:7017
+```
+
+Then start the platform (`make run-local`) and open the login UI at
+<http://localhost:7020>.
+
+### Host port map
+
+| Host port | Bound to | Service | Purpose |
+|-----------|----------|---------|---------|
+| 7020 | `127.0.0.1` | Uptrace UI | Login UI — traces/metrics/logs/APM |
+| 7017 | `127.0.0.1` | OTel Collector | OTLP/gRPC ingest (`ZYNAX_OTEL_EXPORTER_OTLP_ENDPOINT`) |
+| 7018 | `127.0.0.1` | OTel Collector | OTLP/HTTP ingest |
+
+**All observability host ports bind to `127.0.0.1` only** — OTLP ingest is never
+publicly exposed. ClickHouse and Postgres have no host ports (container-internal).
+
+## In-cluster — Helm (step O.8)
+
+The `helm/charts/uptrace/` chart mirrors the compose stack: single-binary
+Uptrace + ClickHouse + Postgres + OTel Collector, with persistence and pod
+security context. The whole chart is gated by the umbrella
+`observability.enabled` condition, so telemetry stays off by default and there is
+no second tracing backend.
+
+### 1. Create the credentials Secret (prerequisite)
+
+No credentials are committed; the chart requires a pre-created Secret:
+
+```bash
+kubectl create secret generic zynax-uptrace-credentials \
+  --namespace zynax \
+  --from-literal=admin-email=<you AT example DOT com> \
+  --from-literal=admin-password=<password> \
+  --from-literal=project-token=<token> \
+  --from-literal=pg-password=<pg-password>
+```
+
+The secret name and keys are configurable via `uptrace.existingSecret` and
+`uptrace.secretKeys` in `values.yaml`.
+
+### 2. Install
+
+```bash
+helm install zynax-uptrace helm/charts/uptrace/ --namespace zynax
+```
+
+### 3. Point services at the in-cluster collector
+
+```
+ZYNAX_OTEL_EXPORTER_OTLP_ENDPOINT=http://zynax-uptrace-otel-collector.<namespace>.svc.cluster.local:4317  # gitleaks:allow
+```
+
+(replace `<namespace>` with the release namespace, e.g. `zynax`.)
+
+The collector Service's OTLP/gRPC port (`4317`) is the canonical in-cluster
+ingest endpoint.
+
+### 4. Reach the login UI
+
+The OTLP collector Service is **never** exposed via Ingress. The login UI is
+disabled at Ingress by default; reach it with a port-forward:
+
+```bash
+kubectl port-forward svc/zynax-uptrace 14318:14318 --namespace zynax
+# then open http://localhost:14318
+```
+
+To expose the UI permanently, set `ingress.enabled=true` and configure
+`ingress.host` plus auth/cert-manager annotations — the UI must stay auth-gated.
+
+## Retention and tuning
+
+Local compose pins a one-week TTL on spans, metrics, and logs; the Helm chart
+uses Uptrace defaults. Tune retention and sampling in
+[sampling.md](sampling.md). When telemetry does not appear in the UI, see
+[troubleshooting.md](troubleshooting.md).
+
+## See also
+
+- `infra/docker-compose/docker-compose.observability.yml` — local stack.
+- `helm/charts/uptrace/` — in-cluster chart.
+- [opentelemetry.md](opentelemetry.md) · [sampling.md](sampling.md) ·
+  [troubleshooting.md](troubleshooting.md) · [naming-conventions.md](naming-conventions.md)
+- ADR-030 — OTEL + Uptrace backend decision.


### PR DESCRIPTION
## docs(observability): OpenTelemetry + Uptrace operator guides

Closes #1220

### Why  (problem & intent)
EPIC O shipped OTEL traces/metrics/logs to Uptrace (compose + Helm), but there
was no operator-facing guide. A new operator could not run, view, or tune
telemetry from docs alone — only the naming-conventions reference existed.

### What you'll get  (deliverables ↔ what changed)
- How to enable telemetry and what is emitted ← `docs/observability/opentelemetry.md`
- Run Uptrace locally (compose) and in-cluster (Helm) with the login UI ← `docs/observability/uptrace.md`
- Sampling + retention (TTL) tuning ← `docs/observability/sampling.md`
- Troubleshooting when signals don't appear ← `docs/observability/troubleshooting.md`
- Cross-links from the existing reference ← `docs/observability/naming-conventions.md`

### Scope & boundaries
- **In scope:** OTEL setup, Uptrace compose + Helm (login UI for traces/metrics/logs/APM), sampling/retention/troubleshooting — the D.4 ACs.
- **Out of scope (deferred):** long-term retention / second backend → M8; example-catalog docs → M-dx.

### Test plan & acceptance
| Acceptance criterion (issue #1220) | How verified | Status |
|---|---|---|
| OTEL setup | `opentelemetry.md` documents `ZYNAX_OTEL_EXPORTER_OTLP_ENDPOINT`, off-by-default, signals emitted — matched against `libs/zynaxobs/providers.go` | ✅ |
| Uptrace local + Helm with login UI for logs/traces/APM | `uptrace.md` documents `make obs-up`/ports/`.env.observability` and the Helm chart Secret + port-forward — matched against the compose overlay and `helm/charts/uptrace/` | ✅ |
| sampling + retention + troubleshooting | `sampling.md` (parent-based sampling, collector batch/limit, 168h TTL) + `troubleshooting.md` — matched against `uptrace.yml` and `otel-collector.yaml` | ✅ |

### Evidence
- **Local output:** `gitleaks` Passed; all internal links resolve to files in `docs/observability/`; env vars/ports/commands transcribed verbatim from the running compose + Helm config (not invented).
- Docs-only change; no code gates apply.

### Risk & rollback
Documentation only — no runtime impact. Rollback = revert the commit.

### Review aids
Suggested reading order: `opentelemetry.md` (concepts) → `uptrace.md` (run it) →
`sampling.md` / `troubleshooting.md`. The one subtlety: the in-cluster collector
FQDN examples carry a `gitleaks:allow` marker because the `internal-hostname`
rule flags any new `*.svc.cluster.local:<port>` literal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
