### PR TITLE
docs(authoring): workflow + expert authoring guides

### DIFF
--- a/docs/authoring/experts.md
+++ b/docs/authoring/experts.md
@@ -1,0 +1,273 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+# Expert Authoring Guide
+
+> Audience: expert and task authors. This guide explains how to write a
+> `kind: AgentDef` manifest — its capabilities and runtime — how an **expert**
+> differs from a plain capability provider, and how the authoring ↔ runtime
+> expert mapping ties a Claude Code authoring expert to a dispatchable runtime
+> agent.
+>
+> Reference material: [`spec/schemas/agent-def.schema.json`](../../spec/schemas/agent-def.schema.json),
+> the reusable templates
+> [`spec/templates/expert/expert.template.yaml`](../../spec/templates/expert/expert.template.yaml)
+> and [`spec/templates/task/task.template.yaml`](../../spec/templates/task/task.template.yaml),
+> the reference runtime expert [`agents/examples/go-review-expert/`](../../agents/examples/go-review-expert),
+> and the [expert mapping](../experts/mapping.md).
+> Governing ADRs: ADR-028 (context-bounded experts), ADR-033 (expert-agent substrate).
+
+---
+
+## 1. Two substrates: authoring vs runtime experts
+
+Zynax experts exist on **two substrates** ([mapping](../experts/mapping.md),
+ADR-033):
+
+- **Authoring experts** — `.claude/commands/experts/<slug>.md`. These drive the
+  SPDD authoring/delivery loop (a Claude Code expert that ships a story). They do
+  not run inside a workflow.
+- **Runtime experts** — `kind: AgentDef` agents (under `agents/examples/`) that
+  register in agent-registry and are dispatchable by the task broker inside a
+  workflow.
+
+This guide is primarily about **runtime** agents — the `AgentDef` manifest you
+author so a capability becomes routable. The two substrates are reconciled by the
+mapping table in [§5](#5-the-authoring--runtime-expert-mapping).
+
+---
+
+## 2. The shape of an AgentDef
+
+Every manifest has four required top-level keys
+([`agent-def.schema.json`](../../spec/schemas/agent-def.schema.json)):
+
+```yaml
+kind: AgentDef                 # constant — distinguishes it from Workflow
+apiVersion: zynax.io/v1alpha1  # constant — the registry rejects any other value
+metadata: { ... }              # name, version, namespace, labels
+spec: { ... }                  # capabilities (required) + runtime (optional)
+```
+
+The registry derives its `AgentDef` record from this manifest when you submit it
+with `zynax apply`.
+
+### metadata
+
+| Field | Required | Rule |
+|-------|----------|------|
+| `name` | yes | lowercase DNS-style, `^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`, ≤253; used as `agent_id` in the registry |
+| `version` | no | SemVer 2.0.0; omit for the unversioned baseline. Bump on every **contract** change. |
+| `namespace` | no | defaults to `default` |
+| `labels` | no | Kubernetes label syntax; used by `ListAgents` selectors |
+
+---
+
+## 3. Capabilities
+
+`spec.capabilities` is a non-empty, ordered list. Each capability is the unit the
+task broker routes work to: when a workflow action names `capability: go_review`,
+the broker dispatches it to an agent that declares `go_review`.
+
+| Field | Required | Rule |
+|-------|----------|------|
+| `name` | yes | the routing key — `^[a-z][a-z0-9_]*$` (snake_case), 1–64 chars |
+| `description` | no | shown in the registry UI and generated docs |
+| `input_schema` | no | draft-07-subset JSON Schema; the broker validates dispatch payloads against it |
+| `output_schema` | no | draft-07-subset JSON Schema for the COMPLETED event payload |
+| `timeout_seconds` | no | positive integer; broker marks the task FAILED past this wall-clock limit |
+| `max_retries` | no | ≥0; re-queues on failure (`0` = no retries) |
+
+`input_schema`/`output_schema` must declare `type: object` at the top level. The
+capability `name` is the contract the workflow author references — keep it stable.
+
+Example, from the reference runtime expert
+[`agent-def-expert.yaml`](../../spec/workflows/examples/agent-def-expert.yaml):
+
+```yaml
+spec:
+  capabilities:
+    - name: go_review
+      description: >
+        Rule-based Go code review. Inspects a Go diff or source file and returns
+        structured findings (line, severity, message), a finding count, and an
+        approval flag that is false when any finding has severity 'error'.
+      input_schema:
+        type: object
+        required: [diff]
+        properties:
+          diff: { type: string, description: "Go source or unified-diff text." }
+      output_schema:
+        type: object
+        required: [findings, finding_count, approved]
+        properties:
+          findings:      { type: array }
+          finding_count: { type: integer, minimum: 0 }
+          approved:      { type: boolean }
+      timeout_seconds: 30
+      max_retries: 1
+```
+
+---
+
+## 4. Expert vs task: contracts and context isolation
+
+Both experts and tasks are `AgentDef` manifests. The difference is convention,
+labels, and contract shape:
+
+- A **task** ([task template](../../spec/templates/task/task.template.yaml))
+  declares a single capability with a minimal input/output contract and a
+  `runtime` block. Label `kind: task`.
+- An **expert** ([expert template](../../spec/templates/expert/expert.template.yaml))
+  exposes an advisory `review` capability over a **strictly isolated context
+  slice** (ADR-028). The slice is bound at dispatch time and hard-capped at
+  `max_tokens`. Two hard rules:
+  - The slice contains **only** the declared `files` (glob patterns), capped at
+    `max_tokens`.
+  - **Never** reference another expert's slice or output — strict isolation.
+
+The expert template's `review` capability encodes this contract directly: its
+`input_schema` requires a `context_slice` object with `files` and `max_tokens`,
+and its `output_schema` requires structured `summary`, `recommended_actions`,
+`reasons_decisions`, `confidence`, and `flags`.
+
+### Labels that mark a runtime expert
+
+The reference runtime expert distinguishes itself with labels so operators and
+the mapping can select it via a `ListAgents` selector:
+
+```yaml
+metadata:
+  labels:
+    agent.zynax.io/kind: expert        # marks this AgentDef as a runtime expert
+    agent.zynax.io/expert: go-review
+```
+
+### runtime block
+
+The optional `runtime` block tells the control plane how to run the agent's gRPC
+server:
+
+```yaml
+runtime:
+  image: ghcr.io/zynax-io/zynax/go-review-expert:latest   # required — tag or digest
+  env:
+    LOG_LEVEL: info
+    GRPC_PORT: "50051"
+  resources:
+    requests: { cpu: "100m", memory: "128Mi" }
+    limits:   { cpu: "500m", memory: "512Mi" }
+  replicas: 1
+```
+
+Keep secrets out of `env` — reference Kubernetes Secrets via the CLI rather than
+inlining sensitive values.
+
+---
+
+## 5. The authoring ↔ runtime expert mapping
+
+Each authoring expert (`.claude/commands/experts/<slug>.md`) declares a
+`runtime_mapping` pointing at its runtime `AgentDef` counterpart — or the literal
+`authoring-only` when none exists yet (X.5, #1205; ADR-033). The full table and
+rules live in [`docs/experts/mapping.md`](../experts/mapping.md); the key facts
+for authors:
+
+- **Source of truth:** `automation/experts/runtime_mapping.yaml` (machine-readable,
+  one entry per authoring expert). The table in the mapping doc and the ADR-033
+  table mirror it.
+- **Why it lives outside `.claude/**`:** that tree is CODEOWNERS-gated; the drift
+  guard reads the authoring experts there read-only.
+- **In M7 only `go-services → go-review-expert` is dual-substrate** (capability
+  `code.review.go`, runtime at `agents/examples/go-review-expert`). The other
+  authoring experts are explicitly `authoring-only` until the full library lands
+  in M-dx — a deliberate, reviewable declaration, not an omission.
+
+### Drift guard (CI)
+
+`automation/scripts/check_expert_mapping.py` enforces three ADR-033 rules:
+
+1. **Declared mapping is mandatory** — every authoring expert appears in the
+   mapping file with a non-empty `runtime_mapping`.
+2. **Runtime reference must resolve** — a named `runtime_mapping` resolves to
+   `agents/examples/<name>`.
+3. **Table reconciliation** — the mapping file stays identical to ADR-033's table.
+
+Run it locally with `make check-expert-mapping` (CI runs it in `lint-python`).
+**Adding a new authoring expert without updating the mapping file and ADR-033's
+table fails the build.** So when you add a runtime expert that backs an authoring
+expert, update the mapping in the same change.
+
+---
+
+## 6. Authoring with the `zynax` CLI
+
+### Scaffold from the reusable template
+
+`zynax init expert` copies the versioned baseline from
+[`spec/templates/expert/expert.template.yaml`](../../spec/templates/expert/expert.template.yaml).
+It runs entirely locally (no api-gateway connection):
+
+```bash
+# Print a fresh expert manifest to stdout
+zynax init expert
+
+# Name it and write it to a file
+zynax init expert my-review-expert -o my-review-expert.yaml
+```
+
+The optional `[name]` argument overrides `metadata.name`; `--output`/`-o` writes
+to a file; `--template-dir` (default `spec/templates`) points at the template
+tree. For a plain task agent, copy `spec/templates/task/task.template.yaml`
+directly (the CLI scaffolds the `workflow` and `expert` kinds).
+
+### Validate
+
+`zynax validate <file>` reads `kind:` from the YAML and validates against
+`spec/schemas/agent-def.schema.json`:
+
+```bash
+zynax validate my-review-expert.yaml             # exits 1 on any error
+zynax validate my-review-expert.yaml --format json
+```
+
+`make validate-spec` runs the same checks across `spec/` in CI.
+
+### Apply (register)
+
+```bash
+zynax apply my-review-expert.yaml             # submit to agent-registry
+zynax apply --dry-run my-review-expert.yaml   # validate only, no submit
+```
+
+---
+
+## 7. Reference runtime expert
+
+[`agents/examples/go-review-expert/`](../../agents/examples/go-review-expert) is
+the M7 reference implementation — a Python adapter whose `go_review` capability
+matches the `agent-def-expert.yaml` manifest's routing key. Use it as the
+end-to-end model for a new runtime expert:
+
+- `capability.json` — the declared capability contract
+- `src/go_review_expert/agent.py` — the gRPC adapter implementation
+- `tests/features/go_review.feature` — the BDD contract at the gRPC boundary
+
+---
+
+## 8. Checklist before you ship
+
+- [ ] `kind: AgentDef` and `apiVersion: zynax.io/v1alpha1` are exact.
+- [ ] `metadata.name` is lowercase DNS-style and unique in its namespace.
+- [ ] `metadata.version` is bumped (SemVer) on any capability-contract change.
+- [ ] Every capability `name` is snake_case (`^[a-z][a-z0-9_]*$`), 1–64 chars,
+      and stable (workflows reference it).
+- [ ] `input_schema`/`output_schema` declare `type: object` at the top level.
+- [ ] For an **expert**: the slice declares only its own `files`, capped at
+      `max_tokens`; it never reads another expert's slice or output (ADR-028).
+- [ ] Runtime experts carry the `agent.zynax.io/kind: expert` label.
+- [ ] `runtime.image` is fully qualified (tag or digest); no secrets inlined in `env`.
+- [ ] If this runtime expert backs an authoring expert, the mapping file and
+      ADR-033 table are updated in the same change (`make check-expert-mapping`).
+- [ ] `zynax validate <file>` exits 0.
+
+See also: the [Workflow Authoring Guide](workflows.md) and the
+[expert mapping](../experts/mapping.md).

--- a/docs/authoring/workflows.md
+++ b/docs/authoring/workflows.md
@@ -1,0 +1,321 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+# Workflow Authoring Guide
+
+> Audience: workflow authors. This guide explains how to write a Zynax
+> `kind: Workflow` manifest — its states, transitions, CEL guards, and the
+> cross-state data-flow bindings — and how to scaffold, validate, and apply it
+> with the `zynax` CLI.
+>
+> Reference material: [`spec/schemas/workflow.schema.json`](../../spec/schemas/workflow.schema.json),
+> the reusable template [`spec/templates/workflow/workflow.template.yaml`](../../spec/templates/workflow/workflow.template.yaml),
+> and the runnable examples under [`spec/workflows/examples/`](../../spec/workflows/examples/).
+> Governing ADRs: ADR-029 (data-flow bindings), ADR-015 (pluggable engine).
+
+---
+
+## 1. The shape of a Workflow
+
+A workflow is a declarative state machine. Every manifest has four top-level keys
+(all four are required by [`workflow.schema.json`](../../spec/schemas/workflow.schema.json)):
+
+```yaml
+kind: Workflow            # constant — distinguishes it from AgentDef
+apiVersion: zynax.io/v1   # constant — the compiler rejects any other value
+metadata: { ... }         # name, version, namespace, labels, annotations
+spec: { ... }             # initial_state, optional triggers, states
+```
+
+The workflow compiler (`WorkflowCompilerService`) consumes this manifest; `make
+validate-spec` and `zynax validate` check it against the schema before it ever
+reaches the engine.
+
+### metadata
+
+| Field | Required | Rule |
+|-------|----------|------|
+| `name` | yes | lowercase DNS-style, `^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`, ≤253 chars, unique per namespace |
+| `version` | no | SemVer 2.0.0 (e.g. `1.0.0`, `2.1.0-rc.1`). Omit for the unversioned baseline. See [Versioning](#6-versioning). |
+| `namespace` | no | defaults to `default`; same DNS pattern, ≤63 chars |
+| `labels` | no | arbitrary string key/value pairs for grouping and filtering |
+| `annotations` | no | tooling metadata; conventionally carry a one-line `description` |
+
+### spec
+
+`spec` requires `initial_state` and a non-empty `states` map. `triggers` is
+optional.
+
+- **`initial_state`** — the state entered on submission. It **must** match a key
+  under `states` (enforced by `zynax validate`'s data-flow pass, not the schema).
+- **`triggers`** — CloudEvent patterns that auto-start a *new* instance. Omit for
+  workflows you submit manually.
+- **`states`** — the state machine itself (see [§2](#2-states)).
+
+---
+
+## 2. States
+
+`spec.states` is a map of state name → state definition. State names are
+lowercase and descriptive; they double as the routing targets of transitions.
+
+```yaml
+spec:
+  initial_state: review
+  states:
+    review:                # ← a normal state
+      actions: [ ... ]     # capability invocations run on entry
+      on: [ ... ]          # outbound transitions
+```
+
+### State types
+
+The optional `type` field (default `normal`) classifies behaviour:
+
+| `type` | Meaning |
+|--------|---------|
+| `normal` | runs its actions, then waits for a transition event (default) |
+| `terminal` | an end state — **must not** declare `on` transitions |
+| `human_in_the_loop` | pauses execution until an external signal arrives |
+
+**At least one terminal state must be reachable.** This is enforced by the
+compiler. A typical workflow has two terminals — a success (`done`) and a
+failure (`failed`/`abandon`) — as in
+[`feature-implementation.yaml`](../../spec/workflows/examples/feature-implementation.yaml).
+
+### Actions
+
+Each state runs an ordered list of `actions` on entry. An action invokes one
+**capability** — never an agent name. The task broker routes the capability to a
+registered agent that advertises it (see the
+[Expert Authoring Guide](experts.md) for how capabilities are declared).
+
+```yaml
+actions:
+  - capability: request_review     # required — must match a registered AgentDef capability
+    input:                         # template values passed to the agent
+      pr_url: "{{ .trigger.pr_url }}"
+    output:                        # write result fields back into context (see §4)
+      feedback_summary: summary
+    timeout: 24h                   # ISO-8601-style duration; absent → only the workflow TTL applies
+```
+
+- `input` values may reference workflow context (`{{ .context.key }}`), trigger
+  data (`{{ .trigger.field }}`), or a cross-state binding (`$.states.<state>.output.<key>` — see [§4](#4-data-flow-cross-state-output--input)).
+- `timeout` matches `^([0-9]+(ns|us|ms|s|m|h))+$` (e.g. `30m`, `1h`, `24h`).
+
+### Transitions (`on`)
+
+Outbound edges are evaluated **in order**; the first transition whose `event`
+matches and whose `guard` (if any) is true fires. Terminal states have no `on`.
+
+```yaml
+on:
+  - event: review.approved      # required — matched against the incoming event 'type'
+    goto: merge                 # required — must be a defined state
+  - event: review.needswork
+    goto: fix
+    set:                        # optional — write into context when this edge fires
+      context.latest_feedback: "{{ .event.comments }}"
+```
+
+`zynax validate` confirms every `goto` (and `initial_state`) targets a defined
+state — a typo like `goto: mrege` fails validation before deploy.
+
+---
+
+## 3. CEL guards
+
+When two transitions share the same `event`, a `guard` disambiguates them. A
+guard is a [CEL](https://github.com/google/cel-spec) expression evaluated in the
+workflow context; the transition fires only when it returns `true`.
+
+From [`code-review.yaml`](../../spec/workflows/examples/code-review.yaml):
+
+```yaml
+on:
+  - event: review.timeout
+    goto: escalate
+    guard: "escalation_count < 2"     # escalate the first two timeouts
+  - event: review.timeout
+    goto: abandon
+    guard: "escalation_count >= 2"    # give up after that
+```
+
+Guidelines:
+
+- Reference context keys directly (`escalation_count`, not `.context.escalation_count`).
+- Keep guards total — for a shared event, the guards should cover every case so
+  the workflow never stalls with no matching transition.
+- Guards only **select** an edge; to **mutate** context use `set:` on the
+  transition or `output:` on an action.
+
+---
+
+## 4. Data-flow: cross-state `output:` / `input:`
+
+Data-flow bindings (ADR-029) thread a result produced in one state into a later
+state without round-tripping through a fragile template string.
+
+**Publish** with an action's `output:` map — `<context-key>: <result-field>`:
+
+```yaml
+fix:
+  actions:
+    - capability: summarize_feedback
+      input:
+        feedback: "{{ .context.latest_feedback }}"
+      output:
+        feedback_summary: summary    # publish the action's `summary` result as `feedback_summary`
+```
+
+**Consume** in a later state with an `input:` binding rooted at
+`$.states.<state>.output.<key>`:
+
+```yaml
+escalate:
+  type: human_in_the_loop
+  actions:
+    - capability: notify_human
+      input:
+        review_summary: "$.states.fix.output.feedback_summary"   # ← cross-state binding
+```
+
+The binding path is literal — `$.states.<producing-state>.output.<published-key>`.
+No `{{ }}` template indirection is needed (or used) for these bindings.
+
+`feature-implementation.yaml` chains four stages this way:
+
+```
+plan      → publishes implementation_plan
+implement → consumes the plan, publishes branch_name + diff_summary
+verify    → consumes the branch,  publishes test_report
+open_pr   → consumes branch + diff_summary to draft the PR body
+```
+
+```yaml
+implement:
+  actions:
+    - capability: write_code
+      input:
+        plan: "$.states.plan.output.implementation_plan"   # consume
+      output:
+        branch_name: branch                                # publish
+        diff_summary: summary
+```
+
+Contrast the binding styles:
+
+| Reference | Use |
+|-----------|-----|
+| `{{ .trigger.field }}` | data from the event that started the instance |
+| `{{ .context.key }}` | a value written earlier via `set:` or a same-key `output:` |
+| `$.states.<state>.output.<key>` | a value published by another state's action `output:` |
+
+---
+
+## 5. Triggers
+
+A trigger auto-starts a new instance when a matching CloudEvent arrives. Each
+trigger needs an `event` type; `filter` adds key/value conditions where **all**
+entries must match:
+
+```yaml
+triggers:
+  - event: github.pull_request.opened
+    filter:
+      repo: "zynax-io/zynax"
+      base_branch: "main"
+```
+
+Omit `triggers` entirely for workflows you submit by hand with `zynax apply`.
+
+---
+
+## 6. Versioning
+
+`metadata.version` is an optional SemVer 2.0.0 string. The compiler and CLI
+surface it so you can evolve a workflow without breaking in-flight instances:
+
+- **Omit it** for the unversioned baseline (e.g. while iterating locally).
+- **Bump it on every change** once the workflow is in use — `MAJOR` for a
+  breaking state-machine change, `MINOR` for additive states/transitions,
+  `PATCH` for fixes. The reusable template ships at `0.1.0`; the runnable
+  examples pin `1.0.0`.
+
+---
+
+## 7. Authoring with the `zynax` CLI
+
+### Scaffold from the reusable template
+
+`zynax init workflow` copies the versioned baseline from
+[`spec/templates/workflow/workflow.template.yaml`](../../spec/templates/workflow/workflow.template.yaml)
+— a known-good starting point instead of a blank file. It runs entirely locally
+(no api-gateway connection):
+
+```bash
+# Print a fresh manifest to stdout
+zynax init workflow
+
+# Name it and write it to a file
+zynax init workflow my-release-pipeline -o my-release-pipeline.yaml
+```
+
+The optional `[name]` argument overrides `metadata.name`; `--output`/`-o` writes
+to a file (otherwise stdout). `--template-dir` (default `spec/templates`) points
+at the template tree.
+
+### Validate before you apply
+
+`zynax validate <file>` reads `kind:` from the YAML, loads the matching schema
+from `spec/schemas/<kind>.schema.json`, and — for `kind: Workflow` — also runs
+the **data-flow pass** that confirms `initial_state` and every transition `goto`
+resolve to a defined state:
+
+```bash
+zynax validate my-release-pipeline.yaml          # human-readable; exits 1 on any error
+zynax validate my-release-pipeline.yaml --format json
+```
+
+`make validate-spec` runs the same schema validation across the whole `spec/`
+tree in CI.
+
+### Apply
+
+```bash
+zynax apply spec/workflows/examples/code-review.yaml             # submit
+zynax apply --dry-run spec/workflows/examples/code-review.yaml   # validate only, no submit
+```
+
+`--dry-run` validates the manifest without submitting; `--engine` forwards an
+engine hint to `SubmitWorkflow` (ADR-015).
+
+---
+
+## 8. Worked examples
+
+All of these live under [`spec/workflows/examples/`](../../spec/workflows/examples/)
+and are validated in CI:
+
+| File | Demonstrates |
+|------|--------------|
+| [`feature-implementation.yaml`](../../spec/workflows/examples/feature-implementation.yaml) | a four-stage data-flow chain (plan → implement → verify → open_pr) |
+| [`code-review.yaml`](../../spec/workflows/examples/code-review.yaml) | loops, `human_in_the_loop`, timeouts, CEL guards, and `output:`/`input:` data-flow |
+| [`research-task.yaml`](../../spec/workflows/examples/research-task.yaml) | a simpler linear task |
+| [`agent-def-expert.yaml`](../../spec/workflows/examples/agent-def-expert.yaml) | a runtime expert manifest (see the [Expert Authoring Guide](experts.md)) |
+
+---
+
+## 9. Checklist before you ship
+
+- [ ] `kind: Workflow` and `apiVersion: zynax.io/v1` are present and exact.
+- [ ] `metadata.name` is lowercase DNS-style and unique in its namespace.
+- [ ] `metadata.version` is bumped (SemVer) if the workflow is already in use.
+- [ ] `initial_state` names a defined state; every `goto` targets a defined state.
+- [ ] At least one terminal state is reachable; terminal states have no `on`.
+- [ ] Shared-event transitions are disambiguated by total CEL guards.
+- [ ] Every `capability` matches one declared by a registered AgentDef.
+- [ ] Cross-state inputs use `$.states.<state>.output.<key>` against an action that
+      actually publishes that key via `output:`.
+- [ ] `zynax validate <file>` exits 0.
+
+See also: the [Expert Authoring Guide](experts.md).


### PR DESCRIPTION
## docs(authoring): workflow + expert authoring guides

Closes #1218

### Why  (problem & intent)
EPIC D (#1173) step D.2 calls for authoring guides so authors can write workflows
and experts correctly. There was no single place documenting the workflow state
machine, CEL guards, cross-state data-flow bindings, or the `kind: AgentDef`
capability/context-isolation model and the authoring↔runtime expert mapping.

### What you'll get  (deliverables ↔ what changed)
- `docs/authoring/workflows.md` — kinds (`Workflow`/`apiVersion: zynax.io/v1`),
  states + types (`normal`/`terminal`/`human_in_the_loop`), transitions, CEL
  guards, cross-state data-flow `output:`/`input:` (`$.states.<state>.output.<key>`),
  triggers, SemVer versioning, and the `zynax init workflow` / `zynax validate` /
  `zynax apply` flow.
- `docs/authoring/experts.md` — `kind: AgentDef` capabilities, expert vs task
  context isolation (ADR-028), the authoring↔runtime expert mapping (#1205,
  ADR-033) with its CI drift guard, the reference runtime expert, and
  `zynax init expert`.

### Scope & boundaries
Docs only, under `docs/authoring/`. No spec/schema/code changes. The
example-catalog docs and remaining D.x guides are out of scope (separate stories).

### Test plan & acceptance
- Link-check: every relative link in both files resolves on disk (verified
  against `spec/schemas`, `spec/templates`, `spec/workflows/examples`,
  `docs/experts/mapping.md`, `agents/examples/go-review-expert`).
- gitleaks/secret-scan pre-commit hook: passed (no literal emails / secrets).
- No `make validate-spec` needed — no specs or schemas changed.

### Evidence
- Fields cited directly from `spec/schemas/workflow.schema.json` and
  `spec/schemas/agent-def.schema.json`, the `spec/templates/*` baselines, the
  #1208 runnable examples (`code-review.yaml`, `feature-implementation.yaml`),
  and `cmd/zynax/cmd/{init,validate,apply}.go`.

### Review aids
- Start with `docs/authoring/workflows.md` §4 (data-flow) and `experts.md` §5
  (the authoring↔runtime mapping) — the two load-bearing sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
