### PR TITLE
docs(templates): embed SPDD story spine in issue templates + commands

### DIFF
--- a/.claude/commands/experts/bdd-contract.md
+++ b/.claude/commands/experts/bdd-contract.md
@@ -92,7 +92,7 @@ HANDOFF to git-ops:
 
     Closes #<N>
 
-    Assisted-by: Claude/claude-sonnet-4-6
+    Assisted-by: Claude/<model>
   pr_title:     <title ≤ 72 chars>
   pr_body_file: /tmp/pr-body-<N>.md
   next_step:    COMMIT

--- a/.claude/commands/experts/ci-release.md
+++ b/.claude/commands/experts/ci-release.md
@@ -90,7 +90,7 @@ HANDOFF to git-ops:
 
     Closes #<N>
 
-    Assisted-by: Claude/claude-sonnet-4-6
+    Assisted-by: Claude/<model>
   pr_title:     <title ≤ 72 chars>
   pr_body_file: /tmp/pr-body-<N>.md
   next_step:    COMMIT

--- a/.claude/commands/experts/git-ops.md
+++ b/.claude/commands/experts/git-ops.md
@@ -99,7 +99,7 @@ git commit -s -m "$(cat <<'EOF'
 
 Closes #<story-issue-N>
 
-Assisted-by: Claude/claude-sonnet-4-6
+Assisted-by: Claude/<model>
 EOF
 )"
 ```

--- a/.claude/commands/experts/go-services.md
+++ b/.claude/commands/experts/go-services.md
@@ -91,7 +91,7 @@ HANDOFF to git-ops:
 
     Closes #<N>
 
-    Assisted-by: Claude/claude-sonnet-4-6
+    Assisted-by: Claude/<model>
   pr_title:     <title ≤ 72 chars>
   pr_body_file: /tmp/pr-body-<N>.md
   next_step:    COMMIT
@@ -324,7 +324,7 @@ git commit -s -m "<type>(<scope>): <subject>
 
 Closes #<story-issue-N>
 
-Assisted-by: Claude/claude-sonnet-4-6"
+Assisted-by: Claude/<model>"
 ```
 
 - `<type>`: feat / fix / refactor / test / chore / docs / ci — **never** spec/service/proto/make/adr

--- a/.claude/commands/experts/infra-helm.md
+++ b/.claude/commands/experts/infra-helm.md
@@ -88,7 +88,7 @@ HANDOFF to git-ops:
 
     Closes #<N>
 
-    Assisted-by: Claude/claude-sonnet-4-6
+    Assisted-by: Claude/<model>
   pr_title:     <title ≤ 72 chars>
   pr_body_file: /tmp/pr-body-<N>.md
   next_step:    COMMIT
@@ -262,7 +262,7 @@ git commit -s -m "feat(infra): <subject>
 
 Closes #<story-issue-N>
 
-Assisted-by: Claude/claude-sonnet-4-6"
+Assisted-by: Claude/<model>"
 ```
 
 Infra commits use `feat(infra):`, `chore(infra):`, or `ci(infra):` — never `infra:` alone

--- a/.claude/commands/experts/post-merge.md
+++ b/.claude/commands/experts/post-merge.md
@@ -282,7 +282,7 @@ Updated:$(echo $COMPOSE_PINS_UPDATED $YAML_PINS_UPDATED | xargs).
 
 ${CLOSE_LINE}
 
-Assisted-by: Claude/claude-sonnet-4-6"
+Assisted-by: Claude/<model>"
 
 git push -u origin "$DIGEST_BRANCH"
 
@@ -293,7 +293,7 @@ DIGEST_PR=$(gh pr create \
   --body "Post-merge digest update triggered by PR #${PR_NUMBER}.
 Updated: $(echo $COMPOSE_PINS_UPDATED $YAML_PINS_UPDATED | xargs).
 Stale closed: ${STALE_ISSUES:-none}. Implements: ${IMPLEMENT_ISSUE:+#$IMPLEMENT_ISSUE}.
-Assisted-by: Claude/claude-sonnet-4-6" | tail -1)
+Assisted-by: Claude/<model>" | tail -1)
 
 gh pr merge "$DIGEST_PR" --squash --auto
 echo "Digest PR: $DIGEST_PR"

--- a/.claude/commands/experts/python-adapters.md
+++ b/.claude/commands/experts/python-adapters.md
@@ -88,7 +88,7 @@ HANDOFF to git-ops:
 
     Closes #<N>
 
-    Assisted-by: Claude/claude-sonnet-4-6
+    Assisted-by: Claude/<model>
   pr_title:     <title ≤ 72 chars>
   pr_body_file: /tmp/pr-body-<N>.md
   next_step:    COMMIT
@@ -251,7 +251,7 @@ git commit -s -m "feat(agents): <subject>
 
 Closes #<story-issue-N>
 
-Assisted-by: Claude/claude-sonnet-4-6"
+Assisted-by: Claude/<model>"
 ```
 
 ---

