### PR TITLE
ci(workflows): activate test-integration as a real gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,8 @@
 # Job names match the branch protection required status checks on `main`.
 # Never rename a job without updating branch protection first.
 #
-# Required checks: dco · lint-proto · lint-go · lint-python · test-unit · security
-# (test-integration is non-required until real integration tests exist — #227)
+# Required checks: dco · lint-proto · lint-go · lint-python · test-unit · security · test-integration
+# (test-integration runs the real //go:build integration suite via testcontainers — #227, #553)
 #
 # Job graph:
 #   dco → changes → lint-proto ─╮
@@ -589,13 +589,29 @@ jobs:
           echo "✅ all tests passed or skipped"
 
 # ── Integration Tests ─────────────────────────────────────────────────────────
-# No-op skeleton until real integration tests exist (#227 / M7.C).
+# Runs the real //go:build integration suite (#227, #553). The tests use
+# testcontainers-go to spin up real backing services (Postgres, NATS, pgvector)
+# inside the test, so this job needs a live Docker daemon. It therefore runs on
+# the BARE ubuntu-24.04 host (Docker pre-installed) — NOT inside the ci-runner
+# container (no DinD socket) — with actions/setup-go for the toolchain.
+#
+# Required check (branch protection on main). The job must FAIL — never skip
+# silently — when its scope is empty: a SKIPPED required check is treated as
+# neutral by GitHub and would bypass the gate entirely (#986).
+#
+# Scope = the M5.C cross-service dispatch-path services named in #553 AC#1
+# (task-broker, agent-registry), whose integration suites are green and
+# deterministic. INTEGRATION_SUITES is an explicit allowlist, NOT env
+# SERVICE_LIST: SERVICE_LIST omits the services with integration suites, and a
+# blind glob would also pull in event-bus + memory-service, whose integration
+# suites have pre-existing deterministic failures (event-bus godog step arity +
+# DLQ timeout; memory-service DeleteNamespace cascade) tracked as a follow-up.
+# A self-check below FAILS if any allowlisted suite loses its build-tagged files,
+# so the gate can never silently shrink to a no-op. Expand the allowlist as each
+# additional suite is fixed and proven green.
   test-integration:
     name: test-integration
     runs-on: ubuntu-24.04
-    container:
-      image: ghcr.io/zynax-io/zynax/ci-runner@sha256:7ccd7f7c50bf40a937988e32f9b280a1ef8d62f860410798758720f29ce46c9c
-      options: --user root
     needs: [changes, lint-go, lint-proto, lint-python]
     if: >-
       always() &&
@@ -603,34 +619,49 @@ jobs:
       needs.changes.outputs.code == 'true' &&
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled')
+    env:
+      # Explicit allowlist of dispatch-path service dirs with green integration
+      # suites (#553 AC#1). Keep in sync with branch-protection required check.
+      INTEGRATION_SUITES: "task-broker agent-registry"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Detect integration tests
-        id: int-detect
-        run: |
-          count=$(grep -rl "//go:build integration" services/ 2>/dev/null | wc -l)
-          echo "has_integration=$count" >> "$GITHUB_OUTPUT"
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version: "1.26.4"
+          cache: false
 
-      - name: Run integration tests
-        if: steps.int-detect.outputs.has_integration != '0'
+      - name: Verify allowlisted suites still carry integration files
         run: |
-          failed=false
-          for svc in ${{ env.SERVICE_LIST }}; do
-            if grep -rl "//go:build integration" "services/${svc}/" 2>/dev/null | grep -q .; then
-              echo "── integration: services/${svc}"
-              cd "services/${svc}"
-              GOWORK=off go test -tags=integration ./... -v -timeout 120s
-              cd ../..
+          # Guard against the gate silently degrading to a no-op: every
+          # allowlisted service MUST still own //go:build integration files.
+          missing=""
+          for svc in $INTEGRATION_SUITES; do
+            if ! grep -rl "//go:build integration" "services/${svc}/" 2>/dev/null | grep -q .; then
+              missing="${missing} ${svc}"
             fi
           done
