### PR TITLE
feat(infra): default demo model to Qwen2.5-Coder 3B (configurable)

### DIFF
--- a/infra/docker-compose/README.md
+++ b/infra/docker-compose/README.md
@@ -104,8 +104,20 @@ OLLAMA_HOST_MODELS=/path/to/.ollama/models docker compose \
 ```
 
 The adapter config (`ollama/llm-adapter.config.yaml`) registers a `codereview`
-capability against `llama3.2:3b` — pull that model on the host (`ollama pull llama3.2:3b`)
-before bringing the overlay up.
+capability against the default reference model `qwen2.5-coder:3b` — a small, fast,
+code-focused local model chosen so the first-run demo is zero-cost and
+deterministic. Pull it on the host before bringing the overlay up:
+
+```bash
+ollama pull qwen2.5-coder:3b
+```
+
+**Switching model/provider (one-line override):** edit the `model:` line under
+`provider:` in `ollama/llm-adapter.config.yaml` (e.g. `model: llama3.2:3b`), or
+point `provider.name` / `provider.ollama_base_url` at a different provider. The
+model/provider is config-only and never travels in the workflow input payload
+(ADR-013 / ADR-035), so any workflow stays portable across models. A full
+human-validation guide standard is tracked in #1388.
 
 ## Not included
 

--- a/infra/docker-compose/ollama/llm-adapter.config.yaml
+++ b/infra/docker-compose/ollama/llm-adapter.config.yaml
@@ -17,7 +17,12 @@ registry_endpoint: agent-registry:50052
 
 provider:
   name: ollama
-  model: llama3.2:3b
+  # Default reference model for demos/UX-validation: Qwen2.5-Coder 3B — a small,
+  # fast, code-focused local model that makes the first-run experience zero-cost
+  # and deterministic. To switch model/provider, edit this one line (e.g.
+  # `model: llama3.2:3b`, or point `name`/`ollama_base_url` at another provider).
+  # Pull it first on the host: `ollama pull qwen2.5-coder:3b`.
+  model: qwen2.5-coder:3b
   ollama_base_url: http://ollama:11434
   max_tokens: 600
 


### PR DESCRIPTION
Closes #1386

## Why
Demos and UX-validation should be fast, deterministic, zero-cost, and offline on
first run — without anyone wiring up a paid API key. Qwen2.5-Coder 3B is a small,
capable, code-focused local model that makes the quickstart "just work" while
staying fully swappable to any provider/model.

## What you'll get
- The local Ollama overlay now defaults the `codereview` capability to
  `qwen2.5-coder:3b` instead of `llama3.2:3b`.
- A documented one-line override to switch model/provider, plus an inline comment
  in the config pointing the way.
- A short validation note in the compose README; the full human-validation guide
  standard is cross-referenced to #1388 (not duplicated here).

## Scope & boundaries
- In scope: `infra/docker-compose/ollama/llm-adapter.config.yaml` default model +
  override comment; `infra/docker-compose/README.md` model choice + one-line
  override docs + #1388 cross-ref.
- Out of scope: `make demo` end-to-end target (separate issue #1360, not yet
  landed); third-party ollama/qwen images are direct runtime refs and are
  deliberately NOT added to `images/images.yaml`.
- Override is config-only and never travels in the workflow input payload
  (ADR-013 / ADR-035), so workflows stay portable across models.

## Test plan & acceptance
| Acceptance criterion | Verify command | Result |
|----------------------|----------------|--------|
| Default reference model is `qwen2.5-coder:3b` in the overlay config | `grep model: infra/docker-compose/ollama/llm-adapter.config.yaml` | PASS — `model: qwen2.5-coder:3b` |
| Merged compose renders with qwen config wired into llm-adapter | `docker compose -f infra/docker-compose/docker-compose.yml -f infra/docker-compose/docker-compose.ollama.yml config` | PASS — exit 0; llm-adapter mounts `ollama/llm-adapter.config.yaml`; ollama service wired |
| A documented one-line override switches model/provider | review README "Switching model/provider" + config inline comment | PASS — one-line `model:` edit documented |
| Human-validation guide shipped | README validation note + #1388 cross-ref | PASS — note present, full standard tracked in #1388 |
| `make demo` runs on Qwen with no config changes / secrets | `make demo` | PENDING #1360 — `make demo` target not yet landed; config default + override delivered here so it works once #1360 ships |

## Evidence
`docker compose ... config` (exit 0) shows the llm-adapter mounting the qwen
config and the ollama service wired:

```
  llm-adapter:
    environment:
      ZYNAX_LLM_CONFIG: /etc/llm-adapter/config.yaml
    volumes:
      - source: .../infra/docker-compose/ollama/llm-adapter.config.yaml
        target: /etc/llm-adapter/config.yaml
        read_only: true
    depends_on:
      ollama:
        condition: service_healthy
  ollama:
    image: ollama/ollama:latest
    healthcheck:
      test: ["CMD", "ollama", "list"]
```

The `model:` value lives inside the mounted YAML (file mount, so not surfaced in
`config` output); confirmed directly:
```
infra/docker-compose/ollama/llm-adapter.config.yaml:  model: qwen2.5-coder:3b
```

Verified static config only — no live Qwen pull/run (a multi-GB pull risks OOM on
the shared host).

Post-merge digest sync → main: N/A for this change (no banner-marked image refs
touched; ollama/qwen are direct third-party runtime refs by design).

## Risk & rollback
- Risk: low. Config-only default change in a quickstart overlay; no service code,
  no proto, no image refs.
- Rollback: revert the `model:` line back to `llama3.2:3b` (one line) or revert
  this PR.

## Review aids
- 2 files, +20/-3. The default switch is a single line; the rest is documentation
  of the model choice and the one-line override.

SPDD: Canvas `docs/spdd/1370-awesome-quickstart/canvas.md` Aligned; security-review PASS (epic canvas step 15).
