### PR TITLE
feat(cli): surface capability result payloads in get/logs

### DIFF
--- a/cmd/zynax/client/gateway.go
+++ b/cmd/zynax/client/gateway.go
@@ -232,6 +232,48 @@ type LogEvent struct {
 	Payload   string `json:"payload,omitempty"`
 }
 
+// CompletionText extracts the capability result text from a log event's JSON
+// payload. Task-broker completion events carry the result under a nested
+// `result_payload` string whose value is itself JSON ({"completion": "..."});
+// this unwraps one level and returns the `completion` field. It also accepts a
+// bare {"completion": "..."} payload. Returns "" when no completion is present
+// or the payload is not JSON, so callers can skip empty results silently.
+func CompletionText(payload string) string {
+	if payload == "" {
+		return ""
+	}
+	var outer map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(payload), &outer); err != nil {
+		return ""
+	}
+	// Capability events wrap the executor output in a result_payload string.
+	if rp, ok := outer["result_payload"]; ok {
+		var inner string
+		if err := json.Unmarshal(rp, &inner); err == nil {
+			return completionField(inner)
+		}
+	}
+	if c, ok := outer["completion"]; ok {
+		var s string
+		if err := json.Unmarshal(c, &s); err == nil {
+			return s
+		}
+	}
+	return ""
+}
+
+// completionField parses a {"completion": "..."} JSON object and returns the
+// completion string, or "" when absent or unparseable.
+func completionField(s string) string {
+	var inner struct {
+		Completion string `json:"completion"`
+	}
+	if err := json.Unmarshal([]byte(s), &inner); err != nil {
+		return ""
+	}
+	return inner.Completion
+}
+
 // WatchWorkflowLogs streams SSE events from GET /api/v1/workflows/{id}/logs,
 // calling send for each event. Returns when the stream closes or ctx is cancelled.
 func (g *Gateway) WatchWorkflowLogs(ctx context.Context, runID string, send func(LogEvent) error) error {

--- a/cmd/zynax/client/gateway_test.go
+++ b/cmd/zynax/client/gateway_test.go
@@ -259,3 +259,25 @@ func TestPublishEvent_ServerError(t *testing.T) {
 		t.Fatal("expected error on 500, got nil")
 	}
 }
