### PR TITLE
chore(commands): simplify Claude command set to 5 verbs + lib/ + README

### DIFF
--- a/.claude/commands/README.md
+++ b/.claude/commands/README.md
@@ -1,0 +1,125 @@
+---
+description: "Documentation for the Zynax Claude command set — not a runnable command."
+user-invocable: false
+disable-model-invocation: true
+---
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Zynax Claude commands — how to drive this repo
+
+**The one question this answers:** *"What do I run to get from an idea to merged, aligned work in
+this repo — without memorizing 20 commands?"*
+
+You reach for **five verbs**. Everything else is a building block they call for you.
+
+```
+                 idea / prompt / #issue / #epic
+                              │
+                          /plan ──────────────►  aligned REASONS Canvas + linked issues (orchestrate-ready)
+                              │
+                         /deliver ───────────►  claim → implement → PR → CI → squash-merge → post-merge verify
+                              │
+                          /learn  ────────────►  fold session learnings into the expert guides
+                              
+   anytime:  /review   (architecture · security · product · market-fit)
+   on break: /reconcile (recover from a failed run + clean the repo)
+   release:  /milestone (open · close — the only milestone-aware command)
+```
+
+Everything is **milestone-agnostic**: commands work from repository state (issues, epics, canvases,
+labels). Milestone is an **optional `--milestone M` filter**, not the organizing principle.
+Everything is **safe by default**: with no arguments (and without `--execute`) a command *plans and
+proposes* — it doesn't mutate. Add `--execute` (or say "go") to apply.
+
+---
+
+## The five main commands
+
+| Command | Run it to… | No-arg default | Common args |
+|---------|-----------|----------------|-------------|
+| **`/plan`** | turn an idea/prompt/issue/epic into an **Aligned canvas + linked issues** (SPDD pipeline, then align + link) | infer unfiled/ready work and propose canvases (PLAN only) | `"prompt"` · `#issue` · `#epic` · `--milestone M` · `--execute` |
+| **`/deliver`** | **implement ready work** end-to-end → PR → CI → squash-merge → post-merge verify | pick the next ready work repo-wide and deliver a safe batch | `#issue` · `#epic` · `<canvas>` · `--milestone M` · `--batch N` |
+| **`/review`** | produce dated **review docs** (architecture/security/product/market) | run all four in parallel | `--only <kind>` · `--pr` · `--split` · `--since <path>` |
+| **`/reconcile`** | **recover from a failed run** + **clean the repo** (truth-pass surfaces, triage `[AUTO]` issues, prune branches) | PLAN a truth-pass + report recovery items | `--execute` · `--include-stale` · `--milestone M` |
+| **`/learn`** | fold accumulated **session learnings** into the expert guides | synthesize → write PENDING proposals to `APPLY_LOG.md` | `--domain D` · `--apply` |
+
+### Plus one lifecycle command
+**`/milestone open <name> <version> "<title>"` · `/milestone close [--dry-run]`** — the only
+milestone-aware command and the sole writer of `state/milestone.yaml`. No-arg prints current status.
+Use it only when cutting/closing a release; day-to-day work doesn't need it.
+
+---
+
+## The decision tree (same as before — fewer doors)
+
+1. **Have an idea / a prompt / a filed issue?** → `/plan`. It runs `analysis → story → canvas →
+   security-review`, then **aligns** the canvas and **links** issues↔canvas (Operations-step refs,
+   `status: ready`, `spdd: canvas`). `feat:` work must reach an **Aligned** canvas before code (ADR-019).
+2. **Have aligned, ready work?** → `/deliver`. It claims (deterministic `<type>/<N>` branch),
+   dispatches the right `experts/*` persona, generates per Operations step, runs gates, opens a
+   signed PR, watches CI, squash-merges, and verifies post-merge.
+3. **Finished a batch?** → `/learn` to capture what worked into the expert guides.
+4. **Something broke mid-flight, or the repo drifted?** → `/reconcile`.
+5. **Want a fresh read of where the project stands?** → `/review`.
+
+---
+
+## Folder structure
+
+```
+.claude/commands/
+  README.md          ← you are here
+  plan.md  deliver.md  review.md  reconcile.md  learn.md   ← the 5 verbs (top-level, safe defaults)
+  milestone.md        ← release lifecycle (open|close|status)
+  lib/                ← building blocks the main commands invoke (power-users: /lib:<name>)
+  experts/            ← domain personas /deliver dispatches (not run directly)
+```
+
+### `lib/` — building blocks (you rarely call these directly)
+Invoked by the main commands; available as `/lib:<name>` if you want fine-grained control.
+
+| Group | Files | Called by |
+|-------|-------|-----------|
+| SPDD pipeline | `spdd-analysis` `spdd-story` `spdd-canvas` `spdd-security-review` `spdd-generate` `spdd-prompt-update` `spdd-sync` `spdd-api-test` | `/plan`, `/deliver` |
+| Delivery machinery | `deliver-one` `deliver-batch` `deliver-resume` `sequence` | `/deliver` |
+| Roadmap inference | `plan-infer` | `/plan` (no-arg) |
+| Review docs | `architecture-review` `security-review-doc` `product-review` `market-fit-review` | `/review` |
+| Milestone lifecycle | `milestone-open` `milestone-close` | `/milestone` |
+
+### `experts/` — domain personas
+`bdd-contract · go-services · python-adapters · ci-release · infra-helm · git-ops · spdd-canvas ·
+post-merge`. `/deliver` routes each issue to the matching persona (by title scope / file area). They
+are **updated by `/learn`** as session learnings accumulate; you don't invoke them directly.
+
+---
+
+## Worked example — from a prompt to merged
+
+```
+/plan "let a user try Zynax with no clone"        # → drafts epic + stories, canvas, security-review
+/plan "...same..." --execute                       # → files issues, commits Aligned canvas, links them
+/deliver #<epic>                                    # → implements ready O-steps → PRs → CI → merge → verify
+/learn                                              # → proposes expert-guide learnings (you approve)
+# if a run stalls:  /reconcile --execute
+```
+
+---
+
+## Conventions (enforced)
+
+- **Canvas-first for `feat:`** — a REASONS Canvas committed and **Aligned** before any implementation
+  code (ADR-019). Prompt-first: requirements change → update the canvas (`/lib:spdd-prompt-update`)
+  → then code, never the reverse. Guide: [docs/patterns/spdd-guide.md](../../docs/patterns/spdd-guide.md) ·
+  template: [docs/spdd/CANVAS_TEMPLATE.md](../../docs/spdd/CANVAS_TEMPLATE.md).
+- **Commits/PRs** — conventional title (`feat|fix|refactor|docs|test|ci|chore`), DCO `Signed-off-by`,
+  `Assisted-by: Claude/<model>` (never `Co-Authored-By` for AI), squash-merge only.
+- **Canvas safety** — Tier 1 (public) only; sensitive context → gitignored `canvas.private.md`. Never
+  reference a filename containing a dotted `local`/`internal`/`corp` label (gitleaks `internal-hostname`
+  BLOCKs the commit — rename the artifact).
+- **Editing these commands** — `.claude/` is gitignored with a `!.claude/commands/` negation, so a new
+  command file needs `git add -f`. Command files are PR-size-exempt.
+- **Safety** — main commands PLAN by default; mutations gated by `--execute` (or an explicit "go").
+
+## Authoring metadata (frontmatter)
+`description` (menu summary) · `argument-hint` (usage) · optionally `model`, `allowed-tools`. A `lib/`
+file is namespaced `/lib:<name>` and stays model-invocable so the main commands can call it.

--- a/.claude/commands/deliver.md
+++ b/.claude/commands/deliver.md
@@ -1,0 +1,47 @@
+---
+description: Deliver ready work end-to-end — claim → implement (expert dispatch + SPDD generate) → local gates → signed PR → CI → squash auto-merge → post-merge verify → learnings. No-arg picks the next ready work repo-wide; pass #issue for one story, #epic to resume a cluster, --batch N for parallel delivery. Milestone-agnostic; --milestone is an optional filter. Preserves worktree isolation + deterministic claim-key idempotency.
+argument-hint: "[#issue | #epic | <canvas-path> | (none = next ready)] [--milestone M] [--batch N]"
+---
+
+# /deliver — ready work → merged + verified
+
+One front door for implementation. It routes to the battle-tested delivery building blocks under
+`lib/` (worktree isolation, deterministic `<type>/<N>` claim key, parallel batches, post-merge
+verification) — you no longer choose between orchestrate / issue-deliver / resume by hand.
+
+> **Milestone-agnostic.** With no `--milestone`, scope is **repo-wide ready work**: open issues
+> labelled `status: ready`, with an `Aligned` canvas if they are `feat:`. `--milestone M` filters to
+> that milestone. Nothing requires a milestone to exist.
+
+## Parse `$ARGUMENTS` and route
+
+- **`#<issue>`** (single story) → `/lib:deliver-one <issue>` — claim → (canvas if `feat:` and missing
+  → `/plan #<issue>` first) → expert dispatch → `/lib:spdd-generate` per O-step → gates → PR → CI →
+  squash auto-merge → `experts:post-merge` verify.
+- **`#<epic>`** (resume a cluster) → `/lib:deliver-resume <epic>` — deliver the epic's ready O-steps,
+  open PRs in parallel, enable auto-merge, then stop for review.
+- **no argument, or `--batch N`** → `/lib:deliver-batch` — claim up to N (default 3) ready issues
+  repo-wide (or within `--milestone`), route each to the right `experts/*` persona in parallel,
+  run the merge pass, collect results, append learnings.
+- **`<canvas-path>`** → deliver the next unimplemented Operations step of that canvas via
+  `/lib:spdd-generate`.
+
+The orchestration scope (which issues are "ready") is **provided by this dispatcher** to the lib
+procedure: repo-wide ready work by default, or the `--milestone` filter. Where a lib procedure says
+"active milestone", read "the scope this command passed in".
+
+## Guardrails (preserved from the underlying machinery)
+- **Idempotent & parallel-safe:** the `<type>/<N>` branch is the sole claim mutex; a lost race is a
+  no-op. Worktrees are per-run and private — the user's checkout is never mutated.
+- **`feat:` is canvas-gated:** no `Aligned` canvas → route to `/plan` first; never implement from an
+  unaligned canvas (ADR-019).
+- **Commit/PR hygiene:** conventional title, DCO `Signed-off-by`, `Assisted-by: Claude/<model>`,
+  squash auto-merge (rebase blocked by `required_signatures`).
+- **Stops on blockers** (CI red it can't fix, context budget) and reports how to resume — recover
+  with `/reconcile`.
+
+## Output
+Per issue: claim status, PR link, merge state, post-merge verification, and learnings recorded.
+At the end: what merged, what's blocked, and the suggested next `/deliver` or `/reconcile`.
+
+See `.claude/commands/README.md` for the full decision tree.

--- a/.claude/commands/experts/go-services.md
+++ b/.claude/commands/experts/go-services.md
@@ -278,7 +278,7 @@ nats, _ := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerR
 })
 ```
 
-*(Applied via /milestone-learn from #818 (Redis) + #828 (NATS).)*
+*(Applied via /learn from #818 (Redis) + #828 (NATS).)*
 
 ---
 

--- a/.claude/commands/experts/spdd-canvas.md
+++ b/.claude/commands/experts/spdd-canvas.md
@@ -25,7 +25,7 @@ Output a progress line at the start of each phase — before any tool call for t
 | `SECURITY` | Before running the security review on the canvas |
 | `FIX` | When applying security-review findings |
 | `ALIGN` | When setting `Status: Aligned` on the canvas |
-| `STORIES` | When creating story issues via `/spdd-story` |
+| `STORIES` | When creating story issues via `/lib:spdd-story` |
 | `COMMIT` | Before `git add` / `git commit` — handing off to git-ops |
 | `PR` | Before `gh pr create` — build the PR body from docs/contributing/pr-templates.md (your type variant) |
 | `CI_WAIT` | On entering the CI polling loop |
@@ -38,7 +38,7 @@ Example:
 [spdd #772 08:00:01] READ: loading AGENTS.md, ADR index, issue body  [ctx: ~14K | compress=0 | msgs=2]
 [spdd #772 08:03:10] ANALYSIS: scanning services/event-bus/, ADR-001/013/022 constraints  [ctx: ~17K | compress=0 | msgs=3]
 [spdd #772 08:06:40] CANVAS: writing docs/spdd/772-event-bus/canvas.md  [ctx: ~17K | compress=0 | msgs=4]
-[spdd #772 08:10:05] SECURITY: running /spdd-security-review  [ctx: ~18K | compress=0 | msgs=5]
+[spdd #772 08:10:05] SECURITY: running /lib:spdd-security-review  [ctx: ~18K | compress=0 | msgs=5]
 [spdd #772 08:10:20] FIX: removing inline email address from N section  [ctx: ~18K | compress=0 | msgs=6]
 [spdd #772 08:10:35] ALIGN: setting Status: Aligned  [ctx: ~18K | compress=0 | msgs=7]
 [spdd #772 08:10:36] STORIES: creating issues #823–#828 on GitHub  [ctx: ~19K | compress=0 | msgs=8]
@@ -183,7 +183,7 @@ and reference it with: `> Private context: see canvas.private.md (not committed)
 
 ## Security review gates
 
-The `/spdd-security-review` check FAILs if the canvas:
+The `/lib:spdd-security-review` check FAILs if the canvas:
 - Names internal hostnames or IPs
 - Contains tokens, passwords, or secrets
 - Describes attack surface without a mitigation

