### PR TITLE
docs: Context System + Git MCP guides

### DIFF
--- a/docs/context/context-system.md
+++ b/docs/context/context-system.md
@@ -1,0 +1,160 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Context System — correlation, trace, and data-flow propagation
+
+Every Zynax run threads a small, **deterministic context** from the api-gateway,
+through the engine, across each agent hop, and back. This guide explains the two
+kinds of context, the exact carrier keys, and the SDK helpers an agent author
+uses to honour the contract so a run stays traceable and data-scoped end to end.
+
+There are two distinct kinds of context, propagated by different mechanisms:
+
+1. **Correlation + trace context** — flows *on the wire* as gRPC metadata /
+   HTTP headers, so one run is one stitched trace and one searchable log group.
+2. **Data-flow context** — the run-scoped key/value store that carries a state's
+   output to a downstream state's input. It lives **server-side** and is never
+   handed to the agent as a store handle; the agent only ever sees the scope
+   identifiers.
+
+---
+
+## 1. Correlation + trace context
+
+### Carrier keys
+
+These keys are defined once and mirrored byte-for-byte across Go and Python so a
+`request-id` set at the gateway is the *same* value every downstream hop observes
+— there are no bespoke header formats.
+
+| Context field | HTTP header (ingress) | gRPC metadata key (hops) | Set by |
+|---------------|-----------------------|--------------------------|--------|
+| Correlation id | `X-Request-ID` | `request-id` | api-gateway correlation interceptor (generated when absent) |
+| Namespace | `X-Namespace` | `x-namespace` | api-gateway correlation interceptor |
+| Trace context | `traceparent` (W3C) | `traceparent` (W3C) | tracing interceptor |
+| Trace vendor data | `tracestate` (W3C) | `tracestate` (W3C) | tracing interceptor |
+
+The HTTP header constants live in
+`services/api-gateway/internal/api/requestid.go`; the gRPC metadata constants
+(`requestIDMetaKey = "request-id"`, `namespaceMetaKey = "x-namespace"`) live in
+`services/api-gateway/internal/infrastructure/clients.go`. `traceparent` /
+`tracestate` are the standard W3C Trace Context keys propagated by the
+OpenTelemetry propagator in `libs/zynaxobs/propagation.go` — they are *not*
+custom Zynax keys.
+
+`X-Request-ID` is **generated at the gateway when the inbound request omits it**,
+so every run has a correlation id even when the caller supplies none. The
+gateway-set value is authoritative: downstream code reads the wire value first
+and only falls back to a request field when the wire carried none.
+
+### What crosses the handoff — and what never does
+
+Only **correlation ids and W3C trace headers** cross a handoff. Auth tokens,
+cookies, API keys, session data, and secrets never do. The SDK enforces this
+with an explicit forbidden-key set — `authorization`, `cookie`, `x-api-key`,
+`set-cookie`, `proxy-authorization` are dropped before a context is ever built,
+so a credential cannot leak into a downstream hop even by accident.
+
+### The handoff contract (`HandoffContext`)
+
+An agent receives, and forwards, a single immutable value. `HandoffContext`
+(`agents/sdk/src/zynax_sdk/handoff.py`) is a frozen dataclass with these fields:
+
+| Field | Meaning |
+|-------|---------|
+| `request_id` | Stable correlation id; appears in every downstream span and log line. Empty when the call did not originate behind the gateway. |
+| `namespace` | Tenant / routing namespace; also half of the data-context scope key. |
+| `workflow_id` | The workflow run id; with `namespace` it scopes the data context. |
+| `task_id` | The opaque per-task identifier from the originating request. |
+| `traceparent` | W3C `traceparent` carrying the remote span, or empty. |
+| `tracestate` | W3C `tracestate` vendor data, or empty. |
+
+`HandoffContext.is_traced()` returns `True` when a `traceparent` was carried.
+
+### SDK handoff helpers (from #1196)
+
+Two helpers in `zynax_sdk.handoff` are all an agent author needs. The helpers
+keep correlation and trace alive across the *next* hop the agent itself makes.
+
+**`inbound_context(request, context=None)`** — read the context the agent
+**receives**. Correlation (`request_id`, `namespace`) and the W3C trace headers
+are read from the inbound gRPC metadata when `context` is supplied;
+`request_id`, `workflow_id`, and `task_id` fall back to the proto request fields
+so the context is populated even outside a transport (e.g. in unit tests). It
+never raises on missing fields — absent identifiers come back as empty strings.
+
+```python
+from zynax_sdk.handoff import inbound_context, outbound_metadata
+
+def ExecuteCapability(self, request, context):
+    ctx = inbound_context(request, context)   # frozen HandoffContext
+    # ... do the work ...
+```
+
+**`outbound_metadata(ctx)`** — emit the gRPC metadata that **forwards** the
+context to the next hop. Unset fields are omitted (no empty headers), and the
+ordering is deterministic (`request-id` → `x-namespace` → `traceparent` →
+`tracestate`) so two equal contexts always produce identical metadata.
+
+```python
+    # when this agent calls another Zynax hop, forward the context:
+    downstream_stub.SomeMethod(req, metadata=outbound_metadata(ctx))
+```
+
+That single round-trip — `inbound_context` in, `outbound_metadata` out — is what
+keeps a multi-hop run as **one trace** and **one correlation group**.
+
+---
+
+## 2. Data-flow context (scoped, #1195)
+
+The data-flow context is the run-scoped key/value store that carries a state's
+output to a downstream state's input. It backs workflow data-flow bindings and
+is defined in `services/engine-adapter/internal/domain/datacontext.go`.
+
+### Run scoping — cross-run access is denied
+
+A data context is bound to exactly one **`DataContextScope`** at construction:
+
+```go
+type DataContextScope struct {
+    RunID     string  // the workflow run / envelope workflow_id
+    Namespace string  // the run's namespace (may be empty single-namespace)
+}
+```
+
+Every read and write must present a scope **equal** to the owning scope. One run
+can never read or write another run's data — even if it somehow obtains a
+reference to the instance. A mismatched access fails *loudly* with a
+`ScopeError` rather than silently returning or dropping data. Prefer
+`NewScopedWorkflowDataContext(scope)` over the back-compat
+`NewWorkflowDataContext()` so cross-run access is denied. This is why the agent
+receives only the `namespace` + `workflow_id` identifiers and never the store
+handle itself — it has no way to reach across runs.
+
+### Keys and references
+
+`WorkflowDataContext` keys are canonical dotted paths:
+
+```
+states.<stateID>.output.<key>
+```
+
+An input binding references a stored value with the `$.` prefix, e.g.
+`$.states.search.output.results`. There is no implicit fallback to an empty
+value: a reference that cannot resolve, or a value that is not a coercible
+scalar, fails the run with a structured `DataReferenceError` (the offending
+`InputKey`, `Reference`, and `Reason`).
+
+The store is written only by an action's `output_bindings` and read only by a
+downstream action's `input_bindings` — there is no global mutable state. It
+lives for a single run and is never persisted beyond it.
+
+---
+
+## See also
+
+- Workflow data-flow bindings: [`docs/authoring/workflows.md`](../authoring/workflows.md)
+- Git MCP guide (a concrete handoff surface): [`docs/git-mcp/git-mcp.md`](../git-mcp/git-mcp.md)
+- OpenTelemetry setup (where `traceparent` becomes a stitched trace): [`docs/observability/opentelemetry.md`](../observability/opentelemetry.md)
+- Handoff contract source: `agents/sdk/src/zynax_sdk/handoff.py`
+- Data-context source: `services/engine-adapter/internal/domain/datacontext.go`

