### PR TITLE
docs(positioning): engine-portability wedge as the canonical messaging principle

### DIFF
--- a/.claude/commands/lib/market-fit-review.md
+++ b/.claude/commands/lib/market-fit-review.md
@@ -87,6 +87,10 @@ from [docs/contributing/pr-templates.md](docs/contributing/pr-templates.md), doc
 
 - **Lead with Kagent.** The repo's own docs name it the direct competitor — never omit it (the
   cautionary precedent: an earlier informal analysis did, and was wrong).
+- **Audit the wedge discipline.** Against `docs/product/positioning.md`, check whether user-facing
+  copy leads with the engine-portability wedge (run one workflow on Temporal or Argo without a
+  rewrite) or competes on the contested "control plane" category. Report drift as a positioning
+  recommendation (audience + adoption-lever = positioning), not a feature.
 - **Ground everything.** Cite positioning docs; pull adoption metrics live; no invented PMF score.
 - **Longitudinal.** Diff against the prior market-fit review / competitive-positioning doc.
 - **Recommendations carry user-type + adoption-lever annotations** (the `/plan` handoff).

--- a/.claude/commands/lib/product-review.md
+++ b/.claude/commands/lib/product-review.md
@@ -64,7 +64,10 @@ Write `$OUT` (SPDX header first; repo-relative links only):
 
 1. **Header** — type, date, baseline diffed against.
 2. **Executive summary** — the single most important product finding this period.
-3. **Positioning check** — is the messaging still differentiated (esp. vs Kagent)? Drift from `strategy.md`?
+3. **Positioning check** — measured against the canonical principle in `docs/product/positioning.md`:
+   does every user-facing surface (README, CLI help, docs, error copy) **lead with the engine-portability
+   wedge**, or has any drifted back to the generic "control plane for AI agents" framing that competes
+   on the contested category? Flag each drift. Drift from `strategy.md`? Still differentiated vs Kagent?
 4. **Real vs aspirational** — shipped / partial / aspirational table, reconciled to milestone state.
 5. **Adoption funnel** — time-to-first-workflow, stars/forks/discussions, external adopters,
    contributors — **the numbers from STEP 1**, each with its source. Compare to the baseline.

--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -58,3 +58,8 @@ Operations-step link; labels per [docs/labels.md](../../docs/labels.md). Convent
 (feat/fix/refactor/docs/test/ci/chore) · DCO `Signed-off-by` + `Assisted-by: Claude/<model>` (never
 `Co-Authored-By` for AI) · canvas committed before any implementation code (ADR-019) · new
 `.claude/commands` files need `git add -f`. Full guide: `.claude/commands/README.md`.
+
+**Positioning fit.** For any user-facing `feat:`/`docs:` work, the issue's "Positioning fit" line and
+the canvas A — Approach must state how it advances the **engine-portability wedge**, and any
+user-facing copy it introduces must lead with that wedge — never the generic "control plane for AI
+agents" framing. Canonical rule: [docs/product/positioning.md](../../docs/product/positioning.md).

--- a/.github/ISSUE_TEMPLATE/epic.md
+++ b/.github/ISSUE_TEMPLATE/epic.md
@@ -32,6 +32,9 @@ Keep child stories small, independent, testable, and individually valuable.
   - Enterprises (security, scale, operability, trust)
   - CNCF interest / ecosystem credibility
   - Community / contributor pull
+- **Positioning fit:** <how does this advance the engine-portability wedge (run one workflow on
+  Temporal or Argo without a rewrite)? Does the epic's user-facing surface lead with the wedge, not
+  the contested "control plane for AI agents" framing? See [docs/product/positioning.md](../../docs/product/positioning.md).>
 - **Cost of not doing it:** <what stays broken, who stays blocked, what adoption is lost>
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -37,6 +37,9 @@ Before filing a feature request:
 
 - **For the Zynax user / adopter:** <the observable value this story delivers>
 - **Adoption angle:** <which lever — individual users · enterprises · CNCF interest · community>