--- a/.claude/commands/learn.md
+++ b/.claude/commands/learn.md
@@ -3,22 +3,25 @@ description: Expert knowledge synthesizer — reads docs/ai-learnings/*.md, spaw
 argument-hint: "[--domain go-services|ci-release|...] [--apply]  default: synthesize all"
 ---
 
-# /milestone-learn — Expert Knowledge Synthesizer
+# /learn — Expert Knowledge Synthesizer
+
+> **Milestone-agnostic.** Synthesize learnings on demand from `docs/ai-learnings/*.md`; nothing here
+> depends on a milestone. `/deliver` and `/reconcile` append the raw session learnings this digests.
 
 Read accumulated session learnings → spawn synthesizer subagent → output proposed additions
 to expert prompt files → write pending entries to APPLY_LOG.md → stop for human review.
 
 Two modes:
-- **`/milestone-learn`** (default) — synthesize and write proposals to APPLY_LOG.md as PENDING.
-- **`/milestone-learn --apply`** — apply PENDING entries already approved by the human in APPLY_LOG.md,
+- **`/learn`** (default) — synthesize and write proposals to APPLY_LOG.md as PENDING.
+- **`/learn --apply`** — apply PENDING entries already approved by the human in APPLY_LOG.md,
   then commit expert files + log update together.
 
 > **This command never auto-commits in synthesis mode.** Human edits APPLY_LOG.md entries
-> (`pending` → `applied` / `rejected`) then runs `/milestone-learn --apply` to commit.
+> (`pending` → `applied` / `rejected`) then runs `/learn --apply` to commit.
 
 ---
 
-## APPLY mode (`/milestone-learn --apply`)
+## APPLY mode (`/learn --apply`)
 
 Check if any PENDING entries in APPLY_LOG.md were approved (`applied`) by the human.
 If yes: edit the expert files to add approved text, mark entries as `committed` in the log,
@@ -26,7 +29,7 @@ commit everything, open a PR, and stop.
 
 ```bash
 LOG="docs/ai-learnings/APPLY_LOG.md"
-[ ! -f "$LOG" ] && echo "No APPLY_LOG.md found — run /milestone-learn first." && exit 1
+[ ! -f "$LOG" ] && echo "No APPLY_LOG.md found — run /learn first." && exit 1
 
 # Find the most recent run with approved-but-not-yet-committed entries
 APPROVED=$(python3 - "$LOG" <<'PYEOF'
@@ -65,14 +68,14 @@ git checkout -b "$LEARN_BRANCH"
 git add .claude/commands/experts/ docs/ai-learnings/APPLY_LOG.md
 git commit -s -m "docs(automation): apply expert learnings — $(date +%Y-%m-%d)
 
-Synthesized from session learnings via /milestone-learn.
+Synthesized from session learnings via /learn.
 See docs/ai-learnings/APPLY_LOG.md for applied entries.
 
 Assisted-by: Claude/<model-id-of-this-session>"
 git push -u origin "$LEARN_BRANCH"
 gh pr create \
   --title "docs(automation): apply expert learnings — $(date +%Y-%m-%d)" \
-  --body "Applying approved /milestone-learn proposals. See APPLY_LOG.md for details." \
+  --body "Applying approved /learn proposals. See APPLY_LOG.md for details." \
   --label "type: docs" --label "$MILESTONE_LABEL"
 ```
 
@@ -189,7 +192,7 @@ Agent({
         These are REAL and must persist, but they belong in the **dispatch-prompt preamble of
         milestone-orchestrate.md / issue-deliver.md** (injected into every agent), NOT scattered
         into the expert guides. Do NOT auto-reject: surface as `pending` with a note that the
-        fix is a manual command-file edit (outside `/milestone-learn --apply`'s expert-file scope).
+        fix is a manual command-file edit (outside `/learn --apply`'s expert-file scope).
       - `domain` — genuine engineering knowledge (API shape, query planner behaviour, proto
         field name, test pattern, gRPC code mapping).
       Prefer the `Category:` line the session already emitted; if absent, infer it.
@@ -210,7 +213,7 @@ Agent({
       Seen in: #NNN, #NNN (N sessions). Recurrence: N.
     ```
 
-    Then, output a APPLY_LOG_ENTRY block (used by /milestone-learn to append to the log):
+    Then, output a APPLY_LOG_ENTRY block (used by /learn to append to the log):
 
     ```apply-log
     ## Run <YYYY-MM-DD HH:MM> — domains: <list>
@@ -279,10 +282,10 @@ echo "Run entry written to docs/ai-learnings/APPLY_LOG.md"
                then manually edit the target expert file to add the text
    - Reject:   change Status from "pending" to "rejected"
                leave Delta as "—"
-   - Defer:    leave Status as "pending" (will re-appear in next /milestone-learn run)
+   - Defer:    leave Status as "pending" (will re-appear in next /learn run)
 
 3. After editing expert file(s) and APPLY_LOG.md, run:
-   /milestone-learn --apply
+   /learn --apply
    This stages, commits, and opens a PR for the approved entries.
 
 === APPLY_LOG.md written to docs/ai-learnings/APPLY_LOG.md ===
@@ -293,13 +296,13 @@ echo "Run entry written to docs/ai-learnings/APPLY_LOG.md"
 ## Learning loop lifecycle
 
 ```
-/milestone-orchestrate
+/deliver
   → expert sessions run → ## Session Learnings blocks produced
   → orchestrator appends raw learnings to docs/ai-learnings/<domain>.md
   → opens docs: PR for the raw learnings
 
 After ≥3 new session blocks:
-/milestone-learn
+/learn
   → reads learnings + expert files + APPLY_LOG.md
   → synthesizer clusters patterns (recurrence ≥2, dedup vs applied)
   → prints proposals
@@ -309,7 +312,7 @@ Human reviews:
   → edits APPLY_LOG.md: pending → applied/rejected
   → manually edits expert files to add approved text
 
-/milestone-learn --apply
+/learn --apply
   → finds approved-but-not-committed entries in APPLY_LOG.md
   → updates log entries to committed
   → commits expert files + APPLY_LOG.md
@@ -323,8 +326,8 @@ Human reviews:
 ```markdown
 # Expert Learning Apply Log
 
-> Append-only. Each run of /milestone-learn adds one entry. Human edits Status column.
-> Delta column records what changed in the expert file (filled in by /milestone-learn --apply).
+> Append-only. Each run of /learn adds one entry. Human edits Status column.
+> Delta column records what changed in the expert file (filled in by /learn --apply).
 
 ---
 
@@ -346,10 +349,10 @@ Human reviews:
 > `env-constraint` rows (runtime/sandbox constraints worktree isolation does NOT fix — e.g.
 > background-subagent compound-Bash denial, non-persistent shell state) are NOT auto-rejected:
 > leave them `pending` and apply them by hand to the dispatch-prompt preamble in
-> `milestone-orchestrate.md` / `issue-deliver.md` — they are outside `/milestone-learn --apply`'s
+> `milestone-orchestrate.md` / `issue-deliver.md` — they are outside `/learn --apply`'s
 > expert-file scope, so `--apply` will not commit them.
 
-Status lifecycle: `pending` → `applied` (human sets) → `committed` (/milestone-learn --apply sets)
+Status lifecycle: `pending` → `applied` (human sets) → `committed` (/learn --apply sets)
 Or: `pending` → `rejected` (human sets, stays rejected)
 
 ---

--- a/.claude/commands/lib/architecture-review.md
+++ b/.claude/commands/lib/architecture-review.md
@@ -3,7 +3,7 @@ description: Generate a dated, scored architecture review document grounded in t
 argument-hint: "[--pr] [--since <prev-review-path>]   default: working draft, no PR"
 ---
 
-# /architecture-review — Architecture Review Document Generator
+# /lib:architecture-review — Architecture Review Document Generator
 
 Produce a principal-engineer-grade architecture review as a **dated document**, in the exact
 shape and home of the existing reviews under [docs/architecture/](docs/architecture/) (e.g.
@@ -82,9 +82,9 @@ SPDX header `<!-- SPDX-License-Identifier: Apache-2.0 -->` and use **repo-relati
    `partially-closed` / `open`, with the commit/PR/issue that closed it. (This is what makes the
    series valuable; cf. the post-M6 deltas in [docs/product/strategy.md](docs/product/strategy.md).)
 8. **Prioritized recommendations** — Critical / High, mapped to issues where they exist.
-9. **Gap analysis** — items not yet filed as issues (feed these to `/roadmap-plan`). Annotate
+9. **Gap analysis** — items not yet filed as issues (feed these to `/plan`). Annotate
    each row with **user type(s)** (developer/operator/maintainer/product-owner/zynax-user/
-   enterprise) and an **adoption lever** note, so `/roadmap-plan` files it with the right
+   enterprise) and an **adoption lever** note, so `/plan` files it with the right
    `product:` / `audience:` labels and a complete `## What for (user impact)` block.
 10. **Appendix** — score card table + key file references.
 
@@ -124,4 +124,4 @@ self-merged once CI is green — squash-only. Leave the merge to the human unles
 - **Read-only on the system under review.** Never edit code, ADRs, `AGENTS.md`, or `.feature` files.
 - **One dated doc per run.** Don't overwrite a prior review — the series is the value.
 - Commit (with `--pr`): `docs:` type, DCO `-s`, `Assisted-by: Claude/<model>`, squash-merge, signed; repo-relative links; no literal email; no skip-ci token.
-- Pairs with `/roadmap-plan`: this review's **gap analysis** is exactly the input `/roadmap-plan` mines into issues.
+- Pairs with `/plan`: this review's **gap analysis** is exactly the input `/plan` mines into issues.

--- a/.claude/commands/lib/deliver-batch.md
+++ b/.claude/commands/lib/deliver-batch.md
@@ -3,7 +3,9 @@ description: Parallel milestone orchestrator — reads state, claims up to 3 iss
 argument-hint: "[--batch-size N]  default: 3"
 ---
 
-# /milestone-orchestrate — Parallel Milestone Delivery Orchestrator
+# /lib:deliver-batch — Parallel delivery orchestrator (building block of /deliver)
+
+> **Building block** — invoked by `/deliver` (no-arg or `--batch N`), not run directly.\n> **Scope contract:** the caller provides scope — repo-wide `status: ready` work by default, or a\n> `--milestone M` filter. Where this says "active milestone", read "the caller-provided scope".\n
 
 Thin coordination layer: read state → claim issues → fan out to expert subagents in parallel →
 collect results → persist learnings → report.
@@ -53,7 +55,7 @@ cd "$COORD_WT"
 
 # ── Active-milestone config (SSoT: state/milestone.yaml) ────────────────────
 # Loaded at runtime; no milestone name, number, or label is hardcoded in this
-# file. Updated only by /milestone-close and /milestone-new.
+# file. Updated only by /milestone close and /milestone open.
 CFG=state/milestone.yaml
 MILESTONE_NAME=$(awk '/^active:/{f=1} f && /^  name:/{print $2; exit}' "$CFG")
 MILESTONE_TITLE=$(awk -F'"' '/^active:/{f=1} f && /^  title:/{print $2; exit}' "$CFG")
@@ -119,7 +121,7 @@ done <<< "$OPEN_PRS_JSON"
 
 ## STEP 3 — Select READY batch
 
-Using the same classification logic as `/milestone-plan`:
+Using the same classification logic as `/deliver`:
 
 ```bash
 # For each open issue: classify as READY / IN_PROGRESS / BLOCKED
@@ -288,7 +290,7 @@ Agent({
        If already claimed: remove your worktree (cleanup below), stop, and report.
     2. From inside "$WT", claim with the DETERMINISTIC KEY before any code: the branch
        ref is `<type>/<N>` — a pure function of the issue number, NO slug. Push it empty
-       (atomic hard claim). This is the same key /issue-deliver derives, so it is the
+       (atomic hard claim). This is the same key /deliver derives, so it is the
        sole mutex: if a sibling already pushed `<type>/<N>` your push is rejected → stop,
        run cleanup, report "claim lost". Apply any human-readable slug only AFTER the push
        wins (rename + push the slugged ref); never let a slug into the claim push.
@@ -326,7 +328,7 @@ Agent({
     - Affected services: <comma-separated list, e.g. "memory-service,event-bus" or "none">
     ```
 
-    ## Session Learnings (required — emit verbatim in this shape so /milestone-learn can parse it)
+    ## Session Learnings (required — emit verbatim in this shape so /learn can parse it)
     ```
     ## Session Learnings
     - domain: <go-services|ci-release|infra-helm|python-adapters|bdd-contract|spdd-canvas>
@@ -659,7 +661,7 @@ Batch size: N issues
 | #NNN | none (docs-only) | — | — | — | — | SKIP |
 
 Learnings: appended to docs/ai-learnings/ — PR #NNN opened for review.
-Next: run /milestone-plan to see the next available batch.
+Next: run /deliver to see the next available batch.
 ```
 
 After the report, remove the coordinator worktree (the per-run agent/post-merge trees were
@@ -707,7 +709,7 @@ tree, so cross-agent branch/staging/commit corruption is structurally impossible
   coordinator can only ever reclaim *this* run's trees. Globbing `/tmp/zynax-orch-*` is forbidden.
 - **User's checkout is never mutated:** the orchestrator does all its own git work in the
   coordinator worktree; `main` stays checked out (untouched) in the user's primary worktree.
-- Distinct from `/issue-deliver`'s `/tmp/zynax-auto-<N>` — no namespace collision.
+- Distinct from `/deliver`'s `/tmp/zynax-auto-<N>` — no namespace collision.
 
 ---
 
@@ -719,15 +721,15 @@ not replace the authoritative one:
 
 | Layer | Where | Mechanism | Strength |
 |-------|-------|-----------|----------|
-| 1 — Deterministic claim key | STEP 6 dispatch prompt (+ `/issue-deliver` STEP 5) | Branch ref `<type>/<N>` is a pure function of the issue number; the atomic empty-branch push is the **sole mutex** shared by both entry points. Slug applied only post-claim. | Prevents two live branches for one issue. |
+| 1 — Deterministic claim key | STEP 6 dispatch prompt (+ `/deliver` STEP 5) | Branch ref `<type>/<N>` is a pure function of the issue number; the atomic empty-branch push is the **sole mutex** shared by both entry points. Slug applied only post-claim. | Prevents two live branches for one issue. |
 | 2 — Pre-spawn reconcile | STEP 5 | Re-query `gh issue view` + merged-PR search before spawning; skip + drop soft claim if already delivered. | Cheap early-out; can be defeated by API lag. |
 | 3 — Completion-time merge-SHA dedupe | STEP 7 | `SEEN_ISSUES` / `SEEN_MERGE_SHAS`; on each completion re-query the authoritative merged PR; close the loser PR and skip its verifier when a different PR already delivered the issue. | **Authoritative** — operates on a merge fact (a SHA on `main`), immune to API lag. |
 
 - **Completion-time is authoritative.** Layers 1–2 reduce the race window; only layer 3 acts on
   a fact that cannot be wrong. Never treat the claim key or the pre-spawn reconcile as sufficient
   on its own.
-- **The claim key is the single mutex across both entry points.** `/milestone-orchestrate` and
-  `/issue-deliver` derive the identical `<type>/<N>` ref, so a race between them collides on
+- **The claim key is the single mutex across both entry points.** `/deliver` and
+  `/deliver` derive the identical `<type>/<N>` ref, so a race between them collides on
   one push. A slug must never enter the claim push.
 - **A loser PR is closed, never merged.** When two PRs target one issue, layer 3 keeps the first
   merged (the winner) and closes the redundant one; `gh pr merge` flags and the push-to-main
@@ -756,4 +758,4 @@ Heuristics:
 | Condition | Action |
 |-----------|--------|
 | `CTX_TOKENS > 60K` | Stop claiming new issues — only collect existing agent results |
-| `CTX_TOKENS > 100K` OR `CTX_COMPRESSIONS >= 1` | **STOP. Report collected results so far.** Let the human run `/milestone-plan` for the next batch. |
+| `CTX_TOKENS > 100K` OR `CTX_COMPRESSIONS >= 1` | **STOP. Report collected results so far.** Let the human run `/deliver` for the next batch. |

--- a/.claude/commands/lib/deliver-one.md
+++ b/.claude/commands/lib/deliver-one.md
@@ -3,7 +3,9 @@ description: Fully autonomous milestone story delivery — claims issue via GitH
 argument-hint: "<story-or-epic-issue-number>"
 ---
 
-# /issue-deliver — Autonomous Milestone Story Delivery
+# /lib:deliver-one — Autonomous single-story delivery (building block of /deliver)
+
+> **Building block** — invoked by `/deliver <#issue>`, not run directly.\n> **Scope contract:** milestone-agnostic; the caller may pass `--milestone M` as a filter.\n
 
 End-to-end, unattended delivery of a single story issue: claim → canvas (if feat:) → implement →
 local checks → push → PR → wait for CI → verify artifacts → squash-merge → cleanup → done.
@@ -12,8 +14,8 @@ local checks → push → PR → wait for CI → verify artifacts → squash-mer
 > PR-size limits, hexagonal layout, coverage gates, and the SPDD workflow all live in **`AGENTS.md`**
 > and **`CLAUDE.md`**. Read them before starting. This file is the *execution loop only*.
 
-> **Canvas auto-alignment policy.** For `feat:` issues this skill auto-runs `/spdd-analysis`,
-> `/spdd-reasons-canvas`, and `/spdd-security-review`. If the security review PASSes, Status is set
+> **Canvas auto-alignment policy.** For `feat:` issues this skill auto-runs `/lib:spdd-analysis`,
+> `/lib:spdd-canvas`, and `/lib:spdd-security-review`. If the security review PASSes, Status is set
 > to `Aligned` automatically and implementation proceeds. If it **FAILs** (Tier 2 findings that
 > cannot be resolved inline), the skill stops and reports — do not proceed from a failed review.
 
@@ -24,7 +26,7 @@ local checks → push → PR → wait for CI → verify artifacts → squash-mer
 Two layers prevent duplicate work across concurrent sessions on any machine:
 
 1. **Soft claim** — add `status: in-progress` label + self-assign the issue on GitHub (visible
-   immediately to all sessions and to `/milestone-plan`). This is a *signal*, not a lock.
+   immediately to all sessions and to `/deliver`). This is a *signal*, not a lock.
 2. **Hard claim** — push an empty branch to GitHub before writing any code. Only one `git push -u
    origin $BRANCH` wins when two sessions race. A rejected push means the story is taken → stop.
 
@@ -37,7 +39,7 @@ Always check both before starting. Never assume an issue is free just because yo
 ```bash
 # ── Active-milestone config (SSoT: state/milestone.yaml) ────────────────────
 # Loaded at runtime; no milestone name, number, or label is hardcoded in this
-# file. Updated only by /milestone-close and /milestone-new.
+# file. Updated only by /milestone close and /milestone open.
 CFG=state/milestone.yaml
 MILESTONE_NAME=$(awk '/^active:/{f=1} f && /^  name:/{print $2; exit}' "$CFG")
 MILESTONE_TITLE=$(awk -F'"' '/^active:/{f=1} f && /^  title:/{print $2; exit}' "$CFG")
@@ -165,7 +167,7 @@ Go to **STEP 3-EPIC**. Otherwise skip to **STEP 3.5**.
 
 ## STEP 3.5 — Identify expert persona and start activity log
 
-Determine which expert persona applies to this issue (same routing table as `/milestone-orchestrate`):
+Determine which expert persona applies to this issue (same routing table as `/deliver`):
 
 ```bash
 EXPERT_TAG="general"
@@ -300,16 +302,16 @@ if [ -z "$CANVAS_DIR" ] || [ "$CANVAS_STATUS" != "Aligned" ]; then
   echo "Running SPDD pipeline for EPIC #$EPIC_N..."
 
   # Analysis — understand codebase impact, ADR constraints, Tier 2 flags
-  /spdd-analysis "$EPIC_N"
+  /lib:spdd-analysis "$EPIC_N"
 
   # Generate canvas (Status: Draft)
-  /spdd-reasons-canvas "$EPIC_N"
+  /lib:spdd-canvas "$EPIC_N"
 
   CANVAS_DIR=$(ls docs/spdd/ | grep -E "^${EPIC_N}-" | head -1)
   CANVAS_PATH="docs/spdd/$CANVAS_DIR/canvas.md"
 
   # Security review — MUST PASS before auto-alignment
-  REVIEW_RESULT=$(/spdd-security-review "$CANVAS_PATH" 2>&1)
+  REVIEW_RESULT=$(/lib:spdd-security-review "$CANVAS_PATH" 2>&1)
   echo "$REVIEW_RESULT"
   if echo "$REVIEW_RESULT" | grep -qi "FAIL\|Tier 2 finding\|BLOCKED"; then
     echo "Security review FAILED — cannot auto-align. Resolve Tier 2 findings and re-run."
@@ -326,9 +328,9 @@ fi
 # Create story issues if not yet created for this EPIC
 STORY_COUNT=$(gh issue list --milestone "$GH_MILESTONE" --state all \
   --json body --jq "[.[] | select(.body | test(\"#${EPIC_N}\"))] | length")
-[ "$STORY_COUNT" -eq 0 ] && /spdd-story "$EPIC_N"
+[ "$STORY_COUNT" -eq 0 ] && /lib:spdd-story "$EPIC_N"
 
-# Locked decision (#1107): /spdd-story is milestone-agnostic — it applies NO
+# Locked decision (#1107): /lib:spdd-story is milestone-agnostic — it applies NO
 # milestone label. The CALLER (this command) injects the active milestone label
 # and GitHub milestone on every story it just created.
 for STORY in $(gh issue list --state open --limit 100 --json number,body \
@@ -348,7 +350,7 @@ echo "[$EXPERT_TAG #$ISSUE_N $(date +%H:%M:%S)] CLAIM: creating branch + hard cl
 
 # Deterministic claim key (load-bearing). The branch ref pushed here is a PURE
 # function of the issue number — `<type>/<N>`, with NO slug. This is the SAME ref
-# `/milestone-orchestrate` derives for the same issue, so the two entry points share one
+# `/deliver` derives for the same issue, so the two entry points share one
 # mutex: when two sessions race the same story they push the identical ref and only
 # one `git push` wins. A title-derived slug must NOT be part of the claim key — two
 # sessions could otherwise derive two different branches and both win.
@@ -388,16 +390,16 @@ CURRENT_STEP="6-CODE"; check_ctx_budget
 echo "[$EXPERT_TAG #$ISSUE_N $(date +%H:%M:%S)] CODE: implementing — reading issue scope and referenced files  [ctx: ~${CTX_TOKENS}K | compress=${CTX_COMPRESSIONS} | msgs=${CTX_MSGS}]"
 ```
 
-For `feat:` issues with an Aligned canvas, use `/spdd-generate`:
+For `feat:` issues with an Aligned canvas, use `/lib:spdd-generate`:
 
 ```bash
 if [ "$NEEDS_CANVAS" = "true" ]; then
   CANVAS_PATH="docs/spdd/$CANVAS_DIR/canvas.md"
   # Identify which O-step this story covers (from story title "step N")
   STEP_N=$(echo "$ISSUE_TITLE" | grep -oP '(?<=step )\d+' | head -1)
-  echo "Implementing canvas O-step $STEP_N via /spdd-generate"
-  /spdd-generate "$CANVAS_PATH"
-  # /spdd-generate stops after one O-step — verify it generated the right step
+  echo "Implementing canvas O-step $STEP_N via /lib:spdd-generate"
+  /lib:spdd-generate "$CANVAS_PATH"
+  # /lib:spdd-generate stops after one O-step — verify it generated the right step
 fi
 ```
 
@@ -412,7 +414,7 @@ flags a stale milestone label) and compounds every iteration, so reconcile at de
    `Implemented`/COMPLETE if this was the last open O-step); refresh the "Last updated" line.
 2. `state/current-milestone.md` — update EPIC progress + the "as of" date.
 3. Canvas O-step — mark ✅. **If this issue closed the EPIC's last O-step, flip the canvas
-   `Status:` `Aligned`→`Implemented`.** Run `/spdd-sync <canvas>` if implementation diverged.
+   `Status:` `Aligned`→`Implemented`.** Run `/lib:spdd-sync <canvas>` if implementation diverged.
 4. **Cross-cutting human docs — only when an EPIC completes or a service's status changes:**
    the milestone tables in `README.md`, `ROADMAP.md`, `ARCHITECTURE.md`, `CLAUDE.md`, and the
    README per-service status table. Update the marker (📅 Planned → 🚧 Active → ✅ Complete)
@@ -527,10 +529,10 @@ Closes #${ISSUE_N}
 ### Engineering hygiene
 - [x] Planning-doc row ⬜→✅ in this diff
 - [x] `current-milestone.md` updated in this diff
-- [x] Canvas O-step ✅ (feat:); `/spdd-sync` run if impl diverged · Status Aligned
+- [x] Canvas O-step ✅ (feat:); `/lib:spdd-sync` run if impl diverged · Status Aligned
 - [x] Branched off fresh `origin/main` · PR ≤900 lines · DCO + `Assisted-by` on every commit
 
-<!-- feat: only --> **SPDD:** Canvas `docs/spdd/<EPIC_N>-<slug>/canvas.md` — Status: Aligned · `/spdd-security-review` PASS
+<!-- feat: only --> **SPDD:** Canvas `docs/spdd/<EPIC_N>-<slug>/canvas.md` — Status: Aligned · `/lib:spdd-security-review` PASS
 EOF
 
 # Fill in every <placeholder> with real evidence from STEP 7 output before committing the PR body.
@@ -580,7 +582,7 @@ CURRENT_STEP="10-CI"; check_ctx_budget
 echo "[$EXPERT_TAG #$ISSUE_N $(date +%H:%M:%S)] CI_WAIT: PR #$PR_N — waiting for required checks  [ctx: ~${CTX_TOKENS}K | compress=${CTX_COMPRESSIONS} | msgs=${CTX_MSGS}]"
 ```
 
-Unlike `/resume-milestone`, this command waits for CI to complete before merging. This is intentional —
+Unlike `/deliver`, this command waits for CI to complete before merging. This is intentional —
 the command's contract is end-to-end autonomous delivery, not a fire-and-forget push.
 
 > **Foreground only — never end the turn here.** The CI wait MUST be a blocking foreground
@@ -774,7 +776,7 @@ PR:          #$PR_N — MERGED
 CI:          All required checks passed ✓
 Artifacts:   $([ "$TOUCHES_IMAGE" -gt 0 ] && echo "Docker images verified ✓" || echo "N/A (no image-touching files)")
 Issue state: CLOSED ✓
-Next:        Run /milestone-plan to see what to pick up next.
+Next:        Run /deliver to see what to pick up next.
 EOF
 
 # Remove the isolated worktree — all work is merged, nothing to keep

--- a/.claude/commands/lib/deliver-resume.md
+++ b/.claude/commands/lib/deliver-resume.md
@@ -1,11 +1,13 @@
 ---
-description: Resume work on the active milestone (state/milestone.yaml) — one canvas per EPIC, /spdd-story creates all story issues in GitHub, /spdd-generate implements one O-step at a time, stop after the cluster is merged.
+description: Resume work on the active milestone (state/milestone.yaml) — one canvas per EPIC, /lib:spdd-story creates all story issues in GitHub, /lib:spdd-generate implements one O-step at a time, stop after the cluster is merged.
 argument-hint: "[optional: epic issue number or story issue number to prefer, e.g. 765 766]"
 ---
 
-# Resume Milestone — active milestone from state/milestone.yaml
+# /lib:deliver-resume — Resume an epic cluster (building block of /deliver)
 
-Pick the next ready EPIC, decompose it into story issues via `/spdd-story`, ship each story as its
+> **Building block** — invoked by `/deliver <#epic>` to resume a cluster, not run directly.\n> **Scope contract:** the caller provides scope; milestone is optional (`--milestone` filter).\n
+
+Pick the next ready EPIC, decompose it into story issues via `/lib:spdd-story`, ship each story as its
 own PR in O-step order, merge them in order, leave every state file consistent, then stop.
 
 > **Parallel-session safety.** Multiple sessions may run concurrently. Two mechanisms prevent
@@ -17,8 +19,8 @@ own PR in O-step order, merge them in order, leave every state file consistent, 
 
 **EPIC-canvas model:** every `feat:` EPIC has exactly **one** REASONS Canvas at
 `docs/spdd/<epic-issue>-<slug>/canvas.md`. That canvas's O steps map 1-to-1 to story PRs. Story
-issues are created in GitHub by `/spdd-story` — they reference the parent EPIC and carry full
-labels, milestone, and a test plan template. `/spdd-generate` always operates on the EPIC canvas,
+issues are created in GitHub by `/lib:spdd-story` — they reference the parent EPIC and carry full
+labels, milestone, and a test plan template. `/lib:spdd-generate` always operates on the EPIC canvas,
 not a per-story canvas.
 
 > **Rules are not restated here.** Commit/PR format, conventional types, DCO + `Assisted-by`
@@ -66,7 +68,7 @@ git fetch origin --prune && git checkout main && git pull --rebase origin main
 
 # ── Active-milestone config (SSoT: state/milestone.yaml) ────────────────────
 # Loaded at runtime; no milestone name, number, or label is hardcoded in this
-# file. Updated only by /milestone-close and /milestone-new.
+# file. Updated only by /milestone close and /milestone open.
 CFG=state/milestone.yaml
 MILESTONE_NAME=$(awk '/^active:/{f=1} f && /^  name:/{print $2; exit}' "$CFG")
 MILESTONE_TITLE=$(awk -F'"' '/^active:/{f=1} f && /^  title:/{print $2; exit}' "$CFG")
@@ -222,12 +224,12 @@ ls docs/spdd/ | grep -E "^<EPIC_N>-"   # check if EPIC canvas already exists
 Run in order, stopping between each step for inspection:
 
 ```bash
-/spdd-analysis <EPIC_N>
+/lib:spdd-analysis <EPIC_N>
 ```
 Review output: verify ADR constraints, tier classification, Tier 2 flags.
 
 ```bash
-/spdd-reasons-canvas <EPIC_N>
+/lib:spdd-canvas <EPIC_N>
 ```
 Canvas is written to `docs/spdd/<EPIC_N>-<slug>/canvas.md` (Status: Draft).
 
@@ -241,7 +243,7 @@ Canvas is written to `docs/spdd/<EPIC_N>-<slug>/canvas.md` (Status: Draft).
 - **S-Safeguards**: architecture invariants, state-minimization rule (where applicable)
 
 ```bash
-/spdd-security-review docs/spdd/<EPIC_N>-<slug>/canvas.md
+/lib:spdd-security-review docs/spdd/<EPIC_N>-<slug>/canvas.md
 ```
 Must PASS before committing. Any Tier 2 findings → move to `canvas.private.md`.
 
@@ -257,10 +259,10 @@ gh issue list --milestone "$GH_MILESTONE" --state all \
 
 If stories are missing, run:
 ```bash
-/spdd-story <EPIC_N>
+/lib:spdd-story <EPIC_N>
 ```
 
-`/spdd-story` will create one GitHub issue per O-step. **Each story issue MUST have:**
+`/lib:spdd-story` will create one GitHub issue per O-step. **Each story issue MUST have:**
 - Title: `feat(<scope>): <story-title> (#<EPIC_N>, step <N>)` — conventional-commit form
 - Labels: `type: feature`, `area: <area>`, `$MILESTONE_LABEL`, `size/<S|M|L>`, `spdd: canvas-step`
 - Milestone: `$GH_MILESTONE`
@@ -380,11 +382,11 @@ Missing `.feature` → write and commit it FIRST, in a separate commit on this b
 
 ---
 
-## STEP 5 — Implement via /spdd-generate
+## STEP 5 — Implement via /lib:spdd-generate
 
 For `feat:` O-steps with an Aligned epic canvas:
 ```bash
-/spdd-generate docs/spdd/<EPIC_N>-<slug>/canvas.md
+/lib:spdd-generate docs/spdd/<EPIC_N>-<slug>/canvas.md
 ```
 The skill reads the canvas, identifies the current O-step, generates the code for that step only,
 and stops. Review the output; if it would violate a safeguard, halt and report.
@@ -409,7 +411,7 @@ Capture all output — paste into PR body test plan checkboxes.
 Each story PR updates:
 1. `"$PLANNING_DOC"` — flip this story's row ⬜→✅; bump "Last updated"
 2. `state/current-milestone.md` — update EPIC progress; note if EPIC is now fully done
-3. Epic canvas O-step — mark it ✅; run `/spdd-sync <canvas>` if implementation diverged
+3. Epic canvas O-step — mark it ✅; run `/lib:spdd-sync <canvas>` if implementation diverged
 4. `services/<svc>/AGENTS.md` — only if a new gRPC method, K8s resource type, or env var was added
 
 ---
@@ -521,7 +523,7 @@ Mark the EPIC canvas `Status: Implemented` (small docs: commit). Post the sessio
 | EPIC has canvas Aligned but no story issues | STEP 3B: create stories, then STEP 4 |
 | EPIC has no canvas | STEP 3A: full pipeline |
 | EPIC is BLOCKED (#764 for EPIC I, #626 for EPIC J, #626+#772 for DevAuto.8 #881) | Pick next unblocked EPIC |
-| All EPICs exhausted | Report milestone exit-criteria; recommend /milestone-close |
+| All EPICs exhausted | Report milestone exit-criteria; recommend /milestone close |
 
 ---
 
@@ -565,7 +567,7 @@ Mark the EPIC canvas `Status: Implemented` (small docs: commit). Post the sessio
 ### Engineering hygiene
 - [ ] **Planning-doc row ⬜→✅ in this diff** (mandatory)
 - [ ] **`current-milestone.md` updated in this diff** (mandatory)
-- [ ] Canvas O-step <N> marked ✅; `/spdd-sync` run if impl diverged
+- [ ] Canvas O-step <N> marked ✅; `/lib:spdd-sync` run if impl diverged
 - [ ] Branched from fresh `origin/main` · PR ≤900 lines · trailers on every commit
 - [ ] No out-of-scope edits · observability (traces/dashboards) deferred to a later milestone
 ```

--- a/.claude/commands/lib/market-fit-review.md
+++ b/.claude/commands/lib/market-fit-review.md
@@ -3,7 +3,7 @@ description: Generate a dated market-fit review document grounded in the repo + 
 argument-hint: "[--pr] [--since <prev-review-path>]   default: working draft, no PR"
 ---
 
-# /market-fit-review — Market-Fit Review Document Generator
+# /lib:market-fit-review — Market-Fit Review Document Generator
 
 Produce a point-in-time **product-market-fit** assessment as a dated document under
 [docs/product/](docs/product/), extending the competitive analysis in
@@ -66,7 +66,7 @@ Write `$OUT` (SPDX header; repo-relative links):
    targets in `strategy.md §7`. Honest baseline.
 7. **PMF verdict + score** — reconciled to the architect review's grounded basis; no invented number.
 8. **Recommendations (prioritized)** — each classified by **user type** + **adoption lever**, for
-   the `/roadmap-plan` handoff (`product:`/`audience:` labels + `## What for (user impact)` block).
+   the `/plan` handoff (`product:`/`audience:` labels + `## What for (user impact)` block).
 9. **Longitudinal delta vs `$PREV`** — what moved (positioning, competitors, metrics).
 10. **Appendix** — sources.
 
@@ -89,6 +89,6 @@ from [docs/contributing/pr-templates.md](docs/contributing/pr-templates.md), doc
   cautionary precedent: an earlier informal analysis did, and was wrong).
 - **Ground everything.** Cite positioning docs; pull adoption metrics live; no invented PMF score.
 - **Longitudinal.** Diff against the prior market-fit review / competitive-positioning doc.
-- **Recommendations carry user-type + adoption-lever annotations** (the `/roadmap-plan` handoff).
+- **Recommendations carry user-type + adoption-lever annotations** (the `/plan` handoff).
 - One dated doc per run; never overwrite a prior review.
-- Pairs with `/product-review` (internal product lens) and `/roadmap-plan` (recommendations → issues).
+- Pairs with `/lib:product-review` (internal product lens) and `/plan` (recommendations → issues).

--- a/.claude/commands/lib/milestone-close.md
+++ b/.claude/commands/lib/milestone-close.md
@@ -1,11 +1,11 @@
 ---
-description: Close the active milestone — verify EPICs done, truth-pass docs, signed version tag, GitHub Release, rotate state/milestone.yaml active→history. The only sanctioned writer of milestone.yaml besides /milestone-new.
+description: Close the active milestone — verify EPICs done, truth-pass docs, signed version tag, GitHub Release, rotate state/milestone.yaml active→history. The only sanctioned writer of milestone.yaml besides /milestone open.
 argument-hint: "[--dry-run]  verify + report only, change nothing"
 ---
 
-# /milestone-close — Milestone Lifecycle: Close
+# /milestone close — Milestone Lifecycle: Close
 
-Close the active milestone end-to-end. This command (with `/milestone-new`) is the ONLY
+Close the active milestone end-to-end. This command (with `/milestone open`) is the ONLY
 sanctioned writer of `state/milestone.yaml` — every other command reads it.
 
 > **Destructive surface:** pushes a signed version tag and creates a public GitHub Release.
@@ -54,7 +54,7 @@ If `--dry-run`: print the verification result and STOP here.
 
 ## STEP 2 — Truth-pass all doc surfaces
 
-Run `/repo-clean` (plans first, executes on approval) to reconcile every status surface
+Run `/reconcile` (plans first, executes on approval) to reconcile every status surface
 (README / ROADMAP / ARCHITECTURE / CLAUDE / state / planning doc / canvases) to live GitHub
 state. Do not proceed until its PR is merged.
 
@@ -88,15 +88,15 @@ gh api -X PATCH "repos/{owner}/{repo}/milestones/${MILESTONE_NUMBER}" -f state=c
 Edit `state/milestone.yaml` (this command is a sanctioned writer):
 1. Prepend the active block to `history:` with `released: <today YYYY-MM-DD>`.
 2. Leave `active:` EMPTY of milestone content except a placeholder comment —
-   `/milestone-new` fills it. (If the next milestone is already decided, run
-   `/milestone-new` immediately after and let it write the block.)
+   `/milestone open` fills it. (If the next milestone is already decided, run
+   `/milestone open` immediately after and let it write the block.)
 3. Clear `open_epics`.
 4. Run `make validate-milestone-state` — must pass before committing.
 
 ## STEP 7 — Update state/current-milestone.md header
 
 Mark the closed milestone Complete with its version; note that the next milestone is not
-yet open (or hand off to `/milestone-new`).
+yet open (or hand off to `/milestone open`).
 
 ## STEP 8 — Commit + PR (never direct to main — ADR-023)
 
@@ -123,5 +123,5 @@ gh pr merge --squash
 Release:   <version> — <release URL>
 Milestone: <GitHub milestone URL> (closed)
 Config:    state/milestone.yaml rotated (PR #N merged)
-Next:      run /milestone-new to scaffold the next milestone.
+Next:      run /milestone open to scaffold the next milestone.
 ```

--- a/.claude/commands/lib/milestone-open.md
+++ b/.claude/commands/lib/milestone-open.md
@@ -1,11 +1,11 @@
 ---
-description: Scaffold the next milestone — GitHub milestone, planning doc skeleton, state/milestone.yaml active block. The only sanctioned writer of milestone.yaml besides /milestone-close.
+description: Scaffold the next milestone — GitHub milestone, planning doc skeleton, state/milestone.yaml active block. The only sanctioned writer of milestone.yaml besides /milestone close.
 argument-hint: "<name> <version> \"<title>\"  (next milestone per ROADMAP.md)"
 ---
 
-# /milestone-new — Milestone Lifecycle: Open
+# /milestone open — Milestone Lifecycle: Open
 
-Scaffold the next milestone. This command (with `/milestone-close`) is the ONLY sanctioned
+Scaffold the next milestone. This command (with `/milestone close`) is the ONLY sanctioned
 writer of `state/milestone.yaml` — every other command reads it.
 
 Inputs (from arguments; ask the operator if missing): short name (e.g. the next sequential
@@ -21,7 +21,7 @@ git fetch origin --prune && git checkout main && git pull --rebase origin main
 [ -z "$(git status --porcelain)" ] || { echo "dirty tree — STOP"; exit 1; }
 
 # The previous milestone must be rotated to history (active block empty/placeholder).
-# If /milestone-close has not run, STOP and run it first.
+# If /milestone close has not run, STOP and run it first.
 grep -A2 '^active:' state/milestone.yaml
 ```
 
@@ -100,5 +100,5 @@ gh pr merge --squash
 GitHub:   milestone #<number> + label "milestone: <name>"
 Planning: docs/milestones/<name>-planning.md (skeleton — fill EPIC table next)
 Config:   state/milestone.yaml active block written (PR #N merged)
-Next:     create EPIC issues, then /milestone-plan.
+Next:     create EPIC issues, then /deliver.
 ```

--- a/.claude/commands/lib/plan-infer.md
+++ b/.claude/commands/lib/plan-infer.md
@@ -3,31 +3,33 @@ description: SPDD-native roadmap planner — reads the whole repo (ROADMAP, arch
 argument-hint: "[--execute] [--area <scope>] [--max N]   default: PLAN only"
 ---
 
-# /roadmap-plan — SPDD-Native Roadmap Planner & Orchestration-Readiness Pass
+# /lib:plan-infer — Roadmap inference (building block of /plan)
 
-Answer the question **/milestone-plan cannot**: *what stories and fixes SHOULD exist for the
+> **Building block** — invoked by `/plan` (no-arg) to infer unfiled work, not run directly.\n> **Scope contract:** repo-wide by default; `--milestone M` filters.\n
+
+Answer the question **/deliver cannot**: *what stories and fixes SHOULD exist for the
 active milestone that don't yet* — then create them the SPDD way and leave the repo ready for
