### PR TITLE
docs(ai-learnings): M7 awesome-quickstart cluster session

### DIFF
--- a/docs/ai-learnings/ci-release.md
+++ b/docs/ai-learnings/ci-release.md
@@ -637,3 +637,11 @@ Story: Q.4 — verify + document Go module consumption path (pkg.go.dev). PR #12
 - "CI runs/tests X" ACs: grep the workflow for the loop's SOURCE variable, not just the loop's presence. A `for x in ${{ env.LIST }}` over a hardcoded-empty `LIST` is a silently-inert gate (green but covers nothing — same class as a skipped required check). Fix with in-job discovery: an `id:` step writing `agents=<glob>` to `$GITHUB_OUTPUT`, consumed as `${{ steps.<id>.outputs.agents }}`, mirroring the Makefile's `$(shell find …)` glob so make and CI never diverge.
 - actionlint runs shellcheck and exits 1 on warnings; distinguish NEW from baseline by running against `git show origin/main:<file>`. Prefer a shell-glob `for dir in agents/examples/*/` over `find|xargs basename` (avoids SC2038).
 - A `.github/workflows/`-only PR does NOT trigger the python/go lint/test lanes (changes-filter path is `^agents/`), so they show "skipping" and the effect lands on the next matching PR — note this in the PR body.
+
+## Session — 2026-06-19 (EPIC #1370 — M7 awesome-quickstart cluster)
+
+### #1379 (docs: reconcile CLI claims with the live surface)
+- Before editing docs that claim a CLI command/flag does NOT exist, confirm against source twice: grep the cobra `Use:` strings AND run `GOWORK=off go -C cmd/zynax run . --help`. Issue bodies describing the CLI surface go stale fast as intervening PRs merge — reconcile to the live surface, do not blindly delete real commands.
+
+### Cross-cutting (structural)
+- On this repo's fast-moving main (up-to-date required, no merge queue), after the final rebase + force-push run `gh pr merge <PR> --squash --auto` rather than polling-then-merging — armed auto-merge fires the instant the branch is green AND current, avoiding the BEHIND race a manual merge keeps losing. (structural-workaround)

--- a/docs/ai-learnings/go-services.md
+++ b/docs/ai-learnings/go-services.md
@@ -619,3 +619,15 @@ Story: Q.5 — ADR-034 ManifestWorkflowID 64-bit collision domain + canonicaliza
 
 ### #1372 (fix: workflow-compiler underscore in event-type)
 - When widening a domain validation regex, first grep the same file for a sibling identifier regex (e.g. `capabilityNameRe`) — Zynax encodes the underscore-surrounded-by-alphanumerics rule once as `(_[a-z0-9]+)*`; reuse that exact sub-pattern instead of `[a-z0-9_]+`, which would wrongly accept leading/trailing/double underscores. The pre-existing test case asserting the bug (`{"underscore", "review_approved", true}`) is the natural regression marker — flip it to `false`. (domain)
+
+## Session — 2026-06-19 (EPIC #1370 — M7 awesome-quickstart cluster)
+
+### #1373 (fix: SSE streaming 500 through middleware chain)
+- A status-capturing `http.ResponseWriter` wrapper (e.g. a `statusRecorder` for metrics/work-tracking) MUST forward `Flush()` (guarded `if f, ok := w.(http.Flusher); ok`) and expose `Unwrap() http.ResponseWriter`, or any SSE/streaming handler asserting `w.(http.Flusher)` 500s with "streaming not supported". Two such wrappers existed (`libs/zynaxobs` + `cmd/api-gateway`) — fix both. Tests must exercise the full middleware chain, not the bare mux: httptest's writer is already a Flusher and hides the bug. (domain)
+
+### #1381 (fix: non-retryable NotFound dispatch error in Temporal)
+- Make a gRPC `codes.NotFound` dispatch error non-retryable in Temporal by wrapping it at the INFRA activity boundary as `temporal.NewNonRetryableApplicationError(..., "ErrCapabilityNotFound", err)` — the RetryPolicy already listed that type in `NonRetryableErrorTypes` but nothing produced it. This keeps the domain layer Temporal-free (ADR-015). `//nolint:wrapcheck` the sentinel constructor — re-wrapping it breaks Temporal's `errors.As` classification. (domain)
+
+### #1377 / #1378 (chore: surface payload field in CLI; add domain port method)
+- Adding a method to an existing domain port interface breaks ALL its test doubles, including BDD `tests/steps_test.go` fakes — grep the module for implementers and add the method to every stub in the SAME commit, or the module fails to build with "does not implement <Port>". (domain)
+- For "surface X in the CLI" issues, trace the payload end-to-end first (producer → event/REST field → CLI struct); often no proto change is needed because the carrier is an opaque `CloudEvent.data []byte` — add a JSON field at the producer plus a render line at the CLI. (domain)

