### PR TITLE
feat(spec): declarative scenario manifest (manifest-set)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,8 +128,14 @@ logs-local: ## Tail all local stack logs
 .PHONY: demo demo-clean
 DEMO_WORKFLOW ?= spec/workflows/examples/code-review-ollama.yaml
 ZYNAX        ?= zynax
+# Optional: run a declarative scenario manifest set instead of the single hero
+# workflow — e.g. `make demo SCENARIO=code-review`. When SCENARIO is set, the
+# whole directory spec/scenarios/$(SCENARIO) is applied (AgentDef then Workflow,
+# in the index's apply_order) over the existing /api/v1/apply REST path.
+SCENARIO     ?=
+DEMO_TARGET   = $(if $(SCENARIO),spec/scenarios/$(SCENARIO),$(DEMO_WORKFLOW))
 
-demo: check-docker ## ★ One command: boot the Ollama stack + run the hero code-review workflow
+demo: check-docker ## ★ One command: boot the Ollama stack + run the hero workflow (or a SCENARIO=<name> manifest set)
 	@command -v $(ZYNAX) >/dev/null 2>&1 || \
 	  (echo "❌ zynax CLI not found — run 'make install-cli' and ensure ~/bin is on your PATH" && exit 1)
 	@echo "🧠 Demo model: qwen2.5-coder:3b — pull it once on the host if you have not:"
@@ -137,8 +143,8 @@ demo: check-docker ## ★ One command: boot the Ollama stack + run the hero code
 	@echo "🚀 Booting the minimal stack + Ollama overlay (waiting for health)..."
 	$(COMPOSE_DEMO) up -d --wait
 	@export ZYNAX_API_URL=http://localhost:7080; \
-	  echo "▶  zynax apply $(DEMO_WORKFLOW)"; \
-	  run_id=$$($(ZYNAX) apply $(DEMO_WORKFLOW) | sed -n 's/^run_id: //p'); \
+	  echo "▶  zynax apply $(DEMO_TARGET)"; \
+	  run_id=$$($(ZYNAX) apply $(DEMO_TARGET) | sed -n 's/^run_id: //p' | tail -n1); \
 	  test -n "$$run_id" || (echo "❌ apply did not return a run_id" && exit 1); \
 	  echo "   run_id: $$run_id"; \
 	  echo "⏳ Streaming to terminal + printing the model's review..."; \
@@ -148,7 +154,7 @@ demo: check-docker ## ★ One command: boot the Ollama stack + run the hero code
 	@echo ""
 	@echo "✅ Demo complete. Next steps:"
 	@echo "   • Inspect logs:    ZYNAX_API_URL=http://localhost:7080 zynax logs <run-id> --follow"
-	@echo "   • Author your own: cp $(DEMO_WORKFLOW) my-workflow.yaml  (see docs/quickstart.md)"
+	@echo "   • Run a scenario:  make demo SCENARIO=code-review  (see docs/scenarios/scenario-manifest.md)"
 	@echo "   • Tear it all down: make demo-clean"
 
 demo-clean: ## Stop and remove the demo stack (base + Ollama overlay)
@@ -413,13 +419,13 @@ clean-tools: ## Remove tools image
 clean-all: clean dev-down clean-tools ## ⚠ Remove everything
 
 # ── Spec validation ───────────────────────────────────────────────────────────
-.PHONY: validate-spec validate-asyncapi validate-workflow-schema validate-agent-def-schema validate-policy-schema check-expert-mapping validate-canvas validate-milestone-state dry-run
+.PHONY: validate-spec validate-asyncapi validate-workflow-schema validate-agent-def-schema validate-policy-schema validate-scenario-schema check-expert-mapping validate-canvas validate-milestone-state dry-run
 
 validate-milestone-state: ## Validate state/milestone.yaml against state/milestone.schema.json
 	cd cmd/zynax-ci && GOWORK=off go run . validate milestone --root "$(CURDIR)"
 	@echo "✅ Milestone state valid"
 
-validate-spec: validate-asyncapi validate-capability-schemas validate-workflow-schema validate-agent-def-schema validate-policy-schema check-expert-mapping ## Validate all specs (AsyncAPI + capability schemas + workflow + agent-def + policy manifests + expert mapping)
+validate-spec: validate-asyncapi validate-capability-schemas validate-workflow-schema validate-agent-def-schema validate-policy-schema validate-scenario-schema check-expert-mapping ## Validate all specs (AsyncAPI + capability schemas + workflow + agent-def + policy + scenario manifests + expert mapping)
 
 validate-canvas: ensure-tools ## Validate REASONS Canvas files under docs/spdd/ (SPDD — ADR-019)
 	$(TOOLS_RUN) zynax-ci validate canvas docs/spdd/
@@ -429,9 +435,10 @@ validate-capability-schemas: ensure-tools ## Validate capability declarations in
 	$(TOOLS_RUN) zynax-ci validate capabilities spec/workflows/examples/ --schema-dir spec/schemas
 	@echo "✅ Capability schemas valid"
 
-validate-workflow-schema: ensure-tools ## Validate Workflow manifests (spec examples + templates + automation/workflows) against workflow.schema.json
+validate-workflow-schema: ensure-tools ## Validate Workflow manifests (spec examples + templates + scenarios + automation/workflows) against workflow.schema.json
 	$(TOOLS_RUN) zynax-ci validate workflows spec/workflows/examples/ --schema-dir spec/schemas
 	$(TOOLS_RUN) zynax-ci validate workflows spec/templates/workflow/ --schema-dir spec/schemas
+	$(TOOLS_RUN) zynax-ci validate workflows spec/scenarios/code-review/ --schema-dir spec/schemas
 	$(TOOLS_RUN) zynax-ci validate workflows automation/workflows/ --schema-dir spec/schemas
 	@echo "✅ Workflow schemas valid"
 
@@ -439,6 +446,7 @@ validate-agent-def-schema: ensure-tools ## Validate AgentDef manifests (spec exa
 	$(TOOLS_RUN) zynax-ci validate agent-defs spec/workflows/examples/ --schema-dir spec/schemas
 	$(TOOLS_RUN) zynax-ci validate agent-defs spec/templates/task/ --schema-dir spec/schemas
 	$(TOOLS_RUN) zynax-ci validate agent-defs spec/templates/expert/ --schema-dir spec/schemas
+	$(TOOLS_RUN) zynax-ci validate agent-defs spec/scenarios/code-review/ --schema-dir spec/schemas
 	$(TOOLS_RUN) zynax-ci validate agent-defs automation/workflows/ --schema-dir spec/schemas
 	$(TOOLS_RUN) zynax-ci validate agent-defs automation/workflows/experts/ --schema-dir spec/schemas
 	@echo "✅ AgentDef schemas valid"
@@ -446,6 +454,10 @@ validate-agent-def-schema: ensure-tools ## Validate AgentDef manifests (spec exa
 validate-policy-schema: ensure-tools ## Validate Policy manifests in spec/workflows/examples/ against policy.schema.json
 	$(TOOLS_RUN) zynax-ci validate policies spec/workflows/examples/ --schema-dir spec/schemas
 	@echo "✅ Policy schemas valid"
+
+validate-scenario-schema: ensure-tools ## Validate Scenario index files in spec/scenarios/ against scenario.schema.json
+	$(TOOLS_RUN) zynax-ci validate scenarios spec/scenarios/code-review/ --schema-dir spec/schemas
+	@echo "✅ Scenario schemas valid"
 
 check-expert-mapping: ## Drift guard: authoring <-> runtime expert mapping (ADR-033)
 	cd cmd/zynax-ci && GOWORK=off go run . check expert-mapping --root "$(CURDIR)"