-`/milestone-orchestrate`.
+`/deliver`.
 
 ```
-/roadmap-plan  →  infer stories + fixes from the whole repo (this command)
-/milestone-plan        →  sequence the EXISTING issues into parallel batches
-/milestone-orchestrate →  deliver batches via expert subagents
-/milestone-learn       →  synthesize session learnings into expert guides
-/repo-clean            →  reconcile status surfaces to live state
-/milestone-close + /milestone-new →  advance to the next milestone
+/plan  →  infer stories + fixes from the whole repo (this command)
+/deliver        →  sequence the EXISTING issues into parallel batches
+/deliver →  deliver batches via expert subagents
+/learn       →  synthesize session learnings into expert guides
+/reconcile            →  reconcile status surfaces to live state
+/milestone close + /milestone open →  advance to the next milestone
 ```
 
-`/milestone-plan` sequences issues that already exist. **`/roadmap-plan` is the step before
+`/deliver` sequences issues that already exist. **`/plan` is the step before
 it** — it mines the repo for work that is implied but unfiled, files it correctly (SPDD for
 `feat:`), aligns the active milestone's canvases to their EPICs and issues, and runs a
-`/repo-clean` reconcile so the next `/milestone-orchestrate` starts from a true, complete state.
+`/reconcile` reconcile so the next `/deliver` starts from a true, complete state.
 
 > **This command is PLAN-by-default and read-mostly.** It prints a traceable plan and **stops**.
 > It mutates GitHub (creates issues, runs SPDD canvases/security-reviews, cross-links,
 > reconciles) **only** with `--execute` or an explicit "go" after the plan. It never edits
 > `AGENTS.md`, ADRs, or any `.claude/commands/**` file — refinements to those are *proposed*