-          echo "✅ Integration tests passed"
+          if [ -n "$missing" ]; then
+            echo "::error::Allowlisted integration suite(s) have no //go:build integration files:${missing}"
+            echo "This REQUIRED gate must never pass as a no-op (#553)."
+            exit 1
+          fi
+          echo "✅ all allowlisted suites carry integration files"
 
-      - name: No integration tests yet
-        if: steps.int-detect.outputs.has_integration == '0'
+      - name: Run integration tests (testcontainers — real Docker daemon)
+        env:
+          GOWORK: "off"
         run: |
-          echo "ℹ️  No integration test files found — job passes as a no-op."
-          echo "   Tag test files with '//go:build integration' to include them here."
+          failed=false
+          for svc in $INTEGRATION_SUITES; do
+            echo "── integration: services/${svc}"
+            ( cd "services/${svc}" && go test -tags=integration ./... -race -timeout 120s ) || failed=true
+          done
+          if [ "$failed" = "true" ]; then
+            echo "::error::One or more integration suites failed."
+            exit 1
+          fi
+          echo "✅ Integration tests passed"
 
 # ── Security ──────────────────────────────────────────────────────────────────
 # govulncheck (Go CVE), bandit + pip-audit (Python SAST/CVE), trivy (Dockerfile).


### PR DESCRIPTION
## ci(workflows): activate test-integration as a real gate

Closes #553
Part of #469

### Why  (problem & intent)

`test-integration` was a no-op skeleton: it looped over `SERVICE_LIST` (which omits the services that actually have integration tests), ran inside the `ci-runner` container (no Docker socket — testcontainers cannot start sidecars), and fell through to a "passes as a no-op" branch when nothing matched. It was removed from required checks in #547 precisely because a skeleton that always succeeds gates nothing. Now that real `//go:build integration` suites exist behind the build tag (#227), this activates the job so cross-service / persistence regressions are caught pre-merge.

### What you'll get  (deliverables ↔ what changed)

