### PR TITLE
test(automation): flip platform-readiness xfail to real e2e

### DIFF
--- a/automation/tests/conftest.py
+++ b/automation/tests/conftest.py
@@ -1,20 +1,69 @@
 """
-conftest.py — stub fixtures for automation/tests/.
+conftest.py — fixtures for automation/tests/.
 
-The zynax_client fixture is intentionally unimplemented: it raises pytest.fail
-so that tests depending on a live platform xfail (not error) when the platform
-is not running. Because all tests that use this fixture are wrapped in
-pytest.mark.xfail(strict=True), the failure is treated as XFAIL.
+The ``zynax_client`` fixture is the seam between the platform-readiness e2e and a
+running Zynax platform (api-gateway + Postgres-backed repos + EventBus). It is
+*opt-in*: unless ``ZYNAX_PLATFORM_E2E=1`` is set AND a gateway endpoint is
+configured, the fixture calls ``pytest.skip`` so the live-platform test SKIPS
+CLEANLY (never ERROR, never a false xfail) on every machine that has no platform
+— including the default PR check, where ``automation/tests/`` is not even wired
+into CI.
+
+The real assertion (``zynax apply`` of the orchestrator Workflow → aggregated
+verdict + decision-log entry) runs only in the gated e2e job once a live platform
+exposes the orchestration-side capability providers and an outputs/decision-log
+read path. Until then the honest state is a clean skip, not a green expected
+failure.
+
+Opt-in contract:
+  ZYNAX_PLATFORM_E2E=1            enable the live-platform leg (else skip)
+  ZYNAX_GATEWAY_URL=<base url>    api-gateway base, e.g. http://localhost:8080
+  ZYNAX_API_TOKEN=<bearer>        bearer token for POST /api/v1/apply (optional)
 """
+
+import os
 
 import pytest
 
 
+def _platform_enabled() -> bool:
+    """True only when the live-platform e2e is explicitly opted into."""
+    return os.environ.get("ZYNAX_PLATFORM_E2E") == "1"
+
+
 @pytest.fixture
 def zynax_client():
-    """Stub for a live Zynax platform client.
+    """Client for a live Zynax platform, or a clean skip when none is configured.
 