-> into the human-gated `/milestone-learn` + `/repo-clean` loop (STEP 6).
+> into the human-gated `/learn` + `/reconcile` loop (STEP 6).
 
 > **Rules are not restated.** Domain + contribution rules live in [AGENTS.md](AGENTS.md),
 > [CLAUDE.md](CLAUDE.md), [docs/git-workflow.md](docs/git-workflow.md), and the SPDD guide
@@ -44,7 +46,7 @@ it** — it mines the repo for work that is implied but unfiled, files it correc
 - **Live GitHub state is the source of truth** — never memory, never a stale doc. Every decision
   is driven by `gh issue list` / `gh pr list` / `gh api .../milestones` and the files read fresh.
 - **SPDD for every `feat:`.** Inferred *capabilities* are never filed as bare issues. They go
-  through `/spdd-analysis` → `/spdd-story` → `/spdd-reasons-canvas` → `/spdd-security-review` →
+  through `/lib:spdd-analysis` → `/lib:spdd-story` → `/lib:spdd-canvas` → `/lib:spdd-security-review` →
   human aligns the canvas. `fix:` / `refactor:` / `docs:` / `test:` / `ci:` / `chore:` are
   SPDD-exempt and may be filed directly.
 - **Two phases.** PLAN (default) computes and prints; EXECUTE (`--execute` or "go") mutates.
