### PR TITLE
docs(ai-learnings): record EPIC #1370 live-validation learnings + milestone-learn run

### DIFF
--- a/docs/ai-learnings/APPLY_LOG.md
+++ b/docs/ai-learnings/APPLY_LOG.md
@@ -88,3 +88,12 @@
 > in PR #1293 (dispatch preamble + STEP 7 crash-recovery), where they belong.
 
 **Summary:** 11 entries — 8 → expert guides (committed, #1275) · 3 cross-cutting → orchestrator commands (committed, #1293) · 0 rejected · 0 pending
+
+## Run 2026-06-18 16:42 — domains: spdd-canvas, go-services
+
+| # | Domain | Pattern | Category | Source sessions | Status | Delta |
+|---|--------|---------|----------|-----------------|--------|-------|
+| 1 | spdd-canvas | gitleaks internal-hostname blocks committed dotted filename; private.md no help | domain | #1383, #796 | pending | — |
+| 2 | go-services | gh projectCards deprecation: read via --json, label via REST API | domain | #1206, #1183 | pending | — |
+
+**Summary:** 2 proposed | 0 applied | 0 rejected (structural) | 2 pending

--- a/docs/ai-learnings/infra-helm.md
+++ b/docs/ai-learnings/infra-helm.md
@@ -144,3 +144,12 @@ Story: O.7 — local Uptrace docker-compose observability stack (Uptrace + Click
 - Rule: The shared OTEL package is `libs/zynaxobs`; the OTLP exporter endpoint env var is `ZYNAX_OTEL_EXPORTER_OTLP_ENDPOINT`. Any collector/OTLP wiring must match this name.
   Category: domain
   Reason: Permanent naming fact other observability stories (O.8 Helm chart, O.9 logs) will need.
+
+## Session — 2026-06-18 (EPIC #1370 — bundled local LLM for the quickstart)
+
+### Effective patterns
+- Zero-cost local LLM in compose: add an `ollama` service **inside** the compose network (never expose it on the host LAN), and reuse host-pulled models via a **read-only** bind mount of the models dir into `/root/.ollama/models` — no multi-GB re-download. Mount only the `models` subdir RO so the container keeps a writable `/root/.ollama` for its startup keypair. Parameterise the host path (`OLLAMA_HOST_MODELS`).
+- Reaching a host daemon bound to loopback from a container is undesirable (binding it to all interfaces exposes it to the LAN). Prefer bundling the dependency in-network over reconfiguring the host daemon.
+
+### Edge cases discovered
+- A fresh `make run-local` silently leaves git/ci/llm adapters `Exited(1)` for missing `GITHUB_TOKEN`/`OPENAI_API_KEY`; only the langgraph `echo` capability works out of the box (#1375). `zynax logs` streaming returns HTTP 500 `streaming not supported` against the compose api-gateway (#1373).

--- a/docs/ai-learnings/python-adapters.md
+++ b/docs/ai-learnings/python-adapters.md
@@ -109,3 +109,12 @@ ADR-proposal docs story with a security dimension (ADR-032 Git MCP shim + auth m
 - OTLP **exporter** (`opentelemetry-exporter-otlp-proto-grpc`, all versions) caps `protobuf<7` via `opentelemetry-proto` — conflicts with the SDK's `protobuf>=7`. uv resolves extras in one universe, so even an optional-dependency extra fails. Omit the exporter entirely; run on `opentelemetry-api`/`-sdk`; import the exporter lazily with graceful degradation. Live OTLP export is a deployment-image concern.
 - OTel global `TracerProvider` is set-once per process; in tests patch module-level `trace.get_tracer` to return your own provider + `InMemorySpanExporter` (do NOT rely on `set_tracer_provider` — silently no-ops after first set → zero spans).
 - Pre-commit ruff fails on root-owned `.ruff_cache` left by Docker `make lint`; prefix `RUFF_CACHE_DIR=/tmp/ruff-cache-<N> git commit -s -F <file>` (bare single-assignment prefix is sandbox-permitted).
+
+## Session — 2026-06-18 (EPIC #1370 — live quickstart validation with Ollama)
+
+### Effective patterns
+- A capability adapter must register a **resolvable advertised address**, not a bind-only `:PORT`. The Go llm-adapter uses one `endpoint` field for *both* `net.Listen` and the registry advertise; shipping `:50070` (no host) makes the task-broker dial localhost and fail with `connection refused`. Set the advertised host to the resolvable service name, or split bind-vs-advertise like the langgraph-adapter's `ADAPTER_ENDPOINT`. Seen live; filed as #1371.
+- The ollama provider needs **no API key** (`ResolveSecret` returns empty when `api_key_env` is unset) — an ollama config boots the llm-adapter with zero secrets. The baked default is `provider: openai`, which crash-loops on a fresh `make run-local` for a missing key. Adapters should degrade gracefully when a secret is absent rather than `Exited(1)` (#1375).
+
+### Edge cases discovered
+- A `snake_case` capability name (mandated by `agents/adapters/AGENTS.md`) yields the engine-derived completion event `<name>.completed`, which the workflow-compiler **rejects** (event types must be dot-separated lowercase, no underscores). So a `summarize_feedback` capability's completion event can't be referenced in a transition. Filed as #1372.

--- a/docs/ai-learnings/spdd-canvas.md
+++ b/docs/ai-learnings/spdd-canvas.md
@@ -115,3 +115,18 @@ domain: spdd-canvas · two ADR-proposal stories (ADR-031 context propagation; AD
 ### Proposed expert prompt update
 - Rule: For ADR-proposal / docs issues, before claiming a branch or writing, glob `docs/adr/ADR-<N>*` AND grep the number in INDEX.md. If the file exists, diff its content against each acceptance-criterion clause: close as completed (with file+commit reference) if every AC is met; otherwise enhance only the gaps. Never create a second numbered ADR or a no-op PR.
   Category: domain
+
+## Session — 2026-06-18 (EPIC #1370 — SPDD pipeline run)
+
+### Effective patterns
+- **Don't duplicate stories.** When an epic already has child issues, `/spdd-story` must reconcile/validate them against INVEST and link the canvas — not create a second set. Guard added to the command (#1383).
+- Map every canvas Operations step 1:1 to an existing story issue (`#`) and back-link the canvas path + step into each issue, so the set is orchestrate-ready (`spdd: canvas` on the epic, `status: ready` on stories).
+
+### Edge cases discovered
+- The gitleaks `internal-hostname` rule BLOCKs a canvas commit that references a **filename** containing a dotted `local`/`internal`/`corp` label (a project artifact name, not a hostname). Rename the artifact to drop the segment at authoring time — moving it to `canvas.private.md` doesn't help because the artifact still ships. Guards added to spdd-reasons-canvas + spdd-security-review (#1383).
+- Re-applying the same manifest reuses the **same `run_id`** — deterministic `ManifestWorkflowID` (ADR-034), by design, not a bug. A closed run restarts under a fresh Temporal RunID with the same WorkflowID.
+
+### Proposed expert prompt update
+- Rule: Before `/spdd-story` creates issues, check the epic for existing children and reconcile instead of duplicating; never reference a filename with a dotted `local`/`internal`/`corp` segment in a committed Canvas (gitleaks `internal-hostname` BLOCK) — rename the artifact.
+  Category: structural-workaround
+  Reason: Both traps silently break the SPDD ceremony; encoding them prevents the next run from hitting them.


### PR DESCRIPTION
Raw session learnings from the 2026-06-18 quickstart live-validation + SPDD run, plus the /milestone-learn synthesize run.

## Raw learnings added
- python-adapters: adapter must advertise a resolvable address (#1371); ollama needs no key / graceful degradation (#1375); snake_case capability vs event-grammar (#1372).
- infra-helm: bundled-ollama compose pattern; run-local secret crashes + logs HTTP 500 (#1373/#1375).
- spdd-canvas: story-dedup guard, gitleaks filename trap, deterministic ManifestWorkflowID (ADR-034).

## /milestone-learn run
Appended a PENDING run to APPLY_LOG.md with **2 recurrence-qualifying proposals** (spdd-canvas gitleaks-filename, go-services gh projectCards). EPIC #1370 single-session items are held in raw logs per the ≥2-session rule. **Not auto-applied** — human marks applied/rejected then runs /milestone-learn --apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)