+- **Positioning fit:** <does this advance the engine-portability wedge? If it adds user-facing copy
+  (CLI help, docs, error strings), does that copy lead with the wedge, not the generic "control
+  plane" framing? See [docs/product/positioning.md](../../docs/product/positioning.md).>
 - **Cost of not doing it:** <what stays broken / who stays blocked>
 
 ---

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,14 @@ It IS:
 
 It is NOT an LLM framework, a workflow engine, or a DevOps tool.
 
+**North-Star differentiator (lead with this, everywhere).** Of the four "IS" points, one is the
+wedge a Kubernetes-locked competitor cannot match: **engine portability — the same declarative
+workflow runs on Temporal _or_ Argo without a rewrite.** All user-facing copy (README, CLI help,
+docs, error strings, issue/PR titles) leads with this, never with the generic, contested "control
+plane for AI agents" framing. The full rule — the wedge, the "ruthless" discipline, the co-existence
+story, and the honesty guardrails — is in [docs/product/positioning.md](docs/product/positioning.md),
+the single source of truth that planning, review, execution, and docs all point to.
+
 ---
 
 ## The Three-Layer Separation (Non-Negotiable)
@@ -133,7 +141,7 @@ A feature is DONE when **all** are true:
 - Always rebase (`git rebase origin/main`), never merge main into feature branches
 - `Assisted-by: Claude/<model-id>` for AI — use the exact model ID from the current session (e.g. `claude-sonnet-4-6`); never `Co-Authored-By:` for AI
 - No `🤖 Generated with [Claude Code]` lines in commit messages
-- Every commit needs `Signed-off-by: Oscar Gómez Manresa <ogomezmanresa@gmail.com>`
+- Every commit needs a DCO `Signed-off-by:` trailer with your real name and email — set them in your git config; `git commit -s` adds the trailer automatically (no literal email in this file: the AI-context PII gate forbids it)
 
 **PR title (CI-enforced `conventional-commit` check):**
 - Format: `<type>: <subject>` · total ≤ 72 characters
@@ -215,6 +223,7 @@ Observed mistakes in AI-assisted contributions — check before writing code.
 
 | What you need | Where to look |
 |--------------|---------------|
+| Positioning & messaging principle (the engine-portability wedge; lead with it everywhere) | `docs/product/positioning.md` |
 | Go service templates (bootstrap, domain, repo, API, Dockerfile) | `docs/patterns/go-service-patterns.md` |
 | Python agent options A–D, config, testing, BDD template | `docs/patterns/python-agent-guide.md` |
 | Multi-language proto consuming guide | `docs/patterns/proto-interop.md` |

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 
 # Zynax
 
