### PR TITLE
docs(quickstart): one-command make demo + README hero

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ BENCH_BASELINE := tools/bench-baseline.txt
 # Auto-discovered from agents/examples/*/pyproject.toml — no manual update needed when adding a new agent.
 AGENTS        := $(shell find agents/examples -maxdepth 2 -name pyproject.toml -exec dirname {} \; 2>/dev/null | xargs -rI{} basename {} | sort)
 COMPOSE          := docker compose -f infra/docker-compose/docker-compose.yml
+COMPOSE_DEMO     := docker compose -f infra/docker-compose/docker-compose.yml -f infra/docker-compose/docker-compose.ollama.yml
 COMPOSE_SERVICES := docker compose -f infra/docker-compose/docker-compose.services.yml
 COMPOSE_TOOLS    := docker compose -f infra/docker-compose/docker-compose.tools.yml
 COMPOSE_OBS      := docker compose --env-file infra/docker-compose/observability/.env.observability -f infra/docker-compose/docker-compose.observability.yml
@@ -118,6 +119,41 @@ stop-local: ## Stop and remove local stack containers
 
 logs-local: ## Tail all local stack logs
 	$(COMPOSE) logs -f
+
+# ── One-command demo ────────────────────────────────────────────────────────
+# Boots the minimal stack + the zero-secret Ollama overlay, runs the hero
+# code-review workflow to a terminal state, and prints the model's review.
+# Prereq: pull the demo model once on the host — `ollama pull qwen2.5-coder:3b`
+# (the overlay reuses host-pulled models read-only; nothing is auto-downloaded).
+.PHONY: demo demo-clean
+DEMO_WORKFLOW ?= spec/workflows/examples/code-review-ollama.yaml
+ZYNAX        ?= zynax
+
+demo: check-docker ## ★ One command: boot the Ollama stack + run the hero code-review workflow
+	@command -v $(ZYNAX) >/dev/null 2>&1 || \
+	  (echo "❌ zynax CLI not found — run 'make install-cli' and ensure ~/bin is on your PATH" && exit 1)
+	@echo "🧠 Demo model: qwen2.5-coder:3b — pull it once on the host if you have not:"
+	@echo "     ollama pull qwen2.5-coder:3b"
+	@echo "🚀 Booting the minimal stack + Ollama overlay (waiting for health)..."
+	$(COMPOSE_DEMO) up -d --wait
+	@export ZYNAX_API_URL=http://localhost:7080; \
+	  echo "▶  zynax apply $(DEMO_WORKFLOW)"; \
+	  run_id=$$($(ZYNAX) apply $(DEMO_WORKFLOW) | sed -n 's/^run_id: //p'); \
+	  test -n "$$run_id" || (echo "❌ apply did not return a run_id" && exit 1); \
+	  echo "   run_id: $$run_id"; \
+	  echo "⏳ Streaming to terminal + printing the model's review..."; \
+	  echo "── review ──────────────────────────────────────────────"; \
+	  $(ZYNAX) result "$$run_id"; \
+	  echo "────────────────────────────────────────────────────────"
+	@echo ""
+	@echo "✅ Demo complete. Next steps:"
+	@echo "   • Inspect logs:    ZYNAX_API_URL=http://localhost:7080 zynax logs <run-id> --follow"
+	@echo "   • Author your own: cp $(DEMO_WORKFLOW) my-workflow.yaml  (see docs/quickstart.md)"
+	@echo "   • Tear it all down: make demo-clean"
+
+demo-clean: ## Stop and remove the demo stack (base + Ollama overlay)
+	$(COMPOSE_DEMO) down --remove-orphans
+	@echo "✅ Demo stack removed"
 
 install-cli: ## Build and install zynax CLI to ~/bin/zynax (requires Go 1.26.3)
 	cd cmd/zynax && GOWORK=off go build -trimpath -o ~/bin/zynax .

--- a/README.md
+++ b/README.md
@@ -21,6 +21,27 @@ _The engine-portability layer for agentic automation._
 
 ---
 
