### PR TITLE
fix(api-gateway): rate-limit the events publish endpoint

### DIFF
--- a/services/api-gateway/internal/api/handler.go
+++ b/services/api-gateway/internal/api/handler.go
@@ -34,15 +34,17 @@ func NewHandler(svc *domain.ApplyService, apiKey string) *Handler {
 // RegisterRoutes registers all HTTP routes on mux. Requires Go 1.22+ ServeMux.
 // Mutating endpoints (POST, DELETE) are protected by bearer-token auth when
 // ZYNAX_API_KEY is set; read-only endpoints (GET) are always open.
-// POST /api/v1/apply is additionally protected by a per-IP token-bucket rate
-// limiter (see ratelimit.go); parameters are configured via RATE_LIMIT_RPS and
+// The mutating POST endpoints /api/v1/apply and /api/v1/workflows/{id}/events
+// are additionally protected by a per-IP token-bucket rate limiter (see
+// ratelimit.go); parameters are configured via RATE_LIMIT_RPS and
 // RATE_LIMIT_BURST environment variables.
 func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
 	rl := newIPRateLimiter()
 	applyHandler := rl.Middleware(http.HandlerFunc(requireBearer(h.apiKey, h.handleApply)))
 	mux.Handle("POST /api/v1/apply", applyHandler)
 	mux.HandleFunc("GET /api/v1/workflows/{id}/logs", h.handleWorkflowLogs)
-	mux.HandleFunc("POST /api/v1/workflows/{id}/events", requireBearer(h.apiKey, h.handlePublishEvent))
+	eventsHandler := rl.Middleware(http.HandlerFunc(requireBearer(h.apiKey, h.handlePublishEvent)))
+	mux.Handle("POST /api/v1/workflows/{id}/events", eventsHandler)
 	mux.HandleFunc("GET /api/v1/workflows/{id}", h.handleGetWorkflow)
 	mux.HandleFunc("DELETE /api/v1/workflows/{id}", requireBearer(h.apiKey, h.handleDeleteWorkflow))
 }

--- a/services/api-gateway/internal/api/handler_test.go
+++ b/services/api-gateway/internal/api/handler_test.go
@@ -726,3 +726,38 @@ func TestHandler_PublishEvent_NoEventBus_Returns503(t *testing.T) {
 		t.Errorf("status: got %d, want 503", resp.StatusCode)
 	}
 }
+
+func TestHandler_PublishEvent_RateLimited_Returns429PastBurst(t *testing.T) {
+	// burst=1 so the second request from the same client must be rejected.
+	// Env is read once when RegisterRoutes builds the limiter, so set it first.
+	t.Setenv("RATE_LIMIT_RPS", "0.001")
+	t.Setenv("RATE_LIMIT_BURST", "1")
+	srv := newServerWithEventBus(&stubEventBus{publishID: "evt-rl"})
+	defer srv.Close()
+
+	body := `{"event_type":"review.approved"}`
+
+	// First request consumes the single token.
+	resp1, err := http.Post(srv.URL+"/api/v1/workflows/run-7/events", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp1.Body.Close() }()
+	if resp1.StatusCode != http.StatusAccepted {
+		t.Fatalf("first request: got %d, want 202", resp1.StatusCode)
+	}
+
+	// Second request from the same client must be rate-limited.
+	resp2, err := http.Post(srv.URL+"/api/v1/workflows/run-7/events", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp2.Body.Close() }()
+	if resp2.StatusCode != http.StatusTooManyRequests {
+		t.Errorf("second request: got %d, want 429", resp2.StatusCode)
+	}
+	m := decodeBody(t, resp2)
+	if m["code"] != "RATE_LIMITED" {
+		t.Errorf("code: got %v, want RATE_LIMITED", m["code"])
+	}
+}


### PR DESCRIPTION
## fix(api-gateway): rate-limit the events publish endpoint

Closes #1444

### Why  (symptom & root cause)
`POST /api/v1/workflows/{id}/events` (added in #1377) is bearer-protected and
body-capped, but — unlike `POST /api/v1/apply` (the F9 fix) — it was registered
straight onto the mux with `requireBearer` only and never wrapped in the per-IP
token-bucket rate limiter. Root cause: the new route was added after the F9
`rl.Middleware` wrap and missed the same treatment, leaving the events endpoint
open to per-IP flooding (security finding F11).

### What you'll get  (deliverables ↔ what changed)
- the events publish route now returns HTTP 429 `{"code":"RATE_LIMITED"}` past
  the per-IP burst, identical to `/apply` ← `services/api-gateway/internal/api/handler.go`
- a regression test that drives the events route through the real mux and asserts
  the second request past `burst=1` is rejected ← `services/api-gateway/internal/api/handler_test.go`

### Scope & boundaries
- **In scope:** wrap the existing events handler in the same `rl.Middleware`; add a
  regression test mirroring the `/apply` reject test.
- **Out of scope (deferred):** any change to the limiter parameters, algorithm, or to
  other routes — N/A.

### Test plan & acceptance
| Acceptance criterion | How verified (command) | Result |
|----------------------|------------------------|--------|
| events route returns 429 past the burst | `GOWORK=off go test ./internal/api/ -race -run TestHandler_PublishEvent_RateLimited_Returns429PastBurst -v` | ✅ PASS — 2nd request 429, body `code=RATE_LIMITED` |
| no regression in the api-gateway suite | `GOWORK=off go test ./... -race -timeout 60s` | ✅ all 5 packages ok |

**Local gates:** `GOWORK=off go test ./... -race` ✅ · golangci-lint (pre-commit) ✅ · gofmt ✅

### Evidence
- **CI:** required checks pending — will go green before auto-merge.
- **Local output:** `ok github.com/zynax-io/zynax/services/api-gateway/internal/api 2.053s`; new test PASS.
- **Artifacts / images:** api-gateway source changed → image rebuilt by the release pipeline.
- **Post-merge digest sync → main:** _placeholder — post-merge verifier fills `chore(images): sync digests after main-<sha>`._

### Risk & rollback
Low — additive protection on an existing route, no behaviour change to requests
within the limit (they still reach the handler). Revert this PR to remove the wrap.
No data or migration concern.

### Review aids
One key file: `services/api-gateway/internal/api/handler.go` — the change mirrors the
`applyHandler := rl.Middleware(...)` line two lines above onto the events route. The
test reuses the existing `newServerWithEventBus` helper and the `/apply` reject pattern
(`RATE_LIMIT_BURST=1`, second request 429).

**AI:** `Assisted-by: Claude/Opus 4.8`
