### PR TITLE
fix(engine-adapter): make NotFound dispatch non-retryable

### DIFF
--- a/services/engine-adapter/cmd/engine-adapter/main.go
+++ b/services/engine-adapter/cmd/engine-adapter/main.go
@@ -249,7 +249,10 @@ func buildTemporalEngine(cfg config) (domain.WorkflowEngine, func(), *grpc.Clien
 		Interceptors: []interceptor.WorkerInterceptor{tracingInterceptor},
 	})
 	w.RegisterWorkflow(infrastructure.IRInterpreterWorkflow)
-	w.RegisterActivity(dispatcher.DispatchCapabilityActivity)
+	// Register the infrastructure wrapper, not the bare domain method, so a
+	// codes.NotFound dispatch failure (no agent for the capability) is reclassified
+	// as a non-retryable Temporal ApplicationError and fails the workflow fast (#1381).
+	w.RegisterActivity(infrastructure.NewDispatchActivity(dispatcher).DispatchCapabilityActivity)
 	w.RegisterActivity(activityWorker.PublishLifecycleEventActivity)
 
 	if err := w.Start(); err != nil {

--- a/services/engine-adapter/internal/infrastructure/activity_dispatch.go
+++ b/services/engine-adapter/internal/infrastructure/activity_dispatch.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package infrastructure
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"go.temporal.io/sdk/temporal"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/zynax-io/zynax/services/engine-adapter/internal/domain"
+)
+
+// capabilityNotFoundErrorType is the Temporal ApplicationError Type assigned to a
+// dispatch failure whose underlying gRPC status is codes.NotFound (no agent is
+// registered for the requested capability). It MUST match an entry in
+// nonRetryableActivityErrors so the activity RetryPolicy stops retrying.
+const capabilityNotFoundErrorType = "ErrCapabilityNotFound"
+
+// capabilityDispatcher is the subset of domain.CapabilityDispatcher this wrapper
+// drives. Keeping it as an interface lets unit tests exercise the error
+// classification without a live task-broker.
+type capabilityDispatcher interface {
+	DispatchCapabilityActivity(ctx context.Context, in domain.ActivityInput) (*domain.ActivityResult, error)
+}
+
+// DispatchActivity is the Temporal activity boundary in front of the
+// domain.CapabilityDispatcher. The domain layer is Temporal-free (ADR-015), so
+// the translation of a permanent gRPC failure into a non-retryable Temporal
+// ApplicationError happens here rather than in domain.
+type DispatchActivity struct {
+	dispatcher capabilityDispatcher
+}
+
+// NewDispatchActivity wraps a domain dispatcher for registration as a Temporal activity.
+func NewDispatchActivity(d capabilityDispatcher) *DispatchActivity {
+	return &DispatchActivity{dispatcher: d}
+}
+
+// DispatchCapabilityActivity runs the domain dispatch and reclassifies a
+// codes.NotFound result — "no agent registered for capability" — as a
+// non-retryable Temporal ApplicationError of type capabilityNotFoundErrorType.
+// Without this, a structurally unbacked capability would retry until
+// MaximumAttempts is reached on every workflow forever (#1381); marking it
+// non-retryable fails the workflow fast. Transient codes (Unavailable, deadline)
+// are returned unchanged and stay retryable/bounded by the RetryPolicy.
+func (a *DispatchActivity) DispatchCapabilityActivity(ctx context.Context, in domain.ActivityInput) (*domain.ActivityResult, error) {
+	result, err := a.dispatcher.DispatchCapabilityActivity(ctx, in)
+	if err == nil {
+		return result, nil
+	}
+	if isCapabilityNotFound(err) {
+		// Temporal sentinel: must be returned without an outer fmt.Errorf wrap so
+		// the worker classifies it via errors.As against nonRetryableActivityErrors.
+		return nil, temporal.NewNonRetryableApplicationError( //nolint:wrapcheck // sentinel error; re-wrapping defeats Temporal retry classification
+			err.Error(), capabilityNotFoundErrorType, err,
+		)
+	}
+	// Transient (Unavailable, deadline, ...) — keep retryable; wrap for wrapcheck
+	// while preserving the chain so errors.Is still matches the underlying status.
+	return nil, fmt.Errorf("engine-adapter: dispatch capability: %w", err)
+}
+
+// isCapabilityNotFound reports whether err carries a gRPC codes.NotFound status
+// anywhere in its chain. status.FromError unwraps wrapped status errors, so the
+// domain layer's fmt.Errorf("...: %w", grpcErr) wrapping is preserved.
+func isCapabilityNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	if st, ok := status.FromError(err); ok && st.Code() == codes.NotFound {
+		return true
+	}
+	// Defensive: walk the chain in case an intermediate wrapper hides the
+	// status interface from status.FromError.
+	next := err
+	for next != nil {
+		if st, ok := status.FromError(next); ok && st.Code() == codes.NotFound {
+			return true
+		}
+		next = errors.Unwrap(next)
+	}
+	return false
+}