-    Raises pytest.fail so that xfail-wrapped tests are marked XFAIL rather
-    than ERROR. Replace with a real client once the platform is deployed.
+    Skips (does not fail/error) unless ``ZYNAX_PLATFORM_E2E=1`` and a gateway URL
+    are set, so the live-platform test is a no-op on machines without a platform.
     """
-    pytest.fail("zynax platform not running — Wave 4 prerequisite not met")
+    if not _platform_enabled():
+        pytest.skip(
+            "live-platform e2e disabled — set ZYNAX_PLATFORM_E2E=1 "
+            "(+ ZYNAX_GATEWAY_URL) to run against a running Zynax platform"
+        )
+
+    gateway_url = os.environ.get("ZYNAX_GATEWAY_URL")
+    if not gateway_url:
+        pytest.skip("ZYNAX_PLATFORM_E2E=1 but ZYNAX_GATEWAY_URL is not set")
+
+    # Imported lazily (so the skip path needs no network/HTTP dependency) and by
+    # file location, so the import works regardless of how pytest is invoked.
+    # Registered in sys.modules before exec so dataclass string annotations
+    # (from __future__ import annotations) resolve against the module globals.
+    import importlib.util
+    from pathlib import Path
+    import sys
+
+    spec = importlib.util.spec_from_file_location(
+        "platform_client", Path(__file__).with_name("platform_client.py")
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+
+    return module.ZynaxPlatformClient(
+        gateway_url=gateway_url.rstrip("/"),
+        api_token=os.environ.get("ZYNAX_API_TOKEN"),
+    )

--- a/automation/tests/platform_client.py
+++ b/automation/tests/platform_client.py
@@ -1,0 +1,97 @@
+# automation/tests/platform_client.py
+"""
+ZynaxPlatformClient — thin REST client over api-gateway for the live-platform
+readiness e2e (#1103, EPIC #881 O8).
+
+This is exercised only when ``ZYNAX_PLATFORM_E2E=1`` and ``ZYNAX_GATEWAY_URL``
+are set (see conftest.py). It maps each readiness assertion onto the gateway's
+HTTP surface:
+
+  apply()              → POST   /api/v1/apply              (kind: Workflow body)
+  wait_for_completion()→ GET    /api/v1/workflows/{id}     (poll status)
+  get_outputs()        → GET    /api/v1/workflows/{id}/outputs  (data-flow O,
+                                 ADR-029 / M7 EPIC W) — aggregated verdict +
+                                 decision-log entry
+
+The client makes no assumptions beyond the documented endpoints; when a platform
+does not yet expose the outputs/decision-log read path the e2e fails honestly
+(rather than skipping), which is the correct signal that the platform is
+incomplete for this assertion.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import time
+import urllib.error
+import urllib.request
+
+# Terminal workflow states reported by api-gateway GET /api/v1/workflows/{id}.
+_TERMINAL_OK = {"COMPLETED", "SUCCEEDED"}
+_TERMINAL_FAIL = {"FAILED", "CANCELLED", "TERMINATED"}
+
+
+@dataclass
+class ApplyResult:
+    """Result of POST /api/v1/apply for a kind: Workflow manifest."""
+
+    workflow_id: str
+    status: str
+
+
+class ZynaxPlatformClient:
+    """Minimal REST client for the api-gateway, used by the readiness e2e."""
+
+    def __init__(self, gateway_url: str, api_token: str | None = None):
+        self.gateway_url = gateway_url
+        self.api_token = api_token
+
+    # ── HTTP plumbing ─────────────────────────────────────────────────────
+    def _request(self, method: str, path: str, body: bytes | None = None) -> dict:
+        url = f"{self.gateway_url}{path}"
+        headers = {"Content-Type": "application/json"}
+        if self.api_token:
+            headers["Authorization"] = f"Bearer {self.api_token}"
+        req = urllib.request.Request(url, data=body, method=method, headers=headers)
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            raw = resp.read().decode("utf-8")
+        return json.loads(raw) if raw else {}
+
+    # ── readiness operations ──────────────────────────────────────────────
+    def apply(self, manifest_path: str) -> ApplyResult:
+        """Apply a Workflow manifest; returns the created run/workflow id."""
+        with open(manifest_path, "rb") as f:
+            body = f.read()
+        data = self._request("POST", "/api/v1/apply", body=body)
+        workflow_id = data.get("run_id") or data.get("workflow_id")
+        if not workflow_id:
+            msg = f"apply returned no run id: {data!r}"
+            raise AssertionError(msg)
+        return ApplyResult(
+            workflow_id=workflow_id, status=data.get("status", "PENDING")
+        )
+
+    def wait_for_completion(self, workflow_id: str, timeout: int = 60) -> str:
+        """Poll GET /api/v1/workflows/{id} until terminal or timeout."""
+        deadline = time.monotonic() + timeout
+        last_status = "UNKNOWN"
+        while time.monotonic() < deadline:
+            data = self._request("GET", f"/api/v1/workflows/{workflow_id}")
+            last_status = data.get("status", last_status)
+            if last_status in _TERMINAL_OK or last_status in _TERMINAL_FAIL:
+                return last_status
+            time.sleep(2)
+        return last_status
+
+    def get_outputs(self, workflow_id: str) -> dict:
+        """Read the run's published outputs (aggregated verdict + decision log)."""
+        try:
+            return self._request("GET", f"/api/v1/workflows/{workflow_id}/outputs")
+        except urllib.error.HTTPError as exc:  # pragma: no cover - platform-dependent
+            msg = (
+                "outputs read path not available on this platform "
+                f"(GET /api/v1/workflows/{{id}}/outputs → HTTP {exc.code}); "
+                "the platform is incomplete for the readiness assertion"
+            )
+            raise AssertionError(msg) from exc

--- a/automation/tests/test_platform_readiness.py
+++ b/automation/tests/test_platform_readiness.py
@@ -45,20 +45,41 @@ class TestPlatformReadiness:
                 doc = yaml.safe_load(f)
             jsonschema.validate(doc, schema)
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason=(
-            "Wave 4: requires a running Zynax platform (Postgres #626 + EventBus "
-            "#772) and the orchestrator workflow (O3, #1098). Flips to a real e2e "
-            "in O8 (#1103)."
-        ),
-    )
     def test_orchestrator_executes_on_platform(self, zynax_client):