@@ -56,7 +58,7 @@ it** — it mines the repo for work that is implied but unfiled, files it correc
   `Co-Authored-By` for AI); merge is **squash-only**; never disable signing; never push `main`
   directly; never write a literal `[skip ci]` token (write "skip-ci marker"). Use repo-relative
   paths in any committed markdown; never put a literal email in a `.claude/commands/**` file.
-- **Never writes `state/milestone.yaml`.** Only `/milestone-close` and `/milestone-new` may.
+- **Never writes `state/milestone.yaml`.** Only `/milestone close` and `/milestone open` may.
   When the active milestone is complete, this command *proposes* the transition and hands off.
 
 ---
@@ -69,8 +71,8 @@ Everything this command files follows the canonical shapes — no ad-hoc bodies.
   `feature_request.md` (`feat:`), `bug_report.md` (`fix:`/bug), `documentation.md` (`docs:`),
   `adr_proposal.md` (proposed ADR). Fill every template section; never freehand.
 - **PR body = [docs/contributing/pr-templates.md](docs/contributing/pr-templates.md)** (the
-  per-type skeleton), exactly as `/milestone-orchestrate` and `/issue-deliver` build it.
-- **Stories = `/spdd-story`** output (INVEST stories mapped to the Canvas O section) — never a
+  per-type skeleton), exactly as `/deliver` and `/deliver` build it.
+- **Stories = `/lib:spdd-story`** output (INVEST stories mapped to the Canvas O section) — never a
   bare issue for a `feat:` capability.
 - **Every issue, story, canvas, and PR carries a `## What for (user impact)` block** — see below.
 
@@ -109,14 +111,14 @@ Apply, in addition to `type:` / `area:` / `priority:` / `status:` / `milestone:`
 
 The full `product:` and `audience:` taxonomy lives in [docs/labels.md](docs/labels.md). In the
 EXECUTE phase, ensure each label exists before applying it (`gh label create … 2>/dev/null || true`,
-mirroring `/milestone-orchestrate` STEP 4).
+mirroring `/deliver` STEP 4).
 
 ---
 
 ## STEP 0 — Isolated worktree (leave the user's checkout untouched)
 
 Run all git/inference work in a throwaway worktree detached at `origin/main`, exactly like
-`/repo-clean` and `/milestone-orchestrate` do.
+`/reconcile` and `/deliver` do.
 
 ```bash
 RUN_ID="$(date +%s)-$$"
@@ -213,7 +215,7 @@ For every merged candidate:
    - Clearly a later milestone → label for that milestone (or leave milestone-less as backlog
      with a note). Never stuff out-of-scope work into the active milestone to pad it.
 4. **Attach to an EPIC.** If the active milestone organises work under EPICs, map each story to
-   its parent EPIC (so `/milestone-plan` can sequence it). A story with no EPIC for a milestone
+   its parent EPIC (so `/deliver` can sequence it). A story with no EPIC for a milestone
    that uses EPICs is itself a finding (propose an EPIC or a "misc" bucket).
 
 ---
@@ -235,13 +237,13 @@ done
 
 | Readiness check (per active-milestone EPIC) | Gap → action |
 |---|---|
-| A canvas exists at `docs/spdd/<N>-<slug>/canvas.md` | **missing** → `/spdd-reasons-canvas <N>` (EXECUTE phase) |
-| Canvas `Status:` reflects reality (`Draft`→`Aligned`→`Implemented`) | **stale** → fold into the `/repo-clean` reconcile (STEP 6) |
+| A canvas exists at `docs/spdd/<N>-<slug>/canvas.md` | **missing** → `/lib:spdd-canvas <N>` (EXECUTE phase) |
+| Canvas `Status:` reflects reality (`Draft`→`Aligned`→`Implemented`) | **stale** → fold into the `/reconcile` reconcile (STEP 6) |
 | Canvas **links to its GH issue** (`#<N>` in the canvas header) | **missing** → add the issue ref to the canvas |
 | GH issue **links back to the canvas** (`docs/spdd/<N>-…/canvas.md` in the issue body) | **missing** → `gh issue edit <N>` to add the canvas link |
-| A `docs/spdd/<N>-<slug>/SECURITY-REVIEW.md` exists and **PASSES** (feat EPICs) | **missing/FAIL** → `/spdd-security-review <canvas>` then resolve before align |
+| A `docs/spdd/<N>-<slug>/SECURITY-REVIEW.md` exists and **PASSES** (feat EPICs) | **missing/FAIL** → `/lib:spdd-security-review <canvas>` then resolve before align |
 | Canvas is `Aligned` before any implementation issue is `READY` | **not aligned** → human sets `Aligned` after security-review PASS |
-| Every EPIC O-step has a story issue | **missing** → `/spdd-story <N>` to decompose |
+| Every EPIC O-step has a story issue | **missing** → `/lib:spdd-story <N>` to decompose |
 
 The output of this step is the precise SPDD action list that makes the active milestone
 orchestrate-ready: which EPICs need a canvas, which need stories, which need a security-review,
@@ -254,7 +256,7 @@ which need cross-links, which need an align.
 Print one traceable plan and wait for "go" (unless `--execute`).
 
 ```
-## /roadmap-plan — <date>, active milestone <NAME> "<TITLE>" (#<num>, <version>)
+## /plan — <date>, active milestone <NAME> "<TITLE>" (#<num>, <version>)
 
 ### Milestone fill status
   EPICs: <done>/<total> complete · open EPICs without stories: #…, #…
@@ -264,7 +266,7 @@ Print one traceable plan and wait for "go" (unless `--execute`).
 ### Proposed stories (SPDD — feat:) — into <NAME>
 | candidate | EPIC | SPDD actions needed | evidence |
 |-----------|------|---------------------|----------|
-| feat(engine-adapter): … | #1167 | /spdd-story → /spdd-reasons-canvas → /spdd-security-review → align | review §16 G8 |
+| feat(engine-adapter): … | #1167 | /lib:spdd-story → /lib:spdd-canvas → /lib:spdd-security-review → align | review §16 G8 |
 
 ### Proposed issues (SPDD-exempt — fix/refactor/docs/test/ci/chore) — into <NAME>
 | # (new) | type(scope): title | evidence | labels |
@@ -281,7 +283,7 @@ Print one traceable plan and wait for "go" (unless `--execute`).
 |------|--------|-----------|-----------|-----------------|-------|--------|
 
 ### Repo-clean delta (run after the above)
-  <surfaces that will disagree once issues are created — handed to /repo-clean>
+  <surfaces that will disagree once issues are created — handed to /reconcile>
 
 ### Drift-prevention proposals (propose-only → APPLY_LOG.md / guardrails)
 | pattern | recurrence | proposed guardrail (CI gate / command-step / expert rule) |
@@ -291,7 +293,7 @@ Print one traceable plan and wait for "go" (unless `--execute`).
 | candidate | suggested milestone | why deferred |
 
 ### Handoff
-  After --execute: run /milestone-plan, then /milestone-orchestrate.
+  After --execute: run /deliver, then /deliver.
 ```
 
 ---
@@ -319,12 +321,12 @@ cross-link before align; reconcile last.
 2. **feat: stories — SPDD path only.** For each feat EPIC/story gap, invoke the SPDD skills
    (against the real checkout, not this `/tmp` worktree — they manage their own git):
    ```
-   /spdd-analysis <issue-or-epic>      # research, risk table, Tier-2 flags
-   /spdd-story <epic>                  # decompose into INVEST stories (→ Canvas O section)
-   /spdd-reasons-canvas <epic>         # create docs/spdd/<N>-<slug>/canvas.md (Status: Draft)
-   /spdd-security-review <canvas>      # Tier-2 scan — MUST PASS before align
+   /lib:spdd-analysis <issue-or-epic>      # research, risk table, Tier-2 flags
+   /lib:spdd-story <epic>                  # decompose into INVEST stories (→ Canvas O section)
+   /lib:spdd-canvas <epic>         # create docs/spdd/<N>-<slug>/canvas.md (Status: Draft)
+   /lib:spdd-security-review <canvas>      # Tier-2 scan — MUST PASS before align
    ```
-   Then **stop for the human to set `Status: Aligned`** — `/spdd-generate` refuses an unaligned
+   Then **stop for the human to set `Status: Aligned`** — `/lib:spdd-generate` refuses an unaligned
    canvas by design, and alignment is a human decision (CLAUDE.md SPDD rule).
 3. **Cross-link canvas ⇄ issue** for every gap from STEP 4:
    ```bash
@@ -335,19 +337,19 @@ cross-link before align; reconcile last.
    # canvas → issue: add the `Issue: #<N>` line to the canvas header (edit + commit in the PR below)
    ```
 4. **Security-review** any feat canvas missing a PASSing `SECURITY-REVIEW.md` (step 2's
-   `/spdd-security-review`); resolve findings before the canvas is aligned.
+   `/lib:spdd-security-review`); resolve findings before the canvas is aligned.
 5. **Drift-prevention + command/expert refinements — propose only.** Write each recurring-pattern
    guardrail and any milestone-command refinement as a **PENDING** row in
    [docs/ai-learnings/APPLY_LOG.md](docs/ai-learnings/APPLY_LOG.md) (category `domain` /
    `env-constraint`), and surface it in the report. **Never** auto-edit `experts/*`,
-   `milestone-*.md`, `AGENTS.md`, or ADRs — the human applies via `/milestone-learn --apply`
-   (expert files) or a deliberate command-file PR (CODEOWNERS-gated). This is how `/repo-clean`'s
+   `milestone-*.md`, `AGENTS.md`, or ADRs — the human applies via `/learn --apply`
+   (expert files) or a deliberate command-file PR (CODEOWNERS-gated). This is how `/reconcile`'s
    reconcile rules migrate into CI gates / command guardrails over time, so drift stops at the
-   source and `/repo-clean` is eventually needed only after big context-losing crashes.
-6. **Reconcile (`/repo-clean`).** Once issues exist and canvases are linked, the status surfaces
-   are stale by construction. Run `/repo-clean` to bring README/ROADMAP/ARCHITECTURE/CLAUDE/
+   source and `/reconcile` is eventually needed only after big context-losing crashes.
+6. **Reconcile (`/reconcile`).** Once issues exist and canvases are linked, the status surfaces
+   are stale by construction. Run `/reconcile` to bring README/ROADMAP/ARCHITECTURE/CLAUDE/
    state/planning/canvas surfaces back to live state and dedup-triage any `[AUTO]` noise — leaving
-   the repo "as repo-clean as possible". Let `/repo-clean` own its own PR; don't fold it here.
+   the repo "as repo-clean as possible". Let `/reconcile` own its own PR; don't fold it here.
 7. **Commit canvas/back-link edits** made in this worktree as one `docs:`/`chore:` PR (DCO `-s` +
    `Assisted-by`), squash-merge on the human's call.
 
@@ -359,19 +361,19 @@ After the fill pass, re-assess the active milestone against its exit criteria
 (`$PLANNING_DOC` + `state/current-milestone.md`):
 
 - **FILLING** (open EPICs, unmet exit criteria, or stories just created): report the
-  orchestrate-ready batch and recommend `/milestone-plan` → `/milestone-orchestrate`. Re-run
-  `/roadmap-plan` after the next delivery wave to keep filling.
+  orchestrate-ready batch and recommend `/deliver` → `/deliver`. Re-run
+  `/plan` after the next delivery wave to keep filling.
 - **COMPLETE** (all EPIC stories merged, exit criteria met, `gh` milestone has 0 open issues):
   do **not** create filler. **Propose the transition** (never execute it here):
   ```
   ## Active milestone <NAME> appears COMPLETE
     - Exit criteria: all met (cite each).
-    - Recommended: /milestone-close   (tag <version>, GitHub Release, rotate milestone.yaml)
-    - Then:        /milestone-new      (scaffold the next milestone + planning doc + active block)
+    - Recommended: /milestone close   (tag <version>, GitHub Release, rotate milestone.yaml)
+    - Then:        /milestone open      (scaffold the next milestone + planning doc + active block)
     - Next milestone candidates inferred from ROADMAP/backlog: <list with rationale>
   ```
-  `/milestone-close` and `/milestone-new` are the **only** sanctioned writers of
-  `state/milestone.yaml`. `/roadmap-plan` stops at the proposal.
+  `/milestone close` and `/milestone open` are the **only** sanctioned writers of
+  `state/milestone.yaml`. `/plan` stops at the proposal.
 
 ---
 
@@ -386,7 +388,7 @@ for c in docs/spdd/*/canvas.md; do grep -Hm1 -E 'Issue:|#[0-9]+' "$c"; done
 
 Report: stories created (via SPDD) + issues created (direct), with numbers; canvas/issue
 cross-links added; security-reviews run + status; drift/refinement proposals written to
