### PR TITLE
docs: examples index + best practices + FAQ + v0.5→v0.6 migration

### DIFF
--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -1,0 +1,82 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Best Practices
+
+Conventions that keep Zynax workflows, experts, and operations maintainable. These
+distil the authoring and observability guides into actionable rules. Where a topic has a
+full guide, this page links to it rather than repeating it.
+
+> See also: [Workflow Authoring](authoring/workflows.md) · [Expert Authoring](authoring/experts.md) ·
+> [Observability](observability/opentelemetry.md) · [Examples Index](examples/index.md).
+
+---
+
+## Workflow authoring
+
+- **Name and version every manifest.** Set `metadata.name`, `metadata.namespace`, and a
+  semver `metadata.version`. The namespace plus name is the workflow's identity
+  (ADR-034); reusing a name across namespaces is fine, reusing it within one is a
+  collision.
+- **Keep states single-purpose.** One responsibility per state; branch with `on:` events
+  and `guard:` expressions rather than packing logic into one state.
+- **Always declare terminal states.** Mark end states `type: terminal` so the engine
+  knows the run is complete. A workflow with no reachable terminal state never finishes.
+- **Set timeouts on long-running actions.** Use `timeout:` (e.g. `24h`) and route the
+  emitted timeout event to an escalation or abandon path, as `code-review.yaml` does.
+- **Dry-run before you apply.** `zynax apply --dry-run <file>` validates structure and
+  bindings without starting a run.
+
+## Data flow over templating
+
+Prefer explicit **data-flow bindings** (ADR-029) to passing values through context
+strings:
+
+- Publish a result field with `output:` on the producing action:
+  ```yaml
+  output:
+    feedback_summary: summary   # publish the action's `summary` result as `feedback_summary`
+  ```
+- Consume it downstream with a JSONPath input binding rooted at the producing state:
+  ```yaml
+  review_summary: "$.states.fix.output.feedback_summary"
+  ```
+- Reserve `{{ .context.* }}` / `{{ .event.* }}` templates for trigger and event payloads.
+  Bindings are typed and traceable; deep template indirection is not. The
+  [`code-review.yaml`](../spec/workflows/examples/code-review.yaml) and
+  [`ci-pipeline.yaml`](../spec/workflows/examples/ci-pipeline.yaml) examples show both
+  styles in context.
+
+## Experts and agents
+
+- **Pick the right substrate.** Authoring experts live in `.claude/`; runtime experts are
+  `kind: AgentDef` manifests dispatched by the engine. See
+  [Expert Authoring](authoring/experts.md) for which to use.
+- **Declare schemas on every capability.** Give each capability an `input_schema` and
+  `output_schema` with `required` fields and descriptions, as in
+  [`agent-def-example.yaml`](../spec/workflows/examples/agent-def-example.yaml). The
+  schema is the contract dispatch validates against.
+- **Set `timeout_seconds` and `max_retries` per capability.** Fast health-checks
+  (`ping`) get a short timeout and zero retries; expensive calls get longer windows.
+- **Start from a reference agent.** Copy `agents/examples/echo/` for the smallest working
+  adapter and grow from there. Commit the BDD `.feature` before the implementation
+  (ADR-016).
+
+## Observability
+
+- **Telemetry is off by default.** Enable it by setting the OTLP endpoint env var; see
+  [OpenTelemetry](observability/opentelemetry.md). Do not hard-code endpoints in manifests.
+- **Watch runs live.** Use `zynax logs <run-id> --follow` to tail execution events to a
+  terminal state, and `zynax status` to check current state.
+- **Tune sampling deliberately.** Full-trace sampling is fine locally; sample down in
+  shared environments — see [Sampling and Retention](observability/sampling.md).
+- **Never commit credentials.** Uptrace and OTLP credentials go in gitignored env files,
+  not in YAML or workflow manifests (placeholders only).
+
+## Git and contributions
+
+- **Least-privilege Git access.** The [Git MCP server](git-mcp/README.md) requires a
+  scoped token — grant only the repositories and scopes a workflow needs.
+- **One commit per logical change, one PR per issue.** See `CLAUDE.md` and the contributing
+  docs for commit-type and PR-size rules.
+- **Keep examples true.** If you change a manifest field or CLI flag, update the affected
+  example and guide in the same change — docs are verified against the running stack.

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -1,0 +1,93 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Examples Index
+
+A catalogue of the runnable examples that ship with Zynax: real workflows, manifest
+templates, and reference agents. Everything here is verified against the running stack —
+follow the [Quick Start](../quickstart.md) to bring the platform up, then `zynax apply`
+any workflow below.
+
+> **New here?** Start with the [Quick Start](../quickstart.md), then read the
+> [Workflow Authoring Guide](../authoring/workflows.md) and
+> [Expert Authoring Guide](../authoring/experts.md). This page is the map; those guides
+> explain the concepts.
+
+---
+
+## Workflows — `spec/workflows/examples/`
+
+### Real, runnable reference workflows
+
+These three carry the `real, runnable reference (EPIC T.3, #1208)` marker and compile
+green end-to-end. They are the recommended starting points for authoring your own.
+
+| File | `metadata.name` | Demonstrates |
+|------|-----------------|--------------|
+| [`code-review.yaml`](../../spec/workflows/examples/code-review.yaml) | `code-review-workflow` | Loops, async events, human-in-the-loop, timeout handling, and **data-flow bindings** — `fix` publishes `feedback_summary` via `output:`, `escalate` consumes it via `$.states.fix.output.feedback_summary`. |
+| [`ci-pipeline.yaml`](../../spec/workflows/examples/ci-pipeline.yaml) | `ci-pipeline-workflow` | Test → scan → build → deploy pipeline. `build` publishes `built_image` via `output:`; the deploy state consumes it with an input binding. |
+| [`feature-implementation.yaml`](../../spec/workflows/examples/feature-implementation.yaml) | `feature-implementation-workflow` | Plan → implement → verify → open-PR flow for a tracked feature issue, with data-flow handoff between states. |
+
+```bash
+zynax apply spec/workflows/examples/code-review.yaml
+zynax apply --dry-run spec/workflows/examples/ci-pipeline.yaml   # validate without running
+```
+
+### Additional workflow examples
+
+| File | `kind` / name | Purpose |
+|------|---------------|---------|
+| [`research-task.yaml`](../../spec/workflows/examples/research-task.yaml) | Workflow · `research-task-workflow` | Iterative web research with human review and approval. |
+| [`e2e-demo.yaml`](../../spec/workflows/examples/e2e-demo.yaml) | Workflow · `e2e-demo` | Minimal capability-dispatch fixture exercising the full dispatch chain end-to-end. |
+
+### Manifest examples (non-Workflow kinds)
+
+| File | `kind` / name | Purpose |
+|------|---------------|---------|
+| [`agent-def-example.yaml`](../../spec/workflows/examples/agent-def-example.yaml) | AgentDef · `code-review-agent` | A capability provider declaring `summarize`, `score_complexity`, and `ping` with input/output schemas and a runtime block. |
+| [`agent-def-expert.yaml`](../../spec/workflows/examples/agent-def-expert.yaml) | AgentDef · `go-review-expert` | A **runtime expert** template; mirrors the `go-review-expert` reference agent. See [Expert Authoring](../authoring/experts.md). |
+| [`policy-example.yaml`](../../spec/workflows/examples/policy-example.yaml) | Policy · `platform-policy` | Capability routing, rate-limiting, and quota rules. |
+
+---
+
+## Templates — `spec/templates/`
+
+Copy-and-fill scaffolds for new manifests. `zynax init workflow` and `zynax init expert`
+generate from these.
+
+| File | For |
+|------|-----|
+| [`workflow/workflow.template.yaml`](../../spec/templates/workflow/workflow.template.yaml) | New `kind: Workflow` manifests. |
+| [`expert/expert.template.yaml`](../../spec/templates/expert/expert.template.yaml) | New runtime-expert `kind: AgentDef` manifests. |
+| [`task/task.template.yaml`](../../spec/templates/task/task.template.yaml) | Single-task manifests. |
+
+---
+
+## Reference agents — `agents/examples/`
+
+Runnable adapter agents you can build, test, and register as capability providers. All
+three are Python SDK adapters (see the [Python Agent Guide](../patterns/python-agent-guide.md)).
+
+| Directory | Capability | What it does |
+|-----------|-----------|--------------|
+| [`echo/`](../../agents/examples/echo/) | `echo` | Copies its input payload to its output payload — the smallest possible adapter. |
+| [`summarizer/`](../../agents/examples/summarizer/) | `summarize` | Produces a short extractive summary from a list of documents. |
+| [`go-review-expert/`](../../agents/examples/go-review-expert/) | `go_review` | Rule-based Go code review; returns structured findings and an approval flag. The reference **runtime expert**. |
+
+Each agent directory contains a `capability.json`, a `pyproject.toml`, the adapter source
+under `src/`, and BDD `.feature` tests under `tests/features/`.
+
+### LLM adapter — `agents/adapters/llm/`
+
+The [`llm`](../../agents/adapters/llm/) adapter is the production capability provider for
+LLM calls. As of v0.6.0 it ships a **Go** entry point (`cmd/llm-adapter/`) alongside the
+Python source, with an [`agent-def.yaml.example`](../../agents/adapters/llm/agent-def.yaml.example)
+showing how to register it. See the [v0.5.0 → v0.6.0 migration guide](../migration-v0.6.md).
+
+---
+
+## Where to go next
+
+- [Best Practices](../best-practices.md) — conventions for authoring, data-flow, and observability.
+- [FAQ](../faq.md) — common questions and gotchas.
+- [Observability guides](../observability/opentelemetry.md) — trace and log your runs in Uptrace.
+- [Git MCP server](../git-mcp/README.md) — expose Git operations to MCP clients.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,101 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# FAQ
+
+Common questions about running, authoring, and operating Zynax. For step-by-step setup
+see the [Quick Start](quickstart.md); for the full developer workflow see the
+[Developer Guide](developer-guide.md).
+
+---
+
+## Getting started
+
+**What do I need installed?**
+Only Docker (Desktop, or Engine + the Compose plugin). Go, Python, and `buf` all run
+inside containers. Run `make bootstrap` once after cloning. See the
+[Quick Start](quickstart.md).
+
+**How do I install the `zynax` CLI?**
+`make install-cli` builds it to `~/bin/zynax` (ensure `~/bin` is on your `PATH`), or grab
+a release binary — see [local-dev.md](local-dev.md). The CLI talks to the api-gateway over
+HTTP REST only.
+
+**How do I run a workflow?**
+Bring the stack up (`make run-local`), then `zynax apply <file>`. Try a real example:
+```bash
+zynax apply spec/workflows/examples/code-review.yaml
+```
+The [Examples Index](examples/index.md) lists every runnable manifest.
+
+**How do I watch a run?**
+`zynax status` shows the current state; `zynax logs <run-id> --follow` tails execution
+events until the run reaches a terminal state. Add `--format json` for machine-readable
+output. The same stream is available over REST at `GET /api/v1/workflows/{id}/logs` (SSE).
+
+---
+
+## Authoring
+
+**Data-flow binding vs `{{ template }}` — which do I use?**
+Use **data-flow bindings** (`output:` to publish, `$.states.<state>.output.<field>` to
+consume) for values that flow between states; reserve templates for trigger/event
+payloads. See [Best Practices → Data flow](best-practices.md#data-flow-over-templating)
+and ADR-029.
+
+**My workflow never finishes — why?**
+Likely no reachable `type: terminal` state, or a `guard:` that no event satisfies. Every
+path must end in a terminal state. Validate with `zynax apply --dry-run <file>` first.
+
+**What's the difference between an authoring expert and a runtime expert?**
+Authoring experts live in `.claude/` and assist development; runtime experts are
+`kind: AgentDef` manifests the engine dispatches at run time. The
+[Expert Authoring Guide](authoring/experts.md) covers both substrates and the mapping.
+
+**How do I add a new capability provider?**
+Copy a reference agent from `agents/examples/` (start with `echo/`), declare its
+capabilities with `input_schema`/`output_schema`, and register it. See the
+[Python Agent Guide](patterns/python-agent-guide.md).
+
+**Is there a scaffolder?**
+Yes — `zynax init workflow` and `zynax init expert` generate from the templates under
+`spec/templates/`.
+
+---
+
+## Observability
+
+**I enabled nothing and see no traces — is that a bug?**
+No. Telemetry is **off by default**. Set the OTLP exporter endpoint env var to turn it on.
+See [OpenTelemetry](observability/opentelemetry.md).
+
+**How do I run the Uptrace UI locally?**
+Use the observability Compose overlay; create the env file (credentials are never
+committed) and bring it up. Step-by-step in [Running Uptrace](observability/uptrace.md).
+
+**Traces appear but logs/metrics don't (or the UI is empty).**
+See [Observability Troubleshooting](observability/troubleshooting.md) — it covers an empty
+UI, a stack that won't start, and signal-by-signal checks. Sampling and retention tuning
+is in [Sampling and Retention](observability/sampling.md).
+
+---
+
+## Git and operations
+
+**How do I expose Git to an MCP client?**
+Run `zynax mcp git`. It requires a **least-privilege** token scoped to only the
+repositories and operations you need. Setup in the
+[Git MCP server guide](git-mcp/README.md).
+
+**Where are the architectural decisions recorded?**
+In [docs/adr/INDEX.md](adr/INDEX.md). The M7 features (data-flow, observability, context
+propagation, Git MCP, experts) map to ADR-029 through ADR-033.
+
+---
+
+## Upgrading
+
+**How do I move from v0.5.0 to v0.6.0?**
+Follow the [v0.5.0 → v0.6.0 Migration Guide](migration-v0.6.md). v0.6.0 is additive — no
+breaking manifest changes — but adds data-flow bindings, log streaming, OTEL + Uptrace,
+context propagation, the Git MCP shim, reusable templates, and a Go entry point for the
+LLM adapter.

--- a/docs/migration-v0.6.md
+++ b/docs/migration-v0.6.md
@@ -1,0 +1,153 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Migration Guide: v0.5.0 → v0.6.0
+
+v0.6.0 (milestone M7) makes workflows **usable and observable**. It is an **additive**
+release: existing v0.5.0 manifests continue to apply unchanged, and no proto contract or
+event schema breaks. This guide lists what is new, what you can opt into, and the few
+configuration steps required to use the new capabilities.
+
+> **TL;DR — nothing breaks.** Upgrade the platform images and CLI, and your v0.5.0
+> workflows keep running. Everything below is opt-in.
+
+---
+
+## At a glance
+
+| Area | v0.5.0 | v0.6.0 | ADR |
+|------|--------|--------|-----|
+| Cross-state data | Context strings / templates only | Explicit **output/input data-flow bindings** | ADR-029 |
+| Run visibility | `zynax status` | `zynax logs` streaming + `/logs` REST (SSE) | — |
+| Observability | None built in | **OTEL traces/metrics/logs + Uptrace** UI | ADR-030 |
+| Context | Per-hop, ad hoc | **Trace / data / correlation propagation** across hops | ADR-031 |
+| Git access | Direct adapter calls | **Git MCP shim** (`zynax mcp git`) | ADR-032 |
+| Experts | Manifest only | **Expert-agent substrate** + reference agents | ADR-033 |
+| Authoring | Hand-written manifests | **Reusable templates** + `zynax init` | — |
+| LLM adapter | Python only | **Go entry point** alongside Python | — |
+
+---
+
+## 1. Workflow data-flow bindings (ADR-029)
+
+You can now pass typed values between states explicitly instead of threading them through
+context strings.
+
+- **Publish** a result field from the producing action:
+  ```yaml
+  actions:
+    - capability: summarize_feedback
+      input: { feedback: "{{ .context.latest_feedback }}" }
+      output:
+        feedback_summary: summary   # expose the action's `summary` result as `feedback_summary`
+  ```
+- **Consume** it downstream with a JSONPath binding rooted at the producing state:
+  ```yaml
+  review_summary: "$.states.fix.output.feedback_summary"
+  ```
+
+**Migration:** optional. Existing `{{ .context.* }}` templates still work. Adopt bindings
+where you currently round-trip data through context — see
+[`code-review.yaml`](../spec/workflows/examples/code-review.yaml) and
+[`ci-pipeline.yaml`](../spec/workflows/examples/ci-pipeline.yaml), and the
+[authoring guide](authoring/workflows.md).
+
+## 2. Execution log streaming
+
+A new way to watch runs:
+
+```bash
+zynax logs <run-id>            # stream execution events
+zynax logs <run-id> --follow   # tail until the run reaches a terminal state
+zynax logs <run-id> --format json
+```
+
+The same stream is served over REST as Server-Sent Events at
+`GET /api/v1/workflows/{id}/logs`. Each event carries `timestamp`, `eventType`,
+`fromState`, `toState`, and `status`.
+
+**Migration:** none. New, purely additive command and endpoint.
+
+## 3. OpenTelemetry + Uptrace observability (ADR-030)
+
+Go services emit OTEL traces and RED metrics; Python adapters emit traces and logs.
+**Telemetry is off by default** — enable it by pointing services at an OTLP collector:
+
+```bash
+ZYNAX_OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:7017
+```
+
+Run the Uptrace UI locally with the observability Compose overlay, or in-cluster with the
+Uptrace Helm chart. Credentials live in a gitignored env file — never commit them.
+
+**Migration:** opt-in. Set the env var and start the overlay. Full steps:
+[OpenTelemetry](observability/opentelemetry.md) · [Running Uptrace](observability/uptrace.md) ·
+[Sampling and Retention](observability/sampling.md) ·
+[Troubleshooting](observability/troubleshooting.md).
+
+## 4. Context propagation (ADR-031)
+
+Three kinds of context now flow across every hop (gRPC, Temporal, NATS):
+
+- **Trace context** — W3C `traceparent`, so a run is one trace end-to-end.
+- **Correlation context** — `x-request-id` and `x-namespace` headers.
+- **Data context** — scoped read/write workflow data (the basis for §1 bindings).
+
+**Migration:** none for authors — propagation is automatic. If you wrote custom gRPC
+clients, ensure they forward incoming metadata; the platform clients already do.
+
+## 5. Git MCP shim (ADR-032)
+
+Expose Git operations to MCP clients through the git-adapter:
+
+```bash
+zynax mcp git
+```
+
+It requires a **least-privilege** token scoped to only the repositories and operations
+you need. Setup and the `.mcp.json` shape are in the [Git MCP guide](git-mcp/README.md).
+
+**Migration:** none. New optional surface.
+
+## 6. Reusable templates + scaffolding
+
+Manifest scaffolds now ship under `spec/templates/` and the CLI can generate from them:
+
+```bash
+zynax init workflow
+zynax init expert
+```
+
+**Migration:** none. Optional authoring convenience. See the
+[Examples Index → Templates](examples/index.md#templates--spectemplates).
+
+## 7. Expert-agent substrate (ADR-033)
+
+Runtime experts are `kind: AgentDef` manifests dispatched by the engine, with reference
+agents under `agents/examples/` (`echo`, `summarizer`, `go-review-expert`) and a
+runtime-expert manifest example
+([`agent-def-expert.yaml`](../spec/workflows/examples/agent-def-expert.yaml)).
+
+**Migration:** none. See the [Expert Authoring Guide](authoring/experts.md).
+
+## 8. Go entry point for the LLM adapter
+
+The LLM adapter (`agents/adapters/llm/`) now ships a **Go** entry point
+(`cmd/llm-adapter/`) in addition to its Python source, with a registration example at
+[`agent-def.yaml.example`](../agents/adapters/llm/agent-def.yaml.example).
+
+**Migration:** none. The Python adapter remains; the Go binary is an additional deployment
+option.
+
+---
+
+## Upgrade checklist
+
+1. Pull the v0.6.0 platform images and rebuild/reinstall the CLI (`make install-cli`).
+2. Re-apply your existing workflows — they should apply unchanged.
+3. (Optional) Enable observability: set `ZYNAX_OTEL_EXPORTER_OTLP_ENDPOINT` and start the
+   Uptrace overlay.
+4. (Optional) Adopt data-flow bindings where you currently round-trip values through context.
+5. (Optional) Wire the Git MCP shim and/or the Go LLM adapter as needed.
+
+No manifest rewrites are required to reach v0.6.0. See the [FAQ](faq.md) for common
+upgrade questions.


### PR DESCRIPTION
## docs: examples index + best practices + FAQ + v0.5→v0.6 migration

Closes #1221 — EPIC D (#1173) step D.5, the last D story (finishes EPIC D).

### Why  (problem & intent)
After M7 there was a quick-start, authoring, and observability guide (D.1/D.2/D.4) but no
single map of the runnable examples, no consolidated best-practices/FAQ, and no upgrade
path. A developer could not easily find the real workflows or upgrade cleanly from v0.5.0.

### What you'll get  (deliverables ↔ what changed)
Four new cross-linked docs (no existing docs duplicated — the D.1/D.2/D.4 guides are
linked):

- `docs/examples/index.md` — catalogue of the 3 real, runnable workflows
  (code-review, ci-pipeline, feature-implementation — #1208/T.3), the other
  workflow/AgentDef/Policy examples, `spec/templates/` scaffolds, and the
  `agents/examples/` reference adapters incl. the Go `llm-adapter`.
- `docs/best-practices.md` — workflow/data-flow/expert/observability/Git conventions.
- `docs/faq.md` — getting-started, authoring, observability, Git, and upgrade Q&A.
- `docs/migration-v0.6.md` — additive v0.5.0 → v0.6.0 guide: data-flow bindings
  (ADR-029), `zynax logs` + `/logs` SSE, OTEL+Uptrace (ADR-030), context propagation
  (ADR-031), Git MCP shim (ADR-032), templates, expert substrate (ADR-033),
  Go llm-adapter entry point.

### Scope & boundaries
Docs only — four new files under `docs/`. No code, proto, schema, or workflow changes.
`docs:` is SPDD-exempt. Out of scope: the full K8s/Helm/GitOps example catalogue (M-dx).

### Test plan & acceptance
- Link-check: every cross-link verified to resolve (`docs/*` siblings, `../spec/...`,
  `../agents/...`, in-page anchors) — all OK.
- gitleaks/secret-scan pre-commit hook passed; no literal emails in the new files.
- All four canvas acceptance criteria met: examples index · best practices · FAQ ·
  v0.5→v0.6 migration notes.
- No specs/schemas changed, so `make validate-spec` is not required for this PR.

### Evidence
`git show --stat`: 4 files changed, 429 insertions(+). Facts (real-runnable workflow set,
`zynax logs` flags, OTLP env var, ADR mapping, Go llm-adapter path) verified against the
worktree before writing.

### Review aids
Start with `docs/examples/index.md` (the map), then `docs/migration-v0.6.md` (most
fact-sensitive — cross-check the ADR mapping table against `docs/adr/INDEX.md`).
