### PR TITLE
fix(agents/adapters): tolerate missing secrets without crash-looping

### DIFF
--- a/agents/adapters/ci/cmd/ci-adapter/main.go
+++ b/agents/adapters/ci/cmd/ci-adapter/main.go
@@ -7,6 +7,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -43,9 +44,21 @@ func run() error {
 	}
 	slog.Info("config loaded", "agent_id", cfg.AgentID, "endpoint", cfg.Endpoint) //nolint:gosec
 
+	// Graceful degradation (issue #1375): a missing auth token must not crash the
+	// adapter at boot. Without a token the adapter starts, logs a clear warning,
+	// and runs degraded — it does NOT register its capabilities and reports
+	// NOT_SERVING so readiness reflects the unavailable state. Any other resolution
+	// failure (malformed config) is still fatal.
 	token, err := config.ResolveToken(cfg)
+	degraded := false
 	if err != nil {
-		return fmt.Errorf("resolve token: %w", err)
+		if !errors.Is(err, config.ErrTokenMissing) {
+			return fmt.Errorf("resolve token: %w", err)
+		}
+		degraded = true
+		//nolint:gosec // G706: token_env is operator config (the env-var NAME), never the secret value or request input
+		slog.Warn("ci-adapter starting in degraded mode: auth token not set; capabilities will NOT be registered and readiness is NOT_SERVING",
+			"token_env", cfg.CI.TokenEnv)
 	}
 
 	regClient, cleanup, err := dialRegistry(cfg.RegistryEndpoint)