--- a/services/engine-adapter/internal/infrastructure/activity_dispatch_test.go
+++ b/services/engine-adapter/internal/infrastructure/activity_dispatch_test.go
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package infrastructure
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"go.temporal.io/sdk/temporal"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/zynax-io/zynax/services/engine-adapter/internal/domain"
+)
+
+// fakeDispatcher returns a fixed (result, err) pair, standing in for the domain
+// CapabilityDispatcher without a live task-broker.
+type fakeDispatcher struct {
+	result *domain.ActivityResult
+	err    error
+}
+
+func (f *fakeDispatcher) DispatchCapabilityActivity(_ context.Context, _ domain.ActivityInput) (*domain.ActivityResult, error) {
+	return f.result, f.err
+}
+
+// asNonRetryable extracts a *temporal.ApplicationError from err and reports its
+// non-retryable flag and Type, or fails the test if err is not one.
+func asApplicationError(t *testing.T, err error) *temporal.ApplicationError {
+	t.Helper()
+	var appErr *temporal.ApplicationError
+	if !errors.As(err, &appErr) {
+		t.Fatalf("error %v is not a *temporal.ApplicationError", err)
+	}
+	return appErr
+}
+
+func TestDispatchActivity_NotFound_IsNonRetryable(t *testing.T) {
+	// The domain layer wraps the broker gRPC error with fmt.Errorf("...: %w").
+	grpcErr := status.Error(codes.NotFound, `no agent registered for capability "request_review"`)
+	wrapped := fmt.Errorf("engine-adapter: dispatch capability %q: %w", "request_review", grpcErr)
+
+	act := NewDispatchActivity(&fakeDispatcher{err: wrapped})
+
+	_, err := act.DispatchCapabilityActivity(context.Background(), domain.ActivityInput{
+		CapabilityName: "request_review",
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	appErr := asApplicationError(t, err)
+	if !appErr.NonRetryable() {
+		t.Error("NotFound dispatch error must be marked non-retryable")
+	}
+	if appErr.Type() != capabilityNotFoundErrorType {
+		t.Errorf("ApplicationError Type = %q; want %q", appErr.Type(), capabilityNotFoundErrorType)
+	}
+	// The non-retryable Type must be in the workflow's RetryPolicy block list so
+	// Temporal actually stops retrying.
+	found := false
+	for _, v := range nonRetryableActivityErrors {
+		if v == appErr.Type() {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("Type %q not in nonRetryableActivityErrors; retries would not stop", appErr.Type())
+	}
+}
+
+func TestDispatchActivity_Unavailable_StaysRetryable(t *testing.T) {
+	grpcErr := status.Error(codes.Unavailable, "task-broker connection refused")
+	wrapped := fmt.Errorf("engine-adapter: dispatch capability %q: %w", "search_web", grpcErr)
+
+	act := NewDispatchActivity(&fakeDispatcher{err: wrapped})
+
+	_, err := act.DispatchCapabilityActivity(context.Background(), domain.ActivityInput{
+		CapabilityName: "search_web",
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	// A transient error must NOT be reclassified as a non-retryable
+	// ApplicationError; it is returned verbatim so the RetryPolicy retries it
+	// up to MaximumAttempts.
+	var appErr *temporal.ApplicationError
+	if errors.As(err, &appErr) && appErr.NonRetryable() {
+		t.Error("Unavailable dispatch error must stay retryable, not become non-retryable")
+	}
+	if !errors.Is(err, grpcErr) {
+		t.Error("transient error should be returned unchanged (wrapping preserved)")
+	}
+}
+
+func TestDispatchActivity_DeadlineExceeded_StaysRetryable(t *testing.T) {
+	grpcErr := status.Error(codes.DeadlineExceeded, "broker call timed out")
+	act := NewDispatchActivity(&fakeDispatcher{err: grpcErr})
+
+	_, err := act.DispatchCapabilityActivity(context.Background(), domain.ActivityInput{})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	var appErr *temporal.ApplicationError
+	if errors.As(err, &appErr) && appErr.NonRetryable() {
+		t.Error("DeadlineExceeded must stay retryable")
+	}
+}
+
+func TestDispatchActivity_Success_PassesThrough(t *testing.T) {
+	want := &domain.ActivityResult{EventType: "review.approved"}
+	act := NewDispatchActivity(&fakeDispatcher{result: want})
+
+	got, err := act.DispatchCapabilityActivity(context.Background(), domain.ActivityInput{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.EventType != want.EventType {
+		t.Errorf("EventType = %q; want %q", got.EventType, want.EventType)
+	}
+}
+
+func TestIsCapabilityNotFound(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"plain error", errors.New("boom"), false},
+		{"bare NotFound", status.Error(codes.NotFound, "missing"), true},
+		{"wrapped NotFound", fmt.Errorf("ctx: %w", status.Error(codes.NotFound, "missing")), true},
+		{"Unavailable", status.Error(codes.Unavailable, "down"), false},
+		{"wrapped Unavailable", fmt.Errorf("ctx: %w", status.Error(codes.Unavailable, "down")), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isCapabilityNotFound(tt.err); got != tt.want {
+				t.Errorf("isCapabilityNotFound(%v) = %v; want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #1381

### Why  (problem & intent)

**Symptom:** Live workflow instances retried a single dispatch indefinitely:

```
ActivityType DispatchCapabilityActivity Attempt 145 Error ...
NotFound: no agent registered for capability "request_review" / "search_web"
```

Attempts climbed past 145 with no terminal failure. A transient `Unavailable`
correctly failed after 3 attempts (`ZYNAX_ENGINE_MAX_ACTIVITY_ATTEMPTS=3`), but a
`NotFound` spun forever.

**Root cause:** The activity RetryPolicy already declared
`NonRetryableErrorTypes = ["ErrCapabilityNotFound", ...]`, but **nothing ever
produced an error of that type.** The domain dispatcher wraps the broker's gRPC
`codes.NotFound` with a plain `fmt.Errorf(...: %w)`, so Temporal saw a generic
retryable error and never matched the block list. `NotFound` means no agent will
ever serve the capability — retrying is pointless.

### What you'll get  (deliverables ↔ what changed)

- `internal/infrastructure/activity_dispatch.go` — new thin Temporal activity
  boundary `DispatchActivity` in front of the domain dispatcher. When the
  underlying gRPC status is `codes.NotFound`, it returns a **non-retryable**
  `temporal.NewNonRetryableApplicationError(..., "ErrCapabilityNotFound", ...)`,
  which matches the existing `nonRetryableActivityErrors` block list so the
  workflow reaches `workflow.failed` fast. Transient codes (`Unavailable`,
  `DeadlineExceeded`) pass through unchanged and stay retryable/bounded.
- `cmd/engine-adapter/main.go` — register the wrapper
  (`NewDispatchActivity(dispatcher).DispatchCapabilityActivity`) instead of the
  bare domain method. The activity name is unchanged, so the workflow's
  `dispatchCapabilityActivityName` wiring still resolves.
- `internal/infrastructure/activity_dispatch_test.go` — regression + matrix tests.

### Scope & boundaries

- Domain layer stays Temporal-free (ADR-015): the SDK translation lives only in
  `infrastructure/`. No proto, no domain signature, no env-var changes.
- RetryPolicy values (`MaximumAttempts`, intervals) are untouched.

### Test plan & acceptance

| Acceptance criterion | Verify command | Result |
|---|---|---|
| `NotFound` dispatch error is classified **non-retryable** (type `ErrCapabilityNotFound`, in block list → workflow fails fast, not unbounded retry) | `GOWORK=off go -C services/engine-adapter test ./internal/infrastructure/ -run TestDispatchActivity_NotFound_IsNonRetryable -v` | PASS |
| Transient `Unavailable` stays **retryable** (not reclassified; chain preserved) | `GOWORK=off go -C services/engine-adapter test ./internal/infrastructure/ -run TestDispatchActivity_Unavailable_StaysRetryable -v` | PASS |
| `DeadlineExceeded` stays retryable | `GOWORK=off go -C services/engine-adapter test ./internal/infrastructure/ -run TestDispatchActivity_DeadlineExceeded -v` | PASS |
| Classification helper handles bare + wrapped status errors | `GOWORK=off go -C services/engine-adapter test ./internal/infrastructure/ -run TestIsCapabilityNotFound -v` | PASS |
| Full module green under race | `GOWORK=off go -C services/engine-adapter test ./... -race -timeout 60s` | ok (all 5 packages) |

### Evidence

**Before:** `NotFound` wrapped as a plain error → Temporal treats it as transient
→ Attempt 145+ with no terminal state.

**After:**

```
--- PASS: TestDispatchActivity_NotFound_IsNonRetryable (0.00s)
--- PASS: TestDispatchActivity_Unavailable_StaysRetryable (0.00s)
--- PASS: TestDispatchActivity_DeadlineExceeded_StaysRetryable (0.00s)
--- PASS: TestIsCapabilityNotFound (incl. bare + wrapped subtests)
ok  services/engine-adapter/internal/infrastructure  5.043s
```

`make lint-go` → engine-adapter: 0 issues; Go lint passed.

Post-merge digest sync → main (placeholder).

### Risk & rollback

- **Risk:** low. A real-but-slow capability that the broker briefly reports as
  `NotFound` would now fail fast instead of retrying — but the broker returns
  `NotFound` only when no agent is registered (a structural condition), so this is
  the intended behavior. Transient outages surface as `Unavailable`, still retried.
- **Rollback:** revert the commit; the previous bare-error path (infinite retry on
  `NotFound`) returns.

### Review aids

Read `activity_dispatch.go` first (the whole fix), then the one-line registration
change in `main.go`. Canvas `docs/spdd/1370-awesome-quickstart/canvas.md`
Operations step 4.

Assisted-by: Claude/Opus 4.8
