### PR TITLE
docs: Quick Start + Developer Guide (#1173, step 1)

### DIFF
--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -1,0 +1,167 @@
+# Developer Guide
+
+The day-to-day workflow for contributing to Zynax. If you have not run a workflow
+locally yet, start with the **[Quick Start](quickstart.md)** first.
+
+Everything runs inside Docker — the only prerequisite is Docker Desktop (or Docker
+Engine + the Compose plugin). `make help` lists every target.
+
+---
+
+## One-time setup
+
+```bash
+git clone https://github.com/zynax-io/zynax.git
+cd zynax
+make bootstrap      # pulls ghcr.io/zynax-io/zynax/tools:latest from GHCR — run once
+make install-cli    # builds the zynax CLI → ~/bin/zynax (requires Go 1.26.3)
+```
+
+---
+
+## The local stack
+
+| Command | What it does |
+|---------|-------------|
+| `make run-local` | Build images + start the stack (api-gateway, engine-adapter, workflow-compiler, Temporal, NATS) |
+| `make logs-local` | Tail all stack logs |
+| `make stop-local` | Stop and remove the stack containers |
+
+Aliases: `make dev-up` / `make dev-logs` / `make dev-down`.
+
+After `make run-local`, point the CLI at the local gateway (it defaults to port `8080`):
+
+```bash
+export ZYNAX_API_URL=http://localhost:7080
+```
+
+### Observability overlay (optional)
+
+| Command | What it does |
+|---------|-------------|
+| `make obs-up` | Start the local Uptrace stack — UI at `http://localhost:7020` |
+| `make obs-logs` | Tail the observability stack logs |
+| `make obs-down` | Stop the observability stack |
+
+`make obs-up` requires `infra/docker-compose/observability/.env.observability` (copy the
+`.env.observability.example` next to it and set a login + token — there are no committed
+defaults). Telemetry is off until services are pointed at the collector:
+
+```bash
+export ZYNAX_OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:7017
+```
+
+See [infra/docker-compose/README.md](../infra/docker-compose/README.md) and
+[docs/observability/](observability/) for the full telemetry setup.
+
+---
+
+## The `zynax` CLI
+
+The CLI is a standalone tool that talks to the api-gateway over HTTP REST only.
+
+| Command | What it does |
+|---------|-------------|
+| `zynax init workflow [name]` | Scaffold a Workflow manifest from a template (stdout or `-o`) |
+| `zynax init expert [name]` | Scaffold an expert (AgentDef) manifest |
+| `zynax validate <file>` | Static + data-flow validation of a manifest (no gateway needed) |
+| `zynax apply --dry-run <file>` | Compile a manifest without submitting it |
+| `zynax apply <file>` | Apply a Workflow or AgentDef — prints `run_id` / `agent_id` |
+| `zynax get workflow <run-id>` | Full snapshot of a run (id, workflow, status, state, version) |
+| `zynax status workflow <run-id>` | Print the run status (exit `0` if terminal, `2` if running) |
+| `zynax logs <run-id> --follow` | Stream lifecycle events; exit on terminal state |
+
+`init` and `validate` run entirely locally — no gateway connection required. Global
+flags: `--api-url` (defaults to `$ZYNAX_API_URL`) and `--insecure`.
+
+A typical author loop:
+
+```bash
+zynax init workflow my-pipeline -o my-pipeline.yaml   # scaffold
+zynax validate my-pipeline.yaml                       # check before submitting
+zynax apply --dry-run my-pipeline.yaml                # compile-only
+zynax apply my-pipeline.yaml                          # submit → run_id
+zynax logs <run-id> --follow                          # watch
+```
+
+---
+
+## Make targets — daily workflow
+
+| Command | What it does | When to use |
+|---------|-------------|-------------|
+| `make ci` | Full local CI gate — lint → test → security → secret scan | Before opening a PR |
+| `make lint` | Proto + Go + Python lint (ruff, mypy, golangci-lint, buf) | Before every commit |
+| `make test` | Full suite: spec validation + Go unit + BDD + Python | Before pushing |
+| `make test-unit-go` | Go unit tests with coverage for all services | During Go development |
+| `make test-bdd` | Godog BDD contract tests in `protos/tests/` | After a proto/BDD step change |
+| `make test-unit-agents` | pytest-bdd for the SDK and all Python agents | During Python development |
+| `make test-integration` | Integration tests against NATS and Redis (spins up containers) | Before opening a PR |
+| `make generate-protos` | Regenerate Go + Python stubs from `.proto` — commit the output | After editing a `.proto` |
+| `make validate-spec` | Validate YAML manifests against JSON schemas | After editing `spec/` files |
+| `make security` | govulncheck + bandit + pip-audit — full scan | Before releasing |
+| `make audit` | govulncheck + pip-audit only — faster CVE check | Weekly / on dependency change |
+| `make sync-images` | Stamp consumer files with digests from `images/images.yaml` | After an image digest changes |
+| `make check-images` | Verify banner-marked regions match `images/images.yaml` | CI gate / before PR |
+
+> **Image digests** are managed in `images/images.yaml` — the single source of truth. Do
+> not hand-edit banner-marked regions in workflow files or Dockerfiles; use
+> `make sync-images` to update them.
+
+---
+
+## Contributor paths
+
+**Go service contributor** — work in `services/<service-name>/`:
+
+```bash
+make lint            # catch style issues early
+make test-unit-go    # fast feedback while coding
+make test            # full suite before pushing
+make ci              # full CI gate before opening a PR
+```
+
+Use `GOWORK=off` for any `go` command run directly (not via make) inside a service
+directory — see [CLAUDE.md](../CLAUDE.md) for why.
+
+**Python agent contributor** — work in `agents/sdk/` or `agents/examples/<agent>/`:
+
+```bash
+make lint                # ruff + mypy on agents/
+make test-unit-agents    # pytest-bdd for SDK and examples
+make security-agents     # bandit + pip-audit
+make ci                  # full CI gate before opening a PR
+```
+
+**Proto author** — proto changes require a `.feature` file committed first (ADR-016):
+
+```bash
+make lint-protos         # buf lint + format check
+make generate-protos     # regenerate stubs — always commit the output
+make test-bdd            # verify BDD contract tests still pass
+make ci                  # full CI gate before opening a PR
+```
+
+Generated stubs in `protos/generated/` are committed — never hand-edit them.
+
+---
+
+## Before you open a PR
+
+1. `make ci` — the full local gate (lint → test → security → secret scan).
+2. Commit with `Signed-off-by:` (DCO) and, for AI-assisted work, `Assisted-by:`.
+3. Build the PR body from [docs/contributing/pr-templates.md](contributing/pr-templates.md).
+
+Keep PRs small: ≤ 200 lines ideal, 201–400 acceptable, 401–900 justify, > 900 blocked.
+See [CLAUDE.md](../CLAUDE.md) for the full PR-size policy and conventional-commit rules.
+
+---
+
+## Reference
+
+- **[Quick Start](quickstart.md)** — clone → run → traced workflow run.
+- **[Local Development Guide](local-dev.md)** — CLI install options and persona paths.
+- **[Architecture](../ARCHITECTURE.md)** — the three-layer separation.
+- **[docs/adr/INDEX.md](adr/INDEX.md)** — Architecture Decision Records.
+- **[CLAUDE.md](../CLAUDE.md)** / **[CONTRIBUTING.md](../CONTRIBUTING.md)** — engineering contract.
+</content>

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,184 @@
+# Quick Start
+
+Get from a fresh clone to a **traced workflow run** in minutes. Everything runs in
+Docker — the only prerequisite is Docker Desktop (or Docker Engine + the Compose plugin).
+
+By the end you will have:
+
+1. The local platform stack running (`docker compose up` via `make run-local`).
+2. A real workflow applied with `zynax apply`.
+3. The run watched live with `zynax status` and `zynax logs --follow`.
+4. (Optional) The trace and logs for that run visible in the Uptrace UI.
+
+---
+
+## 1. Clone and bootstrap
+
+```bash
+git clone https://github.com/zynax-io/zynax.git
+cd zynax
+make bootstrap    # one-time: pulls ghcr.io/zynax-io/zynax/tools:latest from GHCR
+```
+
+`make bootstrap` is only needed once after cloning. Nothing else needs Go, Python, or
+`buf` installed locally — they all run inside containers.
+
+---
+
+## 2. Install the `zynax` CLI
+
+The CLI talks to the api-gateway over HTTP REST. Build it from source (requires Go
+1.26.3) or grab a release binary:
+
+```bash
+make install-cli                       # builds → ~/bin/zynax (ensure ~/bin is on PATH)
+# or download a pre-built binary — see docs/local-dev.md
+```
+
+Confirm it runs:
+
+```bash
+zynax --version
+```
+
+---
+
+## 3. Start the local stack
+
+A single command builds the images and starts the api-gateway, engine-adapter,
+workflow-compiler, Temporal, and NATS:
+
+```bash
+make run-local    # docker compose up -d --build
+```
+
+When it finishes, the api-gateway is reachable on port `7080`. The CLI defaults to
+`http://localhost:8080`, so point it at the local gateway:
+
+```bash
+export ZYNAX_API_URL=http://localhost:7080
+```
+
+Verify the stack is healthy:
+
+```bash
+curl http://localhost:7080/healthz
+```
+
+Useful endpoints:
+
+| URL | What |
+|-----|------|
+| `http://localhost:7080` | api-gateway HTTP REST (`ZYNAX_API_URL`) |
+| `http://localhost:7088` | Temporal Web UI — inspect workflow executions |
+
+See [infra/docker-compose/README.md](../infra/docker-compose/README.md) for the full
+port map and startup order.
+
+---
+
+## 4. (Optional) Start the observability stack
+
+To see traces and logs in a UI, bring up the Uptrace overlay. Telemetry is **off by
+default** and env-gated, so this step is optional — the workflow run works without it.
+
+```bash
+cp infra/docker-compose/observability/.env.observability.example \
+   infra/docker-compose/observability/.env.observability
+# edit the file — set a login + token (there are no committed defaults)
+
+make obs-up    # Uptrace UI → http://localhost:7020
+```
+
+Then point the platform services at the collector and restart the stack so they export
+telemetry:
+
+```bash
+export ZYNAX_OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:7017
+make run-local
+```
+
+The Uptrace login UI is at `http://localhost:7020` (use the login/token you set in the
+`.env.observability` file). For the full telemetry guide see
+[docs/observability/](observability/).
+
+---
+
+## 5. Apply a real workflow
+
+Three real, runnable reference workflows ship under
+[spec/workflows/examples/](../spec/workflows/examples/). Validate one before applying:
+
+```bash
+zynax validate spec/workflows/examples/code-review.yaml      # static + data-flow checks
+zynax apply --dry-run spec/workflows/examples/code-review.yaml   # compile without submitting
+```
+
+Then submit it:
+
+```bash
+zynax apply spec/workflows/examples/code-review.yaml
+```
+
+`apply` prints the run identifier:
+
+```
+run_id: <run-id>
+```
+
+Copy that `run_id` — the next step uses it.
+
+> **Starting from scratch?** `zynax init workflow my-pipeline -o my-pipeline.yaml`
+> scaffolds a valid, versioned manifest from a template. Run `zynax validate
+> my-pipeline.yaml` before applying.
+
+---
+
+## 6. Watch the run
+
+Check the current status (exits `0` if terminal, `2` if still running):
+
+```bash
+zynax status workflow <run-id>
+```
+
+Tail the run live — the command follows lifecycle events (state transitions and
+capability events) and exits once the workflow reaches a terminal state:
+
+```bash
+zynax logs <run-id> --follow
+```
+
+For a full snapshot of a run (id, workflow, status, current state, version):
+
+```bash
+zynax get workflow <run-id>
+```
+
+---
+
+## 7. See the trace and logs (if observability is running)
+
+Open the Uptrace UI at `http://localhost:7020`, log in, and find the trace for your run.
+Traces, metrics, logs, and APM are correlated by `trace_id`/`span_id`, so you can jump
+from a span to the matching log records for the same run.
+
+---
+
+## 8. Tear down
+
+```bash
+make stop-local    # stop and remove the platform stack
+make obs-down      # stop the observability stack (if started)
+```
+
+---
+
+## What next
+
+- **[Developer Guide](developer-guide.md)** — the Make targets and daily workflow.
+- **[Local Development Guide](local-dev.md)** — CLI install options and persona paths.
+- **[spec/workflows/examples/](../spec/workflows/examples/)** — the three reference
+  workflows and their data-flow patterns.
+</content>
+</invoke>


### PR DESCRIPTION
## docs: Quick Start + Developer Guide

Closes #1217
Part of #1173 (EPIC D — Documentation)

### Why
A new developer could not get from clone to a traced real-workflow run using docs
alone — there was no quick-start and no single developer guide for the make targets.
This is EPIC D step D.1, now unblocked by the real example workflows (#1208), the
`zynax init`/`zynax validate` CLI (#1207/#1209), and the run-local stack.

### What you'll get
- a clone → `make run-local` → `zynax apply` → `zynax status`/`zynax logs --follow`
  walkthrough, with an optional Uptrace step for traces+logs ← `docs/quickstart.md`
- a developer guide covering the full `zynax` CLI surface and every daily make target ←
  `docs/developer-guide.md`

### Scope & boundaries
- **In scope:** Quick Start + Developer Guide (D.1).
- **Out of scope (deferred):** workflow/expert authoring guides → D.2 #1218; context +
  Git MCP → D.3 #1219; deep observability guides → D.4 #1220 (linked, not duplicated);
  examples index / FAQ / migration → D.5 #1221.

### Test plan & acceptance
| Acceptance criterion | How verified | Result |
|----------------------|--------------|--------|
| quick-start: compose up (incl. Uptrace) → apply real workflow → see trace+logs in UI | Read `Makefile` (run-local/obs-up) + `infra/docker-compose/README.md` (ports 7080/7088/7020/7017) + `spec/workflows/examples/code-review.yaml`; every command/port in the doc matches | ✅ all commands real |
| developer guide covering make targets | Grepped each cited target in `Makefile` (ci, lint, test, test-unit-go, test-bdd, test-unit-agents, test-integration, generate-protos, validate-spec, security, audit, sync-images, check-images, lint-protos, security-agents, run/stop/logs-local, obs-up/down/logs) | ✅ all present |
| CLI commands match implementation | Read `cmd/zynax/cmd/{root,apply,status,logs,get,init,validate}.go` — `apply` prints `run_id`, `status workflow <id>`, `logs <id> --follow`, default URL 8080 → doc sets `ZYNAX_API_URL=7080` | ✅ verified |

**Local gates:** gitleaks (pre-commit) ✅ · relative-link targets all resolve ✅

### Evidence
- CI: pending — see checks on this PR.
- Local output: link-target check — all 14 relative links resolve to existing files;
  no literal emails (gitleaks passed at commit).
- Artifacts / images: none — no service source changed.
- Post-merge digest sync → main: N/A — no image rebuild.

### Risk & rollback
Low — docs only, additive. Revert this PR to remove.

### Review aids
Start at `docs/quickstart.md` (the clone→traced-run path). `docs/developer-guide.md` is
the reference companion. Both link to the existing `docs/observability/` guides rather
than duplicating them (D.4). The one subtlety worth checking: the CLI default API URL is
`8080` but `make run-local` exposes `7080`, so both docs set `ZYNAX_API_URL=7080`.

**AI:** `Assisted-by: Claude/claude-opus-4-8`  (label: ai-assisted)