@@ -57,7 +70,7 @@ func run() error {
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 	defer stop()
 
-	return serve(ctx, cfg, token, regClient)
+	return serve(ctx, cfg, token, degraded, regClient)
 }
 
 func dialRegistry(endpoint string) (zynaxv1.AgentRegistryServiceClient, func(), error) {
@@ -68,7 +81,7 @@ func dialRegistry(endpoint string) (zynaxv1.AgentRegistryServiceClient, func(), 
 	return zynaxv1.NewAgentRegistryServiceClient(conn), func() { _ = conn.Close() }, nil
 }
 
-func serve(ctx context.Context, cfg *config.AdapterConfig, token string, regClient zynaxv1.AgentRegistryServiceClient) error {
+func serve(ctx context.Context, cfg *config.AdapterConfig, token string, degraded bool, regClient zynaxv1.AgentRegistryServiceClient) error {
 	lis, err := net.Listen("tcp", cfg.Endpoint)
 	if err != nil {
 		return fmt.Errorf("listen %s: %w", cfg.Endpoint, err)
@@ -78,6 +91,15 @@ func serve(ctx context.Context, cfg *config.AdapterConfig, token string, regClie
 	zynaxv1.RegisterAgentServiceServer(grpcSrv, adapter.NewAgentServer(cfg, token))
 	healthSrv := health.NewServer()
 	grpc_health_v1.RegisterHealthServer(grpcSrv, healthSrv)
+
+	// Degraded mode (issue #1375): no token resolved, so the adapter does not
+	// register its capabilities and reports NOT_SERVING. The gRPC + health servers
+	// still run so the process stays alive and observable instead of crash-looping.
+	if degraded {
+		healthSrv.SetServingStatus("", grpc_health_v1.HealthCheckResponse_NOT_SERVING)
+		slog.Warn("ci-adapter serving DEGRADED (capabilities not registered)", "endpoint", cfg.Endpoint) //nolint:gosec
+		return runServer(ctx, grpcSrv, lis)
+	}
 
 	def := registry.BuildAgentDef(cfg)
 	if err := registry.RegisterAgent(ctx, regClient, def); err != nil {
@@ -100,6 +122,24 @@ func serve(ctx context.Context, cfg *config.AdapterConfig, token string, regClie
 	deregCtx := context.Background()
 	if err := registry.DeregisterAgent(deregCtx, regClient, cfg.AgentID); err != nil { //nolint:contextcheck // signal ctx already cancelled; fresh ctx for cleanup is intentional
 		slog.Warn("deregister failed", "err", err)
+	}
+	grpcSrv.GracefulStop()
+	slog.Info("ci-adapter stopped")
+	return nil
+}
+
+// runServer serves gRPC until the context is cancelled or the server errors. It
+// is used by the degraded path (issue #1375), which has nothing registered to
+// deregister — it just keeps the process alive and drains on shutdown.
+func runServer(ctx context.Context, grpcSrv *grpc.Server, lis net.Listener) error {
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- grpcSrv.Serve(lis) }()
+
+	select {
+	case <-ctx.Done():
+		slog.Info("shutdown signal received")
+	case err := <-serveErr:
+		return fmt.Errorf("grpc serve: %w", err)
 	}
 	grpcSrv.GracefulStop()
 	slog.Info("ci-adapter stopped")

--- a/agents/adapters/ci/cmd/ci-adapter/main_test.go
+++ b/agents/adapters/ci/cmd/ci-adapter/main_test.go
@@ -7,6 +7,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -17,6 +18,8 @@ import (
 	zynaxv1 "github.com/zynax-io/zynax/protos/generated/go/zynax/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/status"
 )
 
@@ -67,23 +70,18 @@ func TestRun_MissingRequiredFields(t *testing.T) {
 	}
 }
 
-func TestRun_MissingToken(t *testing.T) {
-	f, err := os.CreateTemp(t.TempDir(), "ci-adapter-*.yaml")
-	if err != nil {
-		t.Fatal(err)
-	}
-	// Full valid config but CI_TOKEN_UNSET_XYZ is not in the environment.
-	_, _ = fmt.Fprintf(f,
-		"agent_id: ci-test\nname: CI Test\n"+
-			"endpoint: \":50055\"\nregistry_endpoint: \"localhost:50052\"\n"+
-			"ci:\n  provider: github-actions\n  token_env: CI_TOKEN_UNSET_XYZ_407\n"+
-			"capabilities:\n  - name: trigger_workflow\n    owner: o\n    repo: r\n    workflow_id: ci.yml\n",
-	)
-	_ = f.Close()
-	t.Setenv("ADAPTER_CONFIG", f.Name())
-	os.Unsetenv("CI_TOKEN_UNSET_XYZ_407") //nolint:errcheck // test cleanup
-	if err := run(); err == nil {
+// TestResolveToken_MissingIsSentinel proves a missing token surfaces the typed
+// ErrTokenMissing sentinel so the bootstrap layer can degrade gracefully rather
+// than crash-loop (issue #1375).
+func TestResolveToken_MissingIsSentinel(t *testing.T) {
+	cfg := &config.AdapterConfig{CI: config.CIConfig{TokenEnv: "CI_TOKEN_UNSET_XYZ_407"}} //nolint:gosec // G101: env-var NAME, not a credential value
+	os.Unsetenv("CI_TOKEN_UNSET_XYZ_407")                                                 //nolint:errcheck // test cleanup
+	_, err := config.ResolveToken(cfg)
+	if err == nil {
 		t.Fatal("expected error when token env var is not set")
+	}
+	if !errors.Is(err, config.ErrTokenMissing) {
+		t.Fatalf("expected ErrTokenMissing sentinel, got: %v", err)
 	}
 }
 
@@ -193,7 +191,7 @@ func TestServe_GracefulShutdown(t *testing.T) {
 	client := &successRegistryClient{}
 
 	done := make(chan error, 1)
-	go func() { done <- serve(ctx, cfg, "fake-token", client) }()
+	go func() { done <- serve(ctx, cfg, "fake-token", false, client) }()
 
 	time.Sleep(50 * time.Millisecond)
 	cancel()
@@ -205,5 +203,66 @@ func TestServe_GracefulShutdown(t *testing.T) {
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("serve() did not return within 5s after cancel")
+	}
+}
+
+// failRegistryClient fails any RegisterAgent call. The degraded path must never
+// reach it, so wiring it in proves no registration is attempted (issue #1375).
+type failRegistryClient struct{ successRegistryClient }
+
+func (c *failRegistryClient) RegisterAgent(_ context.Context, _ *zynaxv1.RegisterAgentRequest, _ ...grpc.CallOption) (*zynaxv1.RegisterAgentResponse, error) {
+	return nil, status.Error(codes.Internal, "registry must not be called in degraded mode")
+}
+
+// TestServe_DegradedNoSecret proves the core fix (issue #1375): with no token the
+// adapter serves, reports NOT_SERVING readiness, does NOT register its
+// capabilities, and shuts down cleanly on context cancel — it does not crash.
+func TestServe_DegradedNoSecret(t *testing.T) {
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr := lis.Addr().String()
+	_ = lis.Close()
+
+	cfg := &config.AdapterConfig{
+		AgentID:          "ci-test",
+		Name:             "CI Test",
+		Endpoint:         addr,
+		RegistryEndpoint: "127.0.0.1:0",
+		CI:               config.CIConfig{Provider: "github-actions", TokenEnv: "IGNORED"},
+		Capabilities:     []config.CICapabilityConfig{{Name: "trigger_workflow", Owner: "o", Repo: "r", WorkflowID: "ci.yml"}},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	// Degraded=true with a registry client that errors on RegisterAgent: if the
+	// degraded path tried to register, serve would return that error.
+	go func() { done <- serve(ctx, cfg, "", true, &failRegistryClient{}) }()
+
+	// Give the server a moment to bind, then probe health: must be NOT_SERVING.
+	time.Sleep(100 * time.Millisecond)
+	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("dial degraded adapter: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+	hc := grpc_health_v1.NewHealthClient(conn)
+	resp, err := hc.Check(context.Background(), &grpc_health_v1.HealthCheckRequest{})
+	if err != nil {
+		t.Fatalf("health check: %v", err)
+	}
+	if resp.GetStatus() != grpc_health_v1.HealthCheckResponse_NOT_SERVING {
+		t.Fatalf("expected NOT_SERVING in degraded mode, got: %v", resp.GetStatus())
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("degraded serve must not error (no crash), got: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("degraded serve() did not return within 5s after cancel")
 	}
 }

--- a/agents/adapters/ci/internal/config/config.go
+++ b/agents/adapters/ci/internal/config/config.go
@@ -6,11 +6,18 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
 	"gopkg.in/yaml.v3"
 )
+
+// ErrTokenMissing is returned by ResolveToken when the configured auth-token env
+// var is unset or empty. The bootstrap layer distinguishes this from a malformed
+// config so it can degrade gracefully (start, warn, skip registration) instead of
+// crash-looping when no secret is provided (issue #1375).
+var ErrTokenMissing = errors.New("config: auth token env var is not set")
 
 // AdapterConfig is the top-level YAML struct parsed from the file at startup.
 // Path is read from the ADAPTER_CONFIG env var by the bootstrap layer.
@@ -138,7 +145,7 @@ func validate(cfg *AdapterConfig) error {
 func ResolveToken(cfg *AdapterConfig) (string, error) {
 	token := os.Getenv(cfg.CI.TokenEnv)
 	if token == "" {
-		return "", fmt.Errorf("config: env var %s is required but not set", cfg.CI.TokenEnv)
+		return "", fmt.Errorf("env var %s is required but not set: %w", cfg.CI.TokenEnv, ErrTokenMissing)
 	}
 	return token, nil
 }

--- a/agents/adapters/git/cmd/git-adapter/main.go
+++ b/agents/adapters/git/cmd/git-adapter/main.go
@@ -55,25 +55,37 @@ func run() error {
 	// token used to seed the egress redactor (empty for App mode — its token is
 	// minted lazily and never reaches a payload thanks to per-request Bearer
 	// isolation). No secret value is logged at any point.
+	// Graceful degradation (issue #1375): a missing credential (PAT token or App
+	// identity) must not crash the adapter at boot. Without it the adapter starts,
+	// logs a clear warning, and runs degraded — it skips the scope gate, does NOT
+	// register its capabilities, and reports NOT_SERVING so readiness reflects the
+	// unavailable state. Any other resolution failure is still fatal.
 	src, seedToken, err := resolveCredentialSource(cfg)
+	degraded := false
 	if err != nil {
-		return err
+		if !errors.Is(err, config.ErrCredentialMissing) {
+			return err
+		}
+		degraded = true
+		slog.Warn("git-adapter starting in degraded mode: credential not set; capabilities will NOT be registered and readiness is NOT_SERVING") //nolint:gosec
 	}
 
-	// Least-privilege gate (G.5 / #1260): verify the credential cannot reach repos
-	// beyond the configured owner/repo before it is ever used. App installation
-	// tokens carry no X-OAuth-Scopes header and are least-privilege by construction;
-	// the probe classifies them as such. The token value is never logged — only
-	// scope/class metadata.
-	if err := runScopeGate(context.Background(), src); err != nil {
-		return err
-	}
+	if !degraded {
+		// Least-privilege gate (G.5 / #1260): verify the credential cannot reach repos
+		// beyond the configured owner/repo before it is ever used. App installation
+		// tokens carry no X-OAuth-Scopes header and are least-privilege by construction;
+		// the probe classifies them as such. The token value is never logged — only
+		// scope/class metadata.
+		if err := runScopeGate(context.Background(), src); err != nil {
+			return err
+		}
 
-	// `git-adapter mcp` runs the thin MCP stdio shim over the same handlers
-	// instead of the runtime gRPC server (ADR-032 — one implementation, two
-	// surfaces). It needs no registry and binds no port.
-	if len(os.Args) > 1 && os.Args[1] == "mcp" {
-		return serveMCP(cfg, src, seedToken, os.Stdin, os.Stdout)
+		// `git-adapter mcp` runs the thin MCP stdio shim over the same handlers
+		// instead of the runtime gRPC server (ADR-032 — one implementation, two
+		// surfaces). It needs no registry and binds no port.
+		if len(os.Args) > 1 && os.Args[1] == "mcp" {
+			return serveMCP(cfg, src, seedToken, os.Stdin, os.Stdout)
+		}
 	}
 
 	regClient, cleanup, err := dialRegistry(cfg.RegistryEndpoint)
@@ -85,7 +97,7 @@ func run() error {
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 	defer stop()
 
-	return serve(ctx, cfg, src, seedToken, regClient)
+	return serve(ctx, cfg, src, seedToken, degraded, regClient)
 }
 
 // resolveCredentialSource builds the credential.Source for the configured mode.
@@ -201,16 +213,27 @@ func dialRegistry(endpoint string) (zynaxv1.AgentRegistryServiceClient, func(), 
 	return zynaxv1.NewAgentRegistryServiceClient(conn), func() { _ = conn.Close() }, nil
 }
 
-func serve(ctx context.Context, cfg *config.AdapterConfig, src credential.Source, seedToken string, regClient zynaxv1.AgentRegistryServiceClient) error {
+func serve(ctx context.Context, cfg *config.AdapterConfig, src credential.Source, seedToken string, degraded bool, regClient zynaxv1.AgentRegistryServiceClient) error {
 	lis, err := net.Listen("tcp", cfg.Endpoint)
 	if err != nil {
 		return fmt.Errorf("listen %s: %w", cfg.Endpoint, err)
 	}
 
 	grpcSrv := grpc.NewServer()
-	zynaxv1.RegisterAgentServiceServer(grpcSrv, adapter.NewAgentServerWithSource(cfg, src, seedToken))
+	if !degraded {
+		zynaxv1.RegisterAgentServiceServer(grpcSrv, adapter.NewAgentServerWithSource(cfg, src, seedToken))
+	}
 	healthSrv := health.NewServer()
 	grpc_health_v1.RegisterHealthServer(grpcSrv, healthSrv)
+
+	// Degraded mode (issue #1375): no credential resolved, so the adapter does not
+	// register its capabilities and reports NOT_SERVING. The gRPC + health servers
+	// still run so the process stays alive and observable instead of crash-looping.
+	if degraded {
+		healthSrv.SetServingStatus("", grpc_health_v1.HealthCheckResponse_NOT_SERVING)
+		slog.Warn("git-adapter serving DEGRADED (capabilities not registered)", "endpoint", cfg.Endpoint) //nolint:gosec
+		return runDegraded(ctx, grpcSrv, lis)
+	}
 
 	def := registry.BuildAgentDef(cfg)
 	if err := registry.RegisterAgent(ctx, regClient, def); err != nil {
@@ -233,6 +256,24 @@ func serve(ctx context.Context, cfg *config.AdapterConfig, src credential.Source
 	deregCtx := context.Background()
 	if err := registry.DeregisterAgent(deregCtx, regClient, cfg.AgentID); err != nil { //nolint:contextcheck // signal ctx already cancelled; fresh ctx for cleanup is intentional
 		slog.Warn("deregister failed", "err", err)
+	}
+	grpcSrv.GracefulStop()
+	slog.Info("git-adapter stopped")
+	return nil
+}
+
+// runDegraded serves gRPC until the context is cancelled or the server errors.
+// The degraded path (issue #1375) registers no AgentService and no registry
+// entry, so it just keeps the process alive and drains on shutdown.
+func runDegraded(ctx context.Context, grpcSrv *grpc.Server, lis net.Listener) error {
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- grpcSrv.Serve(lis) }()
+
+	select {
+	case <-ctx.Done():
+		slog.Info("shutdown signal received")
+	case err := <-serveErr:
+		return fmt.Errorf("grpc serve: %w", err)
 	}
 	grpcSrv.GracefulStop()
 	slog.Info("git-adapter stopped")

--- a/agents/adapters/git/cmd/git-adapter/main_test.go
+++ b/agents/adapters/git/cmd/git-adapter/main_test.go
@@ -8,6 +8,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -19,6 +20,8 @@ import (
 	zynaxv1 "github.com/zynax-io/zynax/protos/generated/go/zynax/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/status"
 )
 
@@ -69,25 +72,18 @@ func TestRun_MissingRequiredFields(t *testing.T) {
 	}
 }
 
-// TestRun_MissingToken verifies that run() returns an error when the auth
-// token env var referenced in git.auth_env is not set.
-func TestRun_MissingToken(t *testing.T) {
-	f, err := os.CreateTemp(t.TempDir(), "git-adapter-*.yaml")
-	if err != nil {
-		t.Fatal(err)
-	}
-	// Valid full config, but GIT_TOKEN_UNSET_XYZ is not in the environment.
-	_, _ = fmt.Fprintf(f,
-		"agent_id: git-test\nname: Git Test\n"+
-			"endpoint: \":50060\"\nregistry_endpoint: \"localhost:50052\"\n"+
-			"git:\n  provider: github\n  auth_env: GIT_TOKEN_UNSET_XYZ_717\n"+
-			"capabilities:\n  - name: open_pr\n    owner: o\n    repo: r\n",
-	)
-	_ = f.Close()
-	t.Setenv("ADAPTER_CONFIG", f.Name())
-	os.Unsetenv("GIT_TOKEN_UNSET_XYZ_717") //nolint:errcheck // test cleanup
-	if err := run(); err == nil {
+// TestResolveCredentialSource_MissingTokenIsSentinel proves a missing PAT
+// surfaces the typed config.ErrCredentialMissing sentinel so the bootstrap layer
+// degrades gracefully instead of crash-looping (issue #1375).
+func TestResolveCredentialSource_MissingTokenIsSentinel(t *testing.T) {
+	os.Unsetenv("GIT_TOKEN_UNSET_XYZ_717")                                                                      //nolint:errcheck // test cleanup
+	cfg := &config.AdapterConfig{Git: config.GitConfig{Provider: "github", AuthEnv: "GIT_TOKEN_UNSET_XYZ_717"}} //nolint:gosec // G101: env-var NAME, not a credential value
+	_, _, err := resolveCredentialSource(cfg)
+	if err == nil {
 		t.Fatal("expected error when auth token env var is not set")
+	}
+	if !errors.Is(err, config.ErrCredentialMissing) {
+		t.Fatalf("expected ErrCredentialMissing sentinel, got: %v", err)
 	}
 }
 
@@ -211,7 +207,7 @@ func TestServe_GracefulShutdown(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		done <- serve(ctx, cfg, credential.NewStaticSource("fake-token"), "fake-token", client)
+		done <- serve(ctx, cfg, credential.NewStaticSource("fake-token"), "fake-token", false, client)
 	}()
 
 	// Give serve() time to start up (register + begin listening).
@@ -225,5 +221,64 @@ func TestServe_GracefulShutdown(t *testing.T) {
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("serve() did not return within 5s after cancel")
+	}
+}
+
+// failRegisterClient errors on RegisterAgent. The degraded path must never call
+// it, so serve must still return nil with this client wired in (issue #1375).
+type failRegisterClient struct{ successRegistryClient }
+
+func (c *failRegisterClient) RegisterAgent(_ context.Context, _ *zynaxv1.RegisterAgentRequest, _ ...grpc.CallOption) (*zynaxv1.RegisterAgentResponse, error) {
+	return nil, status.Error(codes.Internal, "registry must not be called in degraded mode")
+}
+
+// TestServe_DegradedNoCredential proves the core fix (issue #1375): with no
+// credential the adapter serves, reports NOT_SERVING readiness, does NOT register
+// its capabilities, and shuts down cleanly on context cancel — it does not crash.
+func TestServe_DegradedNoCredential(t *testing.T) {
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr := lis.Addr().String()
+	_ = lis.Close()
+
+	cfg := &config.AdapterConfig{
+		AgentID:          "git-test",
+		Name:             "Git Test",
+		Endpoint:         addr,
+		RegistryEndpoint: "127.0.0.1:0",
+		Git:              config.GitConfig{Provider: "github", AuthEnv: "IGNORED"},
+		Capabilities:     []config.GitCapabilityConfig{{Name: "open_pr", Owner: "o", Repo: "r"}},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	// degraded=true, nil source, and a registry client that errors on register:
+	// if the degraded path tried to register, serve would surface that error.
+	go func() { done <- serve(ctx, cfg, nil, "", true, &failRegisterClient{}) }()
+
+	time.Sleep(100 * time.Millisecond)
+	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("dial degraded adapter: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+	resp, err := grpc_health_v1.NewHealthClient(conn).Check(context.Background(), &grpc_health_v1.HealthCheckRequest{})
+	if err != nil {
+		t.Fatalf("health check: %v", err)
+	}
+	if resp.GetStatus() != grpc_health_v1.HealthCheckResponse_NOT_SERVING {
+		t.Fatalf("expected NOT_SERVING in degraded mode, got: %v", resp.GetStatus())
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("degraded serve must not error (no crash), got: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("degraded serve() did not return within 5s after cancel")
 	}
 }

--- a/agents/adapters/git/internal/config/config.go
+++ b/agents/adapters/git/internal/config/config.go
@@ -6,12 +6,20 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
 
 	"gopkg.in/yaml.v3"
 )
+
+// ErrCredentialMissing is returned when a required credential env var (the PAT
+// auth token, or a GitHub App identity value) is unset or empty. The bootstrap
+// layer distinguishes this from a malformed config so it can degrade gracefully
+// (start, warn, skip registration) instead of crash-looping when no secret is
+// provided (issue #1375).
+var ErrCredentialMissing = errors.New("config: credential env var is not set")
 
 // AdapterConfig is the top-level YAML struct parsed from the file at startup.
 // Path is read from the ADAPTER_CONFIG env var by the bootstrap layer.
@@ -158,7 +166,7 @@ func (c *AdapterConfig) UsesApp() bool {
 func ResolveToken(cfg *AdapterConfig) (string, error) {
 	token := os.Getenv(cfg.Git.AuthEnv)
 	if token == "" {
-		return "", fmt.Errorf("config: env var %s is required but not set", cfg.Git.AuthEnv)
+		return "", fmt.Errorf("env var %s is required but not set: %w", cfg.Git.AuthEnv, ErrCredentialMissing)
 	}
 	return token, nil
 }
@@ -190,7 +198,7 @@ func ResolveAppCredentials(cfg *AdapterConfig) (AppCredentialInputs, error) {
 	}
 	keyPEM := os.Getenv(app.PrivateKeyEnv)
 	if keyPEM == "" {
-		return AppCredentialInputs{}, fmt.Errorf("config: env var %s is required but not set", app.PrivateKeyEnv)
+		return AppCredentialInputs{}, fmt.Errorf("env var %s is required but not set: %w", app.PrivateKeyEnv, ErrCredentialMissing)
 	}
 	return AppCredentialInputs{
 		AppID:          appID,
@@ -203,7 +211,7 @@ func ResolveAppCredentials(cfg *AdapterConfig) (AppCredentialInputs, error) {
 func envInt64(name string) (int64, error) {
 	raw := os.Getenv(name)
 	if raw == "" {
-		return 0, fmt.Errorf("config: env var %s is required but not set", name)
+		return 0, fmt.Errorf("env var %s is required but not set: %w", name, ErrCredentialMissing)
 	}
 	v, err := strconv.ParseInt(raw, 10, 64)
 	if err != nil {

--- a/agents/adapters/llm/cmd/llm-adapter/main.go
+++ b/agents/adapters/llm/cmd/llm-adapter/main.go
@@ -8,6 +8,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -42,7 +43,7 @@ func main() {
 // lifecycle test-friendly: a non-transient registry error returns before the
 // blocking serve loop, exercising the bootstrap paths without a live signal.
 func run() error {
-	cfg, srv, err := build()
+	cfg, srv, degraded, err := build()
 	if err != nil {
 		return err
 	}
@@ -55,32 +56,43 @@ func run() error {
 	defer func() { _ = regConn.Close() }()
 	regClient := zynaxv1.NewAgentRegistryServiceClient(regConn)
 
-	return serve(cfg, srv, regClient)
+	return serve(cfg, srv, degraded, regClient)
 }
 
 // build loads config, resolves the credential, and constructs the provider and
 // AgentService server. The API-key Secret is bound into the provider and never
 // logged.
-func build() (*config.AdapterConfig, *server.AgentServer, error) {
+func build() (*config.AdapterConfig, *server.AgentServer, bool, error) {
 	cfgPath := os.Getenv(configEnvVar)
 	if cfgPath == "" {
-		return nil, nil, fmt.Errorf("%s env var is required", configEnvVar)
+		return nil, nil, false, fmt.Errorf("%s env var is required", configEnvVar)
 	}
 	cfg, err := config.Load(cfgPath)
 	if err != nil {
-		return nil, nil, fmt.Errorf("load config: %w", err)
+		return nil, nil, false, fmt.Errorf("load config: %w", err)
 	}
 	secret, err := cfg.ResolveSecret()
 	if err != nil {
-		return nil, nil, fmt.Errorf("resolve secret: %w", err)
+		// Graceful degradation (issue #1375): a missing API key must not crash the
+		// adapter at boot. Without it the adapter starts, logs a clear warning, and
+		// runs degraded — it does NOT build a provider/server, does NOT register its
+		// capabilities, and reports NOT_SERVING so readiness reflects unavailability.
+		// Any other resolution failure (malformed config) is still fatal.
+		if !errors.Is(err, config.ErrSecretMissing) {
+			return nil, nil, false, fmt.Errorf("resolve secret: %w", err)
+		}
+		//nolint:gosec // G706: api_key_env/provider are operator config (names), never the secret value or request input
+		slog.Warn("llm-adapter starting in degraded mode: API key not set; capabilities will NOT be registered and readiness is NOT_SERVING",
+			"api_key_env", cfg.Provider.APIKeyEnv, "provider", cfg.Provider.Name)
+		return cfg, nil, true, nil
 	}
 	prov, err := provider.New(cfg.Provider, secret)
 	if err != nil {
-		return nil, nil, fmt.Errorf("build provider: %w", err)
+		return nil, nil, false, fmt.Errorf("build provider: %w", err)
 	}
 	srv, err := server.NewAgentServer(cfg, prov)
 	if err != nil {
-		return nil, nil, fmt.Errorf("build server: %w", err)
+		return nil, nil, false, fmt.Errorf("build server: %w", err)
 	}
 	// Fields are operator-controlled config (not request input); the API-key
 	// Secret is never logged. //nolint:gosec — matches sibling adapters.
@@ -90,24 +102,35 @@ func build() (*config.AdapterConfig, *server.AgentServer, error) {
 		"endpoint", cfg.Endpoint,
 		"capabilities", len(cfg.Capabilities),
 	)
-	return cfg, srv, nil
+	return cfg, srv, false, nil
 }
 
 // serve binds the listener, registers the agent (backoff), serves gRPC with the
 // health service, and drains on SIGTERM: NOT_SERVING → deregister → GracefulStop.
-func serve(cfg *config.AdapterConfig, srv *server.AgentServer, regClient zynaxv1.AgentRegistryServiceClient) error {
+func serve(cfg *config.AdapterConfig, srv *server.AgentServer, degraded bool, regClient zynaxv1.AgentRegistryServiceClient) error {
 	lis, err := net.Listen("tcp", cfg.Endpoint)
 	if err != nil {
 		return fmt.Errorf("listen %s: %w", cfg.Endpoint, err)
 	}
 
 	grpcSrv := grpc.NewServer()
-	zynaxv1.RegisterAgentServiceServer(grpcSrv, srv)
+	if !degraded {
+		zynaxv1.RegisterAgentServiceServer(grpcSrv, srv)
+	}
 	healthSrv := health.NewServer()
 	grpc_health_v1.RegisterHealthServer(grpcSrv, healthSrv)
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 	defer stop()
+
+	// Degraded mode (issue #1375): no secret resolved, so the adapter does not
+	// register its capabilities and reports NOT_SERVING. The gRPC + health servers
+	// still run so the process stays alive and observable instead of crash-looping.
+	if degraded {
+		healthSrv.SetServingStatus("", grpc_health_v1.HealthCheckResponse_NOT_SERVING)
+		slog.Warn("llm-adapter serving DEGRADED (capabilities not registered)", "endpoint", cfg.Endpoint) //nolint:gosec
+		return runDegraded(ctx, grpcSrv, lis)
+	}
 
 	def := registry.BuildAgentDef(cfg)
 	if err := registry.RegisterAgent(ctx, regClient, def); err != nil {
@@ -129,6 +152,24 @@ func serve(cfg *config.AdapterConfig, srv *server.AgentServer, regClient zynaxv1
 	healthSrv.SetServingStatus("", grpc_health_v1.HealthCheckResponse_NOT_SERVING)
 	if err := registry.DeregisterAgent(context.Background(), regClient, cfg.AgentID); err != nil {
 		slog.Warn("deregister failed", "err", err)
+	}
+	grpcSrv.GracefulStop()
+	slog.Info("llm-adapter stopped")
+	return nil
+}
+
+// runDegraded serves gRPC until the context is cancelled or the server errors.
+// The degraded path (issue #1375) registers no AgentService and no registry
+// entry, so it just keeps the process alive and drains on shutdown.
+func runDegraded(ctx context.Context, grpcSrv *grpc.Server, lis net.Listener) error {
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- grpcSrv.Serve(lis) }()
+
+	select {
+	case <-ctx.Done():
+		slog.Info("shutdown signal received")
+	case err := <-serveErr:
+		return fmt.Errorf("grpc serve: %w", err)
 	}
 	grpcSrv.GracefulStop()
 	slog.Info("llm-adapter stopped")

--- a/agents/adapters/llm/cmd/llm-adapter/main_test.go
+++ b/agents/adapters/llm/cmd/llm-adapter/main_test.go
@@ -18,6 +18,8 @@ import (
 	zynaxv1 "github.com/zynax-io/zynax/protos/generated/go/zynax/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/status"
 )
 
@@ -64,11 +66,24 @@ func TestRun_InvalidConfig(t *testing.T) {
 	}
 }
 
-func TestRun_UnsetSecret(t *testing.T) {
+// TestBuild_UnsetSecretDegrades proves the core fix (issue #1375): with the API
+// key env unset, build() does NOT error — it returns a degraded flag, a nil
+// server, and the loaded config so the adapter can start without crash-looping.
+func TestBuild_UnsetSecretDegrades(t *testing.T) {
 	t.Setenv(configEnvVar, writeConfig(t, validConfig))
 	t.Setenv("OPENAI_API_KEY", "")
-	if err := run(); err == nil {
-		t.Fatal("expected error when api key env unset")
+	cfg, srv, degraded, err := build()
+	if err != nil {
+		t.Fatalf("build must not error when api key unset, got: %v", err)
+	}
+	if !degraded {
+		t.Fatal("expected degraded=true when api key unset")
+	}
+	if srv != nil {
+		t.Fatal("expected nil server in degraded mode (no provider built)")
+	}
+	if cfg == nil {
+		t.Fatal("expected config to be returned in degraded mode")
 	}
 }
 
@@ -140,7 +155,7 @@ func TestServe_GracefulShutdown(t *testing.T) {
 	fake := &fakeRegistryClient{deregistered: make(chan string, 1)}
 
 	done := make(chan error, 1)
-	go func() { done <- serve(cfg, srv, fake) }()
+	go func() { done <- serve(cfg, srv, false, fake) }()
 
 	// Allow serve() to register and enter its select before signalling SIGTERM.
 	time.Sleep(200 * time.Millisecond)
@@ -164,6 +179,65 @@ func TestServe_GracefulShutdown(t *testing.T) {
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("timed out waiting for serve to return")
+	}
+}
+
+// failRegisterClient errors on RegisterAgent. The degraded path must never call
+// it, so serve must return nil even with this client wired in (issue #1375).
+type failRegisterClient struct {
+	zynaxv1.AgentRegistryServiceClient
+}
+
+func (f *failRegisterClient) RegisterAgent(_ context.Context, _ *zynaxv1.RegisterAgentRequest, _ ...grpc.CallOption) (*zynaxv1.RegisterAgentResponse, error) {
+	return nil, status.Error(codes.Internal, "registry must not be called in degraded mode")
+}
+
+// TestServe_DegradedNoSecret proves the core fix (issue #1375): with no secret
+// (nil server, degraded=true) the adapter serves, reports NOT_SERVING readiness,
+// does NOT register, and shuts down cleanly — it does not crash.
+func TestServe_DegradedNoSecret(t *testing.T) {
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr := lis.Addr().String()
+	_ = lis.Close()
+
+	cfg := &config.AdapterConfig{
+		AgentID:          "llm-adapter-test",
+		Endpoint:         addr,
+		RegistryEndpoint: "localhost:50052",
+		Capabilities:     []config.CapabilityConfig{{Name: "chat_completion"}},
+		Provider:         config.ProviderConfig{Name: "openai", Model: "gpt-4o", APIKeyEnv: "OPENAI_API_KEY"}, //nolint:gosec // G101: env-var NAME, not a credential value
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- serve(cfg, nil, true, &failRegisterClient{}) }()
+
+	time.Sleep(200 * time.Millisecond)
+	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("dial degraded adapter: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+	resp, err := grpc_health_v1.NewHealthClient(conn).Check(context.Background(), &grpc_health_v1.HealthCheckRequest{})
+	if err != nil {
+		t.Fatalf("health check: %v", err)
+	}
+	if resp.GetStatus() != grpc_health_v1.HealthCheckResponse_NOT_SERVING {
+		t.Fatalf("expected NOT_SERVING in degraded mode, got: %v", resp.GetStatus())
+	}
+
+	if err := syscall.Kill(syscall.Getpid(), syscall.SIGTERM); err != nil {
+		t.Fatalf("send SIGTERM: %v", err)
+	}
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("degraded serve must not error (no crash), got: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("degraded serve did not return within 5s")
 	}
 }
 

--- a/agents/adapters/llm/internal/config/config.go
+++ b/agents/adapters/llm/internal/config/config.go
@@ -3,12 +3,19 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"os"
 
 	"gopkg.in/yaml.v3"
 )
+
+// ErrSecretMissing is returned by ResolveSecret when the configured api-key env
+// var is declared but unset or empty. The bootstrap layer distinguishes this from
+// a malformed config so it can degrade gracefully (start, warn, skip registration)
+// instead of crash-looping when no secret is provided (issue #1375).
+var ErrSecretMissing = errors.New("config: api key env var is not set")
 
 // Supported provider names — the closed set per ADR-035.
 const (
@@ -187,7 +194,7 @@ func (c *AdapterConfig) ResolveSecret() (Secret, error) {
 	}
 	value := os.Getenv(c.Provider.APIKeyEnv)
 	if value == "" {
-		return Secret{}, fmt.Errorf("config: env var %s is required but not set", c.Provider.APIKeyEnv)
+		return Secret{}, fmt.Errorf("env var %s is required but not set: %w", c.Provider.APIKeyEnv, ErrSecretMissing)
 	}
 	return NewSecret(value), nil
 }


### PR DESCRIPTION
## fix(agents/adapters): tolerate missing secrets without crash-looping

Closes #1375

### Why  (symptom & root cause)

**Symptom:** a fresh `make run-local` with no secrets leaves 3 of 4 adapters dead in a crash loop; only the `echo` (langgraph) capability works. Nothing warns the user — they discover it only when a workflow fails with `no agent registered for capability ...`:

```
git-adapter  Exited(1): resolve token: env var GITHUB_TOKEN is required but not set
ci-adapter   Exited(1): resolve token: env var GITHUB_TOKEN is required but not set
llm-adapter  Exited(1): resolve secret: env var OPENAI_API_KEY is required but not set
```

**Root cause:** each adapter's `main` resolves the token/secret at boot and returns the error to `os.Exit(1)` — a missing secret is treated identically to a fatal config error, so the container crash-loops with no graceful path.

### What you'll get  (deliverables ↔ what changed)

- Each config package gains a typed sentinel — `ErrTokenMissing` (ci), `ErrSecretMissing` (llm), `ErrCredentialMissing` (git) — wrapped at the resolution sites so bootstrap can tell "no secret" from "malformed config".
- Each `main` now degrades gracefully when the secret is absent: it **starts**, logs a clear `slog.Warn`, **skips capability registration** (never dials `RegisterAgent`), and sets gRPC health to **NOT_SERVING** so readiness reflects the unavailable state. The process stays alive and drains cleanly on SIGTERM.
- Any non-sentinel resolution error (malformed config, App-minter failure) stays **fatal** — unchanged behaviour.

### Scope & boundaries

- In: git / ci / llm adapter `main` + config sentinels and their `main_test.go`.
- Out: the zero-secret ollama overlay / defaults — that is the separate issue #1374 (this PR only makes the adapters *tolerate* missing secrets). No proto, no API, no Layer 1→3 coupling.
- Satisfies EPIC #1370 canvas Operations step 6: "adapters: graceful degradation without secrets; readiness reflects registration."

### Test plan & acceptance

| Criterion | Verify command | Result |
|-----------|----------------|--------|
| Missing secret surfaces typed sentinel (not a generic error) | `GOWORK=off go test ./cmd/... -run Sentinel\|Degrades` (ci, git) | PASS |
| Adapter boots with secret unset and does NOT exit non-zero | `GOWORK=off go test ./cmd/... -run Degraded` (all 3) | PASS — serve returns nil on cancel |
| A clear warning is logged | covered by `build()`/`resolveCredentialSource` sentinel tests + warn path | PASS |
| Secret-requiring capability NOT registered; readiness reflects it | degraded-serve test wires a `RegisterAgent`-that-errors client + health probe asserts NOT_SERVING | PASS |
| Full suites green with `-race` | `GOWORK=off go test ./... -race` (ci, git, llm) | PASS — all `ok` |

Regression tests added (fail on `main`, pass here): `TestServe_DegradedNoSecret` (ci, llm), `TestServe_DegradedNoCredential` (git), `TestBuild_UnsetSecretDegrades` (llm), `TestResolveToken_MissingIsSentinel` (ci), `TestResolveCredentialSource_MissingTokenIsSentinel` (git).

### Evidence

Before (on `main`): `make run-local` → `git/ci/llm-adapter Exited(1): resolve token/secret: ... is required but not set`.

After (this branch): each adapter logs `... starting in degraded mode: ... not set; capabilities will NOT be registered and readiness is NOT_SERVING`, serves, and a health probe returns `NOT_SERVING`. Local gates:

```
ok  github.com/zynax-io/zynax/agents/adapters/ci/...   (-race)
ok  github.com/zynax-io/zynax/agents/adapters/git/...  (-race)
ok  github.com/zynax-io/zynax/agents/adapters/llm/...  (-race)
golangci-lint ... Passed   gofmt ... Passed
```

- **Post-merge digest sync → main:** _placeholder — fill with `chore(images): sync digests after main-<sha>` commit SHA, or "N/A — no image rebuild"._

### Risk & rollback

Low. Behaviour change is confined to the missing-secret path (previously a crash). The fully-configured path is unchanged (same register → SERVING → drain). Rollback = revert the single commit; adapters return to crash-on-missing-secret.

### Review aids

Read order: config sentinel (`internal/config/config.go`) → `main.go` degraded branch in `run`/`serve` → `main_test.go` degraded-serve test. The three adapters apply the identical pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