--- a/docs/ai-learnings/infra-helm.md
+++ b/docs/ai-learnings/infra-helm.md
@@ -151,5 +151,20 @@ Story: O.7 — local Uptrace docker-compose observability stack (Uptrace + Click
 - Zero-cost local LLM in compose: add an `ollama` service **inside** the compose network (never expose it on the host LAN), and reuse host-pulled models via a **read-only** bind mount of the models dir into `/root/.ollama/models` — no multi-GB re-download. Mount only the `models` subdir RO so the container keeps a writable `/root/.ollama` for its startup keypair. Parameterise the host path (`OLLAMA_HOST_MODELS`).
 - Reaching a host daemon bound to loopback from a container is undesirable (binding it to all interfaces exposes it to the LAN). Prefer bundling the dependency in-network over reconfiguring the host daemon.
 
+## Session — 2026-06-19 (EPIC #1370 — M7 awesome-quickstart cluster)
+
+### #1374 (chore: validate a compose overlay)
+- Compose overlays are NOT covered by `make validate-spec` (which only runs AsyncAPI + capability/workflow/agent-def/policy + expert-mapping). Validate an overlay with `docker compose -f base.yml -f overlay.yml config` (exit 0 + rendered merge) and paste the merged service block as PR Evidence.
+- Keep third-party runtime images (ollama/postgres/nats) as direct refs — only first-party/base images go in `images/images.yaml`.
+
+### #1386 (fix: value inside a bind-mounted config file)
+- For a value living inside a BIND-MOUNTED config file (not a compose `environment:` entry), `docker compose config` will NOT surface it — it shows only the mount. Validate the merge AND `grep` the actual value out of the mounted file as separate evidence.
+- Do NOT add `${ENV:-default}` tokens inside a config file the consuming Go service reads literally (no shell interpolation) — document a one-line file edit instead.
+
+### #1360 (chore: one-command demo Make target)
+- For a one-command demo Make target, prefer `docker compose ... up -d --wait` (Compose-native health gating) over a hand-written poll loop.
+- Keep the apply → capture-`run_id` → result sequence in ONE backslash-continued recipe line with a leading `export ...;` — Make runs each recipe line in a fresh shell, so a captured `run_id` is lost across lines unless joined.
+- `make -n <target>` + `docker compose config` is host-safe validation for a target that would otherwise need a multi-GB live run.
+
 ### Edge cases discovered
 - A fresh `make run-local` silently leaves git/ci/llm adapters `Exited(1)` for missing `GITHUB_TOKEN`/`OPENAI_API_KEY`; only the langgraph `echo` capability works out of the box (#1375). `zynax logs` streaming returns HTTP 500 `streaming not supported` against the compose api-gateway (#1373).

--- a/docs/ai-learnings/python-adapters.md
+++ b/docs/ai-learnings/python-adapters.md
@@ -118,3 +118,10 @@ ADR-proposal docs story with a security dimension (ADR-032 Git MCP shim + auth m
 
 ### Edge cases discovered
 - A `snake_case` capability name (mandated by `agents/adapters/AGENTS.md`) yields the engine-derived completion event `<name>.completed`, which the workflow-compiler **rejects** (event types must be dot-separated lowercase, no underscores). So a `summarize_feedback` capability's completion event can't be referenced in a transition. Filed as #1372.
+
+## Session — 2026-06-19 (EPIC #1370 — M7 awesome-quickstart cluster)
+
+### #1375 (fix: adapter graceful degradation on missing secret)
+- Adapters in `agents/adapters/*` are **Go**, not Python (`cmd/<name>/main.go` + `internal/config`) — build/test with `GOWORK=off go -C <moduledir>` (ADR-017). Don't assume a Python dispatch is Python; locate the module first.
+- For missing-secret graceful degradation: add a typed sentinel in the config package, `errors.Is`-branch in `main` to start + warn + skip registry registration + set health `NOT_SERVING` — keep non-sentinel errors fatal. This turns an `Exited(1)` crash-loop into a started-but-degraded adapter.
+- Pre-empt golangci-lint G706 (slog with config args) and G101 (env-var-NAME string literals) with `//nolint:gosec` matching the sibling adapters' existing suppressions.

--- a/docs/ai-learnings/spdd-canvas.md
+++ b/docs/ai-learnings/spdd-canvas.md
@@ -130,3 +130,13 @@ domain: spdd-canvas · two ADR-proposal stories (ADR-031 context propagation; AD
 - Rule: Before `/spdd-story` creates issues, check the epic for existing children and reconcile instead of duplicating; never reference a filename with a dotted `local`/`internal`/`corp` segment in a committed Canvas (gitleaks `internal-hostname` BLOCK) — rename the artifact.
   Category: structural-workaround
   Reason: Both traps silently break the SPDD ceremony; encoding them prevents the next run from hitting them.
+
+## Session — 2026-06-19 (EPIC #1370 — M7 awesome-quickstart cluster)
+
+### #1376 (chore: validated prototype copied from main)
+- When delivering a validated PROTOTYPE copied from the main checkout, treat its header/comment prose as unverified — cross-check capability and derived-event names against the source-of-truth registering config; fix only comment drift.
+- The underscore distinction is load-bearing (the compiler rejects an underscored `<cap>.completed`); a stale `code_review` comment vs the real `codereview` capability can mislead a future editor.
+
+### #1388 (docs: ground a process standard in a real path)
+- Ground a process standard in a real validated path (read the actual workflow/example) so its required sections are concrete.
+- Anchor it to the existing PR template's "Test plan & acceptance" matrix rather than inventing a new concept.


### PR DESCRIPTION
Per-domain expert learnings captured from the EPIC #1370 M7
awesome-quickstart delivery cluster.

Appends one dated session block (2026-06-19) per domain file under
`docs/ai-learnings/`:

- `go-services.md` — #1373 (SSE Flusher/Unwrap forwarding), #1381 (non-retryable NotFound at infra boundary), #1377 / #1378 (port-method test-double fan-out; trace payload end-to-end)
- `python-adapters.md` — #1375 (adapters are Go; graceful missing-secret degradation)
- `infra-helm.md` — #1374, #1386, #1360 (compose-overlay validation, bind-mounted config values, one-command demo targets)
- `spdd-canvas.md` — #1376 (validated prototype comment-drift), #1388 (ground a process standard in a real path)
- `ci-release.md` — #1379 (reconcile CLI doc claims to the live surface) + cross-cutting auto-merge structural note

Issues: #1373 #1375 #1374 #1381 #1376 #1377 #1386 #1378 #1360 #1388 #1379

Docs-only; no code or behavior change.