+## See it run — one command
+
+```bash
+make demo
+```
+
+`make demo` boots the minimal stack with a zero-secret local-LLM ([Ollama](https://ollama.com)) overlay
+and runs the hero code-review workflow end-to-end — a real model reviews a git diff and prints its
+verdict, straight from the CLI. The only prerequisites are Docker and pulling the demo model once
+(`ollama pull qwen2.5-coder:3b`). Tear it down with `make demo-clean`.
+
+<!-- asciinema cast — record locally with `make demo` and `asciinema rec docs/casts/make-demo.cast`.
+     See docs/casts/README.md. Once recorded, replace the placeholder below with the upload embed. -->
+[![asciicast — make demo](https://asciinema.org/a/PLACEHOLDER.svg)](https://asciinema.org/a/PLACEHOLDER)
+
+> The cast above is a placeholder until a maintainer records `docs/casts/make-demo.cast` from a live
+> `make demo` run — see [docs/casts/README.md](docs/casts/README.md). New here? Jump to the
+> [Quickstart](#-quickstart).
+
+---
+
 ## What is Zynax?
 
 > **Define an AI agent workflow once, as a YAML manifest, and run it on whichever engine your org

--- a/docs/casts/README.md
+++ b/docs/casts/README.md
@@ -1,0 +1,40 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Terminal casts
+
+This directory holds the [asciinema](https://asciinema.org) terminal recordings
+embedded across the docs and the top of the [README](../../README.md).
+
+## `make-demo.cast` — needs a human recording
+
+The README hero embed points at a **placeholder**. The real cast must be recorded
+by a maintainer running the demo on real hardware, because the demo pulls a
+multi-GB Ollama model and runs a live LLM inference — neither of which can be
+recorded on the CI host.
+
+### How to record it
+
+```bash
+# 1. One-time: pull the demo model (~2 GB) on the host.
+ollama pull qwen2.5-coder:3b
+
+# 2. Install the CLI if you have not already.
+make install-cli            # → ~/bin/zynax (ensure ~/bin is on your PATH)
+
+# 3. Record the one-command demo.
+asciinema rec docs/casts/make-demo.cast --command "make demo"
+
+# 4. Tear down the stack.
+make demo-clean
+```
+
+### Publishing the embed
+
+1. Upload the cast: `asciinema upload docs/casts/make-demo.cast`.
+2. Copy the returned asciinema.org id.
+3. In [`README.md`](../../README.md), replace both `PLACEHOLDER` tokens in the
+   hero `[![asciicast …]]` line with that id, and delete the placeholder note
+   directly beneath it.
+
+Keep the raw `.cast` file committed here so the embed survives even if the
+upload is ever removed upstream.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,5 +1,9 @@
 # Quick Start
 
+> **In a hurry?** Run `make demo` for the one-command path: it boots a zero-secret local-LLM
+> stack and runs the hero code-review workflow end-to-end. Prereq: `ollama pull qwen2.5-coder:3b`.
+> The steps below walk through the same flow manually.
+
 Get from a fresh clone to a **traced workflow run** in minutes. Everything runs in
 Docker — the only prerequisite is Docker Desktop (or Docker Engine + the Compose plugin).
 


### PR DESCRIPTION
Closes #1360

## Why

The first-run experience is buried in a multi-step quickstart. Issue #1360 asks for a
single `make demo` path that boots the minimal stack and runs a reference workflow to
completion, plus a README-first asciinema cast so the hero flow is the first thing a
visitor sees. All the pieces already landed on main (Ollama overlay #1374/#1386, the
runnable hero workflow #1376, and `zynax apply`/`logs`/`result` #1378) — this PR wires
them into one command and surfaces it.

## What you'll get

- A `make demo` target that: verifies Docker + the `zynax` CLI → boots the base stack
  with the zero-secret Ollama overlay (`up -d --wait` for health) → `zynax apply` the
  hero `code-review-ollama.yaml`, capturing the `run_id` → `zynax result` streams to a
  terminal state and prints the model's review → prints next steps. Plus `make demo-clean`
  for teardown.
- README opens with a "See it run — one command" hero section: the single `make demo`
  command and an asciinema cast embed referencing `docs/casts/make-demo.cast`.
- `docs/casts/README.md` documenting how a human records the real cast (the live
  multi-GB Ollama run cannot be recorded on the CI host).
- A two-line quickstart pointer to `make demo`.

## Scope & boundaries

- Model pull (`qwen2.5-coder:3b`) is a **documented prerequisite**, never an auto-pull —
  no multi-GB download baked into the target or CI.
- The asciinema `.cast` file is **not** included — it is a flagged human follow-up (see
  Test plan). The README embed and `docs/casts/README.md` scaffold it.
- The quickstart edit is intentionally minimal (one note block) so it does not collide
  with the full quickstart reconciliation in #1379.
- No service / Go / proto changes — Makefile + docs only.

## Test plan & acceptance

| Acceptance criterion | Verify command | Result |
|---|---|---|
| `make demo` boots the minimal stack + runs a reference workflow to completion | `make -n demo` (dry-run) | PASS — expands to docker check → CLI check → `up -d --wait` on base+overlay → `zynax apply` (run_id via sed) → `zynax result` → next steps |
| The stack it boots is valid | `docker compose -f docker-compose.yml -f docker-compose.ollama.yml config --quiet` | PASS — exit 0 |
| `make demo-clean` tears it down | `make -n demo-clean` | PASS — `compose ... down --remove-orphans` |
| README opens with the cast embed + single command | visual review of README hero block | PASS — `make demo` + `[![asciicast …]]` embed at top |
| Quickstart links to it | review of docs/quickstart.md | PASS — note block points at `make demo` |
| Asciinema cast recorded | n/a | **Human follow-up — cannot record a multi-GB live Ollama cast on the CI host.** Embed + `docs/casts/README.md` scaffold the recording; a maintainer runs `make demo` + `asciinema rec` locally and swaps the `PLACEHOLDER` token. |

I did **not** run the full live demo end-to-end (multi-GB model pull + live LLM
inference would OOM/saturate this shared host). Validation is dry-run + compose config.

## Evidence

- `make -n demo` → full expansion, no chained-target errors.
- `docker compose -f docker-compose.yml -f docker-compose.ollama.yml config --quiet` → exit 0.
- `make -n demo-clean` → `compose ... down --remove-orphans`.

## Risk & rollback

Low — additive Makefile targets and docs only; no existing target or runtime path is
changed. Rollback is a single-commit revert. The placeholder cast embed renders an
asciinema badge until a maintainer uploads the real recording.

## Review aids

- Makefile: new `COMPOSE_DEMO` var + `demo` / `demo-clean` targets, mirroring the
  existing `run-local` / `stop-local` style.
- README: `## See it run — one command` block above "What is Zynax?".
- `docs/casts/README.md`: the flagged human follow-up for recording the cast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