-**The declarative control plane for AI agent workflows**
+**Write your agent workflow once — run it on Temporal or Argo without a rewrite.**
+
+_The engine-portability layer for agentic automation._
 
 [![CI](https://github.com/zynax-io/zynax/actions/workflows/ci.yml/badge.svg)](https://github.com/zynax-io/zynax/actions/workflows/ci.yml)
 [![AI Context Budget](https://github.com/zynax-io/zynax/actions/workflows/ai-context-budget.yml/badge.svg)](https://github.com/zynax-io/zynax/actions/workflows/ai-context-budget.yml)
@@ -21,12 +23,19 @@
 
 ## What is Zynax?
 
-> Zynax is to AI workflows what Kubernetes is to containers — a control plane
-> that abstracts the execution layer behind a declarative, versionable API.
+> **Define an AI agent workflow once, as a YAML manifest, and run it on whichever engine your org
+> already operates — Temporal or Argo — without changing the workflow.** That portability is the
+> wedge: a Kubernetes-locked agent platform cannot move one workflow across engines.
 
-Zynax lets you define AI agent workflows as YAML manifests and execute them
-on any workflow engine (Temporal, LangGraph, Argo) without changing your
-workflow definition.
+Like Kubernetes for containers, Zynax is a control plane that abstracts the execution layer behind
+a declarative, versionable API — but the point you reach for it is **engine portability** and
+**adapter-first capabilities** (any gRPC service is a capability; no SDK required). It runs on
+Docker Compose **and** Kubernetes/Helm.
+
+**Already standardized on a K8s-native agent tool?** Keep it — those agents register as Zynax
+capabilities, so Zynax orchestrates across your engines rather than replacing them.
+
+> Positioning & messaging principle (lead with the wedge, everywhere): [docs/product/positioning.md](docs/product/positioning.md).
 
 ```yaml
 # code-review.yaml

--- a/docs/contributing/pr-templates.md
+++ b/docs/contributing/pr-templates.md
@@ -81,7 +81,7 @@ your words where the table says.
 
 | Type | Emphasis / required extras | Sections that are usually `N/A` |
 |------|----------------------------|---------------------------------|
-| **feat** | Full template. **SPDD line required** (canvas Aligned + security-review PASS). Test plan maps every canvas AC. Evidence shows new observability (log event / metric / trace). | — |
+| **feat** | Full template. **SPDD line required** (canvas Aligned + security-review PASS). Test plan maps every canvas AC. Evidence shows new observability (log event / metric / trace). **Positioning line required** when the PR adds/changes user-facing copy (README, CLI help, docs, error strings): confirm it leads with the engine-portability wedge, not the generic "control plane" framing — see [docs/product/positioning.md](../product/positioning.md). | — |
 | **fix** | **Why = symptom + root cause** (not just "fixes bug"). A **regression test is mandatory** in the matrix: the test that fails on `main` and passes here. Evidence shows the repro **before → after**. | SPDD |
 | **docs** | Test plan = render/preview check, link-check, and `make validate-spec` when specs/schemas change. Evidence = preview link. | Artifacts/images; SPDD; observability |
 | **test** | "What you'll get" = the scenarios/coverage added. Evidence = coverage % and/or benchmark baseline numbers + the exact command to reproduce. | SPDD (unless the issue is `feat:`) |

--- a/docs/product/positioning.md
+++ b/docs/product/positioning.md
@@ -1,0 +1,118 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Positioning & Messaging Principle — the engine-portability wedge
+
+> **This is the single source of truth for how Zynax positions itself.** Every stage of the
+> project — planning, review, execution, issue authoring, implementation, and documentation —
+> points here rather than restating the rule. Change the principle *here*, and the pointers follow.
+>
+> Canonical grounding: [strategy.md](strategy.md) · competitive analysis in
+> [docs/architecture/2026-05-28-competitive-positioning.md](../architecture/2026-05-28-competitive-positioning.md).
+
+---
+
+## The principle (one line)
+
+**Lead with the one thing a Kubernetes-locked competitor cannot do — run the *same* agent
+workflow on multiple engines without a rewrite — and say it with total consistency, everywhere.**
+
+The enemy is not Kagent. The enemy is **generic positioning** — describing Zynax in the contested
+"control plane for AI agents" language that maps it onto the category leader and forces a comparison
+on axes where a first-mover, CNCF-backed, UI-equipped project wins today.
+
+---
+
+## The wedge — what we lead with
+
+These are the differentiators that are **real, shipped, and structurally unavailable to a
+K8s-locked competitor**. Lead with these, in this priority order:
+
+| # | Wedge | Status | Why a K8s-locked tool can't match it |
+|---|-------|--------|--------------------------------------|
+| 1 | **Engine portability** — the same declarative workflow runs on **Temporal _or_ Argo** without a rewrite | ✅ Shipped (both legs in the e2e CI matrix) | It is bound to one runtime / one agent model |
+| 2 | **Runs on Compose _and_ K8s/Helm** | ✅ Shipped | It requires Kubernetes |
+| 3 | **Adapter-first, no SDK required** — any gRPC `AgentService` is a capability | ✅ Shipped | It needs its own agent/SDK model |
+| 4 | **GitOps-native** — `zynax apply` is idempotent via a canonical hash | ✅ Shipped | It is kubectl-imperative |
+
+**The one sentence to lead with everywhere:**
+
+> **"Write your agent workflow once — run it on Temporal or Argo without a rewrite."**
+
+That is the sentence the competitor cannot say. If a headline could be lifted onto a competitor's
+page unchanged, it is not differentiated — rewrite it.
+
+---
+
+## "Ruthless" = the discipline
+
+"Ruthless" does **not** mean aggressive or attacking. It means *disciplined and unsentimental*:
+
+1. **Lead with the wedge, every time.** Hero copy, talk titles, issue descriptions, blog intros,
+   CLI help, error strings — all open on engine portability, not "a control plane for AI agents."
+2. **Cut parity features from the headline.** Multi-LLM support, observability, a workflow DSL —
+   table stakes a competitor also has. True, useful, *not differentiating* → they live in the body,
+   never the lead.
+3. **Don't claim the contested category.** Stop leading with "control plane for AI agents"
+   (the competitor's anchored turf). Lead as **"the portability layer for agent workflows."**
+4. **Consistency over polish.** One perfect README and ten issue/PR/doc strings that drift back to
+   generic language defeats the point. The same wedge, every surface, every time.
+5. **Drop messaging you're attached to** if it doesn't differentiate — even when it's true and
+   sounds good.
+
+---
+
+## The co-existence story (not an attack)
+
+Always pair the wedge with co-existence — it neutralizes an incumbent's advantage instead of
+fighting it head-on. A K8s-native agent can register as a Zynax capability via the gRPC
+`AgentService` contract, so the message is:
+
+> **"Already standardized on a K8s-native agent tool? Keep it. Zynax orchestrates across your
+> engines — including those agents — so you're not locked to one runtime."**
+
+"We orchestrate across engines, including yours" beats "we're better than them": it removes the
+rip-and-replace objection while still owning the portability narrative.
+
+---
+
+## Before → after (grounded in our own copy)
+
+- ❌ *"Zynax is a control plane that abstracts the execution layer behind a declarative API."*
+  → collides with the category leader; the reader compares on CNCF backing / UI and we lose.
+- ✅ *"Zynax runs the same declarative agent workflow on Temporal or Argo without a rewrite — the
+  engine-portability layer for agentic automation."*
+  → no competitor answer; the reader compares on portability and we win.
+
+---
+
+## Two guardrails (non-negotiable)
+
+1. **Ruthless ≠ dishonest.** Differentiators must stay grounded in what is actually shipped, with
+   the [Zynax truth-pass](../architecture/2026-05-22-platform-engineering-review.md) discipline:
+   mark **shipped / partial / aspirational**. A web UI and LangGraph-as-a-full-engine are
+   aspirational; never imply otherwise. Competitor facts are external — flag them as unverified
+   rather than inventing figures. Overclaiming to differentiate backfires and violates our culture.
+2. **This is a distribution lever, not an engineering task.** It changes *how we describe* work, not
+   *what we build*. The technical risks are closed; adoption is the binding constraint. Classify
+   positioning recommendations as **(audience, adoption-lever = positioning)** — not as features.
+
+---
+
+## How this applies at every stage
+
+This principle is wired into each control surface. Each surface carries a one-line check that points
+back here:
+
+| Stage | Surface | The check |
+|-------|---------|-----------|
+| **Constitution** | [AGENTS.md](../../AGENTS.md) §What Is Zynax? | The North-Star differentiator + link here; every agent inherits it. |
+| **Plan / intake** | `.github/ISSUE_TEMPLATE/feature_request.md`, `epic.md`; [/plan](../../.claude/commands/plan.md) | "Positioning fit" — does this advance the wedge? Is user-facing copy lead-with-the-wedge? |
+| **Canvas** | [docs/spdd/CANVAS_TEMPLATE.md](../spdd/CANVAS_TEMPLATE.md) §A — Approach | For user-facing features: how the change advances the wedge; user-facing copy leads with it. |
+| **Execute / PR** | [docs/contributing/pr-templates.md](../contributing/pr-templates.md) | Any new user-facing string (README/CLI help/docs/error copy) leads with the wedge, not the contested category. |
+| **Review** | `/lib:product-review`, `/lib:market-fit-review` | Does every user-facing surface lead with the wedge? Flag copy that competes on the contested category. |
+| **Documentation** | [README.md](../../README.md), `docs/` | Hero + quickstart lead with portability; co-existence story present. |
+
+**Rule of thumb for any contributor or agent:** before merging anything a user will read — a
+README line, CLI help, an error message, a doc heading, an issue title — ask *"could a
+Kubernetes-locked competitor put this exact sentence on their page?"* If yes, it is not
+differentiated. Rewrite it to lead with the wedge.

--- a/docs/product/strategy.md
+++ b/docs/product/strategy.md
@@ -7,6 +7,11 @@
 **Scope:** Tier 1 (public-safe). Where this doc makes strategic claims, it cites the
 repository artifact it is grounded in so nothing here drifts from shipped reality.
 
+> **Messaging principle:** the operational rule for *how* this positioning is expressed — lead with
+> the engine-portability wedge, ruthlessly and consistently, with the co-existence story — is the
+> single source of truth in [docs/product/positioning.md](positioning.md). This strategy doc is the
+> *why*; that doc is the *how we say it*.
+
 > **How to read this.** This is a rewrite and hardening of an earlier informal
 > competitive analysis. The earlier draft was directionally interesting but made
 > several claims that contradict Zynax's own decision record. This version replaces

--- a/docs/spdd/CANVAS_TEMPLATE.md
+++ b/docs/spdd/CANVAS_TEMPLATE.md
@@ -42,6 +42,11 @@
 **We will NOT:**
 - <explicit out-of-scope item (defer to a future milestone or issue)>
 
+**Positioning fit (user-facing features):** <how this advances the engine-portability wedge, and
+the user-facing copy (CLI help, docs, error strings) it introduces — which must lead with the wedge,
+not the generic "control plane" framing. See [docs/product/positioning.md](../product/positioning.md).
+Omit only for purely internal changes with no user-facing surface.>
+
 **Governing ADRs:** ADR-NNN (<title>), ADR-NNN (<title>)
 
 ---


### PR DESCRIPTION
## Why
The market-fit + product reviews (PR #1409) both flagged the top positioning recommendation: Zynax's messaging collides head-on with the category leader by leading with the generic "control plane for AI agents" framing, instead of the one thing a K8s-locked competitor structurally cannot do — **run the same workflow on Temporal or Argo without a rewrite**. This makes that principle durable and enforced at every stage.

## What you'll get
- **New canonical source of truth:** [docs/product/positioning.md](docs/product/positioning.md) — the wedge, the "ruthless" discipline (lead with it / cut parity from the headline / don't claim the contested category / consistency), the co-existence story, before→after examples, and the honesty guardrails (mark shipped/partial/aspirational; competitor facts flagged unverified).
- **Single-SoT + pointers** (not copied prose — avoids the drift `/reconcile` exists to fix). Each surface carries a one-line check pointing back to the doc:

| Stage | Surface | Change |
|-------|---------|--------|
| Constitution | `AGENTS.md` §What Is Zynax? + KB index | North-Star differentiator + index entry |
| Documentation | `README.md` hero + "What is Zynax?" | Leads with portability; adds co-existence line + link |
| Plan / intake | `feature_request.md`, `epic.md`, `/plan` norms | "Positioning fit" prompt/norm |
| Canvas | `docs/spdd/CANVAS_TEMPLATE.md` §A | Positioning-fit line for user-facing features |
| Execute / PR | `docs/contributing/pr-templates.md` | feat positioning line for user-facing copy |
| Review | `/lib:product-review`, `/lib:market-fit-review` | Explicit lead-with-the-wedge audit |
| Strategy | `docs/product/strategy.md` | Pointer: strategy = *why*, positioning = *how we say it* |

## Scope & boundaries
Docs + process only — no code, no ADR, no engineering change. It changes *how we describe* work, not *what we build*. README claims kept honest (Temporal/Argo shipped; LangGraph-as-engine and web UI remain out of the lead).

## Risk & rollback
Low — additive docs/process. Revert the single commit to roll back. `docs/`, `.claude/`, `.github/`, `AGENTS.md`, `README.md` are all PR-size-exempt.

Assisted-by: Claude/claude-opus-4-8