--- a/.claude/commands/experts/spdd-canvas.md
+++ b/.claude/commands/experts/spdd-canvas.md
@@ -93,7 +93,7 @@ HANDOFF to git-ops:
 
     Closes #<N> (canvas work only; O-step stories tracked separately)
 
-    Assisted-by: Claude/claude-sonnet-4-6
+    Assisted-by: Claude/<model>
   pr_title:     docs(spdd): REASONS Canvas for EPIC #<N> — <slug>
   pr_body_file: /tmp/pr-body-<N>.md
   next_step:    COMMIT

--- a/.claude/commands/lib/spdd-analysis.md
+++ b/.claude/commands/lib/spdd-analysis.md
@@ -45,6 +45,10 @@ Given the feature or issue in $ARGUMENTS:
 ### Recommended Design Direction
 <2–3 sentences on the recommended approach before generating the Canvas>
 
+### Recommended Issue Type & Template
+- Conventional type: `<feat|fix|docs|test|refactor|ci|chore>` · Issue template: `.github/ISSUE_TEMPLATE/<…>.md`
+- Stories carry the **Story (INVEST)** block + canvas Operations-step link (filled by `/lib:spdd-story`).
+
 ## Input
 
 $ARGUMENTS — GitHub issue number, issue URL, or feature description

--- a/.claude/commands/lib/spdd-story.md
+++ b/.claude/commands/lib/spdd-story.md
@@ -1,7 +1,8 @@
 # /lib:spdd-story
 
-Break a raw feature description or GitHub issue into INVEST-compliant user stories,
-then create one GitHub issue per story as a child of the parent epic.
+Break a raw feature description or GitHub issue into INVEST-compliant user stories, then create one
+GitHub issue per story — each **populated from the canonical `.github/ISSUE_TEMPLATE/`** template,
+never an ad-hoc body — as a child of the parent epic.
 
 ## Instructions
 
@@ -27,10 +28,19 @@ Read the feature description or GitHub issue provided in $ARGUMENTS.
      right labels + milestone + a canvas link, and report the reconciled set. Only create
      issues for genuinely missing stories.
 6. After presenting the stories, create one GitHub issue **per still-missing story** using `gh issue create`.
-   - Title format: `feat(<scope>): <story title> (#<parent-issue>, step <N>)`
-   - Body includes: Story (as-a/I-want/so-that), Context (link to canvas if it exists), Scope, Acceptance criteria, Out of scope, Size estimate, Dependencies on other steps
-   - End each body with: `Assisted-by: Claude/claude-sonnet-4-6`
-   - Report the created (or reconciled) issue URL after each step
+   - **Populate the matching canonical template** from `.github/ISSUE_TEMPLATE/` — do NOT invent an ad-hoc body:
+     a capability/story → `feature_request.md`; a docs deliverable → `documentation.md`; a bug → `bug_report.md`;
+     an ADR → `adr_proposal.md`. (An **epic** uses `epic.md` via `/plan`, not this command.)
+   - Fill the template's **Story (INVEST)** block: `As a … I want … so that …`, size (XS/S/M/L), the canvas
+     Operations-step link (`docs/spdd/<epic>-<slug>/canvas.md` → step N), and Depends-on / Blocks.
+   - Express the happy-path + error acceptance as **Gherkin** in the template's *Proposed Capability* block —
+     this becomes the `.feature` file when implementation begins (ADR-016).
+   - Title: `<type>(<scope>): <story title> (#<parent-issue>, step <N>)` where `<type>` is the **correct
+     conventional type** for the work (`feat` for new capability, else `fix|docs|test|refactor|ci|chore`).
+   - Labels per [docs/labels.md](../../../docs/labels.md): `type: …` plus relevant `area: …` / `audience: …` /
+     `product: …` (the `/plan` align step adds `status: ready` and the milestone).
+   - End each body with: `Assisted-by: Claude/<model>` (use the running model; **never** `Co-Authored-By` for AI).
+   - Report the created (or reconciled) issue URL after each step.
 
 ## Output Format
 

