### PR TITLE
docs(templates): add Epic template + job-to-be-done framing across issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/adr_proposal.md
+++ b/.github/ISSUE_TEMPLATE/adr_proposal.md
@@ -17,6 +17,14 @@ Use this template when:
 For early-stage exploration of an architectural idea, use GitHub Discussions first.
 -->
 
+## The one question this decision answers
+
+> _One sentence: which recurring design question does this settle, so the team stops re-litigating it?_
+> **Why it matters:** the downstream impact on users/operators/adopters and on adoption levers
+> (operability, enterprise trust, CNCF credibility). The full forces go in **Context** below.
+
+---
+
 ## Decision Title
 
 A short noun phrase describing the decision, e.g.:

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -14,6 +14,15 @@ Before filing a bug:
   3. Reproduce with the latest main or the latest release.
 -->
 
+## The one question this fix answers
+
+> _One sentence: what does a Zynax user/operator get back when this is fixed?_
+> **Why it matters:** who is blocked or losing trust while it's broken — and the
+> adoption cost (a broken first-run, an enterprise blocker, a CNCF-credibility dent)?
+> (Severity is captured in **Impact** below.)
+
+---
+
 ## Which feature is broken?
 
 Link to the `.feature` file and scenario that defines the expected behaviour:

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -5,6 +5,12 @@ labels: ["type: docs", "status: needs-triage"]
 assignees: ''
 ---
 
+## The one question this answers
+
+> _One sentence: what will a reader be able to understand or do once this doc is fixed?_
+
+---
+
 ## What document is affected?
 
 File path(s) or section:
@@ -30,9 +36,11 @@ If you are not sure, just describe the problem and let a maintainer fix it.
 
 ---
 
-## Why Does This Matter?
+## Why Does This Matter? (impact)
 
-Who is confused or blocked by this gap? What are they trying to accomplish?
+Who is confused or blocked by this gap? What are they trying to accomplish? Which adoption
+lever does fixing it move — a smoother first-run for users, an enterprise/operator unblock,
+or CNCF/community credibility?
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/epic.md
+++ b/.github/ISSUE_TEMPLATE/epic.md
@@ -1,0 +1,131 @@
+---
+name: Epic
+about: A large, multi-PR feature that delivers measurable user/adoption value across several stories
+labels: ["type: epic", "status: needs-triage"]
+assignees: ''
+---
+
+<!--
+An Epic is the unit of *value*, not of code. Before filing:
+  1. Search existing epics — extend/merge rather than duplicate.
+  2. Check ROADMAP.md + state/current-milestone.md — which milestone does this serve?
+  3. feat: epics require a REASONS Canvas committed before any implementation (ADR-019).
+Keep child stories small, independent, testable, and individually valuable.
+-->
+
+## The one question this epic answers
+
+> _One sentence, in the reader's words — the job-to-be-done. A Zynax user (or operator,
+> or adopter) should understand the point without any repository knowledge._
+>
+> e.g. "How does someone go from nothing to experiencing Zynax's value with one command?"
+
+---
+
+## Why it matters (product · business · adoption)
+
+> Orient the work toward impact, not mechanics. Which levers does it move, and how?
+
+- **For the Zynax user / adopter:** <the observable value they gain>
+- **Adoption & business angle:** <which of these does this advance, and how — be concrete>
+  - Individual users / "people interest"
+  - Enterprises (security, scale, operability, trust)
+  - CNCF interest / ecosystem credibility
+  - Community / contributor pull
+- **Cost of not doing it:** <what stays broken, who stays blocked, what adoption is lost>
+
+---
+
+## Target experience / outcome
+
+> What does "great" look like once this lands? A short narrative or flow the user lives.
+
+```
+<flow: trigger → … → meaningful visible result → next action>
+```
+
+---
+
+## Scope
+
+**In scope**
+-
+
+**Out of scope** (→ which other epic/milestone owns it)
+-
+
+---
+
+## Acceptance criteria (measurable)
+
+> Observable outcomes that prove the value above is delivered. Avoid "it works".
+
+- [ ]
+- [ ]
+
+---
+
+## Child stories
+
+> Small, independent, testable, individually valuable. Each links back here.
+
+- [ ] #… — <story>
+- [ ] #… — <story>
+
+---
+
+## Dependencies & sequencing
+
+- Depends on: #…
+- Blocks: #…
+- Suggested order / critical path:
+
+---
+
+## Architecture, contracts & decisions
+
+- Proto / gRPC boundary touched? → RFC + `buf breaking` + `.feature` (ADR-016)
+- New one-way-door decision? → ADR (`docs/adr/`)
+- Relevant ADRs / RFCs:
+
+---
+
+## SPDD Canvas (feat: epics)
+
+- REASONS Canvas: `docs/spdd/<this-issue>-<slug>/canvas.md` — Status: Draft → Aligned before code (ADR-019)
+
+---
+
+## Documentation & human validation
+
+- Docs to add/update (Diátaxis: tutorial / how-to / reference / explanation):
+- Each user-visible child story ships a **human-validation guide** (see the validation standard).
+
+---
+
+## Traceability
+
+> Nothing orphaned. Keep the chain linked both ways.
+
+`Milestone → this Epic → Stories → Implementation PRs → Documentation → Human validation → Release notes → Future work`
+
+- Milestone:
+- Release notes line:
+- Future work / follow-on epics:
+
+---
+
+## AI-planning metadata (optional, machine-readable)
+
+```yaml
+objective:          # the one-question, restated for agents
+required_experts:   []   # e.g. go-services, infra-helm, spdd-canvas
+optional_experts:   []
+inputs:             []
+outputs:            []
+dependencies:       []   # issue/epic ids
+risk:               # low | medium | high
+confidence:         # low | medium | high
+context_packs:      []   # docs/paths an agent must load
+large_context_refs: []   # load lazily
+```

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -14,10 +14,37 @@ Before filing a feature request:
      to explore the idea before filing a formal issue.
 -->
 