- `test-integration` now runs the **real** `//go:build integration` suite via `testcontainers-go` (real Postgres containers spun up in-test).
- Job moved off the `ci-runner` container onto the **bare `ubuntu-24.04` host** (live Docker daemon) with `actions/setup-go@v5.5.0` pinned to Go 1.26.4 — the only way testcontainers can start sidecars.
- Scope is an explicit `INTEGRATION_SUITES` allowlist (`task-broker agent-registry`) — the M5.C dispatch-path services named in #553 AC#1 — instead of the env `SERVICE_LIST` (which omits them) or a blind glob (which would pull in known-red suites).
- A **self-check step fails the job** if any allowlisted suite loses its `//go:build integration` files, so the gate can never silently degrade back to a no-op (a SKIPPED required check is neutral to GitHub — #986).
- The `#547` "no-op skeleton" comment block is removed; header now lists `test-integration` among required checks.

### Scope & boundaries

- **In:** `.github/workflows/ci.yml` `test-integration` job rewrite + header comment.
- **Out:** fixing the pre-existing failures in the `event-bus` and `memory-service` integration suites (see Risk); writing new integration scenarios; benchmark/fuzz gates (#493) and real e2e (#1103) — sibling EPIC #469 stories.
- `.github/workflows/` is excluded from PR-size accounting; no Go/Python source touched.

### Test plan & acceptance

Each row maps a #553 acceptance criterion to the exact verify command and observed result.

| Acceptance criterion (#553) | Verify command | Result |
|---|---|---|
| `//go:build integration` files exist in dispatch-path services | `grep -rl "//go:build integration" services/task-broker services/agent-registry` | ✅ 2 files found |
| `test-integration` runs real gRPC/persistence calls (not a no-op) | inspect job: runs `go test -tags=integration ./... -race` per allowlisted svc on bare host w/ Docker | ✅ rewritten |
| `GOWORK=off go test -tags=integration ./... -race -timeout 120s` passes (task-broker) | `cd services/task-broker && GOWORK=off go test -tags=integration ./internal/infrastructure/postgres/... -race -timeout 300s` | ✅ `ok ... 13.857s` |
| same, agent-registry | `cd services/agent-registry && GOWORK=off go test -tags=integration ./internal/infrastructure/postgres/... -race -timeout 300s` | ✅ `ok ... 14.826s` |
| job cannot pass as a no-op (self-check fails on empty scope) | "Verify allowlisted suites still carry integration files" step `exit 1` on missing | ✅ guard added |
| workflow is lint-clean | `docker run --rm -v $PWD:/repo rhysd/actionlint .github/workflows/ci.yml` | ✅ no findings |
| `#547` no-op comment removed; now an active gate | diff of header + job comment | ✅ removed |
| `test-integration` re-added to required checks | branch-protection / ruleset admin change | ⏳ **follow-up — see Risk & rollback** |

**Local gates:** `actionlint` ✅ · `task-broker` + `agent-registry` integration suites ✅ (real Docker). `make lint` (proto+Go+Python) is N/A — this PR touches only workflow YAML.

**GREEN integration-job run link:** https://github.com/zynax-io/zynax/actions/runs/27699265447/job/81931727315 — forced via the `ci: force-full` label (this PR touches only workflow YAML, so the `changes` gate sets `code=false` and the job would otherwise skip). Job log shows real testcontainers runs: `task-broker .../postgres ok 19.843s`, `agent-registry .../postgres ok 14.737s`, "✅ Integration tests passed".

### Evidence

- Local output: `task-broker` postgres integration `ok ... 13.857s`; `agent-registry` postgres integration `ok ... 14.826s` — both via real testcontainers Postgres on Docker 29.4.1 / Go 1.26.4.
- `actionlint` on `ci.yml`: no findings.
- Excluded suites failed locally for documented, deterministic reasons (see Risk) — confirming they are correctly out of the green gate.

### Risk & rollback

- **Why event-bus + memory-service are excluded:** both integration suites are **deterministically RED** today, independent of this change:
  - `event-bus/tests` — godog step `groups "..." and "..." both subscribe to the same topic` (2 regex captures) is wired to `groupsSubscribeToSameTopic(g1, g2, topic string)` (3 args) → `func received more arguments than expected`; plus a DLQ `nats: timeout`.
  - `memory-service/tests` — `DeleteNamespace cascades` expects 0 SearchSimilar results, got 2.
  - Adding them to the gate now would block **every** merge — the exact #547 failure mode. They are deferred to a follow-up issue to fix the harness/cascade bugs, then expand `INTEGRATION_SUITES`.
- **Required-check promotion (admin, deliberate post-merge step):** marking `test-integration` required lives in the `main-protection` ruleset (id `17547241`), not classic branch protection. To avoid making a not-yet-proven job required, promote it **only after this job reports green on `main`**. Exact command (append `test-integration` to the existing required contexts):

  ```bash
  # Required check name to add: test-integration
  gh api repos/zynax-io/zynax/rulesets/17547241 \
    --jq '.rules[] | select(.type=="required_status_checks") | .parameters' > /tmp/rsc.json
  # add {"context":"test-integration"} to required_status_checks[] then PATCH:
  gh api repos/zynax-io/zynax/rulesets/17547241 --method PUT \
    --input <ruleset-json-with-test-integration-added>
  ```
  Current required contexts (for reference): dco, test-unit, security, lint-proto, lint-go, lint-python, GitHub Actions workflow lint, Conventional Commit title, PR size label, Secret scan (gitleaks), e2e smoke (temporal).
- **Rollback:** revert this single-file commit; the job returns to its prior skeleton form. No runtime/service impact.

### Review aids

- Single file changed: `.github/workflows/ci.yml` (+56 / −25).
- The `INTEGRATION_SUITES` allowlist + the self-check step are the two load-bearing pieces — review those first.

## What for (user impact)

- **User type:** maintainer, developer.
- **Impact:** cross-service persistence/dispatch regressions in the M5.C path (task-broker, agent-registry) are caught **pre-merge** against real Postgres, instead of leaking to `main` and surfacing in e2e or production.
- **Adoption lever:** quality / CI trust — a green pipeline now genuinely means integration paths were exercised, not skipped.
- **Real use case:** a release engineer approving a PR that rewires task-broker ↔ agent-registry persistence sees `test-integration` fail on a broken repository query before it ever reaches `main`.

---

Post-merge digest sync → main: _placeholder_

Assisted-by: Claude/claude-opus-4-8