-APPLY_LOG (count, PENDING); the `/repo-clean` result; and the milestone verdict (FILLING with
+APPLY_LOG (count, PENDING); the `/reconcile` result; and the milestone verdict (FILLING with
 the next orchestrate batch, or COMPLETE with the advance proposal).
 
 ```bash
@@ -415,10 +417,10 @@ cd "$REPO" && git worktree remove "$WT" --force 2>/dev/null || true
 
 | Stage | Command | This command's role |
 |-------|---------|---------------------|
-| Infer unfiled work | **`/roadmap-plan`** | mine repo → SPDD-file stories + fixes into active milestone |
-| Make orchestrate-ready | **`/roadmap-plan`** STEP 4–6 | canvas⇄issue⇄security-review align + `/repo-clean` |
-| Sequence existing issues | `/milestone-plan` | (downstream) parallel batches |
-| Deliver | `/milestone-orchestrate`, `/issue-deliver` | (downstream) |
-| Synthesize learnings | `/milestone-learn` | this command *proposes* refinements into its APPLY_LOG |
-| Reconcile surfaces | `/repo-clean` | invoked in STEP 6; this command feeds it guardrail proposals to make it eventually unnecessary |
-| Advance milestone | `/milestone-close` + `/milestone-new` | this command *proposes* the transition in STEP 7; never executes it |
+| Infer unfiled work | **`/plan`** | mine repo → SPDD-file stories + fixes into active milestone |
+| Make orchestrate-ready | **`/plan`** STEP 4–6 | canvas⇄issue⇄security-review align + `/reconcile` |
+| Sequence existing issues | `/deliver` | (downstream) parallel batches |
+| Deliver | `/deliver`, `/deliver` | (downstream) |
+| Synthesize learnings | `/learn` | this command *proposes* refinements into its APPLY_LOG |
+| Reconcile surfaces | `/reconcile` | invoked in STEP 6; this command feeds it guardrail proposals to make it eventually unnecessary |
+| Advance milestone | `/milestone close` + `/milestone open` | this command *proposes* the transition in STEP 7; never executes it |

--- a/.claude/commands/lib/product-review.md
+++ b/.claude/commands/lib/product-review.md
@@ -3,7 +3,7 @@ description: Generate a dated product-strategy review document grounded in the l
 argument-hint: "[--pr] [--since <prev-review-path>]   default: working draft, no PR"
 ---
 
-# /product-review — Product Strategy Review Document Generator
+# /lib:product-review — Product Strategy Review Document Generator
 
 Produce a point-in-time product-strategy review as a **dated document** under
 [docs/product/](docs/product/), building on the living
@@ -71,7 +71,7 @@ Write `$OUT` (SPDX header first; repo-relative links only):
 6. **Beachhead validation** — is the hero use case (agentic SW-engineering automation) holding?
    Evidence from shipped examples / real workflows.
 7. **Recommendations (prioritized)** — each classified by **user type** (developer/operator/
-   maintainer/product-owner/zynax-user/enterprise) and **adoption lever**, so `/roadmap-plan` can
+   maintainer/product-owner/zynax-user/enterprise) and **adoption lever**, so `/plan` can
    file them with the right `product:` / `audience:` labels + `## What for (user impact)` block.
 8. **Longitudinal delta** — prior recommendations → closed / open, with the PR/issue that moved them.
 9. **Appendix** — sources + glossary.
@@ -103,7 +103,7 @@ leave merge to the human unless they say "go".
 - **Ground everything; no invented numbers.** Mark shipped/partial/aspirational. Pull adoption
   metrics live from `gh`, not memory.
 - **Longitudinal.** Always diff against the prior review / `strategy.md`; record what moved.
-- **Recommendations carry user-type + adoption-lever annotations** (the `/roadmap-plan` handoff).
+- **Recommendations carry user-type + adoption-lever annotations** (the `/plan` handoff).
 - **Read-only on the product under review.** One dated doc per run; never overwrite a prior review.
 - Commit (with `--pr`): `docs:` type, DCO `-s`, `Assisted-by`, signed, squash-merge.
-- Pairs with `/roadmap-plan` (recommendations → issues) and `/market-fit-review` (competitive/TAM depth).
+- Pairs with `/plan` (recommendations → issues) and `/lib:market-fit-review` (competitive/TAM depth).

--- a/.claude/commands/lib/security-review-doc.md
+++ b/.claude/commands/lib/security-review-doc.md
@@ -1,15 +1,15 @@
 ---
-description: Generate a dated security-posture review DOCUMENT grounded in the live repo — auth/mTLS/transport, input validation, supply-chain (SBOM/cosign/SLSA), dependency + code-scanning alerts, container hardening, CNCF security criteria — with severity-rated findings, tracked longitudinally. Public doc carries mitigations/status only; unfixed-vuln exploit detail goes to a gitignored .private.md. NOT a diff review (that is the built-in /security-review and /spdd-security-review).
+description: Generate a dated security-posture review DOCUMENT grounded in the live repo — auth/mTLS/transport, input validation, supply-chain (SBOM/cosign/SLSA), dependency + code-scanning alerts, container hardening, CNCF security criteria — with severity-rated findings, tracked longitudinally. Public doc carries mitigations/status only; unfixed-vuln exploit detail goes to a gitignored .private.md. NOT a diff review (that is the built-in /security-review and /lib:spdd-security-review).
 argument-hint: "[--pr] [--since <prev-review-path>]   default: working draft, no PR"
 ---
 
-# /security-review-doc — Security Posture Review Document Generator
+# /lib:security-review-doc — Security Posture Review Document Generator
 
 Produce a point-in-time **security posture review** as a dated document, in the shape of the
 security sections of [docs/architecture/2026-05-20-principal-architect-review.md](docs/architecture/2026-05-20-principal-architect-review.md).
 
 > **Not to be confused with:** the built-in `/security-review` (reviews the current diff) or
-> `/spdd-security-review` (Tier-2 canvas scan before a `feat:` commit). This command writes a
+> `/lib:spdd-security-review` (Tier-2 canvas scan before a `feat:` commit). This command writes a
 > standing **posture document** about the whole system, like an architecture review.
 
 > **Public-safe by construction (Tier 1).** The committed doc states **findings by severity,
@@ -78,7 +78,7 @@ Write `$OUT` (public, SPDX header, repo-relative links). Findings table is the c
 5. **CNCF security criteria** — met vs gap (from the review's §14-style table).
 6. **Longitudinal delta vs `$PREV`** — each prior finding → fixed / mitigated / still-open, with PR/issue.
 7. **Prioritized remediations** — Critical/High, annotated with **user type** (esp. operator /
-   enterprise) + adoption lever, so `/roadmap-plan` files them with the right `product:`/`audience:`
+   enterprise) + adoption lever, so `/plan` files them with the right `product:`/`audience:`
    labels + `## What for (user impact)` block. Map to existing issues where present.
 8. **Appendix** — sources.
 
@@ -109,5 +109,5 @@ git -C "$WT" add "$OUT"          # NEVER: git add -A  (would stage the private f
   open/mitigated/fixed honestly. No invented severities.
 - **Longitudinal.** Diff against the prior security review; record what was fixed.
 - **Read-only on the system.** One dated public doc (+ optional private sibling) per run.
-- Pairs with `/roadmap-plan` (remediations → issues), the built-in `/security-review` (diff), and
-  `/spdd-security-review` (canvas Tier-2 gate) — distinct, complementary tools.
+- Pairs with `/plan` (remediations → issues), the built-in `/security-review` (diff), and
+  `/lib:spdd-security-review` (canvas Tier-2 gate) — distinct, complementary tools.

--- a/.claude/commands/lib/sequence.md
+++ b/.claude/commands/lib/sequence.md
@@ -1,12 +1,14 @@
 ---
-description: Milestone delivery planner — reads live GitHub + canvas state, computes dependency-aware parallel groups, and outputs /issue-deliver commands to run. Respects in-progress issues across all machines.
+description: Milestone delivery planner — reads live GitHub + canvas state, computes dependency-aware parallel groups, and outputs /deliver commands to run. Respects in-progress issues across all machines.
 argument-hint: "[--verbose]"
 ---
 
-# /milestone-plan — Milestone Delivery Planner
+# /lib:sequence — Dependency-aware delivery planner (building block of /deliver)
+
+> **Building block** — invoked by `/deliver` to sequence ready work, not run directly.\n> **Scope contract:** repo-wide `status: ready` work by default; `--milestone M` filters.\n
 
 Read the active milestone's live state, build a dependency graph, detect in-progress sessions on any machine,
-and output the next set of `/issue-deliver` commands to run — in parallel where safe,
+and output the next set of `/deliver` commands to run — in parallel where safe,
 sequentially where dependencies require it.
 
 > **This command is read-only.** It never writes code, creates branches, or modifies issues.
@@ -22,7 +24,7 @@ git checkout main && git pull --rebase origin main 2>/dev/null || true
 
 # ── Active-milestone config (SSoT: state/milestone.yaml) ────────────────────
 # Loaded at runtime; no milestone name, number, or label is hardcoded in this
-# file. Updated only by /milestone-close and /milestone-new.
+# file. Updated only by /milestone close and /milestone open.
 CFG=state/milestone.yaml
 MILESTONE_NAME=$(awk '/^active:/{f=1} f && /^  name:/{print $2; exit}' "$CFG")
 MILESTONE_TITLE=$(awk -F'"' '/^active:/{f=1} f && /^  title:/{print $2; exit}' "$CFG")
@@ -112,7 +114,7 @@ for CANVAS in docs/spdd/*/canvas.md; do
 done
 ```
 
-For EPICs with canvas `Status: Draft` or no canvas at all, `/issue-deliver` will run the SPDD
+For EPICs with canvas `Status: Draft` or no canvas at all, `/deliver` will run the SPDD
 pipeline automatically — but note them as "canvas work needed" in the plan output.
 
 ---
@@ -145,14 +147,14 @@ Produce output in this format:
   ...
 
 ## READY — Parallel batch 1 (run simultaneously in separate terminals)
-  Terminal 1:  /issue-deliver NNN   # <commit-type>(<scope>): <title>
-  Terminal 2:  /issue-deliver NNN   # <commit-type>(<scope>): <title>
-  Terminal 3:  /issue-deliver NNN   # <commit-type>(<scope>): <title>
+  Terminal 1:  /deliver NNN   # <commit-type>(<scope>): <title>
+  Terminal 2:  /deliver NNN   # <commit-type>(<scope>): <title>
+  Terminal 3:  /deliver NNN   # <commit-type>(<scope>): <title>
 
   Note: Batch 2 becomes available once Batch 1 issues are closed.
 
 ## READY — Parallel batch 2 (run after batch 1 completes)
-  /issue-deliver NNN   # depends on #NNN from batch 1
+  /deliver NNN   # depends on #NNN from batch 1
 
 ## BLOCKED — waiting on dependencies
   #NNN  <title>  [blocked by: #NNN (<title>)]
@@ -162,9 +164,9 @@ Produce output in this format:
   #NNN  <title>  [blocked by: <description of blocker>]
   ...
 
-## Canvas work needed (run before /issue-deliver for these EPICs)
-  EPIC #NNN: no canvas → /issue-deliver NNN will auto-create it
-  EPIC #NNN: canvas Status: Draft → /issue-deliver NNN will auto-align it
+## Canvas work needed (run before /deliver for these EPICs)
+  EPIC #NNN: no canvas → /deliver NNN will auto-create it
+  EPIC #NNN: canvas Status: Draft → /deliver NNN will auto-align it
   ...
 
 ## EPIC completion summary
@@ -217,28 +219,28 @@ Example output:
 ```
 ## Recommended next action
 Run the following in 3 parallel terminals (all independent):
-  Terminal 1:  /issue-deliver 859
-  Terminal 2:  /issue-deliver 868
-  Terminal 3:  /issue-deliver 874
+  Terminal 1:  /deliver 859
+  Terminal 2:  /deliver 868
+  Terminal 3:  /deliver 874
 
-Then: once #868 closes, run /issue-deliver 865 (GHCR hygiene chain).
+Then: once #868 closes, run /deliver 865 (GHCR hygiene chain).
 ```
 
 ---
 
-## Shared-state contract with /issue-deliver
+## Shared-state contract with /deliver
 
 | Event | Who updates | What changes |
 |-------|-------------|-------------|
-| Session starts on issue N | `/issue-deliver` | Adds `status: in-progress` label + self-assign |
-| Branch pushed (hard claim) | `/issue-deliver` | Remote branch `<type>/<N>-*` appears |
-| PR opened | `/issue-deliver` | Open PR with headRefName `<type>/<N>-*` |
-| CI completes + PR merged | `/issue-deliver` | PR closed, issue closed, branch deleted, label removed |
+| Session starts on issue N | `/deliver` | Adds `status: in-progress` label + self-assign |
+| Branch pushed (hard claim) | `/deliver` | Remote branch `<type>/<N>-*` appears |
+| PR opened | `/deliver` | Open PR with headRefName `<type>/<N>-*` |
+| CI completes + PR merged | `/deliver` | PR closed, issue closed, branch deleted, label removed |
 | Session crashes mid-run | Manual cleanup | Remove `status: in-progress` label; delete stale branch |
 
-`/milestone-plan` reads all three signals (label + branch + PR) to detect in-progress work. The **branch**
+`/deliver` reads all three signals (label + branch + PR) to detect in-progress work. The **branch**
 is the authoritative hard claim; the **label** is a soft signal visible before any branch push.
-Because label assignment is not atomic with branch push, `/milestone-plan` always cross-checks both.
+Because label assignment is not atomic with branch push, `/deliver` always cross-checks both.
 
 ---
 

--- a/.claude/commands/lib/spdd-analysis.md
+++ b/.claude/commands/lib/spdd-analysis.md
@@ -1,4 +1,4 @@
-# /spdd-analysis
+# /lib:spdd-analysis
 
 Scan the codebase for context relevant to a feature, extract domain keywords, surface risks, and produce a structured analysis ready for Canvas generation.
 

--- a/.claude/commands/lib/spdd-api-test.md
+++ b/.claude/commands/lib/spdd-api-test.md
@@ -1,4 +1,4 @@
-# /spdd-api-test
+# /lib:spdd-api-test
 
 Generate functional test scripts for a feature based on its REASONS Canvas definition of done.
 

--- a/.claude/commands/lib/spdd-canvas.md
+++ b/.claude/commands/lib/spdd-canvas.md
@@ -1,17 +1,17 @@
-# /spdd-reasons-canvas
+# /lib:spdd-canvas
 
-Generate a complete REASONS Canvas from prior /spdd-analysis output. Produces a canvas.md file ready for human alignment review.
+Generate a complete REASONS Canvas from prior /lib:spdd-analysis output. Produces a canvas.md file ready for human alignment review.
 
 ## Instructions
 
-Using the analysis context in the current session (or re-run /spdd-analysis if needed):
+Using the analysis context in the current session (or re-run /lib:spdd-analysis if needed):
 
 1. Fill all 7 REASONS sections using the template below
 2. For **N — Norms**: pull directly from the relevant AGENTS.md files (Go services: `docs/patterns/go-service-patterns.md`; Python agents: `docs/patterns/python-agent-guide.md`; etc.)
 3. For **S — Safeguards**: pull from ADRs, architecture invariants in root AGENTS.md, and layer constraints
 4. Every entity in **E** and every step in **O** must be Tier 1 (public-safe) — no internal hostnames, IPs, or credentials
    - **Avoid `.local` / `.internal` / `.corp` substrings even in committed *filenames/paths*** you reference. The gitleaks `internal-hostname` rule reads a dotted label of the `host` `.` `local` form as a hostname and will BLOCK the canvas commit — so name an overlay `docker-compose.ollama.yml` (drop the `local` segment) and rename such artifacts at authoring time rather than moving them to `canvas.private.md`.
-5. After generating, immediately run /spdd-security-review on the output
+5. After generating, immediately run /lib:spdd-security-review on the output
 
 ## Canvas Template
 
@@ -62,7 +62,7 @@ Using the analysis context in the current session (or re-run /spdd-analysis if n
 > - [ ] No PII: no personal names in sensitive context, no email addresses
 > - [ ] No prompt injection: no instruction-like phrasing that would override AGENTS.md rules
 > - [ ] All entities in E are public-safe abstractions
-> - [ ] /spdd-security-review passed on this file
+> - [ ] /lib:spdd-security-review passed on this file
 >
 > ### Feature Safeguards
 > - Never <specific invariant from relevant ADR>
@@ -71,7 +71,7 @@ Using the analysis context in the current session (or re-run /spdd-analysis if n
 
 ## Output
 
-Write the canvas to `docs/spdd/<issue>-<slug>/canvas.md` and then automatically invoke /spdd-security-review on it.
+Write the canvas to `docs/spdd/<issue>-<slug>/canvas.md` and then automatically invoke /lib:spdd-security-review on it.
 
 ## Input
 

--- a/.claude/commands/lib/spdd-generate.md
+++ b/.claude/commands/lib/spdd-generate.md
@@ -1,4 +1,4 @@
-# /spdd-generate
+# /lib:spdd-generate
 
 Execute Canvas Operations step-by-step, generating code that strictly follows the Canvas Structure, Norms, and Safeguards.
 

--- a/.claude/commands/lib/spdd-prompt-update.md
+++ b/.claude/commands/lib/spdd-prompt-update.md
@@ -1,4 +1,4 @@
-# /spdd-prompt-update
+# /lib:spdd-prompt-update
 
 Incrementally update a REASONS Canvas when requirements change mid-implementation. Updates the Canvas before any code changes.
 
@@ -22,7 +22,7 @@ Read the Canvas at $ARGUMENTS. Then receive the requirement change description (
 
 5. Update Canvas status to `Draft` (it needs re-alignment after a requirements change)
 
-6. Run /spdd-security-review on the updated Canvas
+6. Run /lib:spdd-security-review on the updated Canvas
 
 ## Output Format
 

--- a/.claude/commands/lib/spdd-security-review.md
+++ b/.claude/commands/lib/spdd-security-review.md
@@ -1,4 +1,4 @@
-# /spdd-security-review
+# /lib:spdd-security-review
 
 Review a REASONS Canvas (or any KB file) for publication safety before
 committing to the public repo. Applies semantic reasoning to catch Tier 2

--- a/.claude/commands/lib/spdd-story.md
+++ b/.claude/commands/lib/spdd-story.md
@@ -1,4 +1,4 @@
-# /spdd-story
+# /lib:spdd-story
 
 Break a raw feature description or GitHub issue into INVEST-compliant user stories,
 then create one GitHub issue per story as a child of the parent epic.
@@ -19,7 +19,7 @@ Read the feature description or GitHub issue provided in $ARGUMENTS.
    - **T**estable: has clear, verifiable acceptance criteria
 5. **Idempotency guard — never create duplicate stories.** Before creating anything,
    check whether the parent epic already has child issues (an epic created via
-   `/spdd-analysis`→issue-filing, or a re-run of this command, often already has them):
+   `/lib:spdd-analysis`→issue-filing, or a re-run of this command, often already has them):
    - `gh issue list --search "<parent-#> in:body" --state all` and read the epic body's
      task-list / checklist for existing `#refs`.
    - If children already exist, **do NOT create new issues.** Instead: validate each

--- a/.claude/commands/lib/spdd-sync.md
+++ b/.claude/commands/lib/spdd-sync.md
@@ -1,4 +1,4 @@
-# /spdd-sync
+# /lib:spdd-sync
 
 Synchronise a REASONS Canvas with the current code after refactoring. Updates the Canvas to reflect implementation reality without changing logic.
 
@@ -14,11 +14,11 @@ Read the Canvas at $ARGUMENTS. Then read the implementation files listed in the 
 
 2. For each discrepancy, propose a Canvas update that documents the current reality
 
-3. Do NOT change R (Requirements), A (Approach), or S (Safeguards) — those reflect intent, not implementation details. If they need to change, use /spdd-prompt-update instead.
+3. Do NOT change R (Requirements), A (Approach), or S (Safeguards) — those reflect intent, not implementation details. If they need to change, use /lib:spdd-prompt-update instead.
 
 4. Update Canvas status to `Synced` when complete
 
-5. This command is ONLY for non-behavioural changes (refactoring). If the logic changed, use /spdd-prompt-update first.
+5. This command is ONLY for non-behavioural changes (refactoring). If the logic changed, use /lib:spdd-prompt-update first.
 
 ## Output Format
 

--- a/.claude/commands/milestone.md
+++ b/.claude/commands/milestone.md
@@ -1,0 +1,32 @@
+---
+description: Release-lifecycle command (the only milestone-aware one). `open` scaffolds the next milestone; `close` verifies done, tags a signed version, publishes a release, and rotates state/milestone.yaml. No-arg prints current milestone status (read-only). Everything else in this command set is milestone-agnostic and uses an optional --milestone filter instead.
+argument-hint: "[open <name> <version> \"<title>\" | close [--dry-run]]   default: print status"
+---
+
+# /milestone — open · close · status
+
+Milestones are **optional** in this command set — `/plan` and `/deliver` work repo-wide and treat
+`--milestone` as a filter. This single command is the one place milestones are first-class: it owns
+the **release lifecycle** and is (with nothing else) the sole writer of `state/milestone.yaml`.
+
+## Parse `$ARGUMENTS`
+
+- **no argument** → print the current milestone status: read `state/milestone.yaml` + `state/current-milestone.md`
+  and the live GitHub milestone counts. Read-only.
+- **`open <name> <version> "<title>"`** → `/lib:milestone-open` — create the GitHub milestone, scaffold
+  the planning doc skeleton, and fill the `active` block of `state/milestone.yaml`.
+- **`close [--dry-run]`** → `/lib:milestone-close` — verify every EPIC is done, cut a **signed** version
+  tag, publish the GitHub Release, and rotate the active milestone into `history` in `state/milestone.yaml`.
+
+## Process note (changed)
+`close` no longer auto-runs the repo truth-pass. Before closing, it will **suggest** running
+`/reconcile` to reconcile status surfaces and prune branches — but reconciliation is now an
+on-demand action, not an automatic step in the lifecycle.
+
+## Guardrails
+- Only `/milestone open` and `/milestone close` write `state/milestone.yaml` — never edit it by hand.
+- `close` requires an active milestone whose exit criteria are met; `--dry-run` reports readiness
+  without tagging or rotating.
+- Tagging uses signed tags; never disable signing.
+
+See `.claude/commands/README.md`.

--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -1,0 +1,57 @@
+---
+description: From an idea, prompt, issue, or epic to an aligned REASONS Canvas with linked issues — runs the SPDD pipeline (analysis → story → canvas → security-review), aligns the canvas, and links issues↔canvas so the cluster is orchestrate-ready. No-arg infers unfiled/ready work from the repo. Milestone-agnostic; --milestone is an optional filter. PLAN by default; mutations gated by --execute.
+argument-hint: "[\"prompt\" | #issue | #epic] [--milestone M] [--execute]   default: infer + PLAN, no mutations"
+---
+
+# /plan — idea → aligned canvas + linked issues
+
+Turn *what you need* into a committed, security-reviewed, **Aligned** REASONS Canvas with linked
+GitHub issues, ready for `/deliver`. This is the single front door for the SPDD pipeline — it
+composes the `lib:spdd-*` building blocks so you don't run them by hand.
+
+> **Safe by default.** With no `--execute`, this only researches, drafts, and proposes — it prints
+> the plan (issues it would create, the canvas it would write) and **mutates nothing**. Re-run with
+> `--execute` (or say "go") to file issues, commit the canvas, and link everything.
+
+## Parse `$ARGUMENTS`
+
+- **free-text prompt** (e.g. `/plan "let users try Zynax with no clone"`) → a NEW idea. Draft an epic
+  from it (use the Epic issue template framing: *the one question this answers* + product/adoption
+  impact), then run the pipeline below.
+- **`#<number>`** → an existing issue/epic. Run the pipeline for it.
+- **no argument** → **infer** unfiled/ready work from the repo (delegate to `/lib:plan-infer`) and
+  propose canvases for the highest-value gaps. PLAN only unless `--execute`.
+- **`--milestone M`** → optional filter/assignment (otherwise milestone-agnostic; work from repo state).
+- **`--execute`** → perform the mutations (file issues, commit canvas, link, label).
+
+## Pipeline (the same decision tree, fewer commands)
+
+For a prompt/issue/epic target, run the building blocks in order and stop on any blocker:
+
+1. `/lib:spdd-analysis <target>` — research: codebase scan, ADRs, risk table, Tier 2 flags.
+2. `/lib:spdd-story <target>` — decompose into INVEST stories. **Idempotency guard:** if the epic
+   already has child issues, reconcile/validate them — never create duplicates.
+3. `/lib:spdd-canvas <target>` — generate `docs/spdd/<issue>-<slug>/canvas.md` (Status: Draft),
+   using `docs/spdd/CANVAS_TEMPLATE.md`. Keep it Tier 1; move sensitive context to `canvas.private.md`.
+4. `/lib:spdd-security-review <canvas>` — must return **PASS** before the canvas is committed
+   (no Tier 2 content, no injection, no abstraction leaks). Avoid `.local`/`.internal`/`.corp` in
+   any referenced filename (gitleaks `internal-hostname` BLOCKs the commit — rename the artifact).
+5. **Align + link** (with `--execute`): set the canvas `Status: Aligned`; map every Operations step
+   1:1 to a story issue; back-link the canvas path + step into each issue; label stories
+   `status: ready`; put `spdd: canvas` on the epic; assign `--milestone M` if given. Leave the
+   cluster orchestrate-ready for `/deliver`.
+
+If requirements change later, run `/lib:spdd-prompt-update <canvas>` (prompt-first rule: update the
+Canvas, which resets it to Draft and re-runs the security review — never patch code first).
+
+## Output
+
+- **PLAN mode (default):** the proposed epic/stories, the canvas outline, the link/label plan — and
+  an explicit "re-run with `--execute` to apply" line.
+- **`--execute`:** issue numbers created/reconciled, the committed canvas path, the links applied,
+  and the exact `/deliver` command to run next.
+
+## Norms
+Conventional commits (feat/fix/refactor/docs/test/ci/chore) · DCO `Signed-off-by` + `Assisted-by:
+Claude/<model>` (never `Co-Authored-By` for AI) · canvas committed before any implementation code
+(ADR-019) · new `.claude/commands` files need `git add -f`. Full guide: `.claude/commands/README.md`.

--- a/.claude/commands/reconcile.md
+++ b/.claude/commands/reconcile.md
@@ -1,9 +1,14 @@
 ---
 description: Truth-pass for the repo — reconcile every status surface (README/ROADMAP/ARCHITECTURE/CLAUDE/state/milestone-planning/SPDD canvases) to LIVE GitHub state, triage the pile of [AUTO] pipeline issues (digest-drift / smoke / size / security), close stale issues with traceable reasons, and prune merged/orphaned branches (local + remote) to keep the repo clean. Plans first, executes only on approval, delivers file changes via one signed PR.
-argument-hint: "[--execute] [--include-stale] [--milestone M6]   default: PLAN only, no --include-stale"
+argument-hint: "[--execute] [--include-stale] [--milestone M]   default: PLAN only, no --include-stale"
 ---
 
-# /repo-clean — Repository Truth-Pass & Clean Snapshot
+# /reconcile — Repository Truth-Pass & Clean Snapshot
+
+> **On-demand only.** Run this to **recover from a failed/interrupted run** (stalled or BEHIND PRs,
+> orphaned worktrees, half-finished deliveries) and to **clean the repo** (reconcile status surfaces,
+> triage [AUTO] issues, prune merged/orphaned branches). It is no longer auto-invoked by other
+> commands. Recovery: detect in-flight breakage and offer to rebase/finish/clean before the truth-pass.
 
 Bring every artifact the agents and humans rely on into agreement with the **actual** state of the
 repository — then leave it well-linked and traceable. This is a *truth-pass*, not a refactor.
@@ -20,7 +25,7 @@ repository — then leave it well-linked and traceable. This is a *truth-pass*, 
 
 > **Rules are not restated.** Domain and contribution rules live in [AGENTS.md](AGENTS.md),
 > [CLAUDE.md](CLAUDE.md), and [docs/git-workflow.md](docs/git-workflow.md). The reconcile logic
-> mirrors [.claude/commands/issue-deliver.md](.claude/commands/issue-deliver.md) STEP 6.
+> mirrors [.claude/commands/lib/deliver-one.md](.claude/commands/lib/deliver-one.md) STEP 6.
 > This file is the *cleanup loop* only.
 
 ---
@@ -36,7 +41,7 @@ repository — then leave it well-linked and traceable. This is a *truth-pass*, 
 - **File changes go through PRs (never `main` directly).** Branch protection requires SSH commit
   signing, DCO `Signed-off-by`, and **squash** merge. A pass produces up to **two** PRs, kept
   separate by concern: (1) the **truth-pass PR** — doc surfaces + `images.yaml`; (2) the
-  **expert-learnings PR** — opened by `/milestone-learn --apply` for `.claude/commands/experts/*`. Issue
+  **expert-learnings PR** — opened by `/learn --apply` for `.claude/commands/experts/*`. Issue
   closes happen directly via `gh` and **reference the truth-pass PR**.
 - **Hard constraints (from [AGENTS.md §Hard Constraints](AGENTS.md#hard-constraints) + repo memory):**
   - Commit type must be `docs:` for a pure doc reconcile, `ci:`/`chore:` if it only touches
@@ -141,13 +146,13 @@ Marker vocabulary: `📅 Planned → 🚧 Active → ✅ Complete` (milestones);
 > `Explore` subagent ("report every milestone/service/canvas marker that disagrees with this live
 > state: <paste STEP 1 summary>") so the main context stays lean. All edits stay in the main agent.
 
-### C. Knowledge drift — synthesize session learnings (`/milestone-learn`)
+### C. Knowledge drift — synthesize session learnings (`/learn`)
 The orchestrate/issue-generate flows append `## Session Learnings` blocks to
 [docs/ai-learnings/*.md](docs/ai-learnings/). A clean snapshot folds those into the expert guides.
 Invoke the synthesizer in its default (human-gated) mode:
 
 ```
-/milestone-learn
+/learn
 ```
 
 It clusters the accumulated learnings, dedupes against existing
@@ -156,7 +161,7 @@ It clusters the accumulated learnings, dedupes against existing
 auto-commits in synthesis mode**. Read back the new PENDING rows and fold their one-line summaries
 into the PLAN (STEP 3) so the human can approve/reject them in the same review.
 
-> **`/milestone-learn` owns its own git.** It commits expert-file changes on its own
+> **`/learn` owns its own git.** It commits expert-file changes on its own
 > `docs/expert-learnings-*` branch and opens a **separate** PR (different files, different concern —
 > expert prompts, not status surfaces). Do **not** fold expert-guide edits into the truth-pass doc
 > PR. Because it manages its own branch, invoke it as a skill against the real checkout, not inside
@@ -220,7 +225,7 @@ git rev-list --left-right --count "origin/main...origin/$b"   # behind <TAB> ahe
 Print one traceable plan. Stop here and wait for the human's "go" unless `--execute` was passed.
 
 ```
-## /repo-clean plan — <date>, active milestone <M?>, against main@<short-sha>
+## /reconcile plan — <date>, active milestone <M?>, against main@<short-sha>
 
 ### Issues to close (N)
 | # | family / kind | action | reason | reference |
@@ -239,11 +244,11 @@ Print one traceable plan. Stop here and wait for the human's "go" unless `--exec
 - images/images.yaml  (only if real drift)
 - README.md, ROADMAP.md, ... (list)
 
-### Proposed expert-guide learnings (separate /milestone-learn PR)
+### Proposed expert-guide learnings (separate /learn PR)
 | # | domain | proposed addition | sessions |
 |---|--------|-------------------|----------|
 | .. | ci-release | ... | ... |
-(PENDING in APPLY_LOG.md — human marks applied/rejected before /milestone-learn --apply)
+(PENDING in APPLY_LOG.md — human marks applied/rejected before /learn --apply)
 
 ### Branches to clean (local L / remote R)
 | branch | where | state | action | reason |
@@ -282,13 +287,13 @@ Print one traceable plan. Stop here and wait for the human's "go" unless `--exec
 4. **Close the planned issues**, each with a one-line reason **and a reference** so the trail is
    traceable:
    ```bash
-   gh issue close <N> --comment "Closed by /repo-clean truth-pass: <reason>. See PR #<new> / superseded by #<newest>."
+   gh issue close <N> --comment "Closed by /reconcile truth-pass: <reason>. See PR #<new> / superseded by #<newest>."
    ```
    Apply `duplicate` / `status: stale` / `wontfix` labels where they were proposed in the plan.
 5. **Apply approved learnings.** For every `APPLY_LOG.md` entry the human marked approved
    (`applied` / `pending-commit`), run:
    ```
-   /milestone-learn --apply
+   /learn --apply
    ```
    This edits the expert guides, marks the log entries `committed`, and opens its **own**
    `docs/expert-learnings-*` PR — kept separate from the truth-pass doc PR. If no entries were
@@ -346,6 +351,6 @@ cd "$REPO" && git worktree remove "$WT" --force 2>/dev/null || true
   --merged` (squash-merge hides merges from ancestry). FLAG unmerged orphans; never auto-delete them.
 - If `make check-images` / `make sync-images` can't run (no Docker), say so and fall back to
   dedup-close only for digest-drift — do not hand-edit digests.
-- One truth-pass = one doc PR + (optionally) one `/milestone-learn` PR. These two are separate **by
+- One truth-pass = one doc PR + (optionally) one `/learn` PR. These two are separate **by
   design** — status surfaces vs. expert prompts. Don't fold either into the other, and don't fold
   unrelated code fixes into either.

--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -3,19 +3,19 @@ description: Run the full review suite — architecture, security-posture, produ
 argument-hint: "[--pr] [--split] [--only architecture,security,product,market]   default: working drafts, one bundled PR with --pr"
 ---
 
-# /review-suite — Parallel Review Document Orchestrator
+# /review — Parallel Review Document Orchestrator
 
 Fan out all four review-document generators at once, each in its own isolated subagent, and
 collect their dated docs. Thin coordination layer: spawn → collect → deliver. The orchestrator
 itself reads no code — each review's grounding work happens in its subagent's isolated context
-(same discipline as `/milestone-orchestrate`).
+(same discipline as `/deliver`).
 
 ```
-/review-suite
-  ├─ /architecture-review   → docs/architecture/<date>-architecture-review.md
-  ├─ /security-review-doc   → docs/architecture/<date>-security-review.md (+ .private.md, gitignored)
-  ├─ /product-review        → docs/product/<date>-product-strategy-review.md
-  └─ /market-fit-review     → docs/product/<date>-market-fit-review.md
+/review
+  ├─ /lib:architecture-review   → docs/architecture/<date>-architecture-review.md
+  ├─ /lib:security-review-doc   → docs/architecture/<date>-security-review.md (+ .private.md, gitignored)
+  ├─ /lib:product-review        → docs/product/<date>-product-strategy-review.md
+  └─ /lib:market-fit-review     → docs/product/<date>-market-fit-review.md
 ```
 
 > **Read-mostly.** Subagents read the repo + live GitHub state and return their doc CONTENT;
@@ -23,8 +23,8 @@ itself reads no code — each review's grounding work happens in its subagent's 
 > or `AGENTS.md`. Each review keeps its own truth-pass discipline (grounded claims, longitudinal
 > delta, shipped/partial/aspirational split).
 
-> **Rules are not restated.** Each review command (`/architecture-review`, `/security-review-doc`,
-> `/product-review`, `/market-fit-review`) owns its own contract and guardrails. This file is the
+> **Rules are not restated.** Each review command (`/lib:architecture-review`, `/lib:security-review-doc`,
+> `/lib:product-review`, `/lib:market-fit-review`) owns its own contract and guardrails. This file is the
 > *parallel coordination loop* only.
 
 ---
@@ -71,7 +71,7 @@ Agent({
     Constraints:
     - Read-only. Ground every claim in a cited artifact (file:line / doc / gh result). No invented numbers.
     - Mark shipped / partial / aspirational. Include the longitudinal delta vs the prior review.
-    - Annotate recommendations/gaps with user type(s) + adoption lever (for the /roadmap-plan handoff).
+    - Annotate recommendations/gaps with user type(s) + adoption lever (for the /plan handoff).
     - Pull live signals (stars/forks/contributors/alerts/milestones) via gh yourself.
     - End with: a line `OUTPUT_PATH: <the dated path this review uses>` so the coordinator can place it.
   """
@@ -146,7 +146,7 @@ cd "$REPO" && git worktree remove "$COORD_WT" --force 2>/dev/null || true
 | market-fit   | docs/product/<date>-market-fit-review.md         | <verdict>           | <#1 rec> |
 
 PR: #<n> (bundled) or four PRs (--split).
-Next: feed the reviews' gap-analyses/recommendations to /roadmap-plan to file them as issues.
+Next: feed the reviews' gap-analyses/recommendations to /plan to file them as issues.
 ```
 
 ---
@@ -159,5 +159,5 @@ Next: feed the reviews' gap-analyses/recommendations to /roadmap-plan to file th
 - **One dated doc per review per run.** Never overwrite a prior dated review.
 - Each review keeps truth-pass discipline (grounded, longitudinal, shipped/partial/aspirational).
 - Commit (with `--pr`): `docs:` type, DCO `-s`, `Assisted-by`, signed, squash-merge; repo-relative links.
-- Pairs with `/roadmap-plan`: the suite produces the assessments; `/roadmap-plan` turns their
+- Pairs with `/plan`: the suite produces the assessments; `/plan` turns their
   gaps/recommendations into SPDD-filed, adoption-tagged issues for the active milestone.


### PR DESCRIPTION
Reduces 22 top-level slash commands to **5 generic, milestone-agnostic, safe-by-default verbs** + one lifecycle command + a self-guided README, keeping the *same* decision tree with the heavy machinery preserved.

## Top-level (the safe default set)
- **/plan** — idea/prompt/#issue/#epic -> aligned REASONS Canvas + linked issues (SPDD pipeline -> align -> link). No-arg infers unfiled work.
- **/deliver** — ready work -> implement -> PR -> CI -> squash-merge -> post-merge verify. No-arg picks next ready work.
- **/review** — architecture/security/product/market review docs.
- **/reconcile** — on-demand recovery-from-failures + clean the repo (was repo-clean; no longer auto-invoked).
- **/learn** — synthesize expert-guide learnings.
- **/milestone** — the only milestone-aware command (open|close|status); everything else uses an optional --milestone filter.

## Structure
- **lib/** (19) — SPDD pipeline, delivery machinery, roadmap inference, review docs, milestone lifecycle. Invoked by main commands; /lib:* for power users.
- **experts/** (8) — unchanged dispatch personas.
- **README.md** — self-guided guide: decision tree, the five verbs, folder map, worked example, conventions.

## Notes
- Built with **git mv** to preserve content + history; cross-references updated repo-wide; no stale tokens remain.
- Process changes (per approved plan): milestone-agnostic by default; milestone-plan folded into /deliver; /reconcile on-demand only.
- Follow-up (not in this PR): reconcile command-name references in CLAUDE.md + docs/patterns/spdd-guide.md.

.claude/commands is PR-size-exempt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)