-        """Orchestrator workflow loads and executes on a running Zynax platform."""
+        """`zynax apply` of the orchestrator Workflow on a live platform yields
+        an aggregated verdict + a decision-log entry (O8, #1103).
+
+        This is a real e2e — the ``xfail`` marker is gone. The ``zynax_client``
+        fixture SKIPS CLEANLY (not error, not a false xfail) unless a running
+        platform is opted into via ``ZYNAX_PLATFORM_E2E=1`` (+ ``ZYNAX_GATEWAY_URL``),
+        so the PR-level check is a clean skip and the assertion runs only in the
+        gated e2e job against a real platform (Postgres + EventBus).
+        """
         result = zynax_client.apply(str(ORCHESTRATOR_YAML))
-        assert result.workflow_id is not None
+        assert result.workflow_id is not None, "apply must return a run id"
+
         status = zynax_client.wait_for_completion(result.workflow_id, timeout=60)
-        assert status == "COMPLETED"
+        assert status in ("COMPLETED", "SUCCEEDED"), (
+            f"orchestrator run did not reach a terminal success state: {status}"
+        )
+
         outputs = zynax_client.get_outputs(result.workflow_id)
-        assert "aggregated_verdict" in outputs
-        assert outputs["aggregated_verdict"]["confidence"] in ("low", "medium", "high")
+
+        # Aggregated verdict — the weighted-consensus output of the `aggregate`
+        # state (dev-advisory-orchestrator.yaml).
+        assert "aggregated_verdict" in outputs, (
+            "run produced no aggregated_verdict output"
+        )
+        assert outputs["aggregated_verdict"].get("confidence") in (
+            "low",
+            "medium",
+            "high",
+        ), f"unexpected verdict confidence: {outputs['aggregated_verdict']!r}"
+
+        # Decision-log entry — recorded on every path by the terminal `done`
+        # state (record_decision capability). The verdict alone is not enough;
+        # readiness requires a durable decision record.
+        decision_log = outputs.get("decision_log_artifact") or outputs.get(
+            "decision_log"
+        )
+        assert decision_log, "run produced no decision-log entry"


### PR DESCRIPTION
Closes #1103
Part of #881

### Why  (problem & intent)

`automation/tests/test_platform_readiness.py::test_orchestrator_executes_on_platform` was `@pytest.mark.xfail(strict=True)` — a green "expected failure" that quietly stood in for a real platform check. That made Wave 4's self-hosted automation claim *aspirational, not verified*. #1103 (O8 of EPIC #881) makes the test honest: remove the xfail, assert the real `zynax apply` of the orchestrator Workflow against a running platform, and skip cleanly when no platform exists.

### What you'll get  (deliverables ↔ what changed)

- `automation/tests/test_platform_readiness.py` — `xfail` removed; `test_orchestrator_executes_on_platform` now asserts that `zynax apply` of `dev-advisory-orchestrator.yaml` reaches a terminal success state and produces **both** an `aggregated_verdict` (confidence ∈ low/medium/high) **and** a decision-log entry.
- `automation/tests/conftest.py` — the `zynax_client` fixture now SKIPS CLEANLY (pytest skip, not error, not a false xfail) unless `ZYNAX_PLATFORM_E2E=1` (+ `ZYNAX_GATEWAY_URL`) opt into a running platform.
- `automation/tests/platform_client.py` (new) — `ZynaxPlatformClient`, a thin REST client over the api-gateway surface (`POST /api/v1/apply`, `GET /api/v1/workflows/{id}`, outputs read path).

### Scope & boundaries

