### PR TITLE
fix(agents/adapters): advertise routable llm-adapter endpoint

### DIFF
--- a/agents/adapters/llm/AGENTS.md
+++ b/agents/adapters/llm/AGENTS.md
@@ -40,8 +40,16 @@ See `agent-def.yaml.example` for the full schema. Key fields:
 | `provider.ollama_base_url` | ✓ if ollama | — | Ollama REST base URL, e.g. `http://ollama:11434`. |
 | `provider.region` | ✓ if bedrock | — | AWS region for the Bedrock endpoint. |
 | `provider.max_tokens` | — | `4096` | Maximum token ceiling enforced before calling the provider. |
-| `endpoint` | ✓ | `:50070` | gRPC address the adapter's server binds to. |
+| `endpoint` | ✓ | `:50070` | gRPC address the adapter's server **binds** to (`net.Listen`). A hostless value like `:50070` binds all interfaces but is not routable. |
+| `advertise_endpoint` | ✓ if `endpoint` is hostless | falls back to `endpoint` | Routable gRPC address **advertised** to the registry and dialled by the task-broker, e.g. `llm-adapter:50070`. Mirrors the langgraph-adapter `ADAPTER_ENDPOINT` split. |
 | `registry_endpoint` | ✓ | — | agent-registry gRPC address, e.g. `agent-registry:50052`. |
