### PR TITLE
docs(spdd): scope #1359 zero-Temporal engine — canvas + ADR + stories

### DIFF
--- a/docs/adr/ADR-037-zero-temporal-evaluation-engine.md
+++ b/docs/adr/ADR-037-zero-temporal-evaluation-engine.md
@@ -1,0 +1,82 @@
+# ADR-037: Zero-Temporal in-process evaluation engine
+
+**Status:** Proposed  **Date:** 2026-06-19
+**Related:** ADR-015 (pluggable workflow engines — this adds a third engine behind the same
+port), ADR-012 (Workflow IR — the engine-agnostic IR this engine interprets), ADR-014
+(event-driven state machine), ADR-034 (deterministic ManifestWorkflowID), ADR-022 (EventBusService)
+
+> Scoping canvas: [docs/spdd/1359-zero-temporal-engine/canvas.md](../spdd/1359-zero-temporal-engine/canvas.md) · Issue #1359 (M7)
+
+---
+
+## Context
+
+After the Day-0 onboarding work, **Temporal is the heaviest remaining prerequisite** to run a
+first workflow. The `engine-adapter` ships two `WorkflowEngine` implementations selected by
+`ZYNAX_ENGINE_ADAPTER_ACTIVE_ENGINE` (ADR-015): `temporal` (default) and `argo`. Both require a
+heavy external control plane — a Temporal server or an Argo Workflows cluster on Kubernetes —
+before any workflow can reach a terminal state.
+
+For a new evaluator on a laptop this is the top adoption barrier
+([docs/product/strategy.md](../product/strategy.md) §7.1 / §10, and the 2026-06-19 reviews):
+"needs a Temporal cluster" makes evaluators bounce and pushes time-to-first-workflow well past
+the <15-minute target.
+
+A key structural fact makes a lightweight engine cheap: the IR-interpretation logic is already
+engine-agnostic. `domain.IRInterpreter.Run` is a pure state-machine loop that performs no I/O —
+it delegates every side effect to two ports, `ActivityExecutor` (capability dispatch) and
+`EventPublisher` (lifecycle events). The Temporal engine wires those ports through Temporal
+activities; nothing about the interpreter requires a durable backend.
+
+A new engine is a **one-way door**: once `eval` is a documented, selectable engine value with a
+public evaluation/production boundary, removing or redefining it breaks user expectations and the
+"same YAML graduates to Temporal" promise. It therefore warrants an ADR before implementation.
+
+---
+
+## Decision
+
+We will add a third `WorkflowEngine` implementation, **`EvalEngine`**, that interprets the
+compiled `WorkflowIR` **in-process** for evaluation, selectable via
+`ZYNAX_ENGINE_ADAPTER_ACTIVE_ENGINE=eval` alongside `temporal` and `argo`.
+
+- **Reuse, do not fork, `domain.IRInterpreter`.** The eval engine drives `IRInterpreter.Run`
+  with synchronous in-process implementations of `ActivityExecutor` (calling the existing
+  `domain.CapabilityDispatcher` over the task-broker gRPC client) and `EventPublisher`
+  (best-effort lifecycle events to the EventBusService, degrading to a no-op when unset). Both
+  engines share one state-machine semantics, so "the same YAML runs on Temporal" stays literally true.
+- **No durability.** Runs are tracked in an in-memory store keyed by run id; there is no
+  persistence, no retry, and no crash-recovery. A process restart loses all runs.
+- **Same contract.** `Submit` assigns `RunID = ir.WorkflowId` (deterministic, ADR-034);
+  `GetStatus` / `Watch` / `Signal` / `Cancel` honour the existing `WorkflowEngine` port,
+  including `ErrExecutionNotFound` and `ErrTerminalState`.
+- **Opt-in.** The default `ACTIVE_ENGINE` stays `temporal`; `eval` is selected explicitly for Day-0.
+- **No contract changes.** No change to `WorkflowIR`, workflow YAML, or any proto.
+
+---
+
+## Rationale
+
+| Option | Assessment |
+|--------|------------|
+| **In-process eval engine behind `WorkflowEngine`** | ✅ **Chosen** — reuses the already-pure `IRInterpreter` and the existing capability path; minimal new code; respects ADR-015; removes the heaviest Day-0 prerequisite while keeping a clean graduation path to durable engines. |
+| Embedded Temporal / Templite (in-process Temporal-lite) | ✗ Rejected — heavier dependency surface, replay/persistence semantics we explicitly do not want for an evaluation engine, and a larger maintenance burden than the few hundred lines this engine needs. |
+| Require Temporal (status quo — "do nothing") | ✗ Rejected — leaves the top adoption barrier in place; evaluators bounce before the first workflow runs. |
+| Shell out to an external lightweight runner | ✗ Rejected — adds a process/IPC boundary and a new artifact to ship and version, for no benefit over an in-process Go implementation behind the existing port. |
+
+---
+
+## Consequences
+
+- **Positive:** A new user runs a real workflow end-to-end on a laptop with **no Temporal/K8s
+  cluster** — same declarative YAML, same IR, same capability dispatch path. Graduation to
+  production is one env-var flip (`ACTIVE_ENGINE=temporal`). New code is small and isolated in
+  `services/engine-adapter/internal/infrastructure/`; the engine-agnostic interpreter is reused
+  unchanged, so the two engines cannot drift in semantics.
+- **Negative / trade-off:** The eval engine is **evaluation-grade only** — no durability,
+  persistence, retries, replay, or audit history. A restart loses runs. It must never be used as a
+  production execution backend; this boundary is enforced by the default staying `temporal`, by
+  adding no persistence config, and by mandatory docs/error copy pointing to the graduation path.
+- **Neutral / follow-up required:** add an `eval` reference leg to the e2e-smoke matrix (no
+  Temporal/Argo control plane), update the unsupported-engine error to list `eval`, and document
+  the evaluation-vs-production boundary. No proto, YAML, or persistence-schema changes.

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -47,6 +47,7 @@ a PR against `docs/adr/`.
 | [ADR-034](ADR-034-manifest-workflow-id-collision-domain.md) | ManifestWorkflowID 64-bit collision domain + canonicalization stability | Proposed | 2026-06-15 | workflow-compiler — M7 EPIC Q (#583) |
 | [ADR-035](ADR-035-adapter-language-boundary.md) | Adapter language boundary — Go for provider/proxy adapters, Python for AI-framework adapters | Accepted | 2026-06-16 | `agents/adapters/*` — refines ADR-009 — M7 EPIC P (#1276) |
 | [ADR-036](ADR-036-ci-logic-as-go-cli.md) | CI logic belongs in a tested Go CLI (zynax-ci), not inline workflow bash | Accepted | 2026-06-16 | `cmd/zynax-ci/`, `.github/workflows/*`, `scripts/`, `Makefile` — M7 EPIC S (#1285) |
+| [ADR-037](ADR-037-zero-temporal-evaluation-engine.md) | Zero-Temporal in-process evaluation engine (Day-0 onboarding) | Proposed | 2026-06-19 | `services/engine-adapter/` — third engine behind ADR-015 — M7 (#1359) |
 
 ---
 

--- a/docs/spdd/1359-zero-temporal-engine/canvas.md
+++ b/docs/spdd/1359-zero-temporal-engine/canvas.md
@@ -1,0 +1,246 @@
+# REASONS Canvas — Zero-Temporal lightweight evaluation engine (Day-0 onboarding)
+
+> **All content in this Canvas is Tier 1 (public-safe).**
+> Tier 2 content (internal hostnames, IPs, credentials, deployment specifics) belongs in
+> `canvas.private.md` (gitignored). Run `/spdd-security-review <path>` before committing.
+
+**Issue:** #1359
+**Author:** Oscar Gómez Manresa
+**Date:** 2026-06-19
+**Status:** Aligned (v1 — maintainer-authorized 2026-06-19; scoped into M7 per operator decision)
+**Aligned:** 2026-06-19 (maintainer-authorized; grounded in the live engine-adapter code at `services/engine-adapter/`)
+**ADR:** [ADR-037](../../adr/ADR-037-zero-temporal-evaluation-engine.md) (Proposed — awaits maintainer Accept before `/deliver`)
+
+---
+
+## R — Requirements
+
+> Problem statement: what breaks or is missing without this feature?
+
+A brand-new evaluator cannot run their first workflow without first standing up a Temporal
+cluster. After the Day-0 friction work, Temporal is the single heaviest remaining demo
+prerequisite (per the 2026-06-19 reviews and [docs/product/strategy.md](../../product/strategy.md)
+§7.1 / §10):
+
+- `engine-adapter` defaults to `ZYNAX_ENGINE_ADAPTER_ACTIVE_ENGINE=temporal`
+  (`services/engine-adapter/cmd/engine-adapter/main.go:73`), and the only two valid values are
+  `temporal` and `argo` (`main.go:186-196`). Both require a heavy external control plane —
+  a Temporal server or an Argo Workflows cluster on K8s.
+- There is no in-process path: a laptop evaluator must provision Temporal (`client.Dial`,
+  worker registration — `main.go:215-273`) before any workflow can reach a terminal state.
+- This is the top adoption barrier in the product strategy: "needs a Temporal cluster" makes
+  evaluators bounce, and it pushes time-to-first-workflow well past the <15-minute target.
+
+> Definition of done: the observable outcomes that confirm delivery.
+
+- A third `WorkflowEngine` implementation runs the compiled `WorkflowIR` **in-process** for
+  evaluation, selectable via `ZYNAX_ENGINE_ADAPTER_ACTIVE_ENGINE=eval` alongside `temporal`
+  and `argo`, with **no change to workflow YAML**.
+- A reference workflow runs to a terminal state through the eval engine with **no Temporal
+  container and no Argo/K8s cluster** running.
+- The eval engine is documented as **evaluation-grade**: no durability, persistence, or
+  retries; users are pointed to the Temporal engine for production, with a clear graduation
+  path (same YAML, same IR, flip one env var).
+- Unsupported-engine error message lists `eval` as a valid value (`main.go:192-195`).
+
+---
+
+## E — Entities
+
+> Tier 1 abstractions only. Every type / port / env var this feature touches.
+
+```
+WorkflowIR ──run by──> WorkflowEngine (port: internal/domain/engine.go)
+WorkflowEngine ──selected by──> ACTIVE_ENGINE env var ──> buildEngine() switch (main.go)
+  ├── TemporalEngine   (durable; external Temporal cluster)
+  ├── ArgoEngine       (durable; external Argo/K8s cluster)
+  └── EvalEngine       (NEW — in-process; evaluation-grade, non-durable)
+
+EvalEngine ──drives──> domain.IRInterpreter.Run(ir, exec, pub)   (interpreter.go — pure, no I/O)
+  ├── exec : domain.ActivityExecutor  ──> synchronous in-process impl ──> domain.CapabilityDispatcher ──gRPC──> TaskBroker ──> AgentRegistry ──> Adapter
+  └── pub  : domain.EventPublisher    ──> in-process impl ──> EventBusService (best-effort; degrades to a no-op when unset)
+
+EvalEngine ──keeps──> in-memory run store (map[runID]*WorkflowRun)   (process-local; lost on restart)
+EvalEngine.Submit  ──returns──> WorkflowRun{ RunID = ir.WorkflowId }  (deterministic, ADR-034)
+EvalEngine.Watch   ──reads──>  in-memory event log for the run
+```
+
+- **`WorkflowEngine`** — existing port; `Submit / Signal / Cancel / GetStatus / Watch`
+  (`internal/domain/engine.go:17-41`). The new engine satisfies this contract unchanged.
+- **`domain.IRInterpreter`** — existing pure state-machine driver
+  (`internal/domain/interpreter.go:46-101`). Performs **no I/O**; delegates dispatch and event
+  publication to two ports. The eval engine reuses it verbatim.
+- **`domain.ActivityExecutor`** / **`domain.EventPublisher`** — existing ports
+  (`interpreter.go:24-32`). The eval engine provides synchronous in-process implementations,
+  mirroring how `temporal_workflow.go` (`temporalActivityExecutor` / `temporalEventPublisher`)
+  wraps them in Temporal activities.
+- **`domain.CapabilityDispatcher`** — existing capability dispatch over the task-broker gRPC
+  client (`internal/domain/activity.go:33-47`). Reused by the eval engine directly, with the
+  same NotFound fail-fast semantics (#1381).
+- **Env vars (existing, reused):** `ZYNAX_ENGINE_ADAPTER_ACTIVE_ENGINE` (add `eval`),
+  `ZYNAX_ENGINE_ADAPTER_TASK_BROKER_ADDR`, `ZYNAX_ENGINE_ADAPTER_EVENTBUS_ADDR`,
+  `ZYNAX_ENGINE_ADAPTER_GRPC_CALL_TIMEOUT_S`. **No new persistence config.**
+
+---
+
+## A — Approach
+
+> Solution strategy. Explicitly state what we WILL do AND what we WON'T do.
+
+The IR-interpretation logic is **already engine-agnostic**: `domain.IRInterpreter.Run`
+(`interpreter.go:49`) is a plain loop over the IR state machine that delegates every side
+effect to the `ActivityExecutor` and `EventPublisher` ports. The Temporal engine wires those
+ports through Temporal activities (`temporal_workflow.go`). The eval engine wires the **same
+ports** to synchronous in-process calls — no Temporal, no durability layer.
+
+**We will:**
+- Add `EvalEngine` in `services/engine-adapter/internal/infrastructure/` implementing the
+  existing `domain.WorkflowEngine` port (ADR-015) — mirroring `TemporalEngine`/`ArgoEngine`.
+- Reuse `domain.IRInterpreter.Run` verbatim, providing an in-process `ActivityExecutor` that
+  calls `domain.CapabilityDispatcher.DispatchCapabilityActivity` synchronously (same task-broker
+  → agent-registry → adapter path), and an in-process `EventPublisher` that best-effort-publishes
+  lifecycle events to the EventBusService (degrades to a no-op when no event-bus is configured).
+- On `Submit`, assign `RunID = ir.GetWorkflowId()` (deterministic, matching `TemporalEngine`,
+  ADR-034) and run the interpreter (in a goroutine) against an **in-memory run store**;
+  `GetStatus` / `Watch` read that store; `Signal` / `Cancel` operate on it; unknown run IDs
+  return `domain.ErrExecutionNotFound`, terminal runs return `domain.ErrTerminalState` — same
+  contract as the existing engines.
+- Wire `engineEval = "eval"` into the `buildEngine` switch (`main.go:186`) and add
+  `buildEvalEngine(cfg)` mirroring `buildArgoEngine` — needs the task-broker connection (returned
+  for the readiness probe) and an optional event-bus connection, **no Temporal worker**.
+- Add an e2e reference run that selects `ACTIVE_ENGINE=eval` and asserts a workflow reaches a
+  terminal state with **no Temporal/Argo control plane** up, slotting beside the existing
+  `engine ∈ {temporal, argo}` matrix (`.github/workflows/e2e-smoke.yml:60-61`).
+- Document the evaluation-grade boundary and the one-env-var graduation path to Temporal.
+
+**We will NOT:**
+- Won't add persistence, durable state, retries, or crash-recovery — that is the Temporal
+  engine's role; a process restart loses all eval runs (stated honestly in docs and error copy).
+- Won't change `WorkflowIR`, the workflow YAML, or any proto contract — same IR, same YAML.
+- Won't change `domain.IRInterpreter` behaviour — it is reused exactly as the Temporal path uses it.
+- Won't make `eval` the default `ACTIVE_ENGINE` (stays `temporal`); `eval` is opt-in for Day-0.
+- Won't introduce a shared DB or Layer 1→3 coupling; won't hardcode an engine name outside the
+  selection switch (ADR-015).
+
+**Positioning fit:** This is the core of the **engine-portability wedge** — the same declarative
+workflow runs on a laptop with zero infrastructure (eval) and graduates to durable Temporal/Argo
+by flipping one env var, no rewrite. User-facing copy (the `eval` error-message value, docs, and
+the "evaluation-grade — graduate to Temporal for production" caveat) must lead with that
+portability story, not generic "control plane" framing. See
+[docs/product/positioning.md](../../product/positioning.md).
+
+**Governing ADRs:** ADR-015 (pluggable workflow engines), ADR-037 (zero-Temporal evaluation
+engine — Proposed), ADR-012 (Workflow IR), ADR-014 (event-driven state machine),
+ADR-034 (deterministic ManifestWorkflowID), ADR-022 (EventBusService).
+
+---
+
+## S — Structure (first S)
+
+> Files created or modified, with a one-line purpose.
+
+```
+services/engine-adapter
+├── internal/infrastructure/eval_engine.go        ← NEW — EvalEngine: WorkflowEngine impl (in-process)
+├── internal/infrastructure/eval_engine_test.go   ← NEW — unit tests: submit→terminal, signal, status, watch
+├── internal/infrastructure/eval_ports.go         ← NEW — in-process ActivityExecutor + EventPublisher
+├── internal/infrastructure/eval_ports_test.go    ← NEW — port impl tests
+└── cmd/engine-adapter/main.go                     ← MOD — engineEval const + buildEngine case + buildEvalEngine()
+
+docs/adr/ADR-037-zero-temporal-evaluation-engine.md ← NEW — decision record (Proposed)
+docs/adr/INDEX.md                                    ← MOD — ADR-037 row
+docs/                                                ← MOD — evaluation-grade caveat + graduation-to-Temporal guide
+.github/workflows/e2e-smoke.yml (or scripts/e2e/)    ← MOD — eval reference run (no Temporal/Argo container)
+```
+
+Config env prefix: `ZYNAX_ENGINE_ADAPTER_` · gRPC port: 50055 (unchanged) · No new proto.
+
+---
+
+## O — Operations
+
+> Ordered, testable steps. Each = one reviewable PR (INVEST: Independent, ≤400 lines).
+
+1. **O1 (#1449) — feat(engine-adapter): `EvalEngine` in-process `WorkflowEngine` implementation.**
+   Add `eval_engine.go` + `eval_ports.go` in `internal/infrastructure/`: implement the
+   `domain.WorkflowEngine` port by driving `domain.IRInterpreter.Run` synchronously with
+   in-process `ActivityExecutor` (over `domain.CapabilityDispatcher`) and `EventPublisher`,
+   backed by an in-memory run store. *Acceptance:* unit tests cover submit→terminal, `Signal`,
+   `Cancel`, `GetStatus`, `Watch` and the `ErrExecutionNotFound`/`ErrTerminalState` contract;
+   domain coverage unaffected (logic stays in `internal/domain`); not wired in yet.
+
+2. **O2 (#1450) — feat(engine-adapter): `ACTIVE_ENGINE=eval` selection wiring + config.**
+   Add `engineEval = "eval"` const, a `case engineEval` to the `buildEngine` switch, and
+   `buildEvalEngine(cfg)` (mirrors `buildArgoEngine`; dials task-broker + optional event-bus,
+   no Temporal worker). Update the unsupported-engine error to list `eval`. *Acceptance:*
+   `main_test.go`-style test asserts `eval` selects `EvalEngine`, an unknown value errors and
+   names `eval`, and `eval` needs no Temporal/Argo config to construct.
+
+3. **O3 (#1451) — test(engine-adapter): e2e reference run with no Temporal container + assertions.**
+   Add an `eval` leg to (or a focused script beside) the e2e-smoke engine matrix that brings up
+   only api-gateway → engine-adapter (`ACTIVE_ENGINE=eval`) → task-broker → adapters — **no
+   Temporal, no Argo** — and asserts a reference workflow reaches a terminal state. *Acceptance:*
+   the run is green with no Temporal/Argo control plane started; failure-path (unbacked
+   capability) still fails fast (NotFound, #1381).
+
+4. **O4 (#1452) — docs: evaluation-grade caveat + how to graduate to Temporal.**
+   Document the eval engine: what it is (in-process, fast Day-0), what it is **not** (no
+   durability/persistence/retries; lost on restart), and the graduation path (same YAML/IR,
+   flip `ACTIVE_ENGINE=temporal`). *Acceptance:* quickstart/onboarding doc shows the zero-Temporal
+   path; the caveat and graduation steps are present and link ADR-037.
+
+---
+
+## N — Norms
+
+> Cross-cutting standards (root + layer AGENTS.md, docs/patterns).
+
+- **Commit hygiene:** `Signed-off-by:` (DCO) required; `Assisted-by: Claude/<model>` for AI
+  attribution — never `Co-Authored-By` for AI.
+- **Conventional commits / PR titles:** one of feat/fix/refactor/docs/test/ci/chore; scope maps
+  to directory; one logical change per commit, one PR per issue.
+- **Go services:** `GOWORK=off` for all `go build`/`go test` in `services/engine-adapter/`
+  (ADR-017); `CGO_ENABLED=0`, `-trimpath`; domain unit coverage ≥ 90% on `internal/domain/`
+  (the eval engine adds no domain logic — it reuses `IRInterpreter`).
+- **BDD/`.feature`:** the eval engine adds **no new gRPC boundary** (it satisfies the existing
+  `WorkflowEngine` port and reuses existing task-broker/event-bus clients), so no new `.feature`
+  file is required (ADR-016); the existing engine-adapter gRPC contract tests cover the boundary.
+- **PR size:** ≤ 200 ideal, > 900 blocked.
+- **Image versions:** managed via `images/images.yaml` (`make sync-images`), never hand-edited.
+
+---
+
+## S — Safeguards (second S)
+
+> Things that MUST NEVER happen in this feature.
+
+### Context Security (complete before committing this Canvas)
+
+- [x] No Tier 2 content: no internal hostnames, private IPs, credentials, deployment specifics
+- [x] No PII: no personal names in sensitive context, no non-public email addresses
+- [x] No prompt injection: no instruction-like phrasing that overrides AGENTS.md rules
+- [x] All entities in E are public-safe abstractions
+- [x] `/spdd-security-review` passed on this file (2026-06-19 — PASS; Tier-2 note below)
+
+> **Tier-2 / evaluation-only safety boundary (stated honestly):** the eval engine **removes
+> durability**. There is no persistence, no retry, and no crash-recovery: a process restart
+> loses every in-flight and completed run, and there is no replay/audit log (unlike Temporal's
+> event history). It is therefore **evaluation-grade only** — never a production execution
+> backend. The boundary is enforced in product (default `ACTIVE_ENGINE` stays `temporal`),
+> in code (no persistence config is added), and in docs/error copy (the graduation path to
+> Temporal is mandatory reading). This is a Tier-2 *honesty* note, not a Tier-2 *secret* — it
+> contains no hostnames, IPs, or credentials and is safe to keep in this public canvas.
+
+### Feature Safeguards
+
+- **Never** add persistence, durability, or retry semantics to the eval engine — that would
+  blur the boundary with the Temporal engine; durability stays Temporal/Argo's role.
+- **Never** make `eval` the default `ACTIVE_ENGINE` — it is opt-in; production defaults stay durable.
+- **Never** hardcode an engine name outside the `buildEngine` selection switch (ADR-015).
+- **Never** change `WorkflowIR`, the workflow YAML, or any proto contract — same IR, same YAML.
+- **Never** fork or duplicate `domain.IRInterpreter` — reuse it; both engines must share one
+  state-machine semantics so "same YAML graduates to Temporal" stays literally true.
+- **Never** accept provider/model/endpoint or any engine selection from `input_payload` — engine
+  selection is process-wide config only (ADR-015, `engine.go:16`).
+- **Never** import another service's `internal/` — cross-service via gRPC only (ADR-008).
+- **Never** retry an unbacked capability forever — preserve the NotFound fail-fast contract (#1381).


### PR DESCRIPTION
## What

Scoping artifacts for #1359 — **zero-Temporal lightweight evaluation engine** — produced via `/plan` (maintainer-authorized 2026-06-19; scoped into M7). **No engine implementation** in this PR — planning only.

- **Canvas** — `docs/spdd/1359-zero-temporal-engine/canvas.md` — **Status: Aligned**.
- **ADR-037** — *Zero-Temporal in-process evaluation engine* — **Status: Proposed**.
- **ADR INDEX** row added.

## Approach (grounded in the live engine-adapter)

`domain.IRInterpreter.Run` is already a pure, I/O-free state-machine loop that delegates all side effects to two ports (`ActivityExecutor`, `EventPublisher`). A new `EvalEngine` satisfies the existing `domain.WorkflowEngine` port (ADR-015) by driving that same interpreter **in-process** — synchronous capability dispatch over the existing `CapabilityDispatcher` (task-broker → agent-registry → adapter), an in-memory run store, no Temporal/Argo, no durability. Selected via `ACTIVE_ENGINE=eval` alongside `temporal`/`argo`; workflow YAML unchanged; graduation to production is one env-var flip.

## ADR status — action required

⚠️ **ADR-037 is Proposed, not Accepted.** It is a one-way-door new engine and **needs the maintainer's Accept before `/deliver`.** The canvas is Aligned and the child stories are filed, but O1–O4 should not be implemented until ADR-037 is flipped to Accepted.

## Child story issues (one PR each, ordered)

- #1449 — O1: `EvalEngine` in-process `WorkflowEngine` implementation
- #1450 — O2: `ACTIVE_ENGINE=eval` selection wiring + config
- #1451 — O3: e2e reference run with no Temporal container + assertions
- #1452 — O4: docs — evaluation-grade caveat + how to graduate to Temporal

## Notes

- Evaluation-grade only: no durability/persistence/retries; runs lost on restart. The boundary is stated honestly in the canvas Safeguards and ADR-037 Consequences; Temporal/Argo remain the production backends.
- Not armed for auto-merge — the ADR needs maintainer review/acceptance.

Refs #1359

🤖 Generated with [Claude Code](https://claude.com/claude-code)