+## The one question this story answers
+
+> _One sentence, in the reader's words — the job-to-be-done. A Zynax user should understand
+> the point without repository knowledge. (For a large multi-PR effort, use the **Epic** template.)_
+
+---
+
+## Why it matters (product · adoption)
+
+- **For the Zynax user / adopter:** <the observable value this story delivers>
+- **Adoption angle:** <which lever — individual users · enterprises · CNCF interest · community>
+- **Cost of not doing it:** <what stays broken / who stays blocked>
+
+---
+
 ## Problem / Motivation
 
 What problem are you trying to solve? Who has this problem and in what context?
 Be specific — avoid "it would be nice if...". Describe the pain point.
+
+---
+
+## Parent epic & links
+
+> Keep the chain linked both ways so nothing is orphaned.
+
+- Parent epic: #…
+- Milestone:
+- REASONS Canvas (if the parent epic has one): `docs/spdd/<epic>-<slug>/canvas.md` — Operations step N
+- RFC / ADR: 
+- Related docs / architecture:
 
 ---
 
@@ -47,17 +74,11 @@ Feature: <feature name>
 
 ---
 
-## Is This an Epic or a Story?
+## Story or Epic?
 
-- [ ] **Story** — single, implementable issue (one PR or a small chain of ≤ 3 PRs)
-- [ ] **Epic** — large feature spanning multiple issues and milestones
-  _(If epic: describe the breakdown into child stories below)_
-
-### Child Stories (if epic)
-
-- [ ] Story 1: ...
-- [ ] Story 2: ...
-- [ ] Story 3: ...
+- [ ] **Story** — single, implementable issue (one PR or a small chain of ≤ 3 PRs). Continue below.
+- [ ] **Epic** — large, multi-PR, multi-story effort → **use the Epic template instead** (it captures
+  child stories, the one-question, and adoption impact at the right altitude).
 
 ---
 
@@ -92,6 +113,17 @@ additional observable criteria here.)
 
 1.
 2.
+
+---
+
+## Manual validation (for user-visible stories)
+
+> A tester unfamiliar with Zynax should be able to execute this and confirm the value.
+> Follow the human-validation standard/template.
+
+- Commands to run / expected output:
+- Troubleshooting & rollback:
+- Feedback questions:
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/image_bump.md
+++ b/.github/ISSUE_TEMPLATE/image_bump.md
@@ -19,6 +19,11 @@ image outside of the normal workflow.
 **New digest:** `sha256:<replace-me>`
 **Built by:** (workflow run URL)
 
+> **The one question this answers:** is the toolchain everyone builds against current and pinned?
+> **Why it matters:** a fresh, pinned digest keeps CI **reproducible** and the **supply chain**
+> current (ADR-024/025) — the boring-but-load-bearing trust signal for maintainers, enterprises,
+> and CNCF supply-chain review. Drift here silently breaks builds and erodes that trust.
+
 ---
 
 ## Steps


### PR DESCRIPTION
Bakes the structure that worked for epic #1370 into reusable issue templates, so every artifact states **the one question it answers** with product/business/adoption orientation.

## New
- **`.github/ISSUE_TEMPLATE/epic.md`** — Epic template: *the one question this epic answers*, *why it matters (product · business · adoption: users · enterprises · CNCF · community)*, target experience, scope/AC, child stories, dependencies, contracts/RFC/ADR, SPDD canvas, docs + human-validation, full traceability chain, and an optional machine-readable AI-planning block.

## Updated
- **feature_request.md** (story) — one-question + adoption impact, parent-epic/canvas/RFC links, manual-validation section; epics now routed to the Epic template.
- **bug_report.md** (fix) — the one question this fix answers + who is blocked / adoption cost.
- **image_bump.md** (digest) — why a pinned digest matters (reproducible CI + supply-chain trust).
- **documentation.md** + **adr_proposal.md** — one-question + adoption-impact framing.

The unifying idea: a reader (user, operator, enterprise, contributor) can see the *reason for the job* without repo knowledge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)