### PR TITLE
chore(api-gateway): /healthz returns 200 with JSON body

### DIFF
--- a/services/api-gateway/internal/api/probes.go
+++ b/services/api-gateway/internal/api/probes.go
@@ -3,10 +3,15 @@
 package api
 
 import (
+	"io"
 	"net/http"
 	"sync/atomic"
 	"time"
 )
+
+// healthzBody is the JSON payload returned by /healthz on a 200 response so the
+// documented quickstart `curl` step shows a meaningful result.
+const healthzBody = `{"status":"ok"}`
 
 // Probes holds shared atomic state for the three K8s probe endpoints.
 // All methods are safe for concurrent use without additional locking.
@@ -67,12 +72,28 @@ func (p *Probes) HandleLivez(w http.ResponseWriter, _ *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
+// HandleHealthz is the backward-compatible /healthz endpoint. It applies the
+// same liveness semantics as HandleLivez (503 when work has gone stale) but, on
+// the 200 path, writes a small JSON body so the documented quickstart `curl`
+// step shows a meaningful result. Health semantics are unchanged — no new
+// dependency checks are performed.
+func (p *Probes) HandleHealthz(w http.ResponseWriter, _ *http.Request) {
+	last := p.lastWorkNs.Load()
+	if last != 0 && time.Now().UnixNano()-last > p.thresholdNs {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = io.WriteString(w, healthzBody)
+}
+
 // Register mounts the three probe handlers plus a backward-compatible /healthz
-// alias onto mux. All paths use method-scoped routing (GET only).
+// endpoint onto mux. All paths use method-scoped routing (GET only).
 func (p *Probes) Register(mux *http.ServeMux) {
 	mux.HandleFunc("GET /startupz", p.HandleStartupz)
 	mux.HandleFunc("GET /readyz", p.HandleReadyz)
 	mux.HandleFunc("GET /livez", p.HandleLivez)
 	// /healthz retained for backward compatibility with existing orchestration.
-	mux.HandleFunc("GET /healthz", p.HandleLivez)
+	mux.HandleFunc("GET /healthz", p.HandleHealthz)
 }

--- a/services/api-gateway/internal/api/probes_test.go
+++ b/services/api-gateway/internal/api/probes_test.go
@@ -81,3 +81,37 @@ func TestProbes_Livez_Stale_Work(t *testing.T) {
 		t.Fatalf("want 503, got %d", got)
 	}
 }
+
+// ── /healthz ──────────────────────────────────────────────────────────────────
+
+func TestProbes_Healthz_OK_Body(t *testing.T) {
+	p := api.NewProbes(60, alwaysReady)
+	rec := httptest.NewRecorder()
+	p.HandleHealthz(rec, httptest.NewRequest(http.MethodGet, "/healthz", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Fatalf("want Content-Type application/json, got %q", ct)
+	}
+	if body := rec.Body.String(); body != `{"status":"ok"}` {
+		t.Fatalf("want body %q, got %q", `{"status":"ok"}`, body)
+	}
+}
+
+func TestProbes_Healthz_Stale_Work(t *testing.T) {
+	// Health semantics unchanged: stale work still returns 503 with no body.
+	p := api.NewProbes(0, alwaysReady)
+	p.RecordWork()
+	time.Sleep(time.Millisecond)
+	rec := httptest.NewRecorder()
+	p.HandleHealthz(rec, httptest.NewRequest(http.MethodGet, "/healthz", nil))
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("want 503, got %d", rec.Code)
+	}
+	if body := rec.Body.String(); body != "" {
+		t.Fatalf("want empty body on 503, got %q", body)
+	}
+}


### PR DESCRIPTION
## chore(api-gateway): /healthz returns 200 with JSON body

Closes #1380

### Why  (problem & intent)
`GET /healthz` on the api-gateway returned `200 OK` with `Content-Length: 0`
(empty body). The documented quickstart step (`docs/quickstart.md:65`,
`curl http://localhost:7080/healthz`) implies a meaningful response, so the
empty body leaves users unsure the call succeeded. This is presentation polish:
return a small JSON body so the documented `curl` shows a result.

### What you'll get  (deliverables ↔ what changed)
- New api-gateway-local `Probes.HandleHealthz` handler that applies the same
  liveness check as `HandleLivez` but, on the 200 path, sets
  `Content-Type: application/json` and writes `{"status":"ok"}`.
  (`services/api-gateway/internal/api/probes.go`)
- `/healthz` route now mounts `HandleHealthz` instead of aliasing `HandleLivez`.
- Two handler unit tests: 200 path asserts JSON body + content-type; stale-work
  path asserts 503 with empty body (semantics preserved).
  (`services/api-gateway/internal/api/probes_test.go`)

### Scope & boundaries
- Change is fully api-gateway-local — `/healthz` is served by
  `internal/api/probes.go`, NOT by a shared `libs/zynaxobs` helper, so no other
  service is affected.
- `/readyz`, `/startupz`, and `/livez` are untouched; their handlers and
  semantics are unchanged.
- No new dependency checks added — liveness semantics (503 on stale work) are
  preserved on `/healthz`.

### Test plan & acceptance
| Criterion | Verify command | Result |
|-----------|----------------|--------|
| 200 returns `{"status":"ok"}` + JSON content-type | `GOWORK=off go -C services/api-gateway test ./internal/api/... -run TestProbes_Healthz_OK_Body -v` | PASS |
| Stale-work still returns 503, no body | `GOWORK=off go -C services/api-gateway test ./internal/api/... -run TestProbes_Healthz_Stale_Work -v` | PASS |
| No regression across api-gateway | `GOWORK=off go -C services/api-gateway test ./... -race -timeout 120s` | all packages ok |
| Build clean | `GOWORK=off go -C services/api-gateway build ./...` | exit 0 |
| New handler fully covered | `GOWORK=off go -C services/api-gateway tool cover -func /tmp/cov.out` | `HandleHealthz 100.0%` |
| Domain coverage gate held | `GOWORK=off go -C services/api-gateway test ./internal/domain/... -cover` | 96.2% (untouched) |

### Evidence
- Post-merge digest sync → main: N/A — no image rebuild (Go source-only change).

### Risk & rollback
- Risk: minimal. Adds a body to one endpoint; status codes and liveness logic
  are unchanged. Any client parsing `/healthz` only on status code is unaffected.
- Rollback: revert this commit; `/healthz` returns to an empty 200 body.

### Review aids
- Start at `services/api-gateway/internal/api/probes.go` — `HandleHealthz` mirrors
  `HandleLivez`'s check, then writes the JSON body. `Register` now routes
  `/healthz` to the new handler.
- Tests are appended under the `── /healthz ──` section of `probes_test.go`.