--- a/cmd/zynax-ci/cmd/cmd_test.go
+++ b/cmd/zynax-ci/cmd/cmd_test.go
@@ -219,6 +219,34 @@ func TestPrintManifestResults_TextWithErrors(t *testing.T) {
 	}
 }
 
+// ── validate scenarios ────────────────────────────────────────────────────────
+
+func TestRunValidateScenarios_NoIndexes(t *testing.T) {
+	root := repoRoot(t)
+	scenariosSchemaDir = filepath.Join(root, "spec/schemas")
+	scenariosFormat = formatText
+	dir := t.TempDir()
+	cmd := fakeCmd(t)
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	if err := runValidateScenarios(cmd, []string{dir}); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestRunValidateScenarios_ValidIndex(t *testing.T) {
+	root := repoRoot(t)
+	scenariosSchemaDir = filepath.Join(root, "spec/schemas")
+	scenariosFormat = formatText
+	dir := filepath.Join(root, "spec/scenarios/code-review")
+	cmd := fakeCmd(t)
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	if err := runValidateScenarios(cmd, []string{dir}); err != nil {
+		t.Errorf("reference scenario index should validate, got: %v", err)
+	}
+}
+
 // ── validate agent-defs ───────────────────────────────────────────────────────
 
 func TestRunValidateAgentDefs_NoManifests(t *testing.T) {

--- a/cmd/zynax-ci/cmd/validate_scenarios.go
+++ b/cmd/zynax-ci/cmd/validate_scenarios.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	"github.com/zynax-io/zynax/cmd/zynax-ci/validate"
+)
+
+var scenariosSchemaDir string
+var scenariosFormat string
+
+var validateScenariosCmd = &cobra.Command{
+	Use:   "scenarios <dir>",
+	Short: "Validate Scenario index YAML files against the JSON Schema",
+	Long: `Walk <dir> for *.yaml files, filter those with kind: Scenario,
+and validate each against spec/schemas/scenario.schema.json (or --schema-dir).
+
+A Scenario index is the client-side manifest-set convention (A2, ADR-028):
+it lists the member Workflow/AgentDef manifests, their apply order, and a
+reserved context slot. This validates only the INDEX shape; the member
+manifests are validated by the workflows/agent-defs subcommands.
+
+Exits 0 if all index files pass, 1 on any schema violation.`,
+	Args: cobra.ExactArgs(1),
+	RunE: runValidateScenarios,
+}
+
+func init() {
+	validateScenariosCmd.Flags().StringVar(&scenariosSchemaDir, "schema-dir", "spec/schemas", "directory containing JSON Schema files")
+	validateScenariosCmd.Flags().StringVar(&scenariosFormat, "format", "text", "output format: text or json")
+	validateCmd.AddCommand(validateScenariosCmd)
+}
+
+func runValidateScenarios(cmd *cobra.Command, args []string) error {
+	dir := args[0]
+	schemaPath := filepath.Join(scenariosSchemaDir, "scenario.schema.json")
+
+	results, err := validate.BatchManifests(dir, "Scenario", schemaPath)
+	if err != nil {
+		return err
+	}
+
+	if len(results) == 0 {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "(no Scenario index files found in %s)\n", dir)
+		return nil
+	}
+	return printManifestResults(cmd, results, scenariosFormat)
+}

