### PR TITLE
docs: point service AGENTS.md + ci-runner note at the go.work Go SoT

### DIFF
--- a/docs/engineering/best-practices/github-ci.md
+++ b/docs/engineering/best-practices/github-ci.md
@@ -90,7 +90,7 @@ jobs:
 ```
 
 Use the `ci-runner` container image (built from `infra/docker/Dockerfile.ci-runner`) for
-all Go + Python CI jobs. It bakes in every tool (Go 1.26.3, golangci-lint, buf, uv, ruff,
+all Go + Python CI jobs. It bakes in every tool (the pinned Go toolchain, golangci-lint, buf, uv, ruff,
 mypy, bandit, zynax-ci) so no step downloads tooling at runtime. Built in #551/#552.
 
 ---

--- a/services/agent-registry/AGENTS.md
+++ b/services/agent-registry/AGENTS.md
@@ -1,6 +1,6 @@
 # services/agent-registry — AGENTS.md
 
-> Go 1.26.3. Inherits rules from root `AGENTS.md` and `services/AGENTS.md`.
+> Go toolchain pinned in the workspace [`go.work`](../../go.work). Inherits rules from root `AGENTS.md` and `services/AGENTS.md`.
 > **Status: M5 Complete.** gRPC service wired with in-memory round-robin store; compose-wired (#481); persistence deferred to M6 (#480 delivered).
 
 ---

--- a/services/api-gateway/AGENTS.md
+++ b/services/api-gateway/AGENTS.md
@@ -1,6 +1,6 @@
 # services/api-gateway — AGENTS.md
 
-> Go 1.26.3+. Inherits rules from root `AGENTS.md` and `services/AGENTS.md`.
+> Go toolchain pinned in the workspace [`go.work`](../../go.work). Inherits rules from root `AGENTS.md` and `services/AGENTS.md`.
 > **Status: M5 Complete** — HTTP REST layer, bearer-token auth (constant-time), ReadHeaderTimeout, X-Request-ID middleware, gRPC deadlines all implemented. Rate limiting deferred to M6 (#580).
 
 ---

--- a/services/engine-adapter/AGENTS.md
+++ b/services/engine-adapter/AGENTS.md
@@ -1,6 +1,6 @@
 # services/engine-adapter — AGENTS.md
 
-> Go 1.26.3+. Inherits rules from root `AGENTS.md` and `services/AGENTS.md`.
+> Go toolchain pinned in the workspace [`go.work`](../../go.work). Inherits rules from root `AGENTS.md` and `services/AGENTS.md`.
 > **Status: M5 Complete.** Temporal backend fully implemented; cel-go guard evaluation live (#538); explicit RetryPolicy on `DispatchCapabilityActivity` (#569). LangGraph/Argo `WorkflowEngine` backends deferred to M6+.
 
 ---

--- a/services/event-bus/AGENTS.md
+++ b/services/event-bus/AGENTS.md
@@ -1,6 +1,6 @@
 # services/event-bus — AGENTS.md
 
-> Go 1.22+. Inherits rules from root `AGENTS.md` and `services/AGENTS.md`.
+> Go toolchain pinned in the workspace [`go.work`](../../go.work). Inherits rules from root `AGENTS.md` and `services/AGENTS.md`.
 > **Status: M6 EPIC I (#772) — implementation pending.** Architecture decided by ADR-022: full gRPC `EventBusService` wrapping NATS JetStream; the service is a stateless Deployment (all durability in JetStream). BDD contract tests exist in `protos/tests/`. `PublishLifecycleEventActivity` in engine-adapter is a log-only stub until EPIC I ships.
 
 ---

--- a/services/memory-service/AGENTS.md
+++ b/services/memory-service/AGENTS.md
@@ -1,6 +1,6 @@
 # services/memory-service — AGENTS.md
 
-> Go 1.22+. Inherits rules from root `AGENTS.md` and `services/AGENTS.md`.
+> Go toolchain pinned in the workspace [`go.work`](../../go.work). Inherits rules from root `AGENTS.md` and `services/AGENTS.md`.
 > **Status: M6+ (not yet implemented).** BDD contract tests exist in `protos/tests/`.
 
 ---

--- a/services/task-broker/AGENTS.md
+++ b/services/task-broker/AGENTS.md
@@ -1,6 +1,6 @@
 # services/task-broker — AGENTS.md
 
-> Go 1.26.3+. Inherits rules from root `AGENTS.md` and `services/AGENTS.md`.
+> Go toolchain pinned in the workspace [`go.work`](../../go.work). Inherits rules from root `AGENTS.md` and `services/AGENTS.md`.
 > **Status: M5 Complete** — Implementation merged in PRs #520, #522, #523. BDD aligned (#531), handler unit tests complete (#532). Domain coverage 92.7%. BDD contract tests in `protos/tests/task_broker_service/`.
 
 ---

--- a/services/workflow-compiler/AGENTS.md
+++ b/services/workflow-compiler/AGENTS.md
@@ -1,6 +1,6 @@
 # services/workflow-compiler — AGENTS.md
 
-> Go 1.26.3. Inherits rules from root `AGENTS.md` and `services/AGENTS.md`.
+> Go toolchain pinned in the workspace [`go.work`](../../go.work). Inherits rules from root `AGENTS.md` and `services/AGENTS.md`.
 > **Status: M5 Complete.** Fully implemented — YAML → WorkflowIR, structured error list, cel-go guard wiring. IR store is in-memory (durable storage in M6, #466).
 
 > **⚠ Persistence limitation (M6):** The IR store is an unbounded in-memory map (`sync.RWMutex` +


### PR DESCRIPTION
## Why
Follow-up to #1427. The remaining stale hardcoded Go versions in **active** docs:
- 7 per-service `AGENTS.md` headers pinned `Go 1.26.3` (×5) or `Go 1.22+` (memory-service, event-bus) — while `go.work` pins **1.26.4**.
- `docs/engineering/best-practices/github-ci.md` named `Go 1.26.3` in the ci-runner tool list.

## What changed
- **7 service `AGENTS.md` headers** → `Go toolchain pinned in the workspace [go.work](../../go.work)`. No number to drift; single SoT.
- **github-ci.md** → drops the specific version (it documents the *tools-image* contents, a separate artifact — pointing it at `go.work` would be a false SoT claim, and a number there re-drifts).

## Scope
Active toolchain-statement prose only. **Left untouched:** `ADR-009` (immutable decision record; `Go 1.22+` is a still-valid floor) and historical review docs (point-in-time records).

After this, no active doc hardcodes the Go version — `go.work` is the only place it lives.

Assisted-by: Claude/claude-opus-4-8