### PR TITLE
docs(automation): roadmap-plan + review-doc command suite and product/audience labels

### DIFF
--- a/.claude/commands/architecture-review.md
+++ b/.claude/commands/architecture-review.md
@@ -1,0 +1,127 @@
+---
+description: Generate a dated, scored architecture review document grounded in the live repo — three-layer separation, ADR adherence, hexagonal services, scalability/security/reliability, CNCF fit — and tracked longitudinally against the previous architecture review (which prior risks/recommendations are now closed). Read-only synthesis; writes one dated doc under docs/architecture/ and opens a docs: PR with --pr.
+argument-hint: "[--pr] [--since <prev-review-path>]   default: working draft, no PR"
+---
+
+# /architecture-review — Architecture Review Document Generator
+
+Produce a principal-engineer-grade architecture review as a **dated document**, in the exact
+shape and home of the existing reviews under [docs/architecture/](docs/architecture/) (e.g.
+[2026-05-20-principal-architect-review.md](docs/architecture/2026-05-20-principal-architect-review.md)).
+This is a point-in-time assessment, not a living doc — and it is **longitudinal**: it diffs
+against the previous architecture review and records which risks/recommendations have since closed.
+
+> **Read-mostly.** It reads the repo and live GitHub state and writes exactly one new dated
+> Markdown file. With `--pr` it opens a `docs:` PR; otherwise it leaves the file as an
+> uncommitted working draft for you to review. It never edits code, ADRs, or `AGENTS.md`.
+
+> **Truth-pass discipline (non-negotiable).** Every score, strength, and weakness is **grounded
+> in a cited repo artifact** (`file:line`, ADR#, issue#, or `gh` query result). No invented
+> numbers. Separate **shipped / partial / aspirational** explicitly. This is the lesson the M5.A
+> Truth Pass and [docs/product/strategy.md](docs/product/strategy.md) encode: an ungrounded
+> review is worse than none.
+
+> **Rules are not restated.** Architecture invariants live in [AGENTS.md](AGENTS.md) and
+> [docs/adr/INDEX.md](docs/adr/INDEX.md). Contribution rules in [CLAUDE.md](CLAUDE.md). This file
+> is the *review-doc generation loop* only.
+
+---
+
+## STEP 0 — Resolve output path + previous review (convention-following)
+
+```bash
+REPO=$(git rev-parse --show-toplevel)
+DATE=$(date +%Y-%m-%d)
+OUT="docs/architecture/${DATE}-architecture-review.md"
+# Previous review to diff against (most recent existing review of this kind):
+PREV=$(ls -1 docs/architecture/*review*.md 2>/dev/null | sort | tail -1)
+echo "writing: $OUT   diffing-against: ${PREV:-<none>}"
+```
+
+Honour `--since <path>` to override the previous-review baseline.
+
+---
+
+## STEP 1 — Gather the grounding corpus (delegate heavy code reads)
+
+The planner-style context budget applies: do not read every service file in this context.
+Fan out up to **3 read-only `Explore` subagents** (parallel), each returning grounded findings
+with `file:line` evidence. Suggested split:
+
+| Subagent | Mines | Returns |
+|----------|-------|---------|
+| 1 — structure | `AGENTS.md`, `ARCHITECTURE.md`, `services/*/AGENTS.md`, `internal/{api,domain,infrastructure}` layout | three-layer/hexagonal adherence, layer-boundary violations, coupling, with file paths |
+| 2 — decisions | `docs/adr/INDEX.md` + each ADR | which ADRs are honoured vs drifted; proposed-but-unimplemented; one-way-door integrity |
+| 3 — quality | benchmarks/fuzz/load presence, error handling, timeouts/retries, observability hooks, dep graph | perf/reliability/scalability evidence + gaps |
+
+The coordinator additionally reads live state itself (cheap):
+
+```bash
+sed -n '1,60p' state/current-milestone.md
+gh api repos/:owner/:repo/milestones --jq '.[]|select(.state=="open")|"\(.title) open:\(.open_issues) closed:\(.closed_issues)"'
+[ -n "$PREV" ] && sed -n '1,80p' "$PREV"        # prior scores + risk register to diff against
+```
+
+---
+
+## STEP 2 — Synthesize the review (sections, mirroring the gold template)
+
+Write `$OUT` with this structure (the proven shape of the 2026-05-20 review). Begin with the
+SPDX header `<!-- SPDX-License-Identifier: Apache-2.0 -->` and use **repo-relative links** only.
+
+1. **Header** — document type, date, reviewer-mandate, branch/HEAD reviewed.
+2. **Executive summary** — the single most important finding; what is real vs narrative.
+3. **Scorecard** — per-dimension 1–10 (Architecture, Simplicity, Performance, Security,
+   Maintainability, Scalability, Reliability, Testing, CI/CD, Documentation, CNCF, PMF), **each
+   with a one-line evidence rationale**. No bare numbers.
+4. **Top strengths / Top weaknesses** — each citing `file:line` or ADR#.
+5. **Per-dimension sections** — architecture, code quality, performance, security, scalability,
+   reliability, testing, CI/CD, docs, CNCF fit (mirror the gold template's §2–§14).
+6. **Risk register** — `ID | risk | P | I | mitigation | status`.
+7. **Longitudinal delta vs `$PREV`** — a table: each prior risk/recommendation → `closed` /
+   `partially-closed` / `open`, with the commit/PR/issue that closed it. (This is what makes the
+   series valuable; cf. the post-M6 deltas in [docs/product/strategy.md](docs/product/strategy.md).)
+8. **Prioritized recommendations** — Critical / High, mapped to issues where they exist.
+9. **Gap analysis** — items not yet filed as issues (feed these to `/roadmap-plan`). Annotate
+   each row with **user type(s)** (developer/operator/maintainer/product-owner/zynax-user/
+   enterprise) and an **adoption lever** note, so `/roadmap-plan` files it with the right
+   `product:` / `audience:` labels and a complete `## What for (user impact)` block.
+10. **Appendix** — score card table + key file references.
+
+> **Heavy-write tip.** If the corpus is large, draft each section from the subagents' returned
+> findings; never paste raw code into the doc — cite it.
+
+---
+
+## STEP 3 — Deliver
+
+Default: leave `$OUT` as an uncommitted working draft and print its path + a 10-line summary.
+
+With `--pr`, open a `docs:` PR from an isolated worktree (never the user's checkout, never `main`):
+
+```bash
+RUN_ID="$(date +%s)-$$"; WT="/tmp/zynax-archreview-${RUN_ID}"
+git -C "$REPO" worktree add "$WT" origin/main
+# write $OUT inside $WT, then:
+git -C "$WT" checkout -b "docs/architecture-review-${DATE}"
+git -C "$WT" add "$OUT"
+git -C "$WT" commit -s -F /tmp/archreview-msg-${RUN_ID}.txt   # docs(architecture): … + Assisted-by trailer
+git -C "$WT" push -u origin "docs/architecture-review-${DATE}"
+gh pr create --title "docs(architecture): architecture review ${DATE}" \
+  --body "<exec summary + scorecard table + longitudinal delta>" --label "type: docs"
+git -C "$REPO" worktree remove "$WT" --force 2>/dev/null || true
+```
+
+The review doc lands under `docs/` (PR-size-exempt, **not** CODEOWNERS-gated), so its PR can be
+self-merged once CI is green — squash-only. Leave the merge to the human unless they say "go".
+
+---
+
+## Guardrails
+
+- **Ground everything.** No score or claim without a cited artifact. Mark shipped/partial/aspirational.
+- **Longitudinal, not amnesiac.** Always diff against the previous review; record what closed.
+- **Read-only on the system under review.** Never edit code, ADRs, `AGENTS.md`, or `.feature` files.
+- **One dated doc per run.** Don't overwrite a prior review — the series is the value.
+- Commit (with `--pr`): `docs:` type, DCO `-s`, `Assisted-by: Claude/<model>`, squash-merge, signed; repo-relative links; no literal email; no skip-ci token.
+- Pairs with `/roadmap-plan`: this review's **gap analysis** is exactly the input `/roadmap-plan` mines into issues.

--- a/.claude/commands/market-fit-review.md
+++ b/.claude/commands/market-fit-review.md
@@ -1,0 +1,94 @@
+---
+description: Generate a dated market-fit review document grounded in the repo + live signals — category, competitive landscape (lead vs Kagent), TAM framing, persona/beachhead validation, adoption-funnel reality, and product-market-fit verdict — with recommendations classified by user type + adoption lever, tracked longitudinally. Read-only synthesis; writes one dated doc under docs/product/ and opens a docs: PR with --pr.
+argument-hint: "[--pr] [--since <prev-review-path>]   default: working draft, no PR"
+---
+
+# /market-fit-review — Market-Fit Review Document Generator
+
+Produce a point-in-time **product-market-fit** assessment as a dated document under
+[docs/product/](docs/product/), extending the competitive analysis in
+[docs/architecture/2026-05-28-competitive-positioning.md](docs/architecture/2026-05-28-competitive-positioning.md)
+and the market sections of [docs/product/strategy.md](docs/product/strategy.md).
+
+> **Read-mostly.** Reads the repo + live GitHub signals, writes one dated Markdown file. `--pr`
+> opens a `docs:` PR; otherwise a working draft. Never edits code/ADRs/`AGENTS.md`.
+
+> **Truth-pass discipline.** Competitive claims cite the repo's own positioning docs; adoption
+> numbers come live from `gh`. Mark shipped/partial/aspirational. No invented scores — reconcile
+> any PMF score to the architect review's grounded basis.
+
+> **Rules are not restated.** See `strategy.md`, the competitive-positioning doc, and
+> [ROADMAP.md](ROADMAP.md). This file is the *review-doc generation loop* only.
+
+---
+
+## STEP 0 — Resolve output path + previous review
+
+```bash
+REPO=$(git rev-parse --show-toplevel); DATE=$(date +%Y-%m-%d)
+OUT="docs/product/${DATE}-market-fit-review.md"
+PREV=$(ls -1 docs/product/*market-fit-review.md 2>/dev/null | sort | tail -1)
+echo "writing: $OUT   baseline: ${PREV:-docs/architecture/2026-05-28-competitive-positioning.md}"
+```
+
+Honour `--since <path>`.
+
+---
+
+## STEP 1 — Gather the grounding corpus
+
+Coordinator pulls live adoption/market signals; a read-only `Explore` subagent mines the
+positioning corpus (`strategy.md`, competitive-positioning, README, ROADMAP) for the current
+category framing, the Kagent comparison, and the beachhead definition.
+
+```bash
+gh api repos/:owner/:repo --jq '{stars:.stargazers_count, forks:.forks_count, watchers:.subscribers_count}'
+gh api repos/:owner/:repo/contributors --jq 'length'
+# Optional external signal: maintainers may paste recent competitor/CNCF news for the subagent to weigh.
+```
+
+---
+
+## STEP 2 — Synthesize the review (sections)
+
+Write `$OUT` (SPDX header; repo-relative links):
+
+1. **Header + executive summary** — the PMF verdict in one line; what changed since `$PREV`.
+2. **Category** — the "control plane for AI agents" category in the current period; is it more/less crowded?
+3. **Competitive landscape** — **lead with Zynax vs Kagent** (engine-agnostic vs K8s-locked;
+   capability-routing vs Pod-per-agent; co-existence story), then Temporal/Dapr/Restate/LangGraph/
+   Argo/Flyte-Kubeflow. Extend the matrix from the competitive-positioning doc with any deltas.
+4. **TAM framing** — the three adjacent markets (agent orchestration / workflow engines / AI-ML
+   platforms) and where Zynax's wedge sits.
+5. **Personas & beachhead validation** — does agentic SW-engineering automation still hold as the
+   beachhead? Evidence (shipped examples, demand signals).
+6. **Adoption-funnel reality** — live metrics (stars/forks/contributors/adopters) vs the funnel
+   targets in `strategy.md §7`. Honest baseline.
+7. **PMF verdict + score** — reconciled to the architect review's grounded basis; no invented number.
+8. **Recommendations (prioritized)** — each classified by **user type** + **adoption lever**, for
+   the `/roadmap-plan` handoff (`product:`/`audience:` labels + `## What for (user impact)` block).
+9. **Longitudinal delta vs `$PREV`** — what moved (positioning, competitors, metrics).
+10. **Appendix** — sources.
+
+---
+
+## STEP 3 — Deliver
+
+Default: working draft + summary. With `--pr`, open a `docs:` PR from an isolated worktree (PR body
+from [docs/contributing/pr-templates.md](docs/contributing/pr-templates.md), docs variant; DCO `-s`
++ `Assisted-by`; squash-only; repo-relative links; no literal email). Label `type: docs` +
+`product: strategy`.
+
+`docs/` is not CODEOWNERS-gated → self-mergeable on green CI (squash-only); leave merge to the human.
+
+---
+
+## Guardrails
+
+- **Lead with Kagent.** The repo's own docs name it the direct competitor — never omit it (the
+  cautionary precedent: an earlier informal analysis did, and was wrong).
+- **Ground everything.** Cite positioning docs; pull adoption metrics live; no invented PMF score.
+- **Longitudinal.** Diff against the prior market-fit review / competitive-positioning doc.
+- **Recommendations carry user-type + adoption-lever annotations** (the `/roadmap-plan` handoff).
+- One dated doc per run; never overwrite a prior review.
+- Pairs with `/product-review` (internal product lens) and `/roadmap-plan` (recommendations → issues).

--- a/.claude/commands/product-review.md
+++ b/.claude/commands/product-review.md
@@ -1,0 +1,109 @@
+---
+description: Generate a dated product-strategy review document grounded in the live repo — positioning, real-vs-aspirational capability split, adoption funnel status, beachhead validation, and prioritized recommendations classified by user type + adoption lever — tracked longitudinally against the previous product review / docs/product/strategy.md. Read-only synthesis; writes one dated doc under docs/product/ and opens a docs: PR with --pr.
+argument-hint: "[--pr] [--since <prev-review-path>]   default: working draft, no PR"
+---
+
+# /product-review — Product Strategy Review Document Generator
+
+Produce a point-in-time product-strategy review as a **dated document** under
+[docs/product/](docs/product/), building on the living
+[docs/product/strategy.md](docs/product/strategy.md) and the competitive/architecture reviews.
+Longitudinal: it diffs against the prior product review (and `strategy.md`) and records what
+moved — adoption metrics, positioning, recommendations closed.
+
+> **Read-mostly.** Reads the repo + live GitHub state, writes one dated Markdown file. With
+> `--pr` opens a `docs:` PR; otherwise leaves a working draft. Never edits code/ADRs/`AGENTS.md`.
+
+> **Truth-pass discipline (non-negotiable).** Every claim is **grounded in a cited artifact**
+> (`file:line`, doc, issue#, or `gh` result). No invented numbers — the draft that became
+> `strategy.md` was hardened precisely by removing ungrounded scores. Separate **shipped /
+> partial / aspirational** explicitly.
+
+> **Rules are not restated.** See [AGENTS.md](AGENTS.md), [CLAUDE.md](CLAUDE.md), and
+> `strategy.md` for the canonical positioning. This file is the *review-doc generation loop* only.
+
+---
+
+## STEP 0 — Resolve output path + previous review
+
+```bash
+REPO=$(git rev-parse --show-toplevel); DATE=$(date +%Y-%m-%d)
+OUT="docs/product/${DATE}-product-strategy-review.md"
+PREV=$(ls -1 docs/product/*review*.md 2>/dev/null | sort | tail -1)   # else diff vs strategy.md
+echo "writing: $OUT   baseline: ${PREV:-docs/product/strategy.md}"
+```
+
+Honour `--since <path>` to override the baseline.
+
+---
+
+## STEP 1 — Gather the grounding corpus (delegate heavy reads)
+
+Fan out up to 3 read-only `Explore` subagents (parallel), returning grounded findings:
+
+| Subagent | Mines | Returns |
+|----------|-------|---------|
+| 1 — positioning | `README.md`, `ROADMAP.md`, `docs/product/strategy.md`, `docs/architecture/*positioning*` | current tagline, value prop, real-vs-aspirational split (with refs) |
+| 2 — delivery vs narrative | `state/current-milestone.md`, `docs/milestones/*`, ADR statuses, shipped capabilities | what is actually shipped this milestone vs claimed |
+| 3 — adoption signals | (coordinator does this via `gh`) | stars/forks/discussions, external adopters, contributor count |
+
+Coordinator reads cheap live signals itself:
+
+```bash
+gh api repos/:owner/:repo --jq '{stars:.stargazers_count, forks:.forks_count, watchers:.subscribers_count, open_issues:.open_issues_count}'
+gh api repos/:owner/:repo/contributors --jq 'length'
+gh api repos/:owner/:repo/milestones --jq '.[]|select(.state=="open")|"\(.title) open:\(.open_issues) closed:\(.closed_issues)"'
+sed -n '1,60p' state/current-milestone.md
+```
+
+---
+
+## STEP 2 — Synthesize the review (sections)
+
+Write `$OUT` (SPDX header first; repo-relative links only):
+
+1. **Header** — type, date, baseline diffed against.
+2. **Executive summary** — the single most important product finding this period.
+3. **Positioning check** — is the messaging still differentiated (esp. vs Kagent)? Drift from `strategy.md`?
+4. **Real vs aspirational** — shipped / partial / aspirational table, reconciled to milestone state.
+5. **Adoption funnel** — time-to-first-workflow, stars/forks/discussions, external adopters,
+   contributors — **the numbers from STEP 1**, each with its source. Compare to the baseline.
+6. **Beachhead validation** — is the hero use case (agentic SW-engineering automation) holding?
+   Evidence from shipped examples / real workflows.
+7. **Recommendations (prioritized)** — each classified by **user type** (developer/operator/
+   maintainer/product-owner/zynax-user/enterprise) and **adoption lever**, so `/roadmap-plan` can
+   file them with the right `product:` / `audience:` labels + `## What for (user impact)` block.
+8. **Longitudinal delta** — prior recommendations → closed / open, with the PR/issue that moved them.
+9. **Appendix** — sources + glossary.
+
+---
+
+## STEP 3 — Deliver
+
+Default: leave `$OUT` as a working draft + print a summary. With `--pr`, open a `docs:` PR from an
+isolated worktree (PR body built from [docs/contributing/pr-templates.md](docs/contributing/pr-templates.md),
+docs-emphasis variant; DCO `-s` + `Assisted-by`; squash-only; repo-relative links; no literal email):
+
+```bash
+RUN_ID="$(date +%s)-$$"; WT="/tmp/zynax-prodreview-${RUN_ID}"
+git -C "$REPO" worktree add "$WT" origin/main
+# write $OUT inside $WT, then commit/push from $WT and:
+gh pr create --title "docs(product): product strategy review ${DATE}" \
+  --body-file /tmp/prodreview-prbody-${RUN_ID}.md --label "type: docs" --label "product: strategy"
+git -C "$REPO" worktree remove "$WT" --force 2>/dev/null || true
+```
+
+`docs/` is PR-size-exempt and not CODEOWNERS-gated → self-mergeable once CI is green (squash-only);
+leave merge to the human unless they say "go".
+
+---
+
+## Guardrails
+
+- **Ground everything; no invented numbers.** Mark shipped/partial/aspirational. Pull adoption
+  metrics live from `gh`, not memory.
+- **Longitudinal.** Always diff against the prior review / `strategy.md`; record what moved.
+- **Recommendations carry user-type + adoption-lever annotations** (the `/roadmap-plan` handoff).
+- **Read-only on the product under review.** One dated doc per run; never overwrite a prior review.
+- Commit (with `--pr`): `docs:` type, DCO `-s`, `Assisted-by`, signed, squash-merge.
+- Pairs with `/roadmap-plan` (recommendations → issues) and `/market-fit-review` (competitive/TAM depth).

--- a/.claude/commands/review-suite.md
+++ b/.claude/commands/review-suite.md
@@ -1,0 +1,163 @@
+---
+description: Run the full review suite — architecture, security-posture, product-strategy, and market-fit reviews — in parallel read-only subagents, each producing its dated grounded document, then collect them into one docs: PR (or four, with --split). The single command to take a fresh, truthful read of where the project stands across engineering and product.
+argument-hint: "[--pr] [--split] [--only architecture,security,product,market]   default: working drafts, one bundled PR with --pr"
+---
+
+# /review-suite — Parallel Review Document Orchestrator
+
+Fan out all four review-document generators at once, each in its own isolated subagent, and
+collect their dated docs. Thin coordination layer: spawn → collect → deliver. The orchestrator
+itself reads no code — each review's grounding work happens in its subagent's isolated context
+(same discipline as `/milestone-orchestrate`).
+
+```
+/review-suite
+  ├─ /architecture-review   → docs/architecture/<date>-architecture-review.md
+  ├─ /security-review-doc   → docs/architecture/<date>-security-review.md (+ .private.md, gitignored)
+  ├─ /product-review        → docs/product/<date>-product-strategy-review.md
+  └─ /market-fit-review     → docs/product/<date>-market-fit-review.md
+```
+
+> **Read-mostly.** Subagents read the repo + live GitHub state and return their doc CONTENT;
+> the coordinator writes the files and (with `--pr`) opens the PR(s). Nothing edits code, ADRs,
+> or `AGENTS.md`. Each review keeps its own truth-pass discipline (grounded claims, longitudinal
+> delta, shipped/partial/aspirational split).
+
+> **Rules are not restated.** Each review command (`/architecture-review`, `/security-review-doc`,
+> `/product-review`, `/market-fit-review`) owns its own contract and guardrails. This file is the
+> *parallel coordination loop* only.
+
+---
+
+## STEP 0 — Coordinator worktree + arg parse
+
+```bash
+RUN_ID="$(date +%s)-$$"
+REPO=$(git rev-parse --show-toplevel)
+COORD_WT="/tmp/zynax-reviewsuite-${RUN_ID}"
+git -C "$REPO" worktree remove "$COORD_WT" --force 2>/dev/null || true
+git -C "$REPO" fetch origin --prune
+git -C "$REPO" worktree add "$COORD_WT" origin/main
+cd "$COORD_WT"
+DATE=$(date +%Y-%m-%d)
+```
+
+Parse `--only` (subset of `architecture,security,product,market`; default all four), `--pr`
+(open PR after collecting), `--split` (one PR per review instead of one bundled PR).
+
+---
+
+## STEP 1 — Dispatch the review subagents in parallel (read-only)
+
+Spawn one background `Agent` per selected review. Each runs that review's procedure end-to-end
+against the **real checkout** (read-only) and **returns the finished Markdown** in its result —
+it does NOT commit (the coordinator writes one branch to avoid four agents racing one tree).
+
+For each selected review R with its command file F (e.g. `architecture` → `architecture-review.md`):
+
+```
+Agent({
+  description: "<R> review document",
+  subagent_type: "Explore",          // read-only; no edits
+  run_in_background: true,
+  prompt: """
+    You are generating the <R> review document for Zynax. Follow this command's procedure
+    exactly (STEP 0–2 — gather grounding corpus, synthesize), but DO NOT write a file, create a
+    branch, or open a PR. Instead RETURN the complete review Markdown as your final message,
+    starting with the SPDX header and using repo-relative links only.
+
+    <full content of .claude/commands/<F>>
+
+    Constraints:
+    - Read-only. Ground every claim in a cited artifact (file:line / doc / gh result). No invented numbers.
+    - Mark shipped / partial / aspirational. Include the longitudinal delta vs the prior review.
+    - Annotate recommendations/gaps with user type(s) + adoption lever (for the /roadmap-plan handoff).
+    - Pull live signals (stars/forks/contributors/alerts/milestones) via gh yourself.
+    - End with: a line `OUTPUT_PATH: <the dated path this review uses>` so the coordinator can place it.
+  """
+})
+```
+
+> **Why subagents return content rather than commit:** four agents committing to one branch
+> collide; four separate worktrees + four PRs is noisier than one review snapshot. Returning
+> content lets the coordinator assemble a single, reviewable PR. (`--split` overrides this — see
+> STEP 3.) The security review's `.private.md`, if any, is returned separately and the coordinator
+> writes it **only** if `.gitignore` covers it, and never stages it.
+
+---
+
+## STEP 2 — Collect results
+
+As each subagent completes, extract its `OUTPUT_PATH` and Markdown body. Write each doc to its
+path inside `$COORD_WT`. For the security review, write the public doc; write the `.private.md`
+only if `git -C "$COORD_WT" check-ignore <priv>` succeeds, and never stage it.
+
+```bash
+# per returned review: write the file at its OUTPUT_PATH inside the coordinator worktree
+# (the coordinator holds 4 large docs briefly — acceptable for a snapshot run)
+```
+
+Report any subagent that failed (with reason) and continue with the rest.
+
+---
+
+## STEP 3 — Deliver
+
+**Default (no `--pr`):** leave all docs as working drafts in the coordinator worktree path and
+print each `OUTPUT_PATH` + a 5-line summary per review, then clean up the worktree.
+
+**`--pr` (bundled, default):** one `docs:` PR with all collected docs:
+
+```bash
+git -C "$COORD_WT" checkout -b "docs/review-suite-${DATE}"
+git -C "$COORD_WT" add docs/architecture/${DATE}-*.md docs/product/${DATE}-*.md   # explicit paths; NEVER git add -A (private file)
+git -C "$COORD_WT" commit -s -F /tmp/reviewsuite-msg-${RUN_ID}.txt   # docs: review suite <date> + Assisted-by
+git -C "$COORD_WT" push -u origin "docs/review-suite-${DATE}"
+gh pr create --title "docs: review suite — ${DATE} (architecture · security · product · market-fit)" \
+  --body-file /tmp/reviewsuite-prbody-${RUN_ID}.md --label "type: docs" --label "product: strategy"
+```
+
+PR body is built from [docs/contributing/pr-templates.md](docs/contributing/pr-templates.md)
+(docs variant) and links each review with its one-line headline verdict. DCO `-s` + `Assisted-by`;
+squash-only; repo-relative links; no literal email; no skip-ci token.
+
+**`--split`:** instead, have each subagent open its own `docs:` PR via its own worktree (the
+standalone behaviour of each review command with `--pr`). Use when you want them reviewed/merged
+independently.
+
+`docs/` is PR-size-exempt and not CODEOWNERS-gated → self-mergeable on green CI (squash-only);
+leave merge to the human unless they say "go".
+
+```bash
+cd "$REPO" && git worktree remove "$COORD_WT" --force 2>/dev/null || true
+```
+
+---
+
+## STEP 4 — Report
+
+```
+=== Review Suite — <date> ===
+| Review | Doc | Headline verdict | Top recommendation |
+|--------|-----|------------------|--------------------|
+| architecture | docs/architecture/<date>-architecture-review.md | <score / one-line> | <#1 rec> |
+| security     | docs/architecture/<date>-security-review.md      | <posture>           | <#1 rec> |
+| product      | docs/product/<date>-product-strategy-review.md   | <PMF / one-line>    | <#1 rec> |
+| market-fit   | docs/product/<date>-market-fit-review.md         | <verdict>           | <#1 rec> |
+
+PR: #<n> (bundled) or four PRs (--split).
+Next: feed the reviews' gap-analyses/recommendations to /roadmap-plan to file them as issues.
+```
+
+---
+
+## Guardrails
+
+- **Coordinator reads no code.** All grounding happens in subagents; if you find yourself reading
+  a service file here, stop and let the subagent do it.
+- **Never `git add -A`** in this command — it would stage a security `.private.md`. Stage explicit paths.
+- **One dated doc per review per run.** Never overwrite a prior dated review.
+- Each review keeps truth-pass discipline (grounded, longitudinal, shipped/partial/aspirational).
+- Commit (with `--pr`): `docs:` type, DCO `-s`, `Assisted-by`, signed, squash-merge; repo-relative links.
+- Pairs with `/roadmap-plan`: the suite produces the assessments; `/roadmap-plan` turns their
+  gaps/recommendations into SPDD-filed, adoption-tagged issues for the active milestone.

--- a/.claude/commands/roadmap-plan.md
+++ b/.claude/commands/roadmap-plan.md
@@ -1,0 +1,424 @@
+---
+description: SPDD-native roadmap planner — reads the whole repo (ROADMAP, architecture/security/market reviews, ADRs, AGENTS.md, experts, code, live GH issues/labels/milestones, canvases, ai-learnings) and infers the next stories + unresolved fixes for the ACTIVE milestone. Routes every feat: through the SPDD pipeline (analysis→story→canvas→security-review→align), cross-links canvas↔issue, then leaves the repo orchestrate-ready and as repo-clean as possible. Keeps filling the active milestone until its exit criteria are met, then PROPOSES advancing to the next milestone. PLAN by default; mutations gated behind --execute.
+argument-hint: "[--execute] [--area <scope>] [--max N]   default: PLAN only"
+---
+
+# /roadmap-plan — SPDD-Native Roadmap Planner & Orchestration-Readiness Pass
+
+Answer the question **/milestone-plan cannot**: *what stories and fixes SHOULD exist for the
+active milestone that don't yet* — then create them the SPDD way and leave the repo ready for
+`/milestone-orchestrate`.
+
+```
+/roadmap-plan  →  infer stories + fixes from the whole repo (this command)
+/milestone-plan        →  sequence the EXISTING issues into parallel batches
+/milestone-orchestrate →  deliver batches via expert subagents
+/milestone-learn       →  synthesize session learnings into expert guides
+/repo-clean            →  reconcile status surfaces to live state
+/milestone-close + /milestone-new →  advance to the next milestone
+```
+
+`/milestone-plan` sequences issues that already exist. **`/roadmap-plan` is the step before
+it** — it mines the repo for work that is implied but unfiled, files it correctly (SPDD for
+`feat:`), aligns the active milestone's canvases to their EPICs and issues, and runs a
+`/repo-clean` reconcile so the next `/milestone-orchestrate` starts from a true, complete state.
+
+> **This command is PLAN-by-default and read-mostly.** It prints a traceable plan and **stops**.
+> It mutates GitHub (creates issues, runs SPDD canvases/security-reviews, cross-links,
+> reconciles) **only** with `--execute` or an explicit "go" after the plan. It never edits
+> `AGENTS.md`, ADRs, or any `.claude/commands/**` file — refinements to those are *proposed*
+> into the human-gated `/milestone-learn` + `/repo-clean` loop (STEP 6).
+
+> **Rules are not restated.** Domain + contribution rules live in [AGENTS.md](AGENTS.md),
+> [CLAUDE.md](CLAUDE.md), [docs/git-workflow.md](docs/git-workflow.md), and the SPDD guide
+> [docs/patterns/spdd-guide.md](docs/patterns/spdd-guide.md). The SPDD `feat:` contract is
+> [ADR-019](docs/adr/INDEX.md). This file is the *inference + readiness loop* only.
+
+---
+
+## Operating contract (read before doing anything)
+
+- **Active milestone is the unit of work.** Read it from `state/milestone.yaml` (SSoT). Never
+  hardcode a milestone name/number/label. This command plans **into the active milestone** and
+  keeps filling it until its exit criteria are met (STEP 7).
+- **Live GitHub state is the source of truth** — never memory, never a stale doc. Every decision
+  is driven by `gh issue list` / `gh pr list` / `gh api .../milestones` and the files read fresh.
+- **SPDD for every `feat:`.** Inferred *capabilities* are never filed as bare issues. They go
+  through `/spdd-analysis` → `/spdd-story` → `/spdd-reasons-canvas` → `/spdd-security-review` →
+  human aligns the canvas. `fix:` / `refactor:` / `docs:` / `test:` / `ci:` / `chore:` are
+  SPDD-exempt and may be filed directly.
+- **Two phases.** PLAN (default) computes and prints; EXECUTE (`--execute` or "go") mutates.
+  Never create an issue, run an SPDD canvas, cross-link, or reconcile in PLAN phase.
+- **Hard constraints (mirror of [AGENTS.md §Hard Constraints](AGENTS.md#hard-constraints) + repo memory):**
+  commit type is one of `feat|fix|refactor|docs|test|ci|chore` (never invent one); every commit
+  carries a DCO `Signed-off-by:` (your configured git identity — see
+  [docs/git-workflow.md](docs/git-workflow.md)) **and** `Assisted-by: Claude/<model>` (never
+  `Co-Authored-By` for AI); merge is **squash-only**; never disable signing; never push `main`
+  directly; never write a literal `[skip ci]` token (write "skip-ci marker"). Use repo-relative
+  paths in any committed markdown; never put a literal email in a `.claude/commands/**` file.
+- **Never writes `state/milestone.yaml`.** Only `/milestone-close` and `/milestone-new` may.
+  When the active milestone is complete, this command *proposes* the transition and hands off.
+
+---
+
+## Issue / story / canvas / PR shape (templates · What-for · tags)
+
+Everything this command files follows the canonical shapes — no ad-hoc bodies.
+
+- **Issue body = the matching template** in [.github/ISSUE_TEMPLATE/](.github/ISSUE_TEMPLATE/):
+  `feature_request.md` (`feat:`), `bug_report.md` (`fix:`/bug), `documentation.md` (`docs:`),
+  `adr_proposal.md` (proposed ADR). Fill every template section; never freehand.
+- **PR body = [docs/contributing/pr-templates.md](docs/contributing/pr-templates.md)** (the
+  per-type skeleton), exactly as `/milestone-orchestrate` and `/issue-deliver` build it.
+- **Stories = `/spdd-story`** output (INVEST stories mapped to the Canvas O section) — never a
+  bare issue for a `feat:` capability.
+- **Every issue, story, canvas, and PR carries a `## What for (user impact)` block** — see below.
+
+### The `## What for (user impact)` block (mandatory — paste into body + canvas)
+
+This is the product lens, distinct from the engineering "Why". It states *who benefits and how*,
+with the adoption emphasis this project lives or dies on:
+
+```markdown
+## What for (user impact)
+- **User type(s):** developer | operator | maintainer | product-owner | zynax-user | enterprise
+  (pick all that apply — these map to the `audience:` labels)
+- **Expected impact:** <the observable outcome for that user — what they can now do / no longer suffer>
+- **Adoption lever:** <how this attracts developers, lowers Day-0 friction, or grows the community
+  — REQUIRED when `product: adoption` or `product: dx` applies; "N/A" only if genuinely none>
+- **Real use case:** <the concrete scenario it unlocks, tied to a hero workflow / example where possible>
+```
+
+> **Adoption-first prioritization.** Per [docs/product/strategy.md](docs/product/strategy.md),
+> the binding constraint is **traction, not features**. Candidates that attract developers, cut
+> Day-0 friction, or enable a real use case are **promoted** in the plan (higher `priority:`,
+> tagged `product: adoption` / `product: dx` / `product: use-case`) and surfaced in their own
+> "Adoption-driving" group in the STEP 5 output.
+
+### Label policy (every created issue)
+
+Apply, in addition to `type:` / `area:` / `priority:` / `status:` / `milestone:`:
+
+| Label group | When |
+|-------------|------|
+| `product: strategy` | **Every issue this command files** (it is strategy/roadmap-inferred) |
+| `product: adoption` | Drives user adoption / onboarding / Day-0 experience |
+| `product: dx` | Developer experience / attracting contributors |
+| `product: use-case` | Enables a concrete real-world use case / hero workflow |
+| `audience: <type>` | One per user type in the What-for block (developer/operator/maintainer/product-owner/zynax-user/enterprise) |
+
+The full `product:` and `audience:` taxonomy lives in [docs/labels.md](docs/labels.md). In the
+EXECUTE phase, ensure each label exists before applying it (`gh label create … 2>/dev/null || true`,
+mirroring `/milestone-orchestrate` STEP 4).
+
+---
+
+## STEP 0 — Isolated worktree (leave the user's checkout untouched)
+
+Run all git/inference work in a throwaway worktree detached at `origin/main`, exactly like
+`/repo-clean` and `/milestone-orchestrate` do.
+
+```bash
+RUN_ID="$(date +%s)-$$"
+REPO=$(git rev-parse --show-toplevel)
+WT="/tmp/zynax-roadmap-${RUN_ID}"
+git -C "$REPO" worktree remove "$WT" --force 2>/dev/null || true
+rm -rf "$WT" 2>/dev/null || true
+git -C "$REPO" fetch origin --prune
+git -C "$REPO" worktree add "$WT" origin/main
+cd "$WT"
+```
+
+Parse args: `--execute` (skip the approval gate), `--area <scope>` (restrict inference to one
+service/EPIC scope), `--max N` (cap proposed stories per run; default 8 to keep batches reviewable).
+
+---
+
+## STEP 1 — Load active-milestone config + planning state
+
+```bash
+# ── Active-milestone config (SSoT: state/milestone.yaml) — loaded at runtime ──
+CFG=state/milestone.yaml
+MILESTONE_NAME=$(awk '/^active:/{f=1} f && /^  name:/{print $2; exit}' "$CFG")
+MILESTONE_TITLE=$(awk -F'"' '/^active:/{f=1} f && /^  title:/{print $2; exit}' "$CFG")
+MILESTONE_NUMBER=$(awk '/^active:/{f=1} f && /^  github_milestone_number:/{print $2; exit}' "$CFG")
+MILESTONE_VERSION=$(awk '/^active:/{f=1} f && /^  version:/{print $2; exit}' "$CFG")
+PLANNING_DOC=$(awk '/^active:/{f=1} f && /^  planning_doc:/{print $2; exit}' "$CFG")
+MILESTONE_LABEL=$(awk -F'"' '/^    milestone:/{print $2; exit}' "$CFG")
+GH_MILESTONE="${MILESTONE_TITLE} (${MILESTONE_NAME})"
+# ──────────────────────────────────────────────────────────────────────────────
+
+cat state/current-milestone.md      # active blockers, exit criteria, per-EPIC status
+cat "$PLANNING_DOC"                  # EPIC table + dependency table for the active milestone
+sed -n '1,200p' CLAUDE.md           # per-milestone scope table (In scope / Out of scope)
+```
+
+Snapshot live GitHub state (the dedupe + routing baseline):
+
+```bash
+OPEN=$(gh issue list  --state open   --limit 400 --json number,title,body,labels,milestone)
+CLOSED=$(gh issue list --state closed --limit 400 --json number,title,labels,milestone)
+gh api repos/:owner/:repo/milestones --jq '.[] | "\(.title)\t#\(.number)\topen:\(.open_issues)\tclosed:\(.closed_issues)\tstate:\(.state)"'
+```
+
+---
+
+## STEP 2 — Mine the inference corpus (delegate heavy reads to Explore subagents)
+
+The "read the whole repo" job blows the planner's context. Fan out **read-only `Explore`
+subagents** (max 3, in parallel), each mining one corpus and returning a structured candidate
+list: `kind | title | evidence (file:line or doc#) | suggested type | suggested EPIC/milestone`.
+The planner stays lean and only merges + dedupes the returned lists.
+
+| Source | What to extract → candidate |
+|--------|------------------------------|
+| `docs/architecture/*-review.md`, `docs/reviews/*.md` | **Risk registers** (R1…Rn) and **gap analyses** (e.g. the principal review's §16 G1–G24 "unplanned-gap" list) — every row not yet a GH issue is a candidate |
+| `docs/adr/INDEX.md` + ADRs `Status: Proposed`/`🟡` | An accepted-but-unimplemented or proposed ADR → an implementation candidate (route to SPDD if it adds capability) |
+| `ROADMAP.md`, `state/current-milestone.md`, `$PLANNING_DOC` | Active-milestone EPICs with **no story children**, "blockers", deferred/"M?+" items, unmet exit criteria |
+| `docs/product/strategy.md` + review docs | Product/strategy **recommendations** not yet filed (e.g. recommended features, Day-0 friction cuts) |
+| Code markers | `grep -rnE 'TODO|FIXME|HACK|XXX' --include='*.go' --include='*.py'`; `t.Skip`/`xfail`/`pytest.mark.skip`; `Unimplemented`/`not yet implemented` comments — each is a candidate `fix:`/`feat:` |
+| `docs/spdd/*/canvas.md` | Canvases `Status: Draft`/unaligned, or whose EPIC has open O-steps with no issue |
+| `docs/ai-learnings/*.md` + open `[AUTO]` families | **Recurring** pain (≥2 sessions / repeated AUTO issue) → a systemic fix **or a drift-prevention guardrail** (STEP 6) |
+| `AGENTS.md`, `services/*/AGENTS.md`, `.claude/commands/experts/*` | Documented known limitations / "defer" notes that imply unfiled work |
+
+Example fan-out (one of up to three):
+
+```
+Agent({
+  description: "Mine review/ADR risk+gap registers for unfiled work",
+  subagent_type: "Explore",
+  prompt: """
+    Read every docs/architecture/*-review.md, docs/reviews/*.md, and docs/adr/INDEX.md in
+    <REPO>. Extract every risk-register row, recommendation, and 'gap not yet filed' item.
+    For each, report: a one-line title, the source (file:line), a suggested conventional-commit
+    type (feat|fix|refactor|docs|test|ci|chore), and whether it adds a *capability* (→ SPDD feat)
+    or is a fix/hardening. Do NOT cross-check GitHub — just return the candidate list with
+    evidence. Read only; edit nothing.
+  """
+})
+```
+
+---
+
+## STEP 3 — Dedupe, classify, and route each candidate
+
+For every merged candidate:
+
+1. **Dedupe vs live GH.** Drop it if an open or closed issue already covers it (fuzzy-match
+   title + scope against `$OPEN`/`$CLOSED`). Cite the existing issue in the plan instead.
+2. **Type it.** Assign one of the 7 commit types. A *new capability* ⇒ `feat:` ⇒ **SPDD path**.
+3. **Route to a milestone.** Match the candidate's scope to the per-milestone scope table in
+   [CLAUDE.md](CLAUDE.md) + `ROADMAP.md`:
+   - In active-milestone scope → the **active milestone** (`$GH_MILESTONE`).
+   - Clearly a later milestone → label for that milestone (or leave milestone-less as backlog
+     with a note). Never stuff out-of-scope work into the active milestone to pad it.
+4. **Attach to an EPIC.** If the active milestone organises work under EPICs, map each story to
+   its parent EPIC (so `/milestone-plan` can sequence it). A story with no EPIC for a milestone
+   that uses EPICs is itself a finding (propose an EPIC or a "misc" bucket).
+
+---
+
+## STEP 4 — Active-milestone canvas ⇄ issue ⇄ security-review audit
+
+This is the orchestration-readiness core. For **each EPIC of the active milestone** (from
+`$PLANNING_DOC` / `open_epics` in `state/milestone.yaml`), verify the full SPDD linkage and
+record every gap:
+
+```bash
+for CANVAS in docs/spdd/*/canvas.md; do
+  EPIC_N=$(basename "$(dirname "$CANVAS")" | grep -oP '^\d+')
+  # Status may be its own line OR inline in the header (e.g. "**Author:** … · **Status:** Aligned").
+  STATUS=$(grep -m1 -oiE 'Status:[^|·]*' "$CANVAS" 2>/dev/null)
+  echo "EPIC #$EPIC_N  canvas=$CANVAS  ${STATUS:-<no status>}"
+done
+```
+
+| Readiness check (per active-milestone EPIC) | Gap → action |
+|---|---|
+| A canvas exists at `docs/spdd/<N>-<slug>/canvas.md` | **missing** → `/spdd-reasons-canvas <N>` (EXECUTE phase) |
+| Canvas `Status:` reflects reality (`Draft`→`Aligned`→`Implemented`) | **stale** → fold into the `/repo-clean` reconcile (STEP 6) |
+| Canvas **links to its GH issue** (`#<N>` in the canvas header) | **missing** → add the issue ref to the canvas |
+| GH issue **links back to the canvas** (`docs/spdd/<N>-…/canvas.md` in the issue body) | **missing** → `gh issue edit <N>` to add the canvas link |
+| A `docs/spdd/<N>-<slug>/SECURITY-REVIEW.md` exists and **PASSES** (feat EPICs) | **missing/FAIL** → `/spdd-security-review <canvas>` then resolve before align |
+| Canvas is `Aligned` before any implementation issue is `READY` | **not aligned** → human sets `Aligned` after security-review PASS |
+| Every EPIC O-step has a story issue | **missing** → `/spdd-story <N>` to decompose |
+
+The output of this step is the precise SPDD action list that makes the active milestone
+orchestrate-ready: which EPICs need a canvas, which need stories, which need a security-review,
+which need cross-links, which need an align.
+
+---
+
+## STEP 5 — PLAN output (then STOP unless --execute)
+
+Print one traceable plan and wait for "go" (unless `--execute`).
+
+```
+## /roadmap-plan — <date>, active milestone <NAME> "<TITLE>" (#<num>, <version>)
+
+### Milestone fill status
+  EPICs: <done>/<total> complete · open EPICs without stories: #…, #…
+  Exit criteria unmet: <list from $PLANNING_DOC / current-milestone.md>
+  Verdict: FILLING (work remains) | COMPLETE (propose advance — STEP 7)
+
+### Proposed stories (SPDD — feat:) — into <NAME>
+| candidate | EPIC | SPDD actions needed | evidence |
+|-----------|------|---------------------|----------|
+| feat(engine-adapter): … | #1167 | /spdd-story → /spdd-reasons-canvas → /spdd-security-review → align | review §16 G8 |
+
+### Proposed issues (SPDD-exempt — fix/refactor/docs/test/ci/chore) — into <NAME>
+| # (new) | type(scope): title | evidence | labels |
+|---------|--------------------|----------|--------|
+| — | fix(api-gateway): set ReadHeaderTimeout | review §7 G2 / auth.go:NN | type: bug, milestone: <NAME> |
+
+### Adoption-driving candidates (PROMOTED — product: adoption / dx / use-case)
+| candidate | user type(s) | adoption lever | real use case | labels |
+|-----------|--------------|----------------|---------------|--------|
+(These are surfaced first and priority-bumped — traction is the binding constraint.)
+
+### Canvas ⇄ issue ⇄ security-review gaps (orchestration-readiness)
+| EPIC | canvas | issue link | back-link | security-review | align | action |
+|------|--------|-----------|-----------|-----------------|-------|--------|
+
+### Repo-clean delta (run after the above)
+  <surfaces that will disagree once issues are created — handed to /repo-clean>
+
+### Drift-prevention proposals (propose-only → APPLY_LOG.md / guardrails)
+| pattern | recurrence | proposed guardrail (CI gate / command-step / expert rule) |
+|---------|-----------|-----------------------------------------------------------|
+
+### Out-of-active-milestone candidates (backlog / later milestone — NOT created into <NAME>)
+| candidate | suggested milestone | why deferred |
+
+### Handoff
+  After --execute: run /milestone-plan, then /milestone-orchestrate.
+```
+
+---
+
+## STEP 6 — EXECUTE (on approval / --execute)
+
+Perform the mutations **in dependency order**. SPDD before issues-that-depend-on-canvas;
+cross-link before align; reconcile last.
+
+1. **SPDD-exempt issues** — create directly, into the active milestone. Body = the matching
+   `.github/ISSUE_TEMPLATE/*` filled in (including the `## What for (user impact)` block).
+   Ensure the product/audience labels exist, then apply them alongside the standard groups:
+   ```bash
+   for L in "product: strategy" "product: adoption" "product: dx" "product: use-case" \
+            "audience: developer" "audience: operator" "audience: maintainer" \
+            "audience: product-owner" "audience: zynax-user" "audience: enterprise"; do
+     gh label create "$L" 2>/dev/null || true     # idempotent; colours/desc in docs/labels.md
+   done
+   gh issue create --title "fix(api-gateway): set ReadHeaderTimeout (Slowloris)" \
+     --body-file /tmp/issue-body-${RUN_ID}.md \
+     --milestone "$GH_MILESTONE" \
+     --label "type: bug" --label "$MILESTONE_LABEL" \
+     --label "product: strategy" --label "audience: operator"   # + any other applicable product:/audience:
+   ```
+2. **feat: stories — SPDD path only.** For each feat EPIC/story gap, invoke the SPDD skills
+   (against the real checkout, not this `/tmp` worktree — they manage their own git):
+   ```
+   /spdd-analysis <issue-or-epic>      # research, risk table, Tier-2 flags
+   /spdd-story <epic>                  # decompose into INVEST stories (→ Canvas O section)
+   /spdd-reasons-canvas <epic>         # create docs/spdd/<N>-<slug>/canvas.md (Status: Draft)
+   /spdd-security-review <canvas>      # Tier-2 scan — MUST PASS before align
+   ```
+   Then **stop for the human to set `Status: Aligned`** — `/spdd-generate` refuses an unaligned
+   canvas by design, and alignment is a human decision (CLAUDE.md SPDD rule).
+3. **Cross-link canvas ⇄ issue** for every gap from STEP 4:
+   ```bash
+   # issue → canvas
+   gh issue edit <N> --body "<existing body>
+
+   SPDD canvas: docs/spdd/<N>-<slug>/canvas.md"
+   # canvas → issue: add the `Issue: #<N>` line to the canvas header (edit + commit in the PR below)
+   ```
+4. **Security-review** any feat canvas missing a PASSing `SECURITY-REVIEW.md` (step 2's
+   `/spdd-security-review`); resolve findings before the canvas is aligned.
+5. **Drift-prevention + command/expert refinements — propose only.** Write each recurring-pattern
+   guardrail and any milestone-command refinement as a **PENDING** row in
+   [docs/ai-learnings/APPLY_LOG.md](docs/ai-learnings/APPLY_LOG.md) (category `domain` /
+   `env-constraint`), and surface it in the report. **Never** auto-edit `experts/*`,
+   `milestone-*.md`, `AGENTS.md`, or ADRs — the human applies via `/milestone-learn --apply`
+   (expert files) or a deliberate command-file PR (CODEOWNERS-gated). This is how `/repo-clean`'s
+   reconcile rules migrate into CI gates / command guardrails over time, so drift stops at the
+   source and `/repo-clean` is eventually needed only after big context-losing crashes.
+6. **Reconcile (`/repo-clean`).** Once issues exist and canvases are linked, the status surfaces
+   are stale by construction. Run `/repo-clean` to bring README/ROADMAP/ARCHITECTURE/CLAUDE/
+   state/planning/canvas surfaces back to live state and dedup-triage any `[AUTO]` noise — leaving
+   the repo "as repo-clean as possible". Let `/repo-clean` own its own PR; don't fold it here.
+7. **Commit canvas/back-link edits** made in this worktree as one `docs:`/`chore:` PR (DCO `-s` +
+   `Assisted-by`), squash-merge on the human's call.
+
+---
+
+## STEP 7 — Milestone-completion gate & advance proposal
+
+After the fill pass, re-assess the active milestone against its exit criteria
+(`$PLANNING_DOC` + `state/current-milestone.md`):
+
+- **FILLING** (open EPICs, unmet exit criteria, or stories just created): report the
+  orchestrate-ready batch and recommend `/milestone-plan` → `/milestone-orchestrate`. Re-run
+  `/roadmap-plan` after the next delivery wave to keep filling.
+- **COMPLETE** (all EPIC stories merged, exit criteria met, `gh` milestone has 0 open issues):
+  do **not** create filler. **Propose the transition** (never execute it here):
+  ```
+  ## Active milestone <NAME> appears COMPLETE
+    - Exit criteria: all met (cite each).
+    - Recommended: /milestone-close   (tag <version>, GitHub Release, rotate milestone.yaml)
+    - Then:        /milestone-new      (scaffold the next milestone + planning doc + active block)
+    - Next milestone candidates inferred from ROADMAP/backlog: <list with rationale>
+  ```
+  `/milestone-close` and `/milestone-new` are the **only** sanctioned writers of
+  `state/milestone.yaml`. `/roadmap-plan` stops at the proposal.
+
+---
+
+## STEP 8 — Verify & report, then clean up
+
+```bash
+# Issues created land in the active milestone with the milestone label:
+gh issue list --milestone "$GH_MILESTONE" --state open --json number,title,labels --jq 'length'
+# Canvas linkage spot-check:
+for c in docs/spdd/*/canvas.md; do grep -Hm1 -E 'Issue:|#[0-9]+' "$c"; done
+```
+
+Report: stories created (via SPDD) + issues created (direct), with numbers; canvas/issue
+cross-links added; security-reviews run + status; drift/refinement proposals written to
+APPLY_LOG (count, PENDING); the `/repo-clean` result; and the milestone verdict (FILLING with
+the next orchestrate batch, or COMPLETE with the advance proposal).
+
+```bash
+cd "$REPO" && git worktree remove "$WT" --force 2>/dev/null || true
+```
+
+---
+
+## Guardrails
+
+- **PLAN first, always.** No GitHub or repo mutation without `--execute` / explicit "go".
+- **SPDD is mandatory for `feat:`.** Never file a capability as a bare issue; never skip the
+  canvas → security-review → align gate. Alignment is the human's call.
+- **Dedupe is mandatory.** Never create an issue that duplicates an open/closed one — cite the
+  existing one instead.
+- **Never** auto-edit `AGENTS.md`, ADRs, `.claude/commands/**` (experts or milestone-*), or
+  `state/milestone.yaml`. Propose; the human applies through the sanctioned command.
+- **Never** push `main`, bypass signing/DCO, invent a commit type, or write a literal skip-ci token.
+- **Respect milestone scope.** Don't pad the active milestone with out-of-scope work to avoid
+  declaring it complete — surface those as backlog/later-milestone candidates.
+- If `gh`/Docker is unavailable, fall back to PLAN-only and say so — never guess live state.
+
+---
+
+## Lifecycle / integration map
+
+| Stage | Command | This command's role |
+|-------|---------|---------------------|
+| Infer unfiled work | **`/roadmap-plan`** | mine repo → SPDD-file stories + fixes into active milestone |
+| Make orchestrate-ready | **`/roadmap-plan`** STEP 4–6 | canvas⇄issue⇄security-review align + `/repo-clean` |
+| Sequence existing issues | `/milestone-plan` | (downstream) parallel batches |
+| Deliver | `/milestone-orchestrate`, `/issue-deliver` | (downstream) |
+| Synthesize learnings | `/milestone-learn` | this command *proposes* refinements into its APPLY_LOG |
+| Reconcile surfaces | `/repo-clean` | invoked in STEP 6; this command feeds it guardrail proposals to make it eventually unnecessary |
+| Advance milestone | `/milestone-close` + `/milestone-new` | this command *proposes* the transition in STEP 7; never executes it |

--- a/.claude/commands/security-review-doc.md
+++ b/.claude/commands/security-review-doc.md
@@ -1,0 +1,113 @@
+---
+description: Generate a dated security-posture review DOCUMENT grounded in the live repo — auth/mTLS/transport, input validation, supply-chain (SBOM/cosign/SLSA), dependency + code-scanning alerts, container hardening, CNCF security criteria — with severity-rated findings, tracked longitudinally. Public doc carries mitigations/status only; unfixed-vuln exploit detail goes to a gitignored .private.md. NOT a diff review (that is the built-in /security-review and /spdd-security-review).
+argument-hint: "[--pr] [--since <prev-review-path>]   default: working draft, no PR"
+---
+
+# /security-review-doc — Security Posture Review Document Generator
+
+Produce a point-in-time **security posture review** as a dated document, in the shape of the
+security sections of [docs/architecture/2026-05-20-principal-architect-review.md](docs/architecture/2026-05-20-principal-architect-review.md).
+
+> **Not to be confused with:** the built-in `/security-review` (reviews the current diff) or
+> `/spdd-security-review` (Tier-2 canvas scan before a `feat:` commit). This command writes a
+> standing **posture document** about the whole system, like an architecture review.
+
+> **Public-safe by construction (Tier 1).** The committed doc states **findings by severity,
+> their status, and mitigations** — never a working exploit, a live secret, or step-by-step
+> attack detail for an *unfixed* issue. Any such sensitive detail goes to a sibling
+> `*-security-review.private.md`, which **must be gitignored** (mirrors the `canvas.private.md`
+> pattern). If `.gitignore` does not already cover it, the command writes the private file but
+> refuses to stage it and tells you to add the ignore rule.
+
+> **Truth-pass discipline.** Every finding cites `file:line` / a `gh` alert / a CI result. No
+> invented severities. The cautionary precedent is the May review's central finding: `SECURITY.md`
+> once asserted mTLS/SBOM/cosign that did not exist — **assert only what the code/ CI proves.**
+
+> **Rules are not restated.** See [SECURITY.md](SECURITY.md), [AGENTS.md](AGENTS.md),
+> [docs/adr/INDEX.md](docs/adr/INDEX.md) (ADR-020/024/025). This file is the *review-doc loop* only.
+
+---
+
+## STEP 0 — Resolve output paths + previous review
+
+```bash
+REPO=$(git rev-parse --show-toplevel); DATE=$(date +%Y-%m-%d)
+OUT="docs/architecture/${DATE}-security-review.md"
+PRIV="docs/architecture/${DATE}-security-review.private.md"
+PREV=$(ls -1 docs/architecture/*security-review.md 2>/dev/null | sort | tail -1)
+# Verify the private file would be ignored before writing anything sensitive to it:
+git -C "$REPO" check-ignore "$PRIV" >/dev/null 2>&1 && PRIV_IGNORED=1 || PRIV_IGNORED=0
+echo "public: $OUT   private(ignored=$PRIV_IGNORED): $PRIV   baseline: ${PREV:-<none>}"
+```
+
+If `PRIV_IGNORED=0`, do **not** stage the private file; instruct the human to add
+`docs/architecture/*-security-review.private.md` to `.gitignore` first.
+
+---
+
+## STEP 1 — Gather the grounding corpus (delegate heavy reads)
+
+Fan out read-only `Explore` subagents + cheap coordinator `gh` queries:
+
+```bash
+# Live security signals (authoritative — not memory):
+gh api repos/:owner/:repo/dependabot/alerts --jq '[.[]|select(.state=="open")]|length' 2>/dev/null || echo "n/a"
+gh api repos/:owner/:repo/code-scanning/alerts --jq '[.[]|select(.state=="open")]|length' 2>/dev/null || echo "n/a"
+gh api repos/:owner/:repo/secret-scanning/alerts --jq 'length' 2>/dev/null || echo "n/a"
+```
+
+Subagent mining targets (each returns `file:line` evidence):
+- **Transport/auth:** inter-service gRPC creds (`insecure` vs TLS), bearer/OIDC, constant-time
+  compares, `ReadHeaderTimeout`, rate limiting, request-size caps.
+- **Input handling:** YAML/IR parsing, CEL guard evaluation, template substitution, SSRF surface.
+- **Supply-chain:** SBOM/cosign/SLSA in release workflows, `images/images.yaml` SoT, pinned deps,
+  `govulncheck`/`bandit`/`pip-audit` gates.
+- **Containers:** non-root, distroless/minimal base, healthcheck, read-only rootfs.
+
+---
+
+## STEP 2 — Synthesize the review (sections)
+
+Write `$OUT` (public, SPDX header, repo-relative links). Findings table is the core:
+
+1. **Header + executive summary** — overall posture; biggest gap; what changed since `$PREV`.
+2. **Findings** — `severity | area | finding | status (open/mitigated/fixed) | mitigation | ref`.
+   For **open** findings, describe *impact + mitigation*, not a runnable exploit (that → `$PRIV`).
+3. **Supply-chain** — SBOM/cosign/SLSA/scan-gate status table.
+4. **Container hardening** — checklist with evidence.
+5. **CNCF security criteria** — met vs gap (from the review's §14-style table).
+6. **Longitudinal delta vs `$PREV`** — each prior finding → fixed / mitigated / still-open, with PR/issue.
+7. **Prioritized remediations** — Critical/High, annotated with **user type** (esp. operator /
+   enterprise) + adoption lever, so `/roadmap-plan` files them with the right `product:`/`audience:`
+   labels + `## What for (user impact)` block. Map to existing issues where present.
+8. **Appendix** — sources.
+
+`$PRIV` (only if there is sensitive detail, and only when `PRIV_IGNORED=1`): the exploit specifics,
+unredacted alert payloads, and any reproduction steps for **unfixed** findings.
+
+---
+
+## STEP 3 — Deliver
+
+Default: working drafts (both files) + a summary. With `--pr`, open a `docs:` PR that stages
+**only `$OUT`** (never `$PRIV`), from an isolated worktree; PR body from
+[docs/contributing/pr-templates.md](docs/contributing/pr-templates.md) (docs variant), DCO `-s` +
+`Assisted-by`, squash-only, no literal email, no skip-ci token. Label `type: docs` + `type: security`.
+
+```bash
+git -C "$WT" add "$OUT"          # NEVER: git add -A  (would stage the private file)
+```
+
+---
+
+## Guardrails
+
+- **Tier-1 public-safe always.** No live secret, no working exploit, no attack steps for an
+  **unfixed** issue in the committed doc. Sensitive detail → gitignored `.private.md` only, and
+  only when `check-ignore` confirms it is ignored. Never `git add -A` in this command.
+- **Assert only what code/CI proves.** Pull alerts/scan results live from `gh`; mark
+  open/mitigated/fixed honestly. No invented severities.
+- **Longitudinal.** Diff against the prior security review; record what was fixed.
+- **Read-only on the system.** One dated public doc (+ optional private sibling) per run.
+- Pairs with `/roadmap-plan` (remediations → issues), the built-in `/security-review` (diff), and
+  `/spdd-security-review` (canvas Tier-2 gate) — distinct, complementary tools.

--- a/docs/labels.md
+++ b/docs/labels.md
@@ -99,6 +99,40 @@ Labels use a `group: value` naming convention so they sort and filter predictabl
 
 ---
 
+## `product:` — Why It Matters (Product / Adoption Dimension)
+
+> Applied by `/roadmap-plan` to strategy-inferred work and by maintainers during triage.
+> The binding constraint on this project is **traction, not features**
+> (see [docs/product/strategy.md](product/strategy.md)) — these labels make adoption-driving
+> work filterable and promotable.
+
+| Label | Colour | Description |
+|-------|--------|-------------|
+| `product: strategy` | `#0e8a16` (green) | Inferred from product strategy / roadmap analysis (every `/roadmap-plan` issue carries this) |
+| `product: adoption` | `#0e8a16` (green) | Drives user adoption — onboarding, Day-0 experience, time-to-first-workflow |
+| `product: dx` | `#0e8a16` (green) | Developer experience — attracting and retaining contributors |
+| `product: use-case` | `#0e8a16` (green) | Enables a concrete real-world use case / hero workflow |
+
+## `audience:` — Who Benefits (User Type)
+
+> Mirrors the `## What for (user impact)` block required in every issue, story, canvas, and PR
+> body (see [docs/contributing/pr-templates.md](contributing/pr-templates.md)). Pick all that apply.
+
+| Label | Colour | Description |
+|-------|--------|-------------|
+| `audience: developer` | `#c5def5` (pale blue) | Developers building with or contributing to Zynax |
+| `audience: operator` | `#c5def5` (pale blue) | Teams deploying/running Zynax (K8s, Helm, observability) |
+| `audience: maintainer` | `#c5def5` (pale blue) | Project maintainers (governance, release, CI health) |
+| `audience: product-owner` | `#c5def5` (pale blue) | Product owners evaluating fit, roadmap, governance |
+| `audience: zynax-user` | `#c5def5` (pale blue) | End users authoring workflows / agents (`kind: Workflow` / `AgentDef`) |
+| `audience: enterprise` | `#c5def5` (pale blue) | Enterprises needing RBAC, policy, compliance, audit, multi-tenancy |
+
+> **The `## What for (user impact)` block is required** in every issue/story/canvas/PR body:
+> user type(s) → the `audience:` labels; expected impact; **adoption lever** (how it attracts
+> developers / lowers Day-0 friction); and the **real use case** it unlocks.
+
+---
+
 ## Process Labels
 
 | Label | Colour | Description |


### PR DESCRIPTION
## What for (user impact)
- **User type(s):** maintainer, product-owner
- **Expected impact:** repeatable, SPDD-correct roadmap planning and standing review documents — run a command instead of hand-driving the milestone/SPDD/repo-clean machinery each time.
- **Adoption lever:** the new commands prioritize adoption-driving work (a `product: adoption`/`dx`/`use-case` tag system + a mandatory `## What for` block on every issue/story/PR) so traction work is filterable and promoted.
- **Real use case:** "plan the next batch of stories for the active milestone, get the repo orchestrate-ready, then take a fresh architecture/security/product/market read."

### Why
The repo had no reusable way to (a) infer the *next* issues/fixes from the whole repo and file them the SPDD way, or (b) regenerate the architecture/security/product/market-fit review documents. Both were one-off, hand-driven efforts.

### What you'll get
- `/roadmap-plan` — SPDD-native repo-inference planner ← `.claude/commands/roadmap-plan.md`
- `/architecture-review`, `/product-review`, `/security-review-doc`, `/market-fit-review` — dated, grounded, longitudinal review-doc generators ← `.claude/commands/*-review*.md`
- `/review-suite` — runs all four reviews in parallel read-only subagents → one bundled docs PR ← `.claude/commands/review-suite.md`
- `product:` + `audience:` label groups and the `## What for (user impact)` requirement ← `docs/labels.md`

### Scope & boundaries
- **In scope:** the six command files + the label taxonomy update. All commands are PLAN/read-mostly by default; mutations gated behind `--execute`/`--pr`.
- **Out of scope (deferred):** actually *running* `/roadmap-plan --execute` to file issues and reconcile the repo — proposed as a follow-up after this lands.

### Design contract (baked into the commands)
- **SPDD for every `feat:`** (analysis→story→canvas→`/spdd-security-review`→human-aligns); fixes/docs/etc. filed directly.
- **Canonical templates:** issue bodies = `.github/ISSUE_TEMPLATE/*`; PR bodies = `docs/contributing/pr-templates.md`.
- **Never auto-edits** `AGENTS.md`, ADRs, `state/milestone.yaml`, or `.claude/commands/**` — refinements are *proposed* into the `/milestone-learn` APPLY_LOG + `/repo-clean` loop (the drift-prevention path that makes `/repo-clean` eventually only-after-crashes).
- **Milestone lifecycle:** fills the active milestone until exit criteria met, then *proposes* `/milestone-close` + `/milestone-new`.

### Test plan & acceptance
| Acceptance criterion | How verified | Result |
|---|---|---|
| Six commands register as skills | listed by the harness on save | ✅ all six surfaced |
| No literal emails in command files (PII gate) | `grep -nE '<email-regex>' .claude/commands/*.md` | ✅ none |
| Pre-commit secret scan | local `Detect hardcoded secrets` hook | ✅ Passed |
| Label taxonomy parses | `docs/labels.md` groups render | ✅ product:/audience: added |

### Risk & rollback
Low — additive instruction files + one docs taxonomy edit; no code, no proto, no runtime change. Revert this PR to remove.

### Review aids
- Start at `.claude/commands/roadmap-plan.md` (the centerpiece; the four reviews + suite mirror its conventions).
- `.claude/**` is **CODEOWNERS-gated** — this PR needs a maintainer approval to merge even with CI green. I will not `--admin` bypass; auto-merge (squash) is armed to fire once approved + green.

**AI:** `Assisted-by: Claude/claude-opus-4-8`

🤖 Generated with [Claude Code](https://claude.com/claude-code)