--- a/cmd/zynax/cmd/apply.go
+++ b/cmd/zynax/cmd/apply.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/zynax-io/zynax/cmd/zynax/client"
+	"github.com/zynax-io/zynax/cmd/zynax/validate"
 )
 
 var (
@@ -16,15 +17,29 @@ var (
 )
 
 var applyCmd = &cobra.Command{
-	Use:   "apply <file>",
-	Short: "Apply a YAML manifest (Workflow or AgentDef)",
-	Args:  cobra.ExactArgs(1),
+	Use:   "apply <file|scenario-dir>",
+	Short: "Apply a YAML manifest (Workflow or AgentDef) or a scenario manifest set",
+	Long: `Apply a single YAML manifest, or a scenario manifest set.
+
+A scenario is a directory containing a 'scenario.yaml' index (kind: Scenario)
+plus the member Workflow and AgentDef manifests. When the argument is a scenario
+directory or index, each member is submitted over the existing /api/v1/apply REST
+path in the index's declared apply_order — AgentDefs before the Workflow that
+consumes their capabilities. No new api-gateway endpoint is introduced.`,
+	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		indexPath, isScenario, err := validate.ResolveScenarioIndex(args[0])
+		if err != nil {
+			return err
+		}
+		gw := newGateway()
+		if isScenario {
+			return runApplyScenario(cmd, gw, indexPath)
+		}
 		data, err := os.ReadFile(args[0])
 		if err != nil {
 			return fmt.Errorf("read %s: %w", args[0], err)
 		}
-		gw := newGateway()
 		if applyDryRun {
 			return runDryRun(cmd, gw, data)
 		}
@@ -36,6 +51,33 @@ func init() {
 	applyCmd.Flags().BoolVar(&applyDryRun, "dry-run", false, "validate manifest without submitting")
 	applyCmd.Flags().StringVar(&applyEngine, "engine", "", "engine hint forwarded to SubmitWorkflow (ADR-015)")
 	rootCmd.AddCommand(applyCmd)
+}
+
+// runApplyScenario expands a scenario index and applies each member in
+// apply_order over the existing /api/v1/apply REST path. On --dry-run each member
+// is dry-run-validated instead of submitted.
+func runApplyScenario(cmd *cobra.Command, gw *client.Gateway, indexPath string) error {
+	members, err := validate.ExpandScenario(indexPath)
+	if err != nil {
+		return err
+	}
+	for _, m := range members {
+		data, err := os.ReadFile(m.Path) //nolint:gosec // member path is confined by ExpandScenario
+		if err != nil {
+			return fmt.Errorf("read scenario member %s (%s): %w", m.ID, m.Path, err)
+		}
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "applying %s (%s)...\n", m.ID, m.Kind)
+		if applyDryRun {
+			if err := runDryRun(cmd, gw, data); err != nil {
+				return fmt.Errorf("scenario member %s: %w", m.ID, err)
+			}
+			continue
+		}
+		if err := runApply(cmd, gw, data); err != nil {
+			return fmt.Errorf("scenario member %s: %w", m.ID, err)
+		}
+	}
+	return nil
 }
 
 func runApply(cmd *cobra.Command, gw *client.Gateway, body []byte) error {

--- a/cmd/zynax/cmd/cmd_test.go
+++ b/cmd/zynax/cmd/cmd_test.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -608,6 +609,96 @@ func TestResultCmd_NoResult_Errors(t *testing.T) {
 
 	if _, err := runResult(t, []string{"r6"}); err == nil {
 		t.Error("expected error when run finishes with no result payload")
+	}
+}
+
+// ── scenario apply + validate ─────────────────────────────────────────────────
+
+// TestRunApplyScenario_AppliesMembersInOrder verifies that applying the shipped
+// reference scenario submits each member over the existing /api/v1/apply path in
+// apply_order (AgentDef first), recording the order the server observed.
+func TestRunApplyScenario_AppliesMembersInOrder(t *testing.T) {
+	root := repoRoot(t)
+	var kinds []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		body := string(b)
+		switch {
+		case strings.Contains(body, "kind: AgentDef"):
+			kinds = append(kinds, "AgentDef")
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]string{"agent_id": "agent-xyz"})
+		default:
+			kinds = append(kinds, "Workflow")
+			w.WriteHeader(http.StatusAccepted)
+			_ = json.NewEncoder(w).Encode(map[string]any{"run_id": "wf-001"})
+		}
+	}))
+	defer srv.Close()
+	apiURL = srv.URL
+	applyDryRun = false
+	applyEngine = ""
+
+	idx := filepath.Join(root, "spec/scenarios/code-review", "scenario.yaml")
+	cmd := fakeCmd(t)
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	if err := runApplyScenario(cmd, newGateway(), idx); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(kinds) != 2 || kinds[0] != "AgentDef" || kinds[1] != "Workflow" {
+		t.Errorf("server observed order %v, want [AgentDef Workflow]", kinds)
+	}
+	if !strings.Contains(out.String(), "run_id: wf-001") {
+		t.Errorf("expected workflow run_id in output, got:\n%s", out.String())
+	}
+}
+
+func TestRunApplyScenario_DryRun(t *testing.T) {
+	root := repoRoot(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{"warnings": []string{}})
+	}))
+	defer srv.Close()
+	apiURL = srv.URL
+	applyDryRun = true
+	defer func() { applyDryRun = false }()
+
+	idx := filepath.Join(root, "spec/scenarios/code-review", "scenario.yaml")
+	cmd := fakeCmd(t)
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	if err := runApplyScenario(cmd, newGateway(), idx); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestRunApplyScenario_MemberError(t *testing.T) {
+	root := repoRoot(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	apiURL = srv.URL
+	applyDryRun = false
+
+	idx := filepath.Join(root, "spec/scenarios/code-review", "scenario.yaml")
+	cmd := fakeCmd(t)
+	if err := runApplyScenario(cmd, newGateway(), idx); err == nil {
+		t.Error("expected error when a scenario member fails to apply")
+	}
+}
+
+func TestRunValidate_Scenario(t *testing.T) {
+	root := repoRoot(t)
+	validateSchemaDir = filepath.Join(root, "spec/schemas")
+	validateFormat = formatText
+
+	cmd := fakeCmd(t)
+	dir := filepath.Join(root, "spec/scenarios/code-review")
+	if err := runValidate(cmd, []string{dir}); err != nil {
+		t.Errorf("reference scenario should validate, got: %v", err)
 	}
 }
 

--- a/cmd/zynax/cmd/validate.go
+++ b/cmd/zynax/cmd/validate.go
@@ -53,7 +53,19 @@ func init() {
 
 func runValidate(cmd *cobra.Command, args []string) error {
 	file := args[0]
-	errs, err := validate.File(file, validateSchemaDir)
+
+	indexPath, isScenario, err := validate.ResolveScenarioIndex(file)
+	if err != nil {
+		return err
+	}
+
+	var errs []validate.ValidationError
+	if isScenario {
+		file = indexPath
+		errs, err = validate.ScenarioFile(indexPath, validateSchemaDir)
+	} else {
+		errs, err = validate.File(file, validateSchemaDir)
+	}
 	if err != nil {
 		return err
 	}

--- a/cmd/zynax/validate/manifest.go
+++ b/cmd/zynax/validate/manifest.go
@@ -169,8 +169,10 @@ func kindToSchemaFile(kind string) (string, error) {
 		return "agent-def.schema.json", nil
 	case "Policy":
 		return "policy.schema.json", nil
+	case "Scenario":
+		return "scenario.schema.json", nil
 	default:
-		return "", fmt.Errorf("no JSON schema for kind %q — supported: Workflow, AgentDef, Policy", kind)
+		return "", fmt.Errorf("no JSON schema for kind %q — supported: Workflow, AgentDef, Policy, Scenario", kind)
 	}
 }
 

--- a/cmd/zynax/validate/scenario.go
+++ b/cmd/zynax/validate/scenario.go
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package validate
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ScenarioIndexFile is the conventional file name of a scenario index inside a
+// scenario directory (the manifest-set convention, A2 / ADR-028).
+const ScenarioIndexFile = "scenario.yaml"
+
+// ScenarioMember is one expanded member of a scenario: its declared kind and the
+// absolute path to the member manifest, resolved relative to the index file.
+type ScenarioMember struct {
+	ID   string
+	Kind string
+	Path string // absolute path to the member manifest
+}
+
+// scenarioIndex is the on-disk shape of a scenario index file (kind: Scenario).
+// Only the fields the CLI acts on are decoded; the schema owns full validation.
+type scenarioIndex struct {
+	Kind string `yaml:"kind"`
+	Spec struct {
+		Members []struct {
+			ID   string `yaml:"id"`
+			Kind string `yaml:"kind"`
+			File string `yaml:"file"`
+		} `yaml:"members"`
+		ApplyOrder []string `yaml:"apply_order"`
+	} `yaml:"spec"`
+}
+
+// ResolveScenarioIndex returns the absolute path to a scenario index given either
+// the index file itself or the directory that contains it. A non-Scenario or
+// missing target yields ("", false, nil): callers treat the path as an ordinary
+// single manifest. I/O errors are returned.
+func ResolveScenarioIndex(path string) (indexPath string, ok bool, err error) {
+	info, statErr := os.Stat(path)
+	if statErr != nil {
+		return "", false, fmt.Errorf("scenario: stat %q: %w", path, statErr)
+	}
+	if info.IsDir() {
+		candidate := filepath.Join(path, ScenarioIndexFile)
+		if _, e := os.Stat(candidate); e != nil {
+			return "", false, nil // a plain directory with no index — not a scenario
+		}
+		return candidate, true, nil
+	}
+	// A file: it is a scenario index only when its kind is Scenario.
+	kind, e := readKind(path)
+	if e != nil {
+		return "", false, nil // let the manifest validator report parse errors
+	}
+	return path, kind == "Scenario", nil
+}
+
+// ExpandScenario reads the scenario index at indexPath and returns its members
+// ordered by spec.apply_order, with each member's file resolved (and confined)
+// relative to the index directory. It enforces the cross-field invariants the
+// JSON Schema cannot express: apply_order references only declared members, each
+// member appears exactly once, and member files do not escape the directory.
+func ExpandScenario(indexPath string) ([]ScenarioMember, error) {
+	raw, err := os.ReadFile(indexPath) //nolint:gosec // indexPath is caller-supplied scenario path
+	if err != nil {
+		return nil, fmt.Errorf("scenario: read %q: %w", indexPath, err)
+	}
+	var idx scenarioIndex
+	if err := yaml.Unmarshal(raw, &idx); err != nil {
+		return nil, fmt.Errorf("scenario: parse %q: %w", indexPath, err)
+	}
+
+	dir := filepath.Dir(indexPath)
+	byID := make(map[string]ScenarioMember, len(idx.Spec.Members))
+	for _, m := range idx.Spec.Members {
+		if m.ID == "" {
+			return nil, fmt.Errorf("scenario %q: member with empty id", indexPath)
+		}
+		if _, dup := byID[m.ID]; dup {
+			return nil, fmt.Errorf("scenario %q: duplicate member id %q", indexPath, m.ID)
+		}
+		abs, err := resolveMemberPath(dir, m.File)
+		if err != nil {
+			return nil, fmt.Errorf("scenario %q: member %q: %w", indexPath, m.ID, err)
+		}
+		byID[m.ID] = ScenarioMember{ID: m.ID, Kind: m.Kind, Path: abs}
+	}
+
+	if len(idx.Spec.ApplyOrder) == 0 {
+		return nil, fmt.Errorf("scenario %q: apply_order is empty", indexPath)
+	}
+	seen := make(map[string]bool, len(idx.Spec.ApplyOrder))
+	ordered := make([]ScenarioMember, 0, len(idx.Spec.ApplyOrder))
+	for _, id := range idx.Spec.ApplyOrder {
+		m, ok := byID[id]
+		if !ok {
+			return nil, fmt.Errorf("scenario %q: apply_order references unknown member id %q", indexPath, id)
+		}
+		if seen[id] {
+			return nil, fmt.Errorf("scenario %q: apply_order lists member id %q more than once", indexPath, id)
+		}
+		seen[id] = true
+		ordered = append(ordered, m)
+	}
+	return ordered, nil
+}
+
+// ScenarioFile validates a scenario index plus all of its members. It first
+// validates the index file against scenario.schema.json, then expands it and runs
+// the full per-member pipeline (File: schema + data-flow) against each member's
+// own existing schema. Every error is prefixed with its file so callers can tell
+// index errors from member errors. Returns (nil, nil) when everything is valid.
+func ScenarioFile(indexPath, schemaDir string) ([]ValidationError, error) {
+	idxErrs, err := Manifest(indexPath, schemaDir)
+	if err != nil {
+		return nil, err
+	}
+	// If the index itself is invalid, expansion is unreliable — report and stop.
+	if len(idxErrs) > 0 {
+		return idxErrs, nil
+	}
+
+	members, err := ExpandScenario(indexPath)
+	if err != nil {
+		return single(indexPath, "/spec", err.Error()), nil
+	}
+
+	var out []ValidationError
+	for _, m := range members {
+		memberErrs, err := File(m.Path, schemaDir)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, memberErrs...)
+	}
+	return out, nil
+}
+
+// resolveMemberPath joins a member file to the scenario directory and rejects any
+// path that escapes that directory (path traversal / absolute paths).
+func resolveMemberPath(dir, file string) (string, error) {
+	if file == "" {
+		return "", fmt.Errorf("member file is empty")
+	}
+	if filepath.IsAbs(file) {
+		return "", fmt.Errorf("member file %q must be relative to the index directory", file)
+	}
+	cleanDir := filepath.Clean(dir)
+	abs := filepath.Clean(filepath.Join(cleanDir, file))
+	rel, err := filepath.Rel(cleanDir, abs)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("member file %q escapes the scenario directory", file)
+	}
+	return abs, nil
+}
+
+// readKind decodes only the top-level kind field of a YAML manifest.
+func readKind(path string) (string, error) {
+	raw, err := os.ReadFile(path) //nolint:gosec // path is caller-supplied manifest path
+	if err != nil {
+		return "", fmt.Errorf("scenario: read %q: %w", path, err)
+	}
+	var head struct {
+		Kind string `yaml:"kind"`
+	}
+	if err := yaml.Unmarshal(raw, &head); err != nil {
+		return "", fmt.Errorf("scenario: parse %q: %w", path, err)
+	}
+	return head.Kind, nil
+}