- In scope: the honest test flip + the self-gating client seam (a `test:` change).
- Out of scope: the platform `feat` work the live assertion ultimately needs (compiler `output:`-source mapping for the orchestrator manifest's template values, CEL-valid barrier guards, capability providers for review/aggregate/act/notify/record, an api-gateway outputs/decision-log read path). These remain open M7 platform gaps (canvas O8, issue #1103 comments). This PR does **not** hide them — the test SKIPS rather than pretending they are solved, and fails honestly the moment it is opted in against an incomplete platform.
- `.github/workflows/**` untouched — Wave 0–3 GitHub Actions remain unchanged; the readiness test is **not** wired in as a required PR check.

### Test plan & acceptance

| Acceptance criterion | Verify command | Result |
|---|---|---|
| xfail removed; correct schema path (O1 present) | `python3 -m pytest automation/tests/test_platform_readiness.py -rsA --rootdir automation` | ✅ schema tests PASS; `agent-def.schema.json` + `workflow.schema.json` both present |
| PR-level check SKIPS cleanly when no platform | (same command, no env) | ✅ `1 skipped` — reason: "live-platform e2e disabled — set ZYNAX_PLATFORM_E2E=1 …" (not error, not xfail) |
| Real e2e runs when a platform is opted in | `ZYNAX_PLATFORM_E2E=1 ZYNAX_GATEWAY_URL=http://127.0.0.1:59999 python3 -m pytest …::test_orchestrator_executes_on_platform` | ✅ leaves skip path, performs real `apply` POST, fails with `ConnectionRefusedError` (no platform up) — proves it is a genuine e2e, not a no-op |
| Wave 0–3 Actions unchanged | `git show --stat` | ✅ only 3 files under `automation/tests/` changed |
| Full automation suite stays green | `python3 -m pytest automation/tests/ -q --rootdir automation` | ✅ `114 passed, 1 skipped` |

**Local gates:** pre-commit `gitleaks` ✅ · `ruff` ✅ · `ruff-format` ✅ · expert-mapping drift guard (`automation/scripts/check_expert_mapping.py`) ✅ "8 authoring experts reconciled". `make lint` lints `agents/*` only (automation/tests is covered by the pre-commit ruff hooks, which pass).

### Evidence

- No-platform run: `2 passed, 1 skipped in 0.24s` — `test_orchestrator_executes_on_platform` SKIPPED with the opt-in reason.
- Opt-in run (no real gateway): the fixture loads `ZynaxPlatformClient` and the test fails at `zynax_client.apply(...)` with `urllib.error.URLError: <urlopen error [Errno 111] Connection refused>` — confirming the assertion actually drives `zynax apply`.

### Risk & rollback

- Risk: low. The test self-gates; with no opt-in it is a clean skip everywhere, and `automation/tests/` is not in any required CI lane. The only automation-triggered CI check (the expert-mapping drift guard) is unaffected.
- The live assertion can only pass once the M7 platform gaps close; until then the gated e2e job that opts in will surface those gaps as honest failures rather than a false-green xfail.
- Rollback: revert the single commit; the prior strict-xfail returns.

### Review aids

- The honest boundary is intentional: `conftest.py` skips (not fails) without a platform; `platform_client.py` raises an explicit `AssertionError` when the outputs read path is absent, so an incomplete platform is reported, not silently skipped.
- Start with `test_platform_readiness.py` (the contract), then `conftest.py` (the gate), then `platform_client.py` (the REST seam).

## What for (user impact)

- **User type:** maintainer.
- **Impact:** Wave 4 platform-readiness becomes *real, not aspirational* — the readiness gate stops asserting a green expected-failure and instead skips honestly until a live platform can be exercised.
- **Adoption lever:** trust / honesty of the self-hosted-automation claim — the project no longer reports "ready" via an xfail.
- **Real use case:** the dev-advisory orchestrator Workflow runs on a live platform (Postgres + EventBus) and yields an aggregated verdict + decision-log entry, exercised in the gated e2e job.

---
*Post-merge digest sync → main: <placeholder>*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