+
+> **Bind vs advertise (issue #1371):** the address the server binds to and the
+> address advertised to the registry are distinct. A hostless `endpoint: :50070`
+> binds fine but, if advertised verbatim, makes the broker dial `localhost` and
+> fail. Always set `advertise_endpoint` to the service DNS name / pod IP in any
+> multi-container or K8s deployment. Config load fails fast if `endpoint` is
+> hostless and `advertise_endpoint` is unset.
 
 The API-key value is resolved at startup from the named env var and is never stored in
 config, repr, logs, or error messages.

--- a/agents/adapters/llm/agent-def.yaml.example
+++ b/agents/adapters/llm/agent-def.yaml.example
@@ -9,7 +9,14 @@
 agent_id: llm-adapter
 name: LLM Adapter
 description: Wraps OpenAI / Bedrock / Ollama chat completions as Zynax capabilities.
+# endpoint is the address the gRPC server BINDS to (all interfaces on 50070).
 endpoint: :50070
+# advertise_endpoint is the ROUTABLE address the task-broker dials. It must
+# resolve from the broker's network (service DNS name / pod IP) — a hostless
+# bind address like ":50070" advertised verbatim makes the broker dial
+# localhost and fail (issue #1371). Defaults to endpoint only if endpoint
+# carries an explicit host.
+advertise_endpoint: llm-adapter:50070
 registry_endpoint: agent-registry:50052
 
 provider:

--- a/agents/adapters/llm/internal/config/config.go
+++ b/agents/adapters/llm/internal/config/config.go
@@ -4,6 +4,7 @@ package config
 
 import (
 	"fmt"
+	"net"
 	"os"
 
 	"gopkg.in/yaml.v3"
@@ -27,13 +28,21 @@ var validProviders = map[string]struct{}{
 // The path is read from the ZYNAX_LLM_CONFIG env var by the bootstrap layer.
 // Fields mirror the Python AdapterConfig for behavioural parity.
 type AdapterConfig struct {
-	AgentID          string             `yaml:"agent_id"`
-	Name             string             `yaml:"name"`
-	Description      string             `yaml:"description"`
-	Endpoint         string             `yaml:"endpoint"`
-	RegistryEndpoint string             `yaml:"registry_endpoint"`
-	Capabilities     []CapabilityConfig `yaml:"capabilities"`
-	Provider         ProviderConfig     `yaml:"provider"`
+	AgentID     string `yaml:"agent_id"`
+	Name        string `yaml:"name"`
+	Description string `yaml:"description"`
+	// Endpoint is the address the gRPC server binds to (net.Listen). A hostless
+	// value such as ":50070" binds to all interfaces but is NOT routable, so it
+	// must never be advertised to the registry verbatim (issue #1371).
+	Endpoint string `yaml:"endpoint"`
+	// AdvertiseEndpoint is the routable address the task-broker dials for this
+	// adapter, e.g. "llm-adapter:50070". When empty it falls back to Endpoint —
+	// but only if Endpoint carries an explicit host (see AdvertisedEndpoint).
+	// Mirrors the langgraph-adapter ADAPTER_ENDPOINT split (bind vs advertise).
+	AdvertiseEndpoint string             `yaml:"advertise_endpoint"`
+	RegistryEndpoint  string             `yaml:"registry_endpoint"`
+	Capabilities      []CapabilityConfig `yaml:"capabilities"`
+	Provider          ProviderConfig     `yaml:"provider"`
 }
 
 // CapabilityConfig declares one capability the adapter exposes, with its JSON
@@ -105,7 +114,38 @@ func (c *AdapterConfig) validateIdentity() error {
 	if c.RegistryEndpoint == "" {
 		return fmt.Errorf("config: registry_endpoint is required")
 	}
+	// The address advertised to the registry must be routable. A hostless bind
+	// endpoint (":50070") advertised verbatim makes the broker dial localhost
+	// (issue #1371), so require an explicit advertise_endpoint in that case.
+	if c.AdvertiseEndpoint == "" && !hasExplicitHost(c.Endpoint) {
+		return fmt.Errorf(
+			"config: advertise_endpoint is required when endpoint %q is hostless "+
+				"(a hostless bind address is not routable by the task-broker)", c.Endpoint)
+	}
 	return nil
+}
+
+// AdvertisedEndpoint returns the routable address registered with the registry
+// and dialled by the task-broker. It prefers an explicit advertise_endpoint and
+// otherwise falls back to the bind Endpoint — which validate() guarantees has an
+// explicit host when no advertise_endpoint is set.
+func (c *AdapterConfig) AdvertisedEndpoint() string {
+	if c.AdvertiseEndpoint != "" {
+		return c.AdvertiseEndpoint
+	}
+	return c.Endpoint
+}
+
+// hasExplicitHost reports whether addr carries a non-empty host component.
+// Hostless forms such as ":50070" or "50070" return false; "host:port" and
+// "0.0.0.0:50070" return true. (0.0.0.0 binds all interfaces but, unlike a bare
+// ":port", is at least a concrete address the broker can dial.)
+func hasExplicitHost(addr string) bool {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return false
+	}
+	return host != ""
 }
 
 // validate checks the provider selection and its required fields.

--- a/agents/adapters/llm/internal/config/config_test.go
+++ b/agents/adapters/llm/internal/config/config_test.go
@@ -27,6 +27,7 @@ agent_id: llm-adapter-test
 name: LLM Adapter Test
 description: test
 endpoint: :50070
+advertise_endpoint: llm-adapter:50070
 registry_endpoint: localhost:50052
 capabilities:
   - name: chat_completion
@@ -66,6 +67,7 @@ func TestLoad_ValidOllama(t *testing.T) {
 	body := `
 agent_id: llm-ollama
 endpoint: :50070
+advertise_endpoint: llm-adapter:50070
 registry_endpoint: localhost:50052
 capabilities:
   - name: chat_completion
@@ -142,6 +144,7 @@ func TestLoad_BedrockRequiresRegion(t *testing.T) {
 	body := `
 agent_id: llm-bedrock
 endpoint: :50070
+advertise_endpoint: llm-adapter:50070
 registry_endpoint: localhost:50052
 capabilities:
   - name: chat_completion
@@ -153,6 +156,64 @@ provider:
 	_, err := config.Load(writeYAML(t, body))
 	if err == nil || !strings.Contains(err.Error(), "region") {
 		t.Fatalf("expected region-required error, got: %v", err)
+	}
+}
+
+// TestLoad_HostlessEndpointRequiresAdvertise asserts a hostless bind endpoint
+// with no advertise_endpoint is rejected at load time — the regression guard for
+// issue #1371, where a verbatim ":50070" made the broker dial localhost.
+func TestLoad_HostlessEndpointRequiresAdvertise(t *testing.T) {
+	t.Parallel()
+	body := strings.Replace(validOpenAI, "advertise_endpoint: llm-adapter:50070\n", "", 1)
+	_, err := config.Load(writeYAML(t, body))
+	if err == nil {
+		t.Fatal("expected error for hostless endpoint without advertise_endpoint")
+	}
+	if !strings.Contains(err.Error(), "advertise_endpoint") {
+		t.Errorf("error %q should mention advertise_endpoint", err.Error())
+	}
+}
+
+// TestLoad_ExplicitHostEndpointNeedsNoAdvertise asserts the fallback path: when
+// the bind endpoint already carries an explicit host, advertise_endpoint may be
+// omitted and AdvertisedEndpoint() returns the bind endpoint verbatim.
+func TestLoad_ExplicitHostEndpointNeedsNoAdvertise(t *testing.T) {
+	t.Parallel()
+	body := strings.Replace(validOpenAI,
+		"endpoint: :50070\nadvertise_endpoint: llm-adapter:50070\n",
+		"endpoint: 0.0.0.0:50070\n", 1)
+	cfg, err := config.Load(writeYAML(t, body))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := cfg.AdvertisedEndpoint(); got != "0.0.0.0:50070" {
+		t.Errorf("AdvertisedEndpoint() = %q, want 0.0.0.0:50070", got)
+	}
+}
+
+// TestAdvertisedEndpoint asserts the resolver never returns a hostless address:
+// it prefers advertise_endpoint and otherwise falls back to a host-bearing bind
+// endpoint. This is the core invariant guarding issue #1371.
+func TestAdvertisedEndpoint(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		endpoint  string
+		advertise string
+		want      string
+	}{
+		{"explicit advertise wins over hostless bind", ":50070", "llm-adapter:50070", "llm-adapter:50070"},
+		{"explicit advertise wins over host bind", "0.0.0.0:50070", "llm-adapter:50070", "llm-adapter:50070"},
+		{"falls back to host-bearing bind", "0.0.0.0:50070", "", "0.0.0.0:50070"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := &config.AdapterConfig{Endpoint: tt.endpoint, AdvertiseEndpoint: tt.advertise}
+			if got := cfg.AdvertisedEndpoint(); got != tt.want {
+				t.Errorf("AdvertisedEndpoint() = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }
 
@@ -187,6 +248,7 @@ func TestResolveSecret_NoEnvDeclared(t *testing.T) {
 	cfg, err := config.Load(writeYAML(t, `
 agent_id: llm-ollama
 endpoint: :50070
+advertise_endpoint: llm-adapter:50070
 registry_endpoint: localhost:50052
 capabilities:
   - name: chat_completion

--- a/agents/adapters/llm/internal/registry/client.go
+++ b/agents/adapters/llm/internal/registry/client.go
@@ -78,10 +78,12 @@ func BuildAgentDef(cfg *config.AdapterConfig) *zynaxv1.AgentDef {
 		})
 	}
 	return &zynaxv1.AgentDef{
-		AgentId:      cfg.AgentID,
-		Name:         cfg.Name,
-		Description:  cfg.Description,
-		Endpoint:     cfg.Endpoint,
+		AgentId:     cfg.AgentID,
+		Name:        cfg.Name,
+		Description: cfg.Description,
+		// Advertise the routable address, NOT the (possibly hostless) bind
+		// endpoint — otherwise the broker dials localhost (issue #1371).
+		Endpoint:     cfg.AdvertisedEndpoint(),
 		Capabilities: caps,
 	}
 }

--- a/agents/adapters/llm/internal/registry/client_test.go
+++ b/agents/adapters/llm/internal/registry/client_test.go
@@ -5,6 +5,7 @@ package registry_test
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/zynax-io/zynax/agents/adapters/llm/internal/config"
@@ -191,5 +192,25 @@ func TestBuildAgentDef(t *testing.T) {
 	}
 	if string(def.Capabilities[0].OutputSchema) != `{"type":"string"}` {
 		t.Errorf("output_schema = %s", def.Capabilities[0].OutputSchema)
+	}
+}
+
+// TestBuildAgentDef_AdvertisesRoutableEndpoint guards issue #1371: the address
+// registered with the registry must NOT be the hostless bind endpoint, otherwise
+// the broker dials localhost. With a bind-only ":50070" and an explicit
+// advertise_endpoint, the def must carry the advertised (routable) address.
+func TestBuildAgentDef_AdvertisesRoutableEndpoint(t *testing.T) {
+	cfg := &config.AdapterConfig{
+		AgentID:           "llm-adapter",
+		Endpoint:          ":50070", // hostless bind address
+		AdvertiseEndpoint: "llm-adapter:50070",
+		Capabilities:      []config.CapabilityConfig{{Name: "chat_completion"}},
+	}
+	def := registry.BuildAgentDef(cfg)
+	if def.Endpoint != "llm-adapter:50070" {
+		t.Errorf("advertised endpoint = %q, want routable llm-adapter:50070", def.Endpoint)
+	}
+	if strings.HasPrefix(def.Endpoint, ":") {
+		t.Errorf("advertised endpoint %q is hostless — broker would dial localhost (#1371)", def.Endpoint)
 	}
 }


### PR DESCRIPTION
Closes #1371

### Why  (problem & intent)

**Symptom:** the task-broker cannot dispatch to llm-adapter — `dial tcp [::1]:50070: connection refused` in any multi-container / K8s deployment.

**Root cause:** the adapter used a single `cfg.Endpoint` for BOTH `net.Listen("tcp", cfg.Endpoint)` and the address advertised to `AgentRegistryService` (`BuildAgentDef` set `Endpoint: cfg.Endpoint`). As shipped, `agent-def.yaml.example` uses `endpoint: :50070`. A hostless `:50070` binds all interfaces fine, but advertised verbatim it has no host, so the broker dials localhost and the connection is refused.

### What you'll get  (deliverables ↔ what changed)

- **Bind vs advertise split** (mirrors langgraph-adapter's `ADAPTER_ENDPOINT`): new `advertise_endpoint` config field. `BuildAgentDef` now advertises `cfg.AdvertisedEndpoint()`, never the raw bind endpoint. — `internal/registry/client.go`, `internal/config/config.go`
- **Fail-fast guard:** config load rejects a hostless `endpoint` when no `advertise_endpoint` is set, with an actionable message. Fallback to the bind endpoint is allowed only when it carries an explicit host. — `internal/config/config.go`
- **Reachable shipped default:** `agent-def.yaml.example` (also the baked container default at `/etc/llm-adapter/config.yaml`) now advertises `llm-adapter:50070`. — `agent-def.yaml.example`
- **Docs:** AGENTS.md config table documents bind-vs-advertise and the new field. — `AGENTS.md`

### Scope & boundaries

In scope: llm-adapter config + registry advertise path, its example, AGENTS.md, unit tests. Out of scope: other adapters (langgraph already correct), broker/registry code, proto contracts (`AgentDef.endpoint` unchanged).

### Test plan & acceptance

| Acceptance criterion | Verify command | Result |
|---|---|---|
| Advertised address is not hostless when given a bind-only endpoint (regression guard — fails on `main`, where `BuildAgentDef` advertised `:50070`) | `GOWORK=off go test ./internal/registry/ -run TestBuildAgentDef_AdvertisesRoutableEndpoint -v` | PASS — advertises `llm-adapter:50070` |
| Hostless endpoint without advertise_endpoint is rejected at load | `GOWORK=off go test ./internal/config/ -run TestLoad_HostlessEndpointRequiresAdvertise -v` | PASS |
| Explicit-host bind endpoint needs no advertise_endpoint (fallback) | `GOWORK=off go test ./internal/config/ -run TestLoad_ExplicitHostEndpointNeedsNoAdvertise -v` | PASS |
| `AdvertisedEndpoint()` never returns hostless | `GOWORK=off go test ./internal/config/ -run TestAdvertisedEndpoint -v` | PASS |
| Full module suite green | `GOWORK=off go test ./... -race -timeout 60s` | PASS (all 6 packages ok) |

### Evidence

```
ok  github.com/zynax-io/zynax/agents/adapters/llm/cmd/llm-adapter    1.310s
ok  github.com/zynax-io/zynax/agents/adapters/llm/internal/config    1.050s
ok  github.com/zynax-io/zynax/agents/adapters/llm/internal/domain    2.091s
ok  github.com/zynax-io/zynax/agents/adapters/llm/internal/provider  1.100s
ok  github.com/zynax-io/zynax/agents/adapters/llm/internal/registry  37.059s
ok  github.com/zynax-io/zynax/agents/adapters/llm/internal/server    1.075s
```
Pre-commit gofmt + golangci-lint: Passed. `go vet ./...`: clean.

Before → after (advertised address for `endpoint: :50070`): `:50070` (broker dials localhost → refused) → `llm-adapter:50070` (routable).

Post-merge digest sync → main: _placeholder — to be confirmed after squash-merge._

### Risk & rollback

Low. Behaviour change: a config with a hostless `endpoint` and no `advertise_endpoint` now fails fast at startup instead of silently advertising an unreachable address — the shipped example and baked default are updated so the default path stays valid. Rollback: revert the single commit; no schema or proto change.

### Review aids

Start at `internal/config/config.go` (`AdvertisedEndpoint`, `hasExplicitHost`, `validateIdentity`), then `internal/registry/client.go` (`BuildAgentDef`), then the example + tests.

Assisted-by: Claude/claude-opus-4-8