--- a/cmd/zynax/validate/scenario_test.go
+++ b/cmd/zynax/validate/scenario_test.go
@@ -1,0 +1,232 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package validate
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// repoRoot resolves the repository root from this test file's location.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	_, file, _, _ := runtime.Caller(0)
+	// file = cmd/zynax/validate/scenario_test.go
+	return filepath.Join(filepath.Dir(file), "../../..")
+}
+
+const validIndex = `kind: Scenario
+apiVersion: zynax.io/v1alpha1
+metadata:
+  name: demo
+spec:
+  members:
+    - id: agent
+      kind: AgentDef
+      file: agent.yaml
+    - id: workflow
+      kind: Workflow
+      file: workflow.yaml
+  apply_order:
+    - agent
+    - workflow
+`
+
+func writeIndex(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	idx := filepath.Join(dir, ScenarioIndexFile)
+	if err := os.WriteFile(idx, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return idx
+}
+
+func TestExpandScenario_OrdersMembers(t *testing.T) {
+	idx := writeIndex(t, validIndex)
+	members, err := ExpandScenario(idx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(members) != 2 {
+		t.Fatalf("got %d members, want 2", len(members))
+	}
+	if members[0].ID != "agent" || members[1].ID != "workflow" {
+		t.Errorf("apply order = [%s, %s], want [agent, workflow]", members[0].ID, members[1].ID)
+	}
+	if !strings.HasSuffix(members[0].Path, "agent.yaml") {
+		t.Errorf("member path = %q, want suffix agent.yaml", members[0].Path)
+	}
+}
+
+func TestExpandScenario_UnknownApplyOrderID(t *testing.T) {
+	body := strings.Replace(validIndex, "    - agent\n", "    - ghost\n", 1)
+	idx := writeIndex(t, body)
+	if _, err := ExpandScenario(idx); err == nil {
+		t.Error("expected error for apply_order referencing unknown member id")
+	}
+}
+
+func TestExpandScenario_DuplicateApplyOrder(t *testing.T) {
+	body := strings.Replace(validIndex, "    - workflow\n", "    - agent\n", 1)
+	idx := writeIndex(t, body)
+	if _, err := ExpandScenario(idx); err == nil {
+		t.Error("expected error for duplicate id in apply_order")
+	}
+}
+
+func TestExpandScenario_EmptyApplyOrder(t *testing.T) {
+	body := `kind: Scenario
+apiVersion: zynax.io/v1alpha1
+metadata:
+  name: demo
+spec:
+  members:
+    - id: agent
+      kind: AgentDef
+      file: agent.yaml
+  apply_order: []
+`
+	idx := writeIndex(t, body)
+	if _, err := ExpandScenario(idx); err == nil {
+		t.Error("expected error for empty apply_order")
+	}
+}
+
+func TestExpandScenario_DuplicateMemberID(t *testing.T) {
+	body := `kind: Scenario
+apiVersion: zynax.io/v1alpha1
+metadata:
+  name: demo
+spec:
+  members:
+    - id: agent
+      kind: AgentDef
+      file: agent.yaml
+    - id: agent
+      kind: Workflow
+      file: workflow.yaml
+  apply_order:
+    - agent
+`
+	idx := writeIndex(t, body)
+	if _, err := ExpandScenario(idx); err == nil {
+		t.Error("expected error for duplicate member id")
+	}
+}
+
+func TestExpandScenario_PathTraversalRejected(t *testing.T) {
+	body := strings.Replace(validIndex, "file: agent.yaml", "file: ../../etc/passwd", 1)
+	idx := writeIndex(t, body)
+	if _, err := ExpandScenario(idx); err == nil {
+		t.Error("expected error for member file escaping the scenario directory")
+	}
+}
+
+func TestExpandScenario_AbsolutePathRejected(t *testing.T) {
+	body := strings.Replace(validIndex, "file: agent.yaml", "file: /etc/passwd", 1)
+	idx := writeIndex(t, body)
+	if _, err := ExpandScenario(idx); err == nil {
+		t.Error("expected error for absolute member file path")
+	}
+}
+
+func TestResolveScenarioIndex_Directory(t *testing.T) {
+	idx := writeIndex(t, validIndex)
+	dir := filepath.Dir(idx)
+	got, ok, err := ResolveScenarioIndex(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected directory with scenario.yaml to resolve as a scenario")
+	}
+	if got != idx {
+		t.Errorf("index path = %q, want %q", got, idx)
+	}
+}
+
+func TestResolveScenarioIndex_PlainDirNotScenario(t *testing.T) {
+	dir := t.TempDir()
+	_, ok, err := ResolveScenarioIndex(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ok {
+		t.Error("a directory with no scenario.yaml must not resolve as a scenario")
+	}
+}
+
+func TestResolveScenarioIndex_NonScenarioFile(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "wf.yaml")
+	if err := os.WriteFile(f, []byte("kind: Workflow\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, ok, err := ResolveScenarioIndex(f)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ok {
+		t.Error("a kind: Workflow file must not resolve as a scenario")
+	}
+}
+
+func TestResolveScenarioIndex_ScenarioFile(t *testing.T) {
+	idx := writeIndex(t, validIndex)
+	got, ok, err := ResolveScenarioIndex(idx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ok || got != idx {
+		t.Errorf("scenario index file did not resolve: ok=%v path=%q", ok, got)
+	}
+}
+
+func TestResolveScenarioIndex_Missing(t *testing.T) {
+	if _, _, err := ResolveScenarioIndex("/nonexistent/path"); err == nil {
+		t.Error("expected error for missing path")
+	}
+}
+
+// ScenarioFile end-to-end against the shipped reference scenario: the index and
+// every member must validate against their existing schemas.
+func TestScenarioFile_ReferenceScenarioValid(t *testing.T) {
+	root := repoRoot(t)
+	schemaDir := filepath.Join(root, "spec/schemas")
+	idx := filepath.Join(root, "spec/scenarios/code-review", ScenarioIndexFile)
+	errs, err := ScenarioFile(idx, schemaDir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(errs) != 0 {
+		t.Errorf("reference scenario should be valid, got errors: %v", errs)
+	}
+}
+
+func TestScenarioFile_InvalidIndexStops(t *testing.T) {
+	root := repoRoot(t)
+	schemaDir := filepath.Join(root, "spec/schemas")
+	// Index missing apply_order — schema-invalid.
+	body := `kind: Scenario
+apiVersion: zynax.io/v1alpha1
+metadata:
+  name: demo
+spec:
+  members:
+    - id: agent
+      kind: AgentDef
+      file: agent.yaml
+`
+	idx := writeIndex(t, body)
+	errs, err := ScenarioFile(idx, schemaDir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(errs) == 0 {
+		t.Error("expected schema errors for index missing apply_order")
+	}
+}

--- a/docs/scenarios/code-review.validation.md
+++ b/docs/scenarios/code-review.validation.md
@@ -1,0 +1,83 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+# Human-Validation Guide — Declarative code-review scenario
+
+> **Story:** #1385  ·  **Canvas:** `docs/spdd/1385-scenario-manifest/canvas.md` — O-step 4 & 6
+
+## Purpose
+Validates that **one declarative scenario manifest set** runs a code-review demo to
+a terminal result with **no imperative edits** — the AgentDef and Workflow are
+wired together in `spec/scenarios/code-review/` and brought up by a single command.
+"Working" means `zynax apply` (or `make demo SCENARIO=code-review`) registers the
+AgentDef, submits the Workflow, and the run reaches a terminal state with a
+non-empty model review.
+
+## Prerequisites
+- Docker Engine ≥ 24 running (`docker compose` v2).
+- The `zynax` CLI on PATH (`make install-cli`, then ensure `~/bin` is on PATH).
+- The demo model pulled once on the host: `ollama pull qwen2.5-coder:3b`
+  (the Ollama overlay reuses host-pulled models read-only — nothing auto-downloads).
+
+## Expected duration
+~5 minutes after the model is pulled (most of it is the first model load).
+
+## Setup
+```bash
+# From the repo root. Confirm the scenario validates locally first (no stack needed):
+zynax validate spec/scenarios/code-review
+```
+
+## Steps
+1. Validate the whole manifest set against its schemas (index + each member):
+   ```bash
+   zynax validate spec/scenarios/code-review
+   ```
+2. Bring the scenario up end-to-end with one command:
+   ```bash
+   make demo SCENARIO=code-review
+   ```
+   (Equivalent manual form, if you prefer to drive it yourself:)
+   ```bash
+   export ZYNAX_API_URL=http://localhost:7080
+   zynax apply spec/scenarios/code-review
+   zynax result <run-id-printed-above>
+   ```
+
+## Expected observable result
+```
+ok: spec/scenarios/code-review/scenario.yaml
+...
+applying llm-agent (AgentDef)...
+agent_id: <id>
+applying review-workflow (Workflow)...
+run_id: <id>
+── review ──────────────────────────────────────────────
+<a non-empty, numbered code review ending in APPROVE or REQUEST-CHANGES>
+────────────────────────────────────────────────────────
+✅ Demo complete.
+```
+
+## Pass / fail criteria
+- [ ] **PASS** — `zynax validate spec/scenarios/code-review` exits 0 (AC: "validated by `zynax`").
+- [ ] **PASS** — `make validate-spec` passes including the scenario index (AC: "validated by `make validate-spec`").
+- [ ] **PASS** — applying the scenario registers the AgentDef (prints `agent_id:`) **then** submits the Workflow (prints `run_id:`), in that order, with no manual edits to any compose/adapter/prompt file (AC: "one declarative manifest runs a scenario to a terminal result with no imperative edits").
+- [ ] **PASS** — `zynax result <run-id>` prints a non-empty review and the run reaches a terminal state.
+- [ ] **FAIL** — any of the above errors, the output is empty, members apply out of order, or the run never reaches a terminal state.
+
+## Teardown
+```bash
+make demo-clean
+```
+
+## Troubleshooting
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| `zynax CLI not found` | `~/bin` not on PATH | `make install-cli`; add `~/bin` to PATH. |
+| `apply did not return a run_id` | AgentDef not registered before Workflow, or model not pulled | Check `apply_order` lists the AgentDef first; run `ollama pull qwen2.5-coder:3b`. |
+| Empty review / connection refused | adapter endpoint unreachable | Confirm the Ollama overlay is healthy: `docker compose ps`; see `infra/docker-compose/ollama/`. |
+
+## Feedback / bug reporting
+If validation fails, capture and file:
+- The exact command run and its full output.
+- Expected vs observed result.
+- Versions: `zynax version`, image tags, model name (`qwen2.5-coder:3b`).
+- Open an issue referencing #1385 with the `area: spec` label and attach the above.

--- a/docs/scenarios/scenario-manifest.md
+++ b/docs/scenarios/scenario-manifest.md
@@ -1,0 +1,130 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+# Declarative Scenario Manifests
+
+A **scenario** wires together everything a demo or use-case needs — a `Workflow`,
+the `AgentDef`(s) that supply its capabilities, and a reserved context slot — in
+**one declarative place**, so you run your own scenario without hand-editing
+compose files or adapter configs.
+
+> Issue #1385 · Epic #1370 · Canvas `docs/spdd/1385-scenario-manifest/canvas.md`
+> (approach **A2 — manifest-set convention**, ADR-028 "two kinds, no third schema").
+
+---
+
+## What a scenario is (and is not)
+
+A scenario is **not** a new server-side manifest kind. It is a **client-side
+manifest-set convention**: a directory under `spec/scenarios/<name>/` holding the
+existing `kind: Workflow` and `kind: AgentDef` manifests (unchanged shapes) plus a
+small `scenario.yaml` **index** that declares the members, the order to apply them
+in, and a context slot.
+
+`zynax apply <dir>` expands the index and submits each member over the **existing**
+`/api/v1/apply` REST path — one member at a time, exactly as a hand-applied
+manifest is. There is **no new api-gateway endpoint and no new response shape**:
+the platform only ever sees the two kinds it already understands.
+
+```
+spec/scenarios/code-review/
+├── scenario.yaml   ← the index (kind: Scenario)
+├── agent.yaml      ← member: kind: AgentDef (the capability provider)
+└── workflow.yaml   ← member: kind: Workflow (the runnable workflow)
+```
+
+---
+
+## The index schema (`kind: Scenario`)
+
+Validated against [`spec/schemas/scenario.schema.json`](../../spec/schemas/scenario.schema.json).
+
+```yaml
+kind: Scenario
+apiVersion: zynax.io/v1alpha1
+metadata:
+  name: code-review            # lowercase DNS label; matches the directory name
+  namespace: demo
+  annotations:
+    description: "..."
+spec:
+  members:                     # the member manifests this scenario composes
+    - id: llm-agent            # stable id, referenced from apply_order
+      kind: AgentDef           # only Workflow / AgentDef are valid members
+      file: agent.yaml         # path RELATIVE to this index (no '..' escapes)
+    - id: review-workflow
+      kind: Workflow
+      file: workflow.yaml
+  apply_order:                 # member ids, in the order they are applied
+    - llm-agent                # AgentDef(s) FIRST — see "apply order" below
+    - review-workflow
+  context:                     # RESERVED slot (semantics owned by #1387)
+    language: go               # data only — never provider/model/endpoint/URL
+```
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| `kind` | yes | Must be `Scenario`. |
+| `apiVersion` | yes | Must be `zynax.io/v1alpha1`. |
+| `metadata.name` | yes | Lowercase DNS label; conventionally the directory name. |
+| `spec.members[]` | yes | Each `{id, kind, file}`; `kind` ∈ {Workflow, AgentDef}; `file` is relative. |
+| `spec.apply_order[]` | yes | Member ids in apply order; each declared member referenced once. |
+| `spec.context` | no | **Reserved** pass-through; see below. |
+
+### Apply order
+
+AgentDef members **must precede** the Workflow that consumes their capabilities.
+Registering the AgentDef first means the task broker can route the capability when
+the Workflow dispatches it; an unbacked capability then fails fast rather than
+retrying forever (#1381). The index makes this order **declarative** — you never
+sequence applies by hand.
+
+### The reserved `context` slot
+
+`spec.context` is a **wiring placeholder only** in #1385. The CLI does **not**
+evaluate its values yet. The bounded `{files[], max_tokens}` slice semantics and
+strict isolation are owned by sibling issue **#1387** (ADR-028); once that lands,
+context values bind into a Workflow action's `input` Jinja2 `{{ .ctx.* }}`
+templates.
+
+**Hard rule (ADR-013):** the context slot may carry **data only** — never
+provider/model/endpoint/URL or any field that redirects where a capability runs.
+Provider/model/endpoint live in the `AgentDef`/compose overlay, never here.
+
+---
+
+## Authoring and running a scenario
+
+```bash
+# 1. Validate the whole set locally (index schema + each member's own schema):
+zynax validate spec/scenarios/code-review
+make validate-spec                         # the CI gate runs the same checks
+
+# 2. Apply it — members submit in apply_order over the existing REST path:
+zynax apply spec/scenarios/code-review
+#   applying llm-agent (AgentDef)...
+#   agent_id: ...
+#   applying review-workflow (Workflow)...
+#   run_id: ...
+
+# 3. One-command demo (compose-up → apply → result → cleanup):
+make demo SCENARIO=code-review
+```
+
+`zynax apply` accepts either the scenario **directory** or the `scenario.yaml`
+index file directly. A plain manifest path still works exactly as before — the CLI
+only treats a target as a scenario when it is a directory containing
+`scenario.yaml`, or a file whose `kind` is `Scenario`.
+
+---
+
+## Authoring rules (recap)
+
+- Member manifests follow the normal spec rules (`spec/AGENTS.md`): every manifest
+  has `kind` + `apiVersion` + `metadata.name`; capabilities are `snake_case`;
+  **never reference agent names in a Workflow** — only capability names.
+- Member `file` paths are relative to the index and must not escape the scenario
+  directory (no absolute paths, no `..`).
+- Keep provider/model/endpoint out of manifests and out of the context slot
+  (ADR-013) — they belong in the adapter config / compose overlay.
+
+See also: [`docs/scenarios/code-review.validation.md`](code-review.validation.md)
+for the human-validation walkthrough of the reference scenario.

--- a/spec/scenarios/code-review/agent.yaml
+++ b/spec/scenarios/code-review/agent.yaml
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: Apache-2.0
+# Scenario member (kind: AgentDef) — the capability provider for the code-review
+# demo. Declares the `codereview` capability that the Workflow member dispatches.
+#
+# NOTE: the capability name has NO underscore on purpose — the engine derives the
+# completion event as "<capability>.completed", and the workflow compiler rejects
+# event types containing underscores. This mirrors the llm-adapter Ollama config
+# (infra/docker-compose/ollama/llm-adapter.config.yaml).
+#
+# Provider/model/endpoint live in the adapter config + compose overlay (ADR-013),
+# never in the manifest input — the AgentDef only declares the capability contract.
+# Validated by: make validate-spec (against spec/schemas/agent-def.schema.json).
+
+apiVersion: zynax.io/v1alpha1
+kind: AgentDef
+
+metadata:
+  name: llm-adapter
+  namespace: demo
+  labels:
+    team: platform
+    agent.zynax.io/provider: ollama
+
+spec:
+  capabilities:
+    - name: codereview
+      description: >
+        Review a code diff via a local Ollama-backed LLM and return concrete,
+        actionable findings as a single completion string.
+      input_schema:
+        type: object
+        required: [prompt]
+        properties:
+          prompt:
+            type: string
+            description: The full review prompt, including the diff to review.
+            minLength: 1
+        additionalProperties: false
+      output_schema:
+        type: object
+        properties:
+          completion:
+            type: string
+            description: The model's review text.
+      timeout_seconds: 300
+      max_retries: 1
+
+  runtime:
+    image: ghcr.io/zynax-io/zynax/llm-adapter:latest
+    env:
+      LOG_LEVEL: info
+      GRPC_PORT: "50070"
+    resources:
+      requests:
+        cpu: "100m"
+        memory: "256Mi"
+      limits:
+        cpu: "1000m"
+        memory: "1Gi"
+    replicas: 1

--- a/spec/scenarios/code-review/scenario.yaml
+++ b/spec/scenarios/code-review/scenario.yaml
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+# Scenario INDEX (kind: Scenario) — the declarative code-review demo.
+#
+# A Scenario is a CLIENT-SIDE manifest-set convention (A2, ADR-028 "two kinds,
+# no third schema"): this index lists the member manifests in this directory,
+# declares the order they must be applied in, and reserves a context slot.
+#
+#   zynax validate spec/scenarios/code-review        # schema + per-member checks
+#   zynax apply    spec/scenarios/code-review        # registers AgentDef, submits Workflow
+#   make demo SCENARIO=code-review                    # compose-up → apply → result → cleanup
+#
+# Members are submitted over the EXISTING /api/v1/apply REST path, one at a time,
+# exactly as a hand-applied manifest is — no new api-gateway endpoint.
+# Validated by: make validate-spec (against spec/schemas/scenario.schema.json).
+
+kind: Scenario
+apiVersion: zynax.io/v1alpha1
+
+metadata:
+  name: code-review
+  namespace: demo
+  annotations:
+    description: "Declarative LLM code-review demo: Ollama AgentDef + code-review Workflow."
+
+spec:
+  members:
+    - id: llm-agent
+      kind: AgentDef
+      file: agent.yaml
+    - id: review-workflow
+      kind: Workflow
+      file: workflow.yaml
+
+  # AgentDef MUST register before the Workflow that consumes its `codereview`
+  # capability, so an unbacked capability fails fast rather than retrying (#1381).
+  apply_order:
+    - llm-agent
+    - review-workflow
+
+  # RESERVED context-injection slot (#1387 owns the bounded-slice semantics).
+  # Data-only — never provider/model/endpoint/URL (ADR-013). The CLI does NOT
+  # evaluate these values yet; they are a documented pass-through placeholder.
+  context:
+    language: go

--- a/spec/scenarios/code-review/workflow.yaml
+++ b/spec/scenarios/code-review/workflow.yaml
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: Apache-2.0
+# Scenario member (kind: Workflow) — the runnable code-review workflow.
+#
+# Composes the same shape as spec/workflows/examples/code-review-ollama.yaml: its
+# initial state dispatches the `codereview` capability (served by the AgentDef
+# member agent.yaml) over a git diff, then transitions to a terminal state.
+#
+# Never references the agent by name — only the capability (routing is the
+# platform's job, spec/AGENTS.md). The reserved scenario context slot (#1387)
+# will bind into this action's `input` Jinja2 templates once its semantics land.
+# Validated by: make validate-spec (against spec/schemas/workflow.schema.json).
+
+kind: Workflow
+apiVersion: zynax.io/v1
+
+metadata:
+  name: code-review-scenario
+  namespace: demo
+  version: "1.0.0"
+  annotations:
+    description: "Real LLM code review of a git diff via the scenario's Ollama AgentDef."
+
+spec:
+  initial_state: review
+
+  states:
+    review:
+      actions:
+        - capability: codereview
+          input:
+            prompt: |
+              You are a senior Go code reviewer. Review the following git diff and
+              reply with a short, numbered list of concrete issues (correctness,
+              security, edge cases). Be specific and cite the function name. If a
+              change looks risky, say why. End with an APPROVE or REQUEST-CHANGES verdict.
+
+              ```diff
+              diff --git a/payments.go b/payments.go
+              --- a/payments.go
+              +++ b/payments.go
+              @@ -7,5 +7,12 @@ func Charge(balanceCents, amountCents int) (int, error) {
+               	if amountCents < 0 {
+               		return balanceCents, errors.New("amount must be non-negative")
+               	}
+              -	return balanceCents - amountCents, nil
+              +	// Apply a 2% loyalty discount before charging.
+              +	discounted := amountCents - (amountCents / 50)
+              +	return balanceCents - discounted, nil
+              +}
+              +
+              +// Refund credits amountCents back to the account.
+              +func Refund(balanceCents, amountCents int) int {
+              +	return balanceCents + amountCents
+               }
+              ```
+      on:
+        - event: codereview.completed
+          goto: done
+
+    done:
+      type: terminal

--- a/spec/schemas/scenario.schema.json
+++ b/spec/schemas/scenario.schema.json
@@ -1,0 +1,117 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://zynax.io/schemas/scenario/v1alpha1",
+  "title": "Zynax Scenario Index",
+  "description": "JSON Schema for a Zynax Scenario INDEX (kind: Scenario, apiVersion: zynax.io/v1alpha1). A Scenario is NOT a server-side composite kind: it is a CLIENT-SIDE manifest-set convention (A2, ADR-028 'two kinds, no third schema'). The index lists the member manifests (existing kind: Workflow / kind: AgentDef files), declares the apply order, and reserves a context slot whose bounded-slice semantics are owned by issue #1387. `zynax apply <dir|index>` expands the index and submits each member over the existing /api/v1/apply REST path in apply_order — no new api-gateway endpoint or response shape. See docs/scenarios/scenario-manifest.md and docs/spdd/1385-scenario-manifest/canvas.md.",
+  "type": "object",
+  "required": ["kind", "apiVersion", "metadata", "spec"],
+  "additionalProperties": false,
+  "properties": {
+    "kind": {
+      "type": "string",
+      "const": "Scenario",
+      "description": "Must be 'Scenario'. Marks this file as a client-side scenario index, distinct from the Workflow/AgentDef/Policy server-side kinds."
+    },
+    "apiVersion": {
+      "type": "string",
+      "const": "zynax.io/v1alpha1",
+      "description": "Schema version. The CLI rejects indexes with an unrecognised apiVersion."
+    },
+    "metadata": {
+      "$ref": "#/$defs/metadata"
+    },
+    "spec": {
+      "$ref": "#/$defs/spec"
+    }
+  },
+  "$defs": {
+    "metadata": {
+      "type": "object",
+      "description": "Identifying information for the Scenario.",
+      "required": ["name"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Unique scenario name. Conventionally matches the parent directory name.",
+          "minLength": 1,
+          "maxLength": 253,
+          "pattern": "^[a-z0-9]([a-z0-9-]*[a-z0-9])?$"
+        },
+        "namespace": {
+          "type": "string",
+          "description": "Logical namespace the scenario's members are scoped to. Defaults to 'default' when omitted.",
+          "minLength": 1,
+          "maxLength": 63,
+          "pattern": "^[a-z0-9]([a-z0-9-]*[a-z0-9])?$"
+        },
+        "annotations": {
+          "type": "object",
+          "description": "Free-form key-value annotations, e.g. a human-readable description.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "spec": {
+      "type": "object",
+      "description": "The scenario composition: its members, the order they are applied in, and a reserved context slot.",
+      "required": ["members", "apply_order"],
+      "additionalProperties": false,
+      "properties": {
+        "members": {
+          "type": "array",
+          "description": "The member manifests this scenario composes. Each is an existing kind: Workflow or kind: AgentDef file, referenced by its kind, a stable id, and a path relative to the index file.",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/member"
+          }
+        },
+        "apply_order": {
+          "type": "array",
+          "description": "Member ids in the order they must be applied. AgentDef members MUST precede the Workflow that consumes their capabilities, so an unbacked capability fails fast rather than retrying forever (#1381). Every id here must reference a declared member exactly once.",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "context": {
+          "$ref": "#/$defs/context"
+        }
+      }
+    },
+    "member": {
+      "type": "object",
+      "description": "A single member manifest reference.",
+      "required": ["id", "kind", "file"],
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Stable identifier for this member, referenced from apply_order.",
+          "minLength": 1,
+          "maxLength": 253,
+          "pattern": "^[a-z0-9]([a-z0-9-]*[a-z0-9])?$"
+        },
+        "kind": {
+          "type": "string",
+          "description": "The member's manifest kind. Only the two server-side apply-able kinds are valid in a scenario set.",
+          "enum": ["Workflow", "AgentDef"]
+        },
+        "file": {
+          "type": "string",
+          "description": "Path to the member manifest, relative to the directory containing this index file. Must not escape the scenario directory.",
+          "minLength": 1,
+          "pattern": "^[^/].*$"
+        }
+      }
+    },
+    "context": {
+      "type": "object",
+      "description": "RESERVED context-injection slot. #1385 provides only the wiring placeholder; the bounded {files[], max_tokens} slice semantics and strict isolation are owned by issue #1387 (ADR-028). The slot may carry DATA ONLY — never provider/model/endpoint/URL or any field that redirects where a capability runs (ADR-013). Values declared here are intended to bind into a Workflow action's `input` Jinja2 {{ .ctx.* }} templates once #1387 lands; until then they are a documented pass-through and are NOT evaluated by the CLI.",
+      "additionalProperties": true
+    }
+  }
+}

--- a/spec/tests/features/scenario_schema.feature
+++ b/spec/tests/features/scenario_schema.feature
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: Apache-2.0
+# Zynax — Scenario Index Schema BDD Contract
+#
+# This file is the SPECIFICATION. It is written BEFORE the implementation
+# (ADR-016). It describes what the scenario index schema must enforce and how
+# `zynax apply`/`zynax validate` expand a scenario manifest set.
+# See spec/AGENTS.md for spec governance rules and
+# docs/spdd/1385-scenario-manifest/canvas.md for the A2 approach.
+#
+# Business context: A scenario wires together a Workflow, the AgentDef(s) that
+# supply its capabilities, and a reserved context slot — declaratively, in one
+# place — so a user runs their own scenario without imperative edits (ADR-011).
+# A Scenario is NOT a server-side composite kind: the index is a client-side
+# manifest-set convention (A2, ADR-028 "two kinds, no third schema"). Members
+# are applied over the EXISTING /api/v1/apply REST path — no new boundary.
+
+Feature: Scenario index schema for declarative manifest sets
+  As a scenario author
+  I want to declare a Workflow, its AgentDef(s), and a context slot in one index
+  So that `zynax apply` brings the whole scenario up in dependency order
+
+  Background:
+    Given the JSON Schema at "spec/schemas/scenario.schema.json" is loaded
+
+  # ─── Valid indexes ─────────────────────────────────────────────────────────
+
+  Scenario: A valid scenario index passes schema validation
+    Given a scenario index with kind "Scenario" and apiVersion "zynax.io/v1alpha1"
+    And metadata.name is "code-review"
+    And spec.members lists an AgentDef member "agent" and a Workflow member "workflow"
+    And spec.apply_order is ["agent", "workflow"]
+    When the index is validated against the scenario schema
+    Then validation passes with zero errors
+
+  Scenario: A scenario index may reserve a context slot
+    Given a valid scenario index
+    And spec.context declares a data-only key "language" with value "go"
+    When the index is validated against the scenario schema
+    Then validation passes with zero errors
+    And the context slot is treated as a reserved pass-through (semantics owned by #1387)
+
+  # ─── Rejected indexes ──────────────────────────────────────────────────────
+
+  Scenario: An index missing apply_order is rejected
+    Given a scenario index whose spec omits apply_order
+    When the index is validated against the scenario schema
+    Then validation fails with an error citing the missing apply_order
+
+  Scenario: A member with a kind other than Workflow or AgentDef is rejected
+    Given a scenario index with a member of kind "Policy"
+    When the index is validated against the scenario schema
+    Then validation fails because only Workflow and AgentDef members are allowed
+
+  Scenario: A member file path that escapes the scenario directory is rejected
+    Given a scenario index whose member file is "../../etc/passwd"
+    When the index is validated against the scenario schema
+    Then validation fails because member files must be relative to the index directory
+
+  # ─── CLI expansion contract ────────────────────────────────────────────────
+
+  Scenario: zynax validate expands an index and validates each member
+    Given a scenario directory containing an index, a Workflow, and an AgentDef
+    When "zynax validate" is run against the scenario directory
+    Then each member is validated against its own existing schema
+    And per-member errors are reported with the member file name
+
+  Scenario: zynax apply submits members over the existing REST path in apply_order
+    Given a scenario directory whose apply_order registers the AgentDef before the Workflow
+    When "zynax apply" is run against the scenario directory
+    Then the AgentDef is submitted first and returns an agent_id
+    And the Workflow is submitted next and returns a run_id
+    And no new api-gateway endpoint or response shape is introduced
+
+  Scenario: An apply_order id that names no declared member fails fast
+    Given a scenario index whose apply_order references an unknown member id
+    When "zynax apply" expands the index
+    Then expansion fails with a bounded error naming the unknown id


### PR DESCRIPTION
## feat(spec): declarative scenario manifest (manifest-set)

Closes #1385
Part of #1370

### Why  (problem & intent)
The live 2026-06-18 validation needed manual, imperative edits across three layers
(adapter config, compose overlay, prompt) to run one scenario. A user has no single
declarative artefact to wire a Workflow, the AgentDef(s) that supply its capabilities,
and a context slot together. This implements canvas #1385 O-steps 1–6, approach **A2
(manifest-set convention)** — A1 (a new `kind: Scenario` server-side schema) was REJECTED
(one-way door across the api-gateway contract).

### What you'll get  (deliverables ↔ what changed)
- A scenario index schema (`kind: Scenario`) validated locally ← `spec/schemas/scenario.schema.json`
- A reference scenario you can run as one set (Ollama AgentDef + code-review Workflow) ← `spec/scenarios/code-review/`
- `zynax apply <dir|index>` submits members over the EXISTING `/api/v1/apply` REST path in `apply_order` (AgentDef → Workflow) ← `cmd/zynax/cmd/apply.go`, `cmd/zynax/validate/scenario.go`
- `zynax validate <dir>` expands the index and checks each member against its own schema ← `cmd/zynax/cmd/validate.go`
- `make validate-spec` validates the scenario index + members ← `cmd/zynax-ci/cmd/validate_scenarios.go`, `Makefile`
- `make demo SCENARIO=<name>` brings a scenario up end-to-end ← `Makefile`
- Authoring + human-validation guides ← `docs/scenarios/`
- Index-schema BDD contract committed before impl (ADR-016) ← `spec/tests/features/scenario_schema.feature`

### Scope & boundaries
- **In scope:** the manifest-set convention, client-side expansion/apply, index schema, reference scenario, docs, `make demo SCENARIO=`.
- **Out of scope (deferred):** the bounded context-slice semantics (`{files[], max_tokens}` + strict isolation) — the `spec.context` slot here is a documented **reserved pass-through** owned by **#1387**. No `kind: Scenario` server-side composite; no proto/gRPC change; no new api-gateway endpoint or response shape.

### Test plan & acceptance

| Acceptance criterion | How verified (command) | Result |
|----------------------|------------------------|--------|
| One declarative manifest runs a scenario to a terminal result with no imperative edits | `zynax apply spec/scenarios/code-review` (unit-proven: `TestRunApplyScenario_AppliesMembersInOrder`) | ✅ server observes order [AgentDef, Workflow]; prints `agent_id:` then `run_id:` |
| Schema documented; validated by `zynax` | `zynax validate spec/scenarios/code-review` (`TestRunValidate_Scenario`, `TestScenarioFile_ReferenceScenarioValid`) | ✅ index + both members validate, exit 0 |
| validated by `make validate-spec` | `go run . validate scenarios spec/scenarios/code-review --schema-dir spec/schemas` (+ workflows/agent-defs) | ✅ `OK scenario.yaml` / `OK workflow.yaml` / `OK agent.yaml` |
| Ships a human-validation guide | review `docs/scenarios/code-review.validation.md` | ✅ all required sections (Purpose…Teardown) present |

**Local gates:** `GOWORK=off go test ./… ` (cmd/zynax + cmd/zynax-ci) ✅ · `golangci-lint` (both CLI modules) ✅ `0 issues` · scenario schema/member validation ✅

### Evidence
- **CI:** pending — will update when checks are green.
- **Local output:** `cmd/zynax` + `cmd/zynax-ci` tests pass; new `validate scenarios` subcommand validates the index against `scenario.schema.json`; members validate against `workflow.schema.json` / `agent-def.schema.json`.
- **Artifacts / images:** none — no service source changed (CLI-only + spec/docs).
- **Post-merge digest sync → main:** placeholder — post-merge verifier fills after the release pipeline runs.

### Risk & rollback
Low — additive only. New schema kind, new client-side CLI path, new make target; existing single-manifest `apply`/`validate` behaviour is unchanged (a target is only treated as a scenario when it is a dir with `scenario.yaml` or a `kind: Scenario` file). Rollback = revert this PR. No data/migration concern. Note: the Docker-driven `make validate-spec` target needs the rebuilt `tools` image to pick up the new `validate scenarios` subcommand; CI's spec job only runs `validate schema` (well-formed JSON), which passes today.

### Review aids
Suggested reading order: `spec/schemas/scenario.schema.json` (the contract) → `cmd/zynax/validate/scenario.go` (the ONE key file: expansion, ordering, path-traversal confinement) → `cmd/zynax/cmd/apply.go` (REST reuse). Subtlety: AgentDef members MUST precede the Workflow in `apply_order` so an unbacked capability fails fast (#1381); `resolveMemberPath` rejects `..`/absolute member paths.

**SPDD:** Canvas `docs/spdd/1385-scenario-manifest/canvas.md` — Status: **Aligned (A2)** · security-review **PASS**
**AI:** `Assisted-by: Claude/Opus 4.8`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