+
+func TestCompletionText(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload string
+		want    string
+	}{
+		{"empty", "", ""},
+		{"not json", "not json", ""},
+		{"wrapped result_payload", `{"workflow_id":"w","result_payload":"{\"completion\":\"hello world\"}"}`, "hello world"},
+		{"bare completion", `{"completion":"bare text"}`, "bare text"},
+		{"no completion field", `{"task_id":"t","status":"COMPLETED"}`, ""},
+		{"result_payload not json", `{"result_payload":"plain"}`, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := client.CompletionText(tt.payload); got != tt.want {
+				t.Errorf("CompletionText(%q) = %q, want %q", tt.payload, got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/zynax/cmd/cmd_test.go
+++ b/cmd/zynax/cmd/cmd_test.go
@@ -553,6 +553,64 @@ func TestLogsCmd_NotFound(t *testing.T) {
 	}
 }
 
+// TestLogsCmd_RendersCompletionOutput verifies that a capability completion
+// event's nested result payload is surfaced as an indented output line (#1378).
+func TestLogsCmd_RendersCompletionOutput(t *testing.T) {
+	srv := sseServer(t, []map[string]any{
+		{"run_id": "r4", "event_type": "zynax.v1.task-broker.task.completed", "status": "capability_event",
+			"payload": `{"workflow_id":"r4","result_payload":"{\"completion\":\"LGTM, ship it\"}"}`},
+		{"run_id": "r4", "event_type": "workflow.completed", "status": "WORKFLOW_STATUS_COMPLETED"},
+	})
+	apiURL = srv.URL
+	logsFormat = formatText
+	logsFollow = false
+
+	out, err := runLogs(t, []string{"r4"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "output: LGTM, ship it") {
+		t.Errorf("expected completion text in logs output, got:\n%s", out)
+	}
+}
+
+func runResult(t *testing.T, args []string) (string, error) {
+	t.Helper()
+	cmd := fakeCmd(t)
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	err := resultCmd.RunE(cmd, args)
+	return out.String(), err
+}
+
+func TestResultCmd_PrintsCompletion(t *testing.T) {
+	srv := sseServer(t, []map[string]any{
+		{"run_id": "r5", "event_type": "task.completed", "status": "capability_event",
+			"payload": `{"result_payload":"{\"completion\":\"the model review text\"}"}`},
+		{"run_id": "r5", "event_type": "workflow.completed", "status": "WORKFLOW_STATUS_COMPLETED"},
+	})
+	apiURL = srv.URL
+
+	out, err := runResult(t, []string{"r5"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.TrimSpace(out) != "the model review text" {
+		t.Errorf("result output = %q, want %q", strings.TrimSpace(out), "the model review text")
+	}
+}
+
+func TestResultCmd_NoResult_Errors(t *testing.T) {
+	srv := sseServer(t, []map[string]any{
+		{"run_id": "r6", "event_type": "workflow.failed", "status": "WORKFLOW_STATUS_FAILED"},
+	})
+	apiURL = srv.URL
+
+	if _, err := runResult(t, []string{"r6"}); err == nil {
+		t.Error("expected error when run finishes with no result payload")
+	}
+}
+
 // ── root Execute() ────────────────────────────────────────────────────────────
 
 func TestRootCmd_Version(t *testing.T) {

--- a/cmd/zynax/cmd/logs.go
+++ b/cmd/zynax/cmd/logs.go
@@ -55,7 +55,10 @@ var logsCmd = &cobra.Command{
 
 // printLogEvent renders a single event in human-readable text form. State
 // transitions show a from→to arrow; capability/lifecycle events without a
-// transition show only the event type so progression reads cleanly.
+// transition show only the event type so progression reads cleanly. When a
+// capability event carries a result payload (e.g. the model's review text), the
+// completion is printed on an indented follow-up line so it is visible in the
+// CLI without a DB query (#1378).
 func printLogEvent(cmd *cobra.Command, ev client.LogEvent) {
 	ts := ev.Timestamp
 	if ts == "" {
@@ -68,6 +71,9 @@ func printLogEvent(cmd *cobra.Command, ev client.LogEvent) {
 		return
 	}
 	_, _ = fmt.Fprintf(out, "[%s] %-30s (%s)\n", ts, ev.EventType, ev.Status)
+	if text := client.CompletionText(ev.Payload); text != "" {
+		_, _ = fmt.Fprintf(out, "    output: %s\n", text)
+	}
 }
 
 func init() {

--- a/cmd/zynax/cmd/result.go
+++ b/cmd/zynax/cmd/result.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/zynax-io/zynax/cmd/zynax/client"
+)
+
+// errResultDone is the sentinel returned from the SSE callback to stop the
+// stream once the run reaches a terminal state. It is swallowed at the command
+// boundary and never surfaces as an error.
+var errResultDone = errors.New("result: terminal state reached")
+
+var resultCmd = &cobra.Command{
+	Use:   "result <run-id>",
+	Short: "Print the capability output (result payload) of a workflow run",
+	Long: "Stream a run's events and print the capability result payload — e.g. the " +
+		"model's review text from the code-review example — straight from the CLI.\n\n" +
+		"The command tails the run until it reaches a terminal state and prints the " +
+		"last completion text it saw. Exits with an error if the run finishes with no " +
+		"result (e.g. a failed run).",
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		gw := newGateway()
+		var output string
+		err := gw.WatchWorkflowLogs(cmd.Context(), args[0], func(ev client.LogEvent) error {
+			if text := client.CompletionText(ev.Payload); text != "" {
+				output = text
+			}
+			if terminalStatuses[ev.Status] {
+				return errResultDone
+			}
+			return nil
+		})
+		if err != nil && !errors.Is(err, errResultDone) {
+			return err
+		}
+		if output == "" {
+			return fmt.Errorf("no result payload for run %s", args[0])
+		}
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), output)
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(resultCmd)
+}

--- a/services/task-broker/internal/infrastructure/event_publisher.go
+++ b/services/task-broker/internal/infrastructure/event_publisher.go
@@ -65,13 +65,21 @@ func (p *EventPublisher) PublishTaskEvent(ctx context.Context, task *domain.Task
 		p.warn(eventType, task, err)
 		return
 	}
-	data, err := json.Marshal(map[string]string{
+	fields := map[string]string{
 		"task_id":         task.TaskID,
 		"workflow_id":     task.WorkflowID,
 		"capability_name": task.CapabilityName,
 		"status":          task.Status.String(),
 		"dispatched_to":   task.DispatchedTo,
-	})
+	}
+	// Surface the capability output on completion so it is observable over the
+	// bus and reaches `zynax logs`/`zynax result` without a DB query (#1378).
+	// The payload is the executor's raw JSON (e.g. {"completion": "..."}); it is
+	// omitted for non-terminal/failed events that carry no result.
+	if len(task.ResultPayload) > 0 {
+		fields["result_payload"] = string(task.ResultPayload)
+	}
+	data, err := json.Marshal(fields)
 	if err != nil {
 		p.warn(eventType, task, err)
 		return

--- a/services/task-broker/internal/infrastructure/event_publisher_test.go
+++ b/services/task-broker/internal/infrastructure/event_publisher_test.go
@@ -4,6 +4,7 @@ package infrastructure
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"testing"
 	"time"
@@ -46,7 +47,43 @@ func TestPublishTaskEvent(t *testing.T) {
 		t.Errorf("incomplete CloudEvent envelope: %+v", ev)
 	}
 
+	// Dispatched events carry no result, so result_payload must be absent.
+	if _, ok := decodeData(t, ev.GetData())["result_payload"]; ok {
+		t.Error("dispatched event must not carry result_payload")
+	}
+
 	// Best-effort by port contract: a bus error must not panic or propagate.
 	failing := &EventPublisher{client: &capturingBusClient{err: fmt.Errorf("bus down")}, callTimeout: time.Second}
 	failing.PublishTaskEvent(context.Background(), task)
+}
+
+// TestPublishTaskEventSurfacesResultPayload verifies that a completed task's
+// result payload (the capability output) is surfaced verbatim in the CloudEvent
+// data so it reaches the CLI without a DB query (#1378).
+func TestPublishTaskEventSurfacesResultPayload(t *testing.T) {
+	task := &domain.Task{
+		TaskID: "task-9", WorkflowID: "wf-9", CapabilityName: "review",
+		Status: domain.TaskStatusCompleted, DispatchedTo: "agent-ollama",
+		ResultPayload: []byte(`{"completion":"LGTM, ship it"}`),
+	}
+	bus := &capturingBusClient{}
+	p := &EventPublisher{client: bus, callTimeout: time.Second}
+	p.PublishTaskEvent(context.Background(), task)
+
+	if len(bus.requests) != 1 {
+		t.Fatalf("publish calls = %d, want 1", len(bus.requests))
+	}
+	data := decodeData(t, bus.requests[0].GetEvent().GetData())
+	if got, want := data["result_payload"], `{"completion":"LGTM, ship it"}`; got != want {
+		t.Errorf("result_payload = %q, want %q", got, want)
+	}
+}
+
+func decodeData(t *testing.T, raw []byte) map[string]string {
+	t.Helper()
+	var m map[string]string
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatalf("decode event data: %v", err)
+	}
+	return m
 }


### PR DESCRIPTION
Closes #1378

## Why

After a successful run the capability output was invisible to the CLI. The
Ollama review text lived only in the task-broker DB (`tasks.result_payload` →
`{"completion": "..."}`); `zynax get/status/logs` surfaced status and state but
never the result. The "impressive" output of a run could not be seen without
`psql`. Part of #1370 (M7.K awesome quickstart), Operations step 9.

## What you'll get

- **task-broker** now includes the completed task's `result_payload` in its
  `task.completed` CloudEvent `data` (additive JSON field; omitted for
  non-terminal/failed events). No proto change — `CloudEvent.data` is already
  opaque JSON bytes.
- **api-gateway** already forwards CloudEvent `data` as the `/logs` SSE `payload`
  — no change needed there.
- **CLI `zynax logs`** renders the capability output on an indented `output:`
  line when a completion event carries one.
- **CLI `zynax result <run-id>`** (new) tails the run to a terminal state and
  prints just the model's review text — readable straight from the CLI.

## Scope & boundaries

- No proto changes (verified `CloudEvent.data` is `[]byte` JSON).
- api-gateway untouched — the payload already flowed through `WatchEvent.Payload`.
- CLI stays HTTP-REST only (cmd/zynax AGENTS.md): no gRPC/proto imports.
- Mirrors the event-injection CLI pattern landed in #1377.

## Test plan & acceptance

| Acceptance criterion | Verify command | Result |
|---|---|---|
| task-broker surfaces result_payload on completion | `GOWORK=off go -C services/task-broker test ./internal/infrastructure/... -race -timeout 60s` | PASS (`TestPublishTaskEventSurfacesResultPayload`) |
| CLI `logs` renders completion text | `GOWORK=off go -C cmd/zynax test ./... -timeout 60s` | PASS (`TestLogsCmd_RendersCompletionOutput`) |
| CLI `result` prints model review; errors when none | `GOWORK=off go -C cmd/zynax test ./... -timeout 60s` | PASS (`TestResultCmd_PrintsCompletion`, `TestResultCmd_NoResult_Errors`) |
| CompletionText unwraps nested payload | `GOWORK=off go -C cmd/zynax test ./client/... -timeout 60s` | PASS (`TestCompletionText`) |
| api-gateway unchanged & green | `GOWORK=off go -C services/api-gateway test ./... -race -timeout 60s` | PASS |

A user who runs the code-review example can now read the model's review via
`zynax logs <run-id>` (inline) or `zynax result <run-id>` (text only).

## Evidence

- CLI: `ok github.com/zynax-io/zynax/cmd/zynax/client` · `ok .../cmd/zynax/cmd`
- task-broker: `ok github.com/zynax-io/zynax/services/task-broker/internal/infrastructure`
- api-gateway: all 5 packages `ok`
- gofmt + golangci-lint: PASS (pre-commit)
- Post-merge digest sync → main

## Risk & rollback

- Low. Additive JSON field on an existing CloudEvent + two CLI render paths.
- Backward-compatible: older gateways/CLIs ignore the extra `result_payload`
  field; the new CLI tolerates its absence (prints nothing / errors cleanly).
- Rollback: revert the single commit; no schema or proto migration involved.

## Review aids

- task-broker change: `services/task-broker/internal/infrastructure/event_publisher.go`
  (only adds `result_payload` to the `data` map when present).
- CLI extractor: `cmd/zynax/client/gateway.go` `CompletionText` (unwraps the
  nested `result_payload` → `completion`).
- New command: `cmd/zynax/cmd/result.go`.

SPDD: Canvas `docs/spdd/1370-awesome-quickstart/canvas.md` Aligned; security-review PASS (epic canvas step 9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