--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -16,8 +16,8 @@ composes the `lib:spdd-*` building blocks so you don't run them by hand.
 ## Parse `$ARGUMENTS`
 
 - **free-text prompt** (e.g. `/plan "let users try Zynax with no clone"`) → a NEW idea. Draft an epic
-  from it (use the Epic issue template framing: *the one question this answers* + product/adoption
-  impact), then run the pipeline below.
+  by **filling `.github/ISSUE_TEMPLATE/epic.md`** (*the one question this answers* + product/adoption
+  impact + child stories), then run the pipeline below.
 - **`#<number>`** → an existing issue/epic. Run the pipeline for it.
 - **no argument** → **infer** unfiled/ready work from the repo (delegate to `/lib:plan-infer`) and
   propose canvases for the highest-value gaps. PLAN only unless `--execute`.
@@ -52,6 +52,9 @@ Canvas, which resets it to Draft and re-runs the security review — never patch
   and the exact `/deliver` command to run next.
 
 ## Norms
-Conventional commits (feat/fix/refactor/docs/test/ci/chore) · DCO `Signed-off-by` + `Assisted-by:
-Claude/<model>` (never `Co-Authored-By` for AI) · canvas committed before any implementation code
-(ADR-019) · new `.claude/commands` files need `git add -f`. Full guide: `.claude/commands/README.md`.
+**Every created issue is populated from the matching `.github/ISSUE_TEMPLATE/` template** (`epic.md` /
+`feature_request.md` / `documentation.md` / …) and carries the **SPDD Story (INVEST)** block + a canvas
+Operations-step link; labels per [docs/labels.md](../../docs/labels.md). Conventional commits
+(feat/fix/refactor/docs/test/ci/chore) · DCO `Signed-off-by` + `Assisted-by: Claude/<model>` (never
+`Co-Authored-By` for AI) · canvas committed before any implementation code (ADR-019) · new
+`.claude/commands` files need `git add -f`. Full guide: `.claude/commands/README.md`.

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -44,6 +44,21 @@ or CNCF/community credibility?
 
 ---
 
+## Acceptance criteria
+
+> How will we know the doc is fixed? Observable, checkable outcomes.
+
+- [ ]
+- [ ]
+
+---
+
+## Parent epic & links (if part of an epic)
+
+- Parent epic: #… · Milestone: · REASONS Canvas / Operations step: `docs/spdd/<epic>-<slug>/canvas.md` → step N
+
+---
+
 ## Related
 
 - Related code or feature: #

--- a/.github/ISSUE_TEMPLATE/epic.md
+++ b/.github/ISSUE_TEMPLATE/epic.md
@@ -67,7 +67,8 @@ Keep child stories small, independent, testable, and individually valuable.
 
 ## Child stories
 
-> Small, independent, testable, individually valuable. Each links back here.
+> Small, independent, testable, individually valuable. Each links back here and uses the Feature
+> template's **Story (INVEST)** block (as-a/I-want/so-that · size · canvas Operations-step · deps).
 
 - [ ] #… — <story>
 - [ ] #… — <story>

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -21,6 +21,18 @@ Before filing a feature request:
 
 ---
 
+## Story (INVEST)
+
+> The SPDD story spine. Keep it INVEST: **I**ndependent · **N**egotiable · **V**aluable ·
+> **E**stimable · **S**mall · **T**estable.
+
+- **As a** <role>, **I want** <capability>, **so that** <outcome>.
+- Size: **XS · S · M · L** (Small = one PR, ≤ 400 lines excluding generated code)
+- Canvas Operations step (if the parent epic has a canvas): `docs/spdd/<epic>-<slug>/canvas.md` → step N
+- Depends on: #… · Blocks: #…
+
+---
+
 ## Why it matters (product · adoption)
 
 - **For the Zynax user / adopter:** <the observable value this story delivers>
@@ -42,7 +54,7 @@ Be specific — avoid "it would be nice if...". Describe the pain point.
 
 - Parent epic: #…
 - Milestone:
-- REASONS Canvas (if the parent epic has one): `docs/spdd/<epic>-<slug>/canvas.md` — Operations step N
+- REASONS Canvas / Operations step: see **Story (INVEST)** above
 - RFC / ADR: 
 - Related docs / architecture:
 


### PR DESCRIPTION
## Why  (problem & intent)

> No tracking issue — direct maintainer request (follow-on from the due-diligence epic #1399 work).
> Can file a tracking issue on request.

The original `/spdd-story` command built issue bodies **ad-hoc** and did not use the canonical
`.github/ISSUE_TEMPLATE/` templates; it also hardcoded a stale `Assisted-by` model and always used a
`feat(...)` title regardless of work type. As a result, the SPDD story ideas (As-a/I-want/so-that,
INVEST size, canvas Operations-step link, dependencies) were not consistently present in issue bodies
or in the templates. This aligns **templates + commands** around one SPDD story spine so every issue —
created by hand or by the commands — is structured, traceable, and concise.

---

## What you'll get  (deliverables ↔ what changed)

- A reusable **Story (INVEST)** block in the Feature template ← `.github/ISSUE_TEMPLATE/feature_request.md`
- Child stories explicitly inherit the Story spine ← `.github/ISSUE_TEMPLATE/epic.md`
- Docs issues gain acceptance criteria + parent-epic/canvas traceability ← `.github/ISSUE_TEMPLATE/documentation.md`
- Commands fill the canonical template (no ad-hoc bodies), use the correct conventional title type, and `Assisted-by: Claude/<model>` ← `.claude/commands/lib/spdd-story.md`
- Epic drafting fills `epic.md`; a canonical-template norm is added ← `.claude/commands/plan.md`
- Analysis output recommends the issue type + template ← `.claude/commands/lib/spdd-analysis.md`
- Expert personas use the `Assisted-by: Claude/<model>` placeholder (drop hardcoded `claude-sonnet-4-6`) ← `.claude/commands/experts/*.md` (8 files)

---

## Scope & boundaries

- **In scope:** issue templates + the issue-creating command docs.
- **Out of scope:** the due-diligence framework doc itself (PR #1398); rewriting the already-created
  epic/child issue bodies (#1399, #1401–#1406) — done directly on GitHub as part of the same request.

---

## Test plan & acceptance

| Acceptance criterion | How verified | Result |
|----------------------|--------------|--------|
| Templates carry the SPDD Story (INVEST) spine | review `feature_request.md` / `epic.md` | ✅ |
| Commands point to `.github/ISSUE_TEMPLATE/` (no ad-hoc bodies) | review `spdd-story.md` / `plan.md` | ✅ |
| No hardcoded model trailer | `grep -n "claude-sonnet-4-6" .claude/commands` → none | ✅ |
| Pre-commit secret scan | gitleaks hook on commit | Passed ✅ |

**Local gates:** docs/markdown-only — no Go/Python/proto/spec changed.

---

## Evidence

- **Local output:** `6 files changed, 58 insertions(+), 13 deletions(-)`; commit signature valid (`%G? → G`).
- **Artifacts / images:** none — no service source changed.
- **Post-merge digest sync → main:** N/A — no image rebuild.

---

## Type of Change

- [x] `docs` — documentation/templates/process only

---

## SPDD Canvas (feat: PRs only)

N/A — `docs:` PR (canvas-exempt per ADR-019).

---

## PR Size Self-Check

Lines changed: ~58 across 6 files (well under 200). `.claude/` is size-exempt; `.github/ISSUE_TEMPLATE/`
edits are tiny.

- [x] ≤ 400 lines — proceed

---

## Engineering Checklist

- [x] Conventional Commits format (`docs(templates): …`)
- [x] `Signed-off-by:` present (DCO); SSH-signed
- [x] `Assisted-by: Claude/claude-opus-4-8`; no `Co-Authored-By`
- [x] Documentation/templates only; no code, proto, schema, or service behaviour changed
- [x] No secrets / PII

---

## AI Assistance

- [x] AI-assisted — tool/model: Claude Code / claude-opus-4-8

---

## Testing Notes

Create a test issue from each updated template in the GitHub UI to confirm the new sections render and
read cleanly; run `/plan "<prompt>"` to confirm the drafted epic/stories now populate the canonical
templates with the Story (INVEST) spine.
