### PR TITLE
feat(infra): zero-cost local Ollama quickstart overlay

### DIFF
--- a/infra/docker-compose/README.md
+++ b/infra/docker-compose/README.md
@@ -10,6 +10,7 @@ All Compose files live in this directory:
 | `docker-compose.tools.yml` | Test-runner container for Python integration tests |
 | `docker-compose.test.yml` | CI overlay — disables persistent volumes for ephemeral test runs |
 | `docker-compose.observability.yml` | Local Uptrace stack — traces/metrics/logs/APM with a login UI |
+| `docker-compose.ollama.yml` | Zero-cost local LLM overlay — bundles `ollama` and repoints `llm-adapter` at it (no API key) |
 
 ## Local dev stack
 
@@ -77,6 +78,34 @@ exposed (canvas O.7 Safeguards). ClickHouse and Postgres have no host ports.
 Logs ship to Uptrace as OTLP log records through the collector `logs` pipeline,
 correlated to traces by `trace_id`/`span_id`. Span, metric, and log naming rules
 live in [docs/observability/naming-conventions.md](../../docs/observability/naming-conventions.md).
+
+## Local Ollama overlay (zero-cost, offline LLM)
+
+The shipped `llm-adapter` points at OpenAI/gpt-4o, which needs a paid key. This overlay
+bundles an `ollama` service inside the compose network (nothing exposed to the host LAN),
+reuses host-pulled models via a read-only bind mount, and repoints `llm-adapter` at it
+with an Ollama provider config — no API key, no cost.
+
+```bash
+docker compose \
+  -f infra/docker-compose/docker-compose.yml \
+  -f infra/docker-compose/docker-compose.ollama.yml \
+  up -d ollama llm-adapter
+```
+
+The overlay defaults the host models directory to a systemd `ollama` install
+(`/usr/share/ollama/.ollama/models`). Override it for a different install path:
+
+```bash
+OLLAMA_HOST_MODELS=/path/to/.ollama/models docker compose \
+  -f infra/docker-compose/docker-compose.yml \
+  -f infra/docker-compose/docker-compose.ollama.yml \
+  up -d ollama llm-adapter
+```
+
+The adapter config (`ollama/llm-adapter.config.yaml`) registers a `codereview`
+capability against `llama3.2:3b` — pull that model on the host (`ollama pull llama3.2:3b`)
+before bringing the overlay up.
 
 ## Not included
 

