### PR TITLE
docs: point install instructions at the go.work Go-version SoT

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,7 +113,7 @@ The `zynax` CLI is a standalone module under `cmd/zynax/`. To test it against th
 running platform:
 
 ```bash
-# 1. Install the CLI (requires Go 1.26 locally, or download from GitHub Releases)
+# 1. Install the CLI (requires the Go toolchain pinned in go.work, or download from GitHub Releases)
 make install-cli            # builds cmd/zynax and installs to ~/bin/zynax
 
 # 2. Start the local stack

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Download from the [latest GitHub Release](https://github.com/zynax-io/zynax/rele
 | Linux (amd64) | `curl -fsSL https://github.com/zynax-io/zynax/releases/latest/download/zynax_linux_amd64.tar.gz \| tar xz && sudo mv zynax /usr/local/bin/` |
 | Linux (arm64) | `curl -fsSL https://github.com/zynax-io/zynax/releases/latest/download/zynax_linux_arm64.tar.gz \| tar xz && sudo mv zynax /usr/local/bin/` |
 
-**From source** (requires Go 1.26.3): `cd cmd/zynax && GOWORK=off go build -o ~/bin/zynax .`
+**From source** (requires the Go toolchain pinned in [`go.work`](go.work)): `cd cmd/zynax && GOWORK=off go build -o ~/bin/zynax .`
 **Makefile shortcut:** `make install-cli`
 
 Verify: `zynax --version`
@@ -133,7 +133,7 @@ curl -fsSL https://github.com/zynax-io/zynax/releases/latest/download/zynax-ci-d
   -o ~/bin/zynax-ci && chmod +x ~/bin/zynax-ci
 ```
 
-**From source** (requires Go 1.26.3): `cd cmd/zynax-ci && GOWORK=off go build -o ~/bin/zynax-ci .`
+**From source** (requires the Go toolchain pinned in [`go.work`](go.work)): `cd cmd/zynax-ci && GOWORK=off go build -o ~/bin/zynax-ci .`
 **Makefile shortcut:** `make install-ci-tools`
 
 ---

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -14,7 +14,7 @@ Engine + the Compose plugin). `make help` lists every target.
 git clone https://github.com/zynax-io/zynax.git
 cd zynax
 make bootstrap      # pulls ghcr.io/zynax-io/zynax/tools:latest from GHCR — run once
-make install-cli    # builds the zynax CLI → ~/bin/zynax (requires Go 1.26.3)
+make install-cli    # builds the zynax CLI → ~/bin/zynax (requires the Go toolchain pinned in go.work)
 ```
 
 ---

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -17,7 +17,7 @@ sudo mv zynax /usr/local/bin/
 curl -L https://github.com/zynax-io/zynax/releases/latest/download/zynax_linux_amd64.tar.gz | tar xz
 sudo mv zynax /usr/local/bin/
 
-# Or build from source (requires Go 1.26.3 installed locally):
+# Or build from source (requires the Go toolchain pinned in go.work installed locally):
 cd cmd/zynax && GOWORK=off go build -o ~/bin/zynax .
 # or: make install-cli
 ```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -27,8 +27,8 @@ make bootstrap    # one-time: pulls ghcr.io/zynax-io/zynax/tools:latest from GHC
 
 ## 2. Install the `zynax` CLI
 
-The CLI talks to the api-gateway over HTTP REST. Build it from source (requires Go
-1.26.3) or grab a release binary:
+The CLI talks to the api-gateway over HTTP REST. Build it from source (requires the
+Go toolchain pinned in [go.work](../go.work)) or grab a release binary:
 
 ```bash
 make install-cli                       # builds → ~/bin/zynax (ensure ~/bin is on PATH)


### PR DESCRIPTION
## Why
The README's Go-version badge reads the SoT dynamically (`?filename=go.work` → currently **1.26.4**), but the "build from source" prose hardcoded **Go 1.26.3** — a silent drift the badge can't catch. Same stale number appeared in CONTRIBUTING, quickstart, local-dev, and developer-guide.

## What changed
Dereferenced every install-instruction Go-version mention to the **`go.work` SoT** (the same file the badge links to), instead of duplicating a patch number that re-drifts on every Go bump:

| File | Was | Now |
|------|-----|-----|
| README.md (×2) | `requires Go 1.26.3` | `requires the Go toolchain pinned in [go.work](go.work)` |
| CONTRIBUTING.md | `requires Go 1.26 locally` | `requires the Go toolchain pinned in go.work` |
| docs/quickstart.md | `requires Go 1.26.3` | `requires the Go toolchain pinned in [go.work](../go.work)` |
| docs/local-dev.md | `requires Go 1.26.3` | `…pinned in go.work` |
| docs/developer-guide.md | `requires Go 1.26.3` | `…pinned in go.work` |

GitHub markdown can't execute, so prose can't *read* a file at render time — pointing at the SoT (as the badge's link already does) is the no-drift answer. Both surfaces now reflect `go.work`.

## Scope
Install-instruction prose only. **Not touched:** historical/review docs and per-service `AGENTS.md` version headers (separate, broader pattern — follow-up).

Assisted-by: Claude/claude-opus-4-8