--- a/docs/git-mcp/git-mcp.md
+++ b/docs/git-mcp/git-mcp.md
@@ -1,0 +1,174 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Git MCP guide — least-privilege Git for authoring loops
+
+`zynax mcp git` exposes the Zynax `git-adapter` as a **Model Context Protocol
+(MCP) server**, so an authoring loop (Claude Code, or any MCP client) can perform
+Git operations as MCP tools using a **least-privilege, injected** token. It is a
+thin shim over the existing `git-adapter` (ADR-032): one Git implementation, two
+surfaces — the adapter remains the runtime gRPC capability path, and MCP is an
+additional authoring surface. No Git logic is duplicated in the shim.
+
+> For a quick-start (copy `.mcp.json.example`, export a token, run it), see
+> [`docs/git-mcp/README.md`](README.md). **This guide** covers the tool surface,
+> the credential model (injection, redaction, token scope, refreshable creds),
+> and a complete `.mcp.json` wiring.
+
+---
+
+## The `zynax mcp git` surface (#1200)
+
+```
+MCP client  <--stdio-->  zynax mcp git  --exec-->  git-adapter mcp
+                                                    (1:1 tool ↔ capability)
+```
+
+`zynax mcp git` (`cmd/zynax/cmd/mcp.go`) execs the `git-adapter` binary in its
+`mcp` mode and wires the adapter's stdio through, so it speaks the MCP stdio
+protocol to the MCP client. The binary path resolves from `GIT_ADAPTER_BIN`
+(default `git-adapter`, found via `$PATH`). It reads its configuration from the
+process **environment** — never a CLI flag, never prompt content:
+
+| Variable | Required | Purpose |
+|----------|----------|---------|
+| `ADAPTER_CONFIG` | yes | Path to the git-adapter YAML config (declares `git.provider`, `git.auth_env`, and each capability's static `owner`/`repo`). |
+| `<auth_env>` | yes | The token env var **named by** `git.auth_env` in that config (e.g. `GITHUB_TOKEN`). |
+| `GIT_ADAPTER_BIN` | no | Override the `git-adapter` binary path (default `git-adapter`). |
+
+### Exposed MCP tools (allow-list, 1:1 with gRPC capabilities)
+
+The MCP tool set is an **explicit allow-list** built from `capabilities[].name`
+in the config — the same handlers the runtime gRPC path uses. Three tools are
+exposed:
+
+| MCP tool | Description |
+|----------|-------------|
+| `open_pr` | Open a pull request in the configured repository. Returns PR URL and number. |
+| `request_review` | Add reviewers to an existing PR. |
+| `get_diff` | Fetch the unified diff for a PR. Truncates at 4 MB and sets `truncated: true`. |
+
+All three require `owner` and `repo` declared in config — **never** derived from
+tool input (SSRF prevention, see below).
+
+---
+
+## Configuration
+
+The YAML file at `ADAPTER_CONFIG` declares the provider, the token env-var name,
+and each capability's pinned target. Key fields (full example:
+`agents/adapters/git/agent-def.yaml.example`):
+
+| Field | Description |
+|-------|-------------|
+| `git.provider` | `github` (GitLab returns "not implemented" in M5). |
+| `git.auth_env` | Name of the env var holding the token (e.g. `GITHUB_TOKEN`). |
+| `capabilities[].name` | One of `open_pr`, `request_review`, `get_diff`. |
+| `capabilities[].owner` | Static GitHub org/user — **never** from tool input. |
+| `capabilities[].repo` | Static repository name — **never** from tool input. |
+
+---
+
+## Credential model
+
+### Injection — read once at start, never an argument (#1199)
+
+The token is **injected into the process environment at start** and resolved
+**once** by the git-adapter from the env var named in `git.auth_env`
+(`config.ResolveToken`). It is held only in process memory: it is never a config
+field, never a tool argument, never read from a prompt, and never serialized.
+
+### Redaction — the egress backstop (#1199)
+
+`internal/redact` is the last line of defence against a token leaking into model
+context or logs. A `redact.Redactor` built from the injected token scrubs the
+secret — replaced with the literal `[REDACTED]` — from:
+
+- every caller-visible `CapabilityError` message,
+- the `COMPLETED` tool-result payload,
+- and again at the **MCP prompt boundary**, where tool-result text becomes model
+  context.
+
+The token value itself is never logged. (A trivially short secret is not
+redacted — there is an 8-byte minimum guard against masking common substrings.)
+
+### Token scope — least privilege (#1260)
+
+Use a GitHub **fine-grained PAT** scoped to **only** the `owner/repo` declared in
+config — never a classic PAT with the broad `repo` scope. The three capabilities
+only ever touch pull requests, so the token needs just one permission:
+
+| Capability | Required fine-grained permission |
+|------------|----------------------------------|
+| `open_pr` | Pull requests: **Read and write** |
+| `request_review` | Pull requests: **Read and write** |
+| `get_diff` | Pull requests: **Read** |
+
+Grant **Pull requests: Read and write** on the single configured repository and
+nothing else — no `Contents`, `Administration`, or org-wide access is required.
+
+**Defense in depth:** token scope and `owner/repo` pinning are *distinct,
+complementary* controls. `capabilities[].owner`/`.repo` are config-declared and
+never derived from tool input (SSRF prevention), so even a token broader than
+recommended cannot make the adapter reach a repository the config does not name.
+Pin the config narrowly **and** scope the token narrowly — neither replaces the
+other.
+
+### Lifecycle — read once, no refresh (#1262)
+
+The token is resolved **once at process start** and is **never refreshed** while
+the adapter runs. A short-lived credential — for example a GitHub App
+installation token (~1 h TTL) — would **expire mid-process** and subsequent Git
+calls would then fail with no automatic re-resolution. Until refreshable
+credentials land (epic G, step G.7 / #1262 — App installation tokens minted and
+re-resolved before expiry), use a credential whose lifetime exceeds the process:
+a fine-grained PAT (no expiry, or a long expiry you rotate manually).
+
+---
+
+## `.mcp.json` example
+
+Copy [`.mcp.json.example`](../../.mcp.json.example) to `.mcp.json` and adjust the
+config path. Reference the token **by env name only** — never inline a literal
+(a literal would land in a committed file and reach a prompt):
+
+```json
+{
+  "mcpServers": {
+    "zynax-git": {
+      "command": "zynax",
+      "args": ["mcp", "git"],
+      "env": {
+        "ADAPTER_CONFIG": "agents/adapters/git/config.yaml",
+        "GITHUB_TOKEN": "${GITHUB_TOKEN}"
+      }
+    }
+  }
+}
+```
+
+Export the token in the shell that launches the MCP client (or source it from a
+secret manager); `${GITHUB_TOKEN}` resolves from that environment:
+
+```bash
+export GITHUB_TOKEN="$(your-secret-fetch ...)"   # fine-grained PAT, least-privilege
+```
+
+### Run it directly
+
+```bash
+ADAPTER_CONFIG=agents/adapters/git/config.yaml \
+GITHUB_TOKEN="$GITHUB_TOKEN" \
+zynax mcp git
+```
+
+The server speaks the MCP stdio protocol on stdin/stdout. Press Ctrl+C to stop.
+
+---
+
+## See also
+
+- Quick-start + wiring: [`docs/git-mcp/README.md`](README.md)
+- Context System (the handoff contract Git operations participate in): [`docs/context/context-system.md`](../context/context-system.md)
+- ADR-032 — Git MCP shim over git-adapter: [`docs/adr/ADR-032-git-mcp-shim.md`](../adr/ADR-032-git-mcp-shim.md)
+- Adapter contract + credential details: `agents/adapters/git/AGENTS.md`
+- Operator config example: `agents/adapters/git/agent-def.yaml.example`


### PR DESCRIPTION
## docs: Context System + Git MCP guides

Closes #1219
Part of #1173 (EPIC D — Documentation, step D.3)

### Why
Authors had no guide for how context flows across hops, nor for using the Git
MCP surface safely. Without these, a multi-hop run's tracing/data-scoping rules
and the least-privilege Git token model live only in code and AGENTS.md. D.3
delivers the two author-facing guides the canvas calls for.

### What you'll get
- `docs/context/context-system.md` — the two kinds of context: correlation +
  W3C trace propagation (exact carrier keys `request-id` / `x-namespace` /
  `traceparent` / `tracestate`), the `HandoffContext` contract and the
  `inbound_context` / `outbound_metadata` SDK helpers (#1196), and run-scoped
  data-flow context with `DataContextScope` cross-run denial (#1195).
- `docs/git-mcp/git-mcp.md` — the `zynax mcp git` surface and tool allow-list
  (`open_pr` / `request_review` / `get_diff`, #1200), credential injection +
  `[REDACTED]` redaction (#1199), least-privilege fine-grained PAT scope
  (#1260), read-once/no-refresh lifecycle (#1262), and a complete `.mcp.json`
  example. Complements the existing `docs/git-mcp/README.md` quick-start
  without duplicating it.

### Scope & boundaries
- In scope: the two D.3 guides; every key/flag/type cited from real source.
- Out of scope: the OTEL/Uptrace observability guides (D.4), workflow/expert
  authoring guides (D.2), examples index (D.5).

### Test plan & acceptance
| Acceptance criterion | How verified | Result |
|---|---|---|
| context model + handoff contract documented | guide cites `HandoffContext` + `inbound_context`/`outbound_metadata` verbatim from `agents/sdk/src/zynax_sdk/handoff.py`; data scoping from `services/engine-adapter/internal/domain/datacontext.go` | ✅ |
| Git MCP least-privilege setup documented | guide cites `zynax mcp git` env vars, the 3-capability allow-list, redaction + fine-grained PAT scope from `agents/adapters/git/AGENTS.md` + `cmd/zynax/cmd/mcp.go` | ✅ |
| Links resolve | ADR-032, `docs/observability/opentelemetry.md`, `docs/authoring/workflows.md`, `.mcp.json.example`, `README.md` all confirmed present | ✅ |
| No PII / absolute paths | `grep` for emails + `/home/dietpi` → no matches; pre-commit secrets scan passed | ✅ |

### Evidence
- Preview: both files render as standard Markdown (tables + fenced blocks).
- Pre-commit: `Detect hardcoded secrets … Passed`.
- Carrier keys quoted byte-for-byte from `handoff.py` (`request-id`,
  `x-namespace`, `traceparent`, `tracestate`).

### Review aids
- Read order: `context-system.md` (the contract) → `git-mcp.md` (a concrete
  consumer of that contract).
- Every cited identifier links back to its source file in each guide's "See
  also" section.

**AI:** `Assisted-by: Claude/claude-opus-4-8` (label: ai-assisted)
