### PR TITLE
docs(validation): human-validation guide standard + template

### DIFF
--- a/docs/contributing/human-validation-guide.md
+++ b/docs/contributing/human-validation-guide.md
@@ -1,0 +1,108 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+# Human-Validation Guide Standard
+
+The single source of truth for **what a human-validation guide is** and **when a story
+needs one**. A human-validation guide lets a person who has never seen Zynax execute a
+user-visible feature by hand and report a clear pass or fail — without reading the code,
+the tests, or the PR diff.
+
+It complements, never replaces, automated tests. Unit/BDD tests prove the contract holds
+in CI; a human-validation guide proves a *real human* can reach the advertised outcome on
+their own machine. Both are required for user-visible work.
+
+> Template to copy: [`templates/human-validation-guide.template.md`](templates/human-validation-guide.template.md)
+
+---
+
+## When a story needs one
+
+A story **must** ship a human-validation guide when it is *user-visible* — i.e. it carries
+an `audience: zynax-user` or `audience: developer` label, or its acceptance criteria
+describe something a human observes (a CLI command, a rendered output, a demo path, an
+error message). EPIC #1370 (the awesome-quickstart cluster) made this a standing safeguard:
+*every user-visible story ships a human-validation guide.*
+
+A story does **not** need one when it is purely internal — a refactor, a proto field with
+no surfaced behaviour, a CI gate, or a library change with no user-observable effect.
+Internal stories validate through their automated tests alone.
+
+| Story is… | Needs a human-validation guide? |
+|-----------|---------------------------------|
+| `audience: zynax-user` / `audience: developer`, or user-observable behaviour | **Yes** |
+| Pure internal refactor, CI gate, non-surfaced proto/library change | No |
+
+---
+
+## Required sections
+
+A guide is a short, copy-runnable document. Keep it tight — a reader should finish setup
+and reach a verdict in minutes, not hours. Every guide MUST contain these sections, in order:
+
+1. **Purpose** — one or two sentences: what feature this validates and what "working" means.
+2. **Prerequisites / preconditions** — exactly what must be installed and running before the
+   reader starts (Docker, a model pulled, a compose stack up). State versions where they matter.
+3. **Expected duration** — a realistic estimate (e.g. "~5 minutes after the model is pulled").
+4. **Setup** — the exact commands that bring the system into the starting state. No prose
+   substitutes; the reader copies these verbatim.
+5. **Steps** — the numbered, exact commands a human runs to exercise the feature. One action
+   per step. No "now configure X" hand-waving — show the command.
+6. **Expected observable result** — what the reader should *see* after the steps: the exact
+   terminal output, the rendered field, the status line. Quote it so the reader can compare.
+7. **Pass / fail criteria** — an unambiguous checklist. "PASS if the `zynax result` output
+   shows a non-empty review summary; FAIL otherwise." No interpretation required.
+8. **Teardown** — the commands that return the machine to a clean state (stop the stack,
+   remove volumes), so the reader leaves nothing running.
+9. **Troubleshooting** — the two or three failure modes a first-timer hits, each with a fix.
+10. **Feedback / bug-reporting** — what to capture (command, observed vs expected output,
+    versions) and where to file it, so a failed validation becomes an actionable report.
+
+Sections 1–8 are mandatory. Sections 9–10 are strongly recommended and required for any
+guide on a default first-run or demo path.
+
+---
+
+## How it ties into SPDD and the PR body
+
+A human-validation guide is the human-executable mirror of two existing artefacts:
+
+- **The SPDD Canvas Acceptance Criteria.** Each *user-observable* acceptance criterion in
+  the canvas O-step (or the story's `## Acceptance criteria`) should map to one **Pass / fail
+  criterion** in the guide. If a criterion cannot be turned into a step a human runs and a
+  result they observe, it is not yet testable — tighten the criterion, not the guide.
+- **The PR "Test plan & acceptance" section.** The PR template
+  ([`pr-templates.md`](pr-templates.md)) requires one matrix row per acceptance criterion with
+  the *exact command* used to verify and the observed result. A user-visible PR cites its
+  human-validation guide as the verification method for the user-observable rows — the guide's
+  Steps + Expected observable result *are* the "How verified" column for a human path.
+
+So the chain is: **canvas acceptance criterion → guide pass/fail criterion → PR test-plan row.**
+The same observable outcome appears in all three, worded consistently.
+
+---
+
+## Worked grounding — the Ollama quickstart
+
+The required sections are not abstract: they mirror how EPIC #1370's first runnable workflow
+actually validated. A human brings up the compose stack with the Ollama overlay, applies the
+demo workflow, and observes the terminal result:
+
+```bash
+# Setup
+docker compose -f infra/docker-compose/docker-compose.yml \
+  -f infra/docker-compose/docker-compose.ollama.yml up -d
+
+# Steps
+zynax apply spec/workflows/examples/code-review-ollama.yaml
+zynax logs <run-id> --follow
+
+# Expected observable result
+zynax result <run-id>      # shows a non-empty code-review summary
+```
+
+PASS if `zynax result` prints a code-review summary; FAIL if it is empty or errors. Teardown
+brings the stack down with `docker compose … down -v`. Copy the template, fill these in for
+your story, and you have a complete guide.
+
+---
+
+*See also:* [`pr-templates.md`](pr-templates.md) · [`../patterns/spdd-guide.md`](../patterns/spdd-guide.md) · [`templates/human-validation-guide.template.md`](templates/human-validation-guide.template.md)

--- a/docs/contributing/templates/human-validation-guide.template.md
+++ b/docs/contributing/templates/human-validation-guide.template.md
@@ -1,0 +1,67 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!--
+  Human-Validation Guide TEMPLATE.
+  Copy this file to docs/<area>/validation/<story-slug>.md (or alongside the feature),
+  delete this comment, and replace every <…> placeholder with the real value.
+  Standard this implements: ../human-validation-guide.md
+  Rule: a stranger to Zynax must finish setup and reach a verdict in minutes.
+-->
+# Human-Validation Guide — <feature / story name>
+
+> **Story:** #<issue>  ·  **Canvas:** `docs/spdd/<id>/canvas.md` — O-step <N>
+
+## Purpose
+<One or two sentences: what feature this validates and what "working" looks like.>
+
+## Prerequisites
+- <e.g. Docker Engine ≥ 24 running>
+- <e.g. the `zynax` CLI on PATH (`make build` or the release binary)>
+- <e.g. the demo model pulled: `docker compose … exec ollama ollama pull <model>`>
+
+## Expected duration
+<e.g. ~5 minutes after the model is pulled.>
+
+## Setup
+```bash
+# Exact commands to bring the system into the starting state — copy verbatim.
+<command>
+```
+
+## Steps
+1. <First exact command the human runs.>
+   ```bash
+   <command>
+   ```
+2. <Second exact command.>
+   ```bash
+   <command>
+   ```
+
+## Expected observable result
+```
+<Quote the exact output / status line / rendered field the reader should see.>
+```
+
+## Pass / fail criteria
+- [ ] **PASS** when <unambiguous observable condition, e.g. `zynax result` shows a non-empty summary>.
+- [ ] **FAIL** when <the opposite, e.g. output is empty, errors, or the run never reaches a terminal state>.
+
+<!-- One pass/fail criterion per user-observable acceptance criterion in the canvas / story. -->
+
+## Teardown
+```bash
+# Return the machine to a clean state.
+<command, e.g. docker compose -f … -f … down -v>
+```
+
+## Troubleshooting
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| <what the reader sees> | <why> | <command or step to recover> |
+
+## Feedback / bug reporting
+If validation fails, capture and file:
+- The exact command run and its full output.
+- Expected vs observed result.
+- Versions: `zynax version`, image tags, model name.
+- Open an issue with the `area: docs` (or relevant) label and attach the above.

--- a/docs/patterns/spdd-guide.md
+++ b/docs/patterns/spdd-guide.md
@@ -262,4 +262,4 @@ git commit -S -s -m "docs: SPDD Canvas for M3 Temporal Execution — aligned (#2
 
 ---
 
-*See also:* `docs/adr/ADR-019-spdd-prompt-governance.md` · `docs/spdd/CANVAS_TEMPLATE.md` · `docs/spdd/README.md`
+*See also:* `docs/adr/ADR-019-spdd-prompt-governance.md` · `docs/spdd/CANVAS_TEMPLATE.md` · `docs/spdd/README.md` · `docs/contributing/human-validation-guide.md` (how user-visible canvas acceptance criteria become a human-runnable validation guide)


### PR DESCRIPTION
## docs(validation): human-validation guide standard + template

Closes #1388

### Why
Several user-visible feature issues (e.g. #1385, #1386) require "a human-validation guide"
in their acceptance criteria, but no standard defines what that guide is. Without a standard,
every story validates differently. This defines the standard + a reusable template so every
user-visible story validates the same way.

### What you'll get
- A docs standard: what a human-validation guide is, when a story needs one (`audience:
  zynax-user|developer` / user-observable behaviour), the required sections, and how it ties
  into the SPDD canvas Acceptance Criteria + the PR "Test plan & acceptance" section ← `docs/contributing/human-validation-guide.md`
- A reusable template an author copies and fills in minutes ← `docs/contributing/templates/human-validation-guide.template.md`
- A discoverability pointer from the SPDD guide ← `docs/patterns/spdd-guide.md`

### Scope & boundaries
- **In scope:** one standard, one template, one pointer link. Required sections grounded in
  how the #1370 Ollama quickstart actually validated (compose + ollama overlay → `zynax apply`
  → observe terminal result via `zynax logs`/`zynax result`).
- **Out of scope (deferred):** retrofitting guides into other stories (each user-visible story
  ships its own guide); README / quickstart edits (→ #1360 / #1379).

### Test plan & acceptance
| Acceptance criterion | How verified (command) | Result |
|----------------------|------------------------|--------|
| Template committed and referenced from contributing/authoring docs | `git ls-files docs/contributing/templates/human-validation-guide.template.md` + pointer in `docs/patterns/spdd-guide.md` | ✅ both files present; "See also" link added |
| Standard defines required sections + SPDD/PR tie-in | review `docs/contributing/human-validation-guide.md` (10 sections, canvas-AC→guide→PR-row chain) | ✅ present |

**Local gates:** secret-detection pre-commit ✅ · no markdownlint/docs-lint target in Makefile (N/A)

### Evidence
- **CI:** required checks expected green (docs-only change).
- **Local output:** secret-detection hook Passed; no literal emails (gitleaks PII gate clear); diff = +176/-1 across 3 docs files.
- **Artifacts / images:** none — no service source changed.
- **Post-merge digest sync → main:** N/A — no image rebuild.

### Risk & rollback
Low — additive docs only, no behaviour change. Revert this PR to remove.

### Review aids
Start at `docs/contributing/human-validation-guide.md` (the standard). The template and the
one-line `spdd-guide.md` pointer follow from it. The "Worked grounding" section shows the
Ollama quickstart path the required sections are modelled on.

**AI:** `Assisted-by: Claude/Opus 4.8`