--- a/infra/docker-compose/docker-compose.ollama.yml
+++ b/infra/docker-compose/docker-compose.ollama.yml
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: Apache-2.0
+# Local Ollama overlay for the quickstart — a zero-cost, offline LLM path.
+#
+# Bundles an `ollama` service entirely inside the compose network (nothing is
+# exposed to the host LAN) and reuses models already pulled on the host via a
+# read-only bind mount, so no multi-GB re-download is needed. Repoints the
+# llm-adapter at it with an ollama provider config (no OpenAI key required).
+#
+# Usage (layered on top of the base stack):
+#   docker compose \
+#     -f infra/docker-compose/docker-compose.yml \
+#     -f infra/docker-compose/docker-compose.ollama.yml \
+#     up -d ollama llm-adapter
+#
+# Host models dir override (default assumes a systemd `ollama` install):
+#   OLLAMA_HOST_MODELS=/path/to/.ollama/models docker compose ... up -d
+services:
+  ollama:
+    image: ollama/ollama:latest
+    volumes:
+      # Reuse host-pulled models read-only; the container keeps its own writable
+      # /root/.ollama for the runtime keypair it generates on startup.
+      - ${OLLAMA_HOST_MODELS:-/usr/share/ollama/.ollama/models}:/root/.ollama/models:ro
+    healthcheck:
+      test: ["CMD", "ollama", "list"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 15s
+
+  llm-adapter:
+    environment:
+      ZYNAX_LLM_CONFIG: /etc/llm-adapter/config.yaml
+    volumes:
+      - ./ollama/llm-adapter.config.yaml:/etc/llm-adapter/config.yaml:ro
+    depends_on:
+      ollama:
+        condition: service_healthy
+      agent-registry:
+        condition: service_healthy

--- a/infra/docker-compose/ollama/llm-adapter.config.yaml
+++ b/infra/docker-compose/ollama/llm-adapter.config.yaml
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+# llm-adapter config — local Ollama provider (no API key, zero cost).
+# Mounted over the baked openai default by docker-compose.ollama.yml.
+#
+# Registers a `code_review` capability so a workflow can dispatch a real LLM
+# code review against a locally-served model — the impressive quickstart path.
+
+agent_id: llm-adapter
+name: LLM Adapter (Ollama / local)
+description: Ollama-backed local LLM capabilities for the zero-cost quickstart.
+# Endpoint is used BOTH as the bind address AND the address advertised to the
+# registry (no bind/advertise split in the Go adapter). The shipped example's
+# ":50070" advertises an unreachable host — the broker then dials localhost and
+# gets connection refused. Use the resolvable compose service name instead.
+endpoint: llm-adapter:50070
+registry_endpoint: agent-registry:50052
+
+provider:
+  name: ollama
+  model: llama3.2:3b
+  ollama_base_url: http://ollama:11434
+  max_tokens: 600
+
+capabilities:
+  # NOTE: capability name has NO underscore on purpose — the engine derives the
+  # completion event as "<capability>.completed", and the workflow compiler
+  # rejects event types containing underscores (must be dot-separated lowercase).
+  - name: codereview
+    timeout_seconds: 300
+    description: Review a code diff and return concrete, actionable findings.
+    input_schema_json: |
+      {
+        "type": "object",
+        "required": ["prompt"],
+        "properties": { "prompt": { "type": "string", "minLength": 1 } },
+        "additionalProperties": false
+      }
+    output_schema_json: |
+      {
+        "type": "object",
+        "properties": { "completion": { "type": "string" } }
+      }


### PR DESCRIPTION
## feat(infra): zero-cost local Ollama quickstart overlay

Closes #1374
Part of #1370

### Why  (problem & intent)
The shipped `llm-adapter` points at OpenAI/gpt-4o, which needs a paid key, so the quickstart has no zero-cost LLM path. The Ollama provider exists in the Go adapter but ships with no config, no compose wiring, and no docs — a new user cannot run a real LLM workflow without a wallet. This delivers the offline, zero-secret local-LLM path from canvas #1370 O-step 5.

### What you'll get  (deliverables ↔ what changed)
- A compose overlay that bundles an in-network `ollama` service (nothing exposed to the host LAN) and repoints `llm-adapter` at it ← `infra/docker-compose/docker-compose.ollama.yml`
- An Ollama-backed `llm-adapter` config (no API key, `llama3.2:3b`, `codereview` capability) ← `infra/docker-compose/ollama/llm-adapter.config.yaml`
- Documented overlay usage — the exact layered `docker compose` invocation and the `OLLAMA_HOST_MODELS` override ← `infra/docker-compose/README.md`

### Scope & boundaries
- **In scope:** the overlay file, the adapter config, and a brief README section documenting the overlay invocation + host-models override.
- **Out of scope (deferred):** the full quickstart rewrite → #1379; adding `ollama/ollama` to `images/images.yaml` (third-party runtime, referenced directly like postgres/nats).

### Test plan & acceptance

| Acceptance criterion | How verified (command) | Result |
|----------------------|------------------------|--------|
| Overlay merges and is schema-valid; shows merged `ollama` + repointed `llm-adapter` | `docker compose -f infra/docker-compose/docker-compose.yml -f infra/docker-compose/docker-compose.ollama.yml config` | ✅ exit 0 — `ollama` (image `ollama/ollama:latest`, `ollama list` healthcheck, read-only models bind mount) and `llm-adapter` (`ZYNAX_LLM_CONFIG=/etc/llm-adapter/config.yaml`, config bind-mount, `depends_on: ollama (service_healthy)`) both present |
| `llm-adapter` needs no API key on the Ollama path | inspect merged `llm-adapter.environment` | ✅ `OPENAI_API_KEY: ""` — provider is `ollama` via the mounted config |
| Capability name has no underscore (compiler rejects underscored derived events) | inspect `ollama/llm-adapter.config.yaml` | ✅ capability `name: codereview` (derived event `codereview.completed`) |
| Nothing exposed to host LAN | inspect merged `ollama` service | ✅ no `ports:` on `ollama` — reachable only on the compose network |
| Host-pulled models reused read-only | inspect merged `ollama.volumes` | ✅ `${OLLAMA_HOST_MODELS:-/usr/share/ollama/.ollama/models}:/root/.ollama/models:ro` |

**Local gates:** `docker compose ... config` ✅ (compose merge/schema). `make validate-spec` is AsyncAPI + capability/workflow/agent-def/policy schemas + expert mapping only — it does not cover compose files, so it was not run for this change.

### Evidence
- **CI:** required checks pending — see the run on this PR.
- **Local output (merged `docker compose config`, decisive lines):**
  ```yaml
  ollama:
    image: ollama/ollama:latest
    healthcheck:
      test: [CMD, ollama, list]
    volumes:
      - type: bind
        source: /.../infra/docker-compose/ollama/llm-adapter.config.yaml  # (llm-adapter)
        target: /etc/llm-adapter/config.yaml
        read_only: true
      - type: bind
        source: /usr/share/ollama/.ollama/models  # (ollama)
        target: /root/.ollama/models
        read_only: true
  llm-adapter:
    environment:
      OPENAI_API_KEY: ""
      ZYNAX_LLM_CONFIG: /etc/llm-adapter/config.yaml
    depends_on:
      ollama: { condition: service_healthy }
      agent-registry: { condition: service_healthy }
  ```
- **Live bring-up:** the full live Ollama workflow bring-up was validated in the maintainer's 2026-06-18 run (per the #1370 canvas). This PR verifies static merge validity only — no live Ollama workflow was run here.
- **Artifacts / images:** none — no service source changed (compose YAML + README only).
- **Post-merge digest sync → main:** N/A — no image rebuild.

### Risk & rollback
Low — additive only. Three new/changed files (one overlay, one config, one README section); no existing path changes behaviour unless the overlay is explicitly layered with `-f docker-compose.ollama.yml`. Rollback = revert this PR.

### Review aids
- Key file: `infra/docker-compose/docker-compose.ollama.yml` — start there; the config comments explain the no-underscore capability rule and the `endpoint` resolvable-service-name choice.
- The README section under "Local Ollama overlay" documents the exact invocation and the `OLLAMA_HOST_MODELS` override.

**SPDD:** Canvas `docs/spdd/1370-awesome-quickstart/canvas.md` Aligned; security-review PASS (covered by the Aligned epic canvas, step 5).
**AI:** `Assisted-by: Claude/Opus 4.8`
