### PR TITLE
feat(context): declarative context-injection (context: block)

### DIFF
--- a/cmd/zynax/cmd/apply.go
+++ b/cmd/zynax/cmd/apply.go
@@ -5,6 +5,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
 	"github.com/zynax-io/zynax/cmd/zynax/client"
@@ -61,10 +62,30 @@ func runApplyScenario(cmd *cobra.Command, gw *client.Gateway, indexPath string) 
 	if err != nil {
 		return err
 	}
+	// Resolve the declarative context-injection block (#1387): parse it
+	// (rejecting any routing/provider field — data-only, ADR-013), read its file
+	// sources, and apply the max_tokens cap. The resolved values bind into the
+	// Workflow member's {{ .ctx.* }} references below before it is submitted —
+	// keeping injection client-side over the existing REST path (no new proto
+	// field, no api-gateway endpoint).
+	block, err := validate.ParseContextBlock(indexPath)
+	if err != nil {
+		return err
+	}
+	ctxValues, err := validate.ResolveContext(block, filepath.Dir(indexPath))
+	if err != nil {
+		return err
+	}
 	for _, m := range members {
 		data, err := os.ReadFile(m.Path) //nolint:gosec // member path is confined by ExpandScenario
 		if err != nil {
 			return fmt.Errorf("read scenario member %s (%s): %w", m.ID, m.Path, err)
+		}
+		if m.Kind == "Workflow" {
+			data, err = validate.BindContextIntoWorkflow(data, ctxValues)
+			if err != nil {
+				return fmt.Errorf("scenario member %s: %w", m.ID, err)
+			}
 		}
 		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "applying %s (%s)...\n", m.ID, m.Kind)
 		if applyDryRun {

--- a/cmd/zynax/validate/context.go
+++ b/cmd/zynax/validate/context.go
@@ -1,0 +1,380 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package validate
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"text/template"
+
+	"gopkg.in/yaml.v3"
+)
+
+// routingFields are the keys a context-injection block may NEVER carry: any of
+// them could redirect WHERE or HOW a capability runs. Context injection is
+// strictly data-only (ADR-013/ADR-035) — provider/model/endpoint stay in
+// AgentDef/overlay config and are never accepted from input_payload. The schema
+// forbids these structurally (additionalProperties:false); this Go check is the
+// load-bearing belt-and-suspenders compile-time rejection the canvas mandates
+// (O3 safeguard), so a routing field is caught even if the schema is bypassed.
+var routingFields = map[string]struct{}{
+	"provider": {},
+	"model":    {},
+	"endpoint": {},
+	"url":      {},
+	"uri":      {},
+	"base_url": {},
+	"baseurl":  {},
+	"host":     {},
+	"api_base": {},
+	"api_key":  {},
+}
+
+// tokenCharsPerToken is the approximate character-to-token ratio used to enforce
+// the max_tokens budget. ~4 chars/token is the widely-used rough heuristic for
+// English/code; the cap is a bound, not an exact tokenizer (which is provider
+// specific and out of scope for a data-only injection contract).
+const tokenCharsPerToken = 4
+
+// ContextSource is one resolved entry of a context-injection block: the context
+// key and the files (relative to the scenario directory) that source its value.
+type ContextSource struct {
+	Key   string
+	Files []string
+}
+
+// ContextBlock is the parsed spec.context block of a scenario index. It is the
+// declarative analogue of a hand-pasted prompt blob: bounded, file-rooted, and
+// data-only.
+type ContextBlock struct {
+	Sources   []ContextSource
+	MaxTokens int
+	Overflow  string
+}
+
+// ContextError is a structured failure resolving or binding a context block. It
+// fails loudly — there is no implicit fallback to empty values.
+type ContextError struct {
+	// Key is the offending context key (empty for block-level errors).
+	Key string
+	// Reason is a human-readable explanation.
+	Reason string
+}
+
+func (e *ContextError) Error() string {
+	if e.Key != "" {
+		return fmt.Sprintf("context: key %q: %s", e.Key, e.Reason)
+	}
+	return fmt.Sprintf("context: %s", e.Reason)
+}
+
+// contextIndex decodes only the spec.context block of a scenario index. The
+// block is decoded into a generic map first so a routing field can be rejected
+// before it is interpreted, then into the typed shape.
+type contextIndex struct {
+	Spec struct {
+		Context map[string]any `yaml:"context"`
+	} `yaml:"spec"`
+}
+
+// ParseContextBlock reads the scenario index at indexPath and returns its parsed
+// spec.context block, or (nil, nil) when no context block is declared. It
+// rejects any routing/provider field at the block or source level (data-only,
+// ADR-013) before interpreting the block, so a malicious block can never be
+// silently accepted.
+func ParseContextBlock(indexPath string) (*ContextBlock, error) {
+	raw, err := os.ReadFile(indexPath) //nolint:gosec // indexPath is caller-supplied scenario path
+	if err != nil {
+		return nil, fmt.Errorf("context: read %q: %w", indexPath, err)
+	}
+	var idx contextIndex
+	if err := yaml.Unmarshal(raw, &idx); err != nil {
+		return nil, fmt.Errorf("context: parse %q: %w", indexPath, err)
+	}
+	if len(idx.Spec.Context) == 0 {
+		return nil, nil
+	}
+
+	// Data-only rejection (load-bearing safeguard): no routing field at the top
+	// level of the block, and only the known data keys are accepted.
+	if err := rejectRoutingFields(idx.Spec.Context); err != nil {
+		return nil, err
+	}
+	for k := range idx.Spec.Context {
+		switch k {
+		case "sources", "max_tokens", "overflow":
+		default:
+			return nil, &ContextError{Reason: fmt.Sprintf("unknown field %q — a context block carries sources/max_tokens/overflow only (data-only)", k)}
+		}
+	}
+
+	block, err := decodeContextBlock(idx.Spec.Context)
+	if err != nil {
+		return nil, err
+	}
+	return block, nil
+}
+
+// decodeContextBlock converts the generic map into the typed ContextBlock,
+// re-checking each source for routing fields and validating the budget.
+func decodeContextBlock(m map[string]any) (*ContextBlock, error) {
+	block := &ContextBlock{Overflow: "truncate-oldest"}
+
+	if ov, ok := m["overflow"].(string); ok && ov != "" {
+		if ov != "truncate-oldest" && ov != "error" {
+			return nil, &ContextError{Reason: fmt.Sprintf("overflow %q must be truncate-oldest or error", ov)}
+		}
+		block.Overflow = ov
+	}
+
+	mt, ok := toInt(m["max_tokens"])
+	if !ok || mt <= 0 {
+		return nil, &ContextError{Reason: "max_tokens is required and must be a positive integer"}
+	}
+	block.MaxTokens = mt
+
+	rawSources, ok := m["sources"].([]any)
+	if !ok || len(rawSources) == 0 {
+		return nil, &ContextError{Reason: "sources is required and must list at least one {key, files} entry"}
+	}
+	for i, rs := range rawSources {
+		sm, ok := toStringMap(rs)
+		if !ok {
+			return nil, &ContextError{Reason: fmt.Sprintf("sources[%d] must be a mapping", i)}
+		}
+		if err := rejectRoutingFields(sm); err != nil {
+			return nil, err
+		}
+		key, _ := sm["key"].(string)
+		if key == "" {
+			return nil, &ContextError{Reason: fmt.Sprintf("sources[%d] is missing a key", i)}
+		}
+		files, err := toStringSlice(sm["files"])
+		if err != nil || len(files) == 0 {
+			return nil, &ContextError{Key: key, Reason: "files is required and must list at least one path"}
+		}
+		block.Sources = append(block.Sources, ContextSource{Key: key, Files: files})
+	}
+	return block, nil
+}
+
+// rejectRoutingFields fails when any reserved routing/provider key is present.
+// This is the data-only enforcement the canvas requires in O3 — independent of
+// the JSON Schema so the rule holds even when validation is skipped.
+func rejectRoutingFields(m map[string]any) error {
+	for k := range m {
+		if _, banned := routingFields[strings.ToLower(strings.TrimSpace(k))]; banned {
+			return &ContextError{Reason: fmt.Sprintf("field %q is forbidden — a context block is data-only and may never carry provider/model/endpoint/URL (ADR-013/ADR-035)", k)}
+		}
+	}
+	return nil
+}
+
+// ResolveContext reads each source's files (relative to dir, confined to it),
+// applies the max_tokens hard cap with the block's overflow policy, and returns
+// a key→value map ready to bind into a Workflow action's {{ .ctx.* }} template.
+// Strict isolation is structural: the returned map is freshly built per call
+// from one scenario's own block, so it can never carry another scenario's data.
+func ResolveContext(block *ContextBlock, dir string) (map[string]string, error) {
+	if block == nil {
+		return nil, nil
+	}
+	values := make(map[string]string, len(block.Sources))
+	seen := make(map[string]bool, len(block.Sources))
+	budget := block.MaxTokens * tokenCharsPerToken
+
+	for _, src := range block.Sources {
+		if seen[src.Key] {
+			return nil, &ContextError{Key: src.Key, Reason: "duplicate context key"}
+		}
+		seen[src.Key] = true
+
+		var b strings.Builder
+		for _, file := range src.Files {
+			abs, err := confinePath(dir, file)
+			if err != nil {
+				return nil, &ContextError{Key: src.Key, Reason: err.Error()}
+			}
+			content, err := os.ReadFile(abs) //nolint:gosec // abs is confined to dir by confinePath
+			if err != nil {
+				return nil, &ContextError{Key: src.Key, Reason: fmt.Sprintf("read source file %q: %v", file, err)}
+			}
+			b.Write(content)
+		}
+		values[src.Key] = b.String()
+	}
+
+	if err := enforceBudget(block, values, budget); err != nil {
+		return nil, err
+	}
+	return values, nil
+}
+
+// enforceBudget applies the max_tokens cap to the combined content. Under the
+// 'error' policy an over-budget block fails; under 'truncate-oldest' the
+// earliest-declared sources are dropped/trimmed first until the budget is met,
+// so the most recently declared (typically most relevant) content survives.
+func enforceBudget(block *ContextBlock, values map[string]string, budget int) error {
+	total := 0
+	for _, v := range values {
+		total += len(v)
+	}
+	if total <= budget {
+		return nil
+	}
+	if block.Overflow == "error" {
+		return &ContextError{Reason: fmt.Sprintf("combined context ~%d tokens exceeds max_tokens %d", total/tokenCharsPerToken, block.MaxTokens)}
+	}
+	// truncate-oldest: walk sources in declared order, trimming from the front
+	// until the remaining content fits the budget.
+	overage := total - budget
+	for _, src := range block.Sources {
+		if overage <= 0 {
+			break
+		}
+		v := values[src.Key]
+		if len(v) <= overage {
+			overage -= len(v)
+			values[src.Key] = ""
+			continue
+		}
+		values[src.Key] = v[overage:]
+		overage = 0
+	}
+	return nil
+}
+
+// BindContextIntoWorkflow renders every {{ .ctx.<key> }} reference in the
+// Workflow manifest using the resolved context values and returns the rendered
+// manifest. Binding operates on the PARSED YAML tree (each scalar string node is
+// rendered individually) rather than on the raw bytes, so injected multi-line
+// content (a git diff) stays valid YAML regardless of block-scalar indentation.
+// Each scalar is rendered with the SAME text/template engine the engine-adapter
+// uses for the {{ .ctx.* }} surface (no new template engine, A2). An unresolved
+// {{ .ctx.<key> }} reference (a key the block does not supply) fails loudly
+// rather than substituting an empty value.
+func BindContextIntoWorkflow(manifest []byte, values map[string]string) ([]byte, error) {
+	var root yaml.Node
+	if err := yaml.Unmarshal(manifest, &root); err != nil {
+		return nil, &ContextError{Reason: fmt.Sprintf("parse workflow YAML: %v", err)}
+	}
+	if err := renderScalars(&root, values); err != nil {
+		return nil, err
+	}
+	out, err := yaml.Marshal(&root)
+	if err != nil {
+		return nil, &ContextError{Reason: fmt.Sprintf("re-encode workflow YAML: %v", err)}
+	}
+	return out, nil
+}
+
+// renderScalars walks a YAML node tree and renders every scalar string that
+// contains a template reference, replacing the node's value (and forcing a
+// literal block style when the result is multi-line so the re-encoded YAML stays
+// readable and valid).
+func renderScalars(n *yaml.Node, values map[string]string) error {
+	if n.Kind == yaml.ScalarNode && strings.Contains(n.Value, "{{") {
+		rendered, err := renderScalar(n.Value, values)
+		if err != nil {
+			return err
+		}
+		n.Value = rendered
+		n.Tag = "!!str"
+		if strings.Contains(rendered, "\n") {
+			n.Style = yaml.LiteralStyle
+		} else {
+			n.Style = 0
+		}
+		return nil
+	}
+	for _, child := range n.Content {
+		if err := renderScalars(child, values); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// renderScalar renders one scalar string through text/template with the ctx
+// data root. missingkey=error makes an unresolved {{ .ctx.<key> }} fail loudly.
+func renderScalar(s string, values map[string]string) (string, error) {
+	t, err := template.New("ctx").Option("missingkey=error").Parse(s)
+	if err != nil {
+		return "", &ContextError{Reason: fmt.Sprintf("parse template %q: %v", s, err)}
+	}
+	var buf bytes.Buffer
+	if err := t.Execute(&buf, map[string]any{"ctx": values}); err != nil {
+		return "", &ContextError{Reason: fmt.Sprintf("bind context into workflow: %v", err)}
+	}
+	return buf.String(), nil
+}
+
+// confinePath joins file to dir and rejects any path that escapes dir or is
+// absolute (path traversal). Mirrors resolveMemberPath so context sources obey
+// the same containment rule as scenario members.
+func confinePath(dir, file string) (string, error) {
+	if file == "" {
+		return "", fmt.Errorf("source file is empty")
+	}
+	if filepath.IsAbs(file) {
+		return "", fmt.Errorf("source file %q must be relative to the scenario directory", file)
+	}
+	cleanDir := filepath.Clean(dir)
+	abs := filepath.Clean(filepath.Join(cleanDir, file))
+	rel, err := filepath.Rel(cleanDir, abs)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("source file %q escapes the scenario directory", file)
+	}
+	return abs, nil
+}
+
+// toInt coerces a YAML-decoded numeric value to an int.
+func toInt(v any) (int, bool) {
+	switch n := v.(type) {
+	case int:
+		return n, true
+	case int64:
+		return int(n), true
+	case float64:
+		return int(n), true
+	default:
+		return 0, false
+	}
+}
+
+// toStringMap coerces a YAML-decoded mapping (string or interface keys) to a
+// map[string]any.
+func toStringMap(v any) (map[string]any, bool) {
+	switch m := v.(type) {
+	case map[string]any:
+		return m, true
+	case map[any]any:
+		out := make(map[string]any, len(m))
+		for k, val := range m {
+			out[fmt.Sprintf("%v", k)] = val
+		}
+		return out, true
+	default:
+		return nil, false
+	}
+}
+
+// toStringSlice coerces a YAML-decoded sequence of strings to []string.
+func toStringSlice(v any) ([]string, error) {
+	raw, ok := v.([]any)
+	if !ok {
+		return nil, fmt.Errorf("expected a list")
+	}
+	out := make([]string, 0, len(raw))
+	for _, item := range raw {
+		s, ok := item.(string)
+		if !ok || s == "" {
+			return nil, fmt.Errorf("expected a list of non-empty strings")
+		}
+		out = append(out, s)
+	}
+	return out, nil
+}

--- a/cmd/zynax/validate/context_test.go
+++ b/cmd/zynax/validate/context_test.go
@@ -1,0 +1,363 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package validate
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// writeFile writes content into dir/name and returns dir for chaining.
+func writeFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// writeContextIndex writes a scenario index whose spec.context is the given YAML
+// block (already indented under "  context:") into a fresh temp dir and returns
+// the index path and its dir.
+func writeContextIndex(t *testing.T, contextYAML string) (string, string) {
+	t.Helper()
+	dir := t.TempDir()
+	body := `kind: Scenario
+apiVersion: zynax.io/v1alpha1
+metadata:
+  name: demo
+spec:
+  members:
+    - id: workflow
+      kind: Workflow
+      file: workflow.yaml
+  apply_order:
+    - workflow
+` + contextYAML
+	idx := filepath.Join(dir, ScenarioIndexFile)
+	if err := os.WriteFile(idx, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return idx, dir
+}
+
+// --- Decisive test 1: a valid context block parses, resolves, and substitutes
+// into a Workflow's {{ .ctx.* }} surface.
+
+func TestResolveContext_ValidBlockSubstitutes(t *testing.T) {
+	idx, dir := writeContextIndex(t, `  context:
+    sources:
+      - key: diff
+        files:
+          - diff.patch
+    max_tokens: 8000
+`)
+	writeFile(t, dir, "diff.patch", "DIFF-BODY-LINE-1\nDIFF-BODY-LINE-2\n")
+
+	block, err := ParseContextBlock(idx)
+	if err != nil {
+		t.Fatalf("ParseContextBlock: %v", err)
+	}
+	if block == nil {
+		t.Fatal("expected a context block, got nil")
+	}
+	values, err := ResolveContext(block, dir)
+	if err != nil {
+		t.Fatalf("ResolveContext: %v", err)
+	}
+	if !strings.Contains(values["diff"], "DIFF-BODY-LINE-1") {
+		t.Fatalf("resolved diff missing file content: %q", values["diff"])
+	}
+
+	wf := []byte("kind: Workflow\nspec:\n  states:\n    review:\n      actions:\n        - capability: codereview\n          input:\n            prompt: |\n              ```diff\n              {{ .ctx.diff }}\n              ```\n")
+	bound, err := BindContextIntoWorkflow(wf, values)
+	if err != nil {
+		t.Fatalf("BindContextIntoWorkflow: %v", err)
+	}
+	if !strings.Contains(string(bound), "DIFF-BODY-LINE-1") {
+		t.Fatalf("bound workflow did not substitute {{ .ctx.diff }}:\n%s", bound)
+	}
+	if strings.Contains(string(bound), "{{") {
+		t.Fatalf("bound workflow still contains a template reference:\n%s", bound)
+	}
+}
+
+// --- Decisive test 2: a context block carrying a routing/provider field is
+// REJECTED at compile time (data-only safeguard, ADR-013/035).
+
+func TestParseContextBlock_RejectsRoutingFields(t *testing.T) {
+	for _, field := range []string{"provider", "model", "endpoint", "url", "base_url", "api_key"} {
+		t.Run(field, func(t *testing.T) {
+			idx, dir := writeContextIndex(t, `  context:
+    sources:
+      - key: diff
+        files:
+          - diff.patch
+    max_tokens: 8000
+    `+field+`: anything
+`)
+			writeFile(t, dir, "diff.patch", "x")
+			_, err := ParseContextBlock(idx)
+			if err == nil {
+				t.Fatalf("expected rejection of routing field %q, got nil", field)
+			}
+			if !strings.Contains(err.Error(), field) {
+				t.Fatalf("error should cite the field %q: %v", field, err)
+			}
+		})
+	}
+}
+
+// A routing field nested inside a source entry is also rejected.
+func TestParseContextBlock_RejectsRoutingFieldInSource(t *testing.T) {
+	idx, dir := writeContextIndex(t, `  context:
+    sources:
+      - key: diff
+        files:
+          - diff.patch
+        endpoint: http://evil.example
+    max_tokens: 8000
+`)
+	writeFile(t, dir, "diff.patch", "x")
+	_, err := ParseContextBlock(idx)
+	if err == nil {
+		t.Fatal("expected rejection of routing field nested in a source, got nil")
+	}
+}
+
+// An unknown top-level field is rejected (data-only: only sources/max_tokens/overflow).
+func TestParseContextBlock_RejectsUnknownField(t *testing.T) {
+	idx, dir := writeContextIndex(t, `  context:
+    sources:
+      - key: diff
+        files:
+          - diff.patch
+    max_tokens: 8000
+    language: go
+`)
+	writeFile(t, dir, "diff.patch", "x")
+	_, err := ParseContextBlock(idx)
+	if err == nil {
+		t.Fatal("expected rejection of unknown field, got nil")
+	}
+}
+
+// max_tokens is required.
+func TestParseContextBlock_RequiresMaxTokens(t *testing.T) {
+	idx, dir := writeContextIndex(t, `  context:
+    sources:
+      - key: diff
+        files:
+          - diff.patch
+`)
+	writeFile(t, dir, "diff.patch", "x")
+	_, err := ParseContextBlock(idx)
+	if err == nil {
+		t.Fatal("expected error for missing max_tokens, got nil")
+	}
+}
+
+// --- Decisive test 3: the max_tokens cap is enforced.
+
+func TestResolveContext_TruncatesOldestOverBudget(t *testing.T) {
+	// max_tokens 1 → budget = 4 chars. "old" (3) + "new12345" (8) = 11 > 4.
+	idx, dir := writeContextIndex(t, `  context:
+    sources:
+      - key: old
+        files:
+          - old.txt
+      - key: new
+        files:
+          - new.txt
+    max_tokens: 1
+    overflow: truncate-oldest
+`)
+	writeFile(t, dir, "old.txt", "old")
+	writeFile(t, dir, "new.txt", "new12345")
+
+	block, err := ParseContextBlock(idx)
+	if err != nil {
+		t.Fatalf("ParseContextBlock: %v", err)
+	}
+	values, err := ResolveContext(block, dir)
+	if err != nil {
+		t.Fatalf("ResolveContext: %v", err)
+	}
+	total := len(values["old"]) + len(values["new"])
+	if total > block.MaxTokens*tokenCharsPerToken {
+		t.Fatalf("combined content %d chars exceeds budget %d", total, block.MaxTokens*tokenCharsPerToken)
+	}
+	if values["old"] != "" {
+		t.Errorf("oldest source should be dropped first, got %q", values["old"])
+	}
+}
+
+func TestResolveContext_ErrorOverflowFailsOverBudget(t *testing.T) {
+	idx, dir := writeContextIndex(t, `  context:
+    sources:
+      - key: big
+        files:
+          - big.txt
+    max_tokens: 1
+    overflow: error
+`)
+	writeFile(t, dir, "big.txt", strings.Repeat("x", 100))
+
+	block, err := ParseContextBlock(idx)
+	if err != nil {
+		t.Fatalf("ParseContextBlock: %v", err)
+	}
+	if _, err := ResolveContext(block, dir); err == nil {
+		t.Fatal("expected over-budget error under overflow: error, got nil")
+	}
+}
+
+// --- Strict isolation: each ResolveContext call returns a fresh map built only
+// from its own block; one scenario's values never appear in another's.
+
+func TestResolveContext_IsolatesScenarios(t *testing.T) {
+	idxA, dirA := writeContextIndex(t, `  context:
+    sources:
+      - key: diff
+        files:
+          - diff.patch
+    max_tokens: 8000
+`)
+	writeFile(t, dirA, "diff.patch", "SCENARIO-A-CONTENT")
+	idxB, dirB := writeContextIndex(t, `  context:
+    sources:
+      - key: diff
+        files:
+          - diff.patch
+    max_tokens: 8000
+`)
+	writeFile(t, dirB, "diff.patch", "SCENARIO-B-CONTENT")
+
+	blockA, _ := ParseContextBlock(idxA)
+	blockB, _ := ParseContextBlock(idxB)
+	valsA, err := ResolveContext(blockA, dirA)
+	if err != nil {
+		t.Fatalf("ResolveContext A: %v", err)
+	}
+	valsB, err := ResolveContext(blockB, dirB)
+	if err != nil {
+		t.Fatalf("ResolveContext B: %v", err)
+	}
+	if strings.Contains(valsA["diff"], "SCENARIO-B") || strings.Contains(valsB["diff"], "SCENARIO-A") {
+		t.Fatal("context leaked across scenarios")
+	}
+}
+
+// --- A source file that escapes the scenario directory is rejected (traversal).
+
+func TestResolveContext_RejectsPathTraversal(t *testing.T) {
+	idx, dir := writeContextIndex(t, `  context:
+    sources:
+      - key: secret
+        files:
+          - ../../etc/passwd
+    max_tokens: 8000
+`)
+	block, err := ParseContextBlock(idx)
+	if err != nil {
+		t.Fatalf("ParseContextBlock: %v", err)
+	}
+	if _, err := ResolveContext(block, dir); err == nil {
+		t.Fatal("expected path-traversal rejection, got nil")
+	}
+}
+
+// --- An {{ .ctx.<key> }} reference the block does not supply fails loudly.
+
+func TestBindContextIntoWorkflow_FailsOnUnresolvedKey(t *testing.T) {
+	wf := []byte("kind: Workflow\nspec:\n  prompt: \"{{ .ctx.missing }}\"\n")
+	if _, err := BindContextIntoWorkflow(wf, map[string]string{"diff": "x"}); err == nil {
+		t.Fatal("expected error for unresolved {{ .ctx.missing }}, got nil")
+	}
+}
+
+// --- The shipped code-review scenario fixture binds end-to-end: its declared
+// context block resolves, substitutes into the Workflow member's {{ .ctx.diff }},
+// and the bound member validates against the schema with no unresolved key.
+
+func TestScenarioFile_CodeReviewFixtureBindsAndValidates(t *testing.T) {
+	root := repoRoot(t)
+	idx := filepath.Join(root, "spec", "scenarios", "code-review", "scenario.yaml")
+	if _, err := os.Stat(idx); err != nil {
+		t.Skipf("fixture not present: %v", err)
+	}
+	schemaDir := filepath.Join(root, "spec", "schemas")
+
+	errs, err := ScenarioFile(idx, schemaDir)
+	if err != nil {
+		t.Fatalf("ScenarioFile: %v", err)
+	}
+	if len(errs) != 0 {
+		t.Fatalf("expected zero validation errors for the code-review fixture, got: %v", errs)
+	}
+
+	// Prove the diff actually lands in the bound workflow.
+	block, err := ParseContextBlock(idx)
+	if err != nil {
+		t.Fatalf("ParseContextBlock: %v", err)
+	}
+	values, err := ResolveContext(block, filepath.Dir(idx))
+	if err != nil {
+		t.Fatalf("ResolveContext: %v", err)
+	}
+	wf, err := os.ReadFile(filepath.Join(root, "spec", "scenarios", "code-review", "workflow.yaml")) //nolint:gosec // fixed repo-relative fixture path in a test
+	if err != nil {
+		t.Fatal(err)
+	}
+	bound, err := BindContextIntoWorkflow(wf, values)
+	if err != nil {
+		t.Fatalf("BindContextIntoWorkflow: %v", err)
+	}
+	if !strings.Contains(string(bound), "func Refund") {
+		t.Fatalf("bound workflow did not contain the injected diff content:\n%s", bound)
+	}
+	// No unresolved reference should remain in any scalar VALUE (comments, which
+	// are documentation, are intentionally not templated).
+	if scalarContainsTemplate(t, bound) {
+		t.Fatalf("a scalar value in the bound workflow still contains a {{ ... }} reference:\n%s", bound)
+	}
+}
+
+// scalarContainsTemplate reports whether any scalar string node in the YAML bytes
+// still contains a template reference (ignoring comments).
+func scalarContainsTemplate(t *testing.T, raw []byte) bool {
+	t.Helper()
+	var root yaml.Node
+	if err := yaml.Unmarshal(raw, &root); err != nil {
+		t.Fatalf("re-parse bound YAML: %v", err)
+	}
+	return anyScalarHasTemplate(&root)
+}
+
+func anyScalarHasTemplate(n *yaml.Node) bool {
+	if n.Kind == yaml.ScalarNode && strings.Contains(n.Value, "{{") {
+		return true
+	}
+	for _, c := range n.Content {
+		if anyScalarHasTemplate(c) {
+			return true
+		}
+	}
+	return false
+}
+
+// --- No context block declared → (nil, nil); binding is a no-op.
+
+func TestParseContextBlock_NoBlock(t *testing.T) {
+	idx := writeIndex(t, validIndex)
+	block, err := ParseContextBlock(idx)
+	if err != nil {
+		t.Fatalf("ParseContextBlock: %v", err)
+	}
+	if block != nil {
+		t.Fatalf("expected nil block when none declared, got %+v", block)
+	}
+}

--- a/cmd/zynax/validate/dataflow.go
+++ b/cmd/zynax/validate/dataflow.go
@@ -25,7 +25,13 @@ func DataFlow(filePath string) ([]ValidationError, error) {
 	if err != nil {
 		return nil, fmt.Errorf("validate: read %q: %w", filePath, err)
 	}
+	return DataFlowBytes(filePath, raw)
+}
 
+// DataFlowBytes runs the state-machine data-flow checks over already-loaded
+// manifest bytes, attributing errors to filePath. It backs both DataFlow (file
+// on disk) and the context-bound validation path (#1387).
+func DataFlowBytes(filePath string, raw []byte) ([]ValidationError, error) {
 	var doc struct {
 		Kind string `yaml:"kind"`
 		Spec struct {
@@ -41,7 +47,7 @@ func DataFlow(filePath string) ([]ValidationError, error) {
 		// Structural/YAML errors are surfaced by Manifest's schema pass; skip here.
 		return nil, nil //nolint:nilerr // schema validation owns parse-error reporting
 	}
-	if doc.Kind != "Workflow" {
+	if doc.Kind != kindWorkflow {
 		return nil, nil
 	}
 

--- a/cmd/zynax/validate/manifest.go
+++ b/cmd/zynax/validate/manifest.go
@@ -15,6 +15,10 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// kindWorkflow is the manifest kind whose members get context-injection binding
+// and data-flow validation (the only kind the CLI special-cases beyond schema).
+const kindWorkflow = "Workflow"
+
 // ValidationError is a single schema validation failure.
 type ValidationError struct {
 	File    string `json:"file"`
@@ -40,7 +44,14 @@ func Manifest(filePath, schemaDir string) ([]ValidationError, error) {
 	if err != nil {
 		return nil, fmt.Errorf("validate: read %q: %w", filePath, err)
 	}
+	return ManifestBytes(filePath, raw, schemaDir)
+}
 
+// ManifestBytes validates already-loaded manifest bytes against the JSON Schema
+// for its kind. filePath is used only for error attribution. It backs both
+// Manifest (file on disk) and the context-bound validation path (#1387), where
+// a Workflow's {{ .ctx.* }} references are rendered in memory before validation.
+func ManifestBytes(filePath string, raw []byte, schemaDir string) ([]ValidationError, error) {
 	var doc interface{}
 	if err := yaml.Unmarshal(raw, &doc); err != nil {
 		return single(filePath, "", "YAML parse error: "+err.Error()), nil
@@ -110,6 +121,24 @@ func File(filePath, schemaDir string) ([]ValidationError, error) {
 	return combined, nil
 }
 
+// FileBytes runs the full local validation pipeline (schema + data-flow) over
+// already-loaded manifest bytes, attributing every error to filePath. It backs
+// the context-bound Workflow validation path (#1387): the member's
+// {{ .ctx.* }} references are rendered in memory, then the rendered manifest is
+// validated as if it were on disk.
+func FileBytes(filePath string, raw []byte, schemaDir string) ([]ValidationError, error) {
+	schemaErrs, err := ManifestBytes(filePath, raw, schemaDir)
+	if err != nil {
+		return nil, err
+	}
+	flowErrs, err := DataFlowBytes(filePath, raw)
+	if err != nil {
+		return nil, err
+	}
+	combined := append(schemaErrs, flowErrs...) //nolint:gocritic // intentional new slice
+	return combined, nil
+}
+
 // compileSchema compiles a JSON Schema from an absolute file path.
 func compileSchema(absPath string) (*jsonschema.Schema, error) {
 	c := jsonschema.NewCompiler()
@@ -163,7 +192,7 @@ func normalise(v interface{}) interface{} {
 // kindToSchemaFile maps a manifest kind to its JSON Schema filename.
 func kindToSchemaFile(kind string) (string, error) {
 	switch kind {
-	case "Workflow":
+	case kindWorkflow:
 		return "workflow.schema.json", nil
 	case "AgentDef":
 		return "agent-def.schema.json", nil

--- a/cmd/zynax/validate/scenario.go
+++ b/cmd/zynax/validate/scenario.go
@@ -131,8 +131,32 @@ func ScenarioFile(indexPath, schemaDir string) ([]ValidationError, error) {
 		return single(indexPath, "/spec", err.Error()), nil
 	}
 
+	// Resolve the declarative context-injection block (#1387) once for the
+	// scenario: parse it (rejecting any routing/provider field — data-only),
+	// read its file sources, and apply the max_tokens cap. A block error is an
+	// index error.
+	block, err := ParseContextBlock(indexPath)
+	if err != nil {
+		return single(indexPath, "/spec/context", err.Error()), nil
+	}
+	values, err := ResolveContext(block, filepath.Dir(indexPath))
+	if err != nil {
+		return single(indexPath, "/spec/context", err.Error()), nil
+	}
+
 	var out []ValidationError
 	for _, m := range members {
+		// For a Workflow member, bind the resolved context into its
+		// {{ .ctx.* }} references and validate the BOUND manifest, so an
+		// unresolved key (one the block does not supply) fails validation.
+		if m.Kind == kindWorkflow {
+			memberErrs, err := validateBoundWorkflow(m.Path, schemaDir, values)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, memberErrs...)
+			continue
+		}
 		memberErrs, err := File(m.Path, schemaDir)
 		if err != nil {
 			return nil, err
@@ -140,6 +164,27 @@ func ScenarioFile(indexPath, schemaDir string) ([]ValidationError, error) {
 		out = append(out, memberErrs...)
 	}
 	return out, nil
+}
+
+// validateBoundWorkflow renders the Workflow member's {{ .ctx.* }} references
+// with the resolved context values and validates the result. When the member
+// declares no {{ .ctx.* }} references the binding is a no-op. A reference the
+// context block does not supply surfaces here as a bind error (the file is
+// reported so callers can locate it).
+func validateBoundWorkflow(path, schemaDir string, values map[string]string) ([]ValidationError, error) {
+	raw, err := os.ReadFile(path) //nolint:gosec // path is confined by ExpandScenario
+	if err != nil {
+		return nil, fmt.Errorf("scenario: read member %q: %w", path, err)
+	}
+	if !strings.Contains(string(raw), "{{") {
+		// No template references — validate the file as-is.
+		return File(path, schemaDir)
+	}
+	bound, err := BindContextIntoWorkflow(raw, values)
+	if err != nil {
+		return single(path, "/spec", err.Error()), nil
+	}
+	return FileBytes(path, bound, schemaDir)
 }
 
 // resolveMemberPath joins a member file to the scenario directory and rejects any

--- a/docs/scenarios/code-review.context.validation.md
+++ b/docs/scenarios/code-review.context.validation.md
@@ -1,0 +1,88 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+# Human-Validation Guide — Declarative context-injection (code-review)
+
+> **Story:** #1387 · **Canvas:** `docs/spdd/1387-context-injection/canvas.md` — O-step 4 & 5
+
+## Purpose
+Validates that a scenario injects **real content declaratively** through the
+`spec.context` block — the code-review demo reviews a git diff that lives in a
+**file**, bound into the workflow prompt via `{{ .ctx.diff }}`, with **no prompt
+hand-edit**. "Working" means you can swap in your own diff by editing one file and
+re-applying, and the run reviews exactly that diff.
+
+## Prerequisites
+- Docker Engine ≥ 24 running (`docker compose` v2).
+- The `zynax` CLI on PATH (`make install-cli`, then ensure `~/bin` is on PATH).
+- The demo model pulled once on the host: `ollama pull qwen2.5-coder:3b`.
+
+## Expected duration
+~5 minutes after the model is pulled.
+
+## Setup
+```bash
+# From the repo root. Confirm the scenario (and its context block) validates first:
+zynax validate spec/scenarios/code-review
+```
+
+## Steps
+1. Confirm the diff is injected from a file, not pasted in the workflow:
+   ```bash
+   cat spec/scenarios/code-review/workflow.yaml   # prompt references {{ .ctx.diff }}
+   cat spec/scenarios/code-review/scenario.yaml    # spec.context sources -> diff.patch
+   cat spec/scenarios/code-review/diff.patch        # the actual diff under review
+   ```
+2. Bring the scenario up end-to-end:
+   ```bash
+   export ZYNAX_API_URL=http://localhost:7080
+   zynax apply spec/scenarios/code-review
+   zynax result <run-id-printed-above>
+   ```
+3. **Inject your own diff with no prompt edit** — replace only the data file:
+   ```bash
+   git diff > spec/scenarios/code-review/diff.patch   # your own changes
+   zynax apply spec/scenarios/code-review
+   zynax result <new-run-id>
+   ```
+
+## Expected observable result
+```
+applying llm-agent (AgentDef)...
+agent_id: <id>
+applying review-workflow (Workflow)...
+run_id: <id>
+── review ──────────────────────────────────────────────
+<a non-empty review that refers to the SPECIFIC code in diff.patch
+ (e.g. the Refund/Charge functions in the shipped example)>
+────────────────────────────────────────────────────────
+```
+
+## Pass / fail criteria
+- [ ] **PASS** — `zynax validate spec/scenarios/code-review` exits 0 with the context block present.
+- [ ] **PASS** — the workflow prompt contains `{{ .ctx.diff }}` and **no** inline diff; the diff lives only in `diff.patch`.
+- [ ] **PASS** — the review refers to the actual functions in `diff.patch` (the injected content reached the model).
+- [ ] **PASS** — replacing `diff.patch` (Step 3) and re-applying reviews the **new** diff, with no edit to `workflow.yaml`.
+- [ ] **PASS** — a context block carrying a `provider`/`model`/`endpoint`/`url` field is rejected by `zynax validate` (data-only safeguard). Try it:
+  ```bash
+  # temporarily add `endpoint: http://evil` under spec.context, then:
+  zynax validate spec/scenarios/code-review   # MUST fail citing the forbidden field
+  ```
+- [ ] **FAIL** — any unresolved `{{ .ctx.* }}` reference, an empty review, or a routing field accepted silently.
+
+## Teardown
+```bash
+git checkout spec/scenarios/code-review/diff.patch   # restore the shipped example diff
+make demo-clean
+```
+
+## Troubleshooting
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| `context: ... is forbidden` | a routing field crept into `spec.context` | remove `provider`/`model`/`endpoint`/`url`; those belong in the AgentDef. |
+| `{{ .ctx.diff }}` left unresolved | the `diff` source key is missing or misnamed | confirm `spec.context.sources[].key` matches the `{{ .ctx.<key> }}` reference. |
+| `source file ... escapes the scenario directory` | a `files:` path used `../` or an absolute path | keep source files inside `spec/scenarios/code-review/`. |
+| review ignores the diff | the diff exceeded `max_tokens` and was truncated | raise `max_tokens` or shorten the diff. |
+
+## Feedback / bug reporting
+If validation fails, capture the exact command + full output, expected vs observed,
+and versions (`zynax version`, model `qwen2.5-coder:3b`). Open an issue referencing
+#1387 with the `area: spec` label.

--- a/docs/scenarios/context-injection.md
+++ b/docs/scenarios/context-injection.md
@@ -1,0 +1,114 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+# Declarative context-injection
+
+> **Story:** #1387 · **Canvas:** `docs/spdd/1387-context-injection/canvas.md` (approach A2)
+> **Schema:** `spec/schemas/context-injection.schema.json` · fills the reserved
+> `spec.context` slot of a Scenario index (`spec/schemas/scenario.schema.json`, #1385).
+
+Declare the content a scenario injects **once**, in its index — `zynax` injects it
+into your workflow, **bounded and isolated**. No hand-pasting a diff into a prompt,
+no re-pasting on every run.
+
+## Why
+
+Before #1387 the only way to ground a demo in real content was to paste it into the
+workflow action by hand:
+
+```yaml
+actions:
+  - capability: codereview
+    input:
+      prompt: |
+        Review the following git diff ...
+        ```diff
+        <the entire diff pasted by hand, re-pasted every run, unbounded>
+        ```
+```
+
+This mixes **instructions** (the prompt) with **data** (the diff), has no size
+bound, and must be edited by hand for every new input. The context block makes the
+injection **declarative**: name a file, set a budget, reference it from the prompt.
+
+## How it works
+
+1. A Scenario index declares a `spec.context` block: file-rooted `sources` plus a
+   `max_tokens` budget.
+2. A Workflow member references each source by key via the **existing**
+   `{{ .ctx.<key> }}` template surface (the same one workflow actions already use —
+   no new template engine).
+3. At `zynax apply` (and `zynax validate`) time the CLI reads each source's files,
+   applies the `max_tokens` cap, and binds the result into the Workflow's
+   `{{ .ctx.<key> }}` references **before** the member is submitted over the
+   existing `/api/v1/apply` REST path. Nothing new crosses the gRPC boundary.
+
+## Authoring shape
+
+```yaml
+# spec/scenarios/<name>/scenario.yaml  (kind: Scenario)
+spec:
+  members: [ ... ]
+  apply_order: [ ... ]
+  context:
+    sources:
+      - key: diff               # referenced as {{ .ctx.diff }}
+        files:
+          - diff.patch          # relative to the scenario directory
+      # multiple files are concatenated in declared order:
+      # - key: notes
+      #   files: [intro.md, details.md]
+    max_tokens: 8000            # hard cap on combined source content
+    overflow: truncate-oldest   # or: error
+```
+
+```yaml
+# the Workflow member references the key:
+actions:
+  - capability: codereview
+    input:
+      prompt: |
+        Review the following git diff ...
+        ```diff
+        {{ .ctx.diff }}
+        ```
+```
+
+| Field | Meaning |
+|-------|---------|
+| `sources[].key` | The context key; referenced as `{{ .ctx.<key> }}`. Lowercase alphanumeric, `_`/`-` internal. |
+| `sources[].files` | File paths **relative to the scenario directory**; concatenated in order. Absolute paths or paths escaping the directory are rejected. |
+| `max_tokens` | Hard cap on combined content (≈4 chars/token heuristic). Required. |
+| `overflow` | `truncate-oldest` (default) drops the earliest-declared sources first until the budget is met; `error` fails apply instead. |
+
+## The data-only rule (security)
+
+A context block is **strictly data-only** (ADR-013/ADR-035). It admits content
+sources and a budget **only**. It can **never** carry `provider`, `model`,
+`endpoint`, `url`, `base_url`, `api_key`, or any other field that could redirect
+*where or how* a capability runs — those live in `AgentDef`/overlay config and are
+never accepted from injected content. The CLI **rejects** any such field at compile
+time (both the JSON Schema and the compiler enforce this), so injected content can
+never repoint a capability at an attacker-controlled or paid provider.
+
+Two further guarantees:
+
+- **Bounded** — `max_tokens` caps the dispatched `input_payload`; injection can
+  never silently inflate the payload (ADR-028).
+- **Isolated** — one scenario's context is resolved from its own block only and
+  never reaches another scenario (ADR-028 strict isolation).
+
+## Validate locally
+
+```bash
+zynax validate spec/scenarios/code-review   # schema + per-member + context binding
+make validate-spec                          # CI-equivalent spec gate
+```
+
+`zynax validate` fails fast on: a routing/provider field in the block, a missing
+`max_tokens`, a source file that is missing or escapes the directory, or a
+`{{ .ctx.<key> }}` reference the block does not supply.
+
+## See also
+
+- `docs/scenarios/scenario-manifest.md` — the scenario manifest-set convention (#1385).
+- `docs/scenarios/code-review.context.validation.md` — human-validation guide for the worked example.
+- ADR-028 — the context-slice injection contract (`{files[], max_tokens}` + isolation).

--- a/spec/scenarios/code-review/diff.patch
+++ b/spec/scenarios/code-review/diff.patch
@@ -1,0 +1,17 @@
+diff --git a/payments.go b/payments.go
+--- a/payments.go
++++ b/payments.go
+@@ -7,5 +7,12 @@ func Charge(balanceCents, amountCents int) (int, error) {
+ 	if amountCents < 0 {
+ 		return balanceCents, errors.New("amount must be non-negative")
+ 	}
+-	return balanceCents - amountCents, nil
++	// Apply a 2% loyalty discount before charging.
++	discounted := amountCents - (amountCents / 50)
++	return balanceCents - discounted, nil
++}
++
++// Refund credits amountCents back to the account.
++func Refund(balanceCents, amountCents int) int {
++	return balanceCents + amountCents
+ }

--- a/spec/scenarios/code-review/scenario.yaml
+++ b/spec/scenarios/code-review/scenario.yaml
@@ -37,8 +37,17 @@ spec:
     - llm-agent
     - review-workflow
 
-  # RESERVED context-injection slot (#1387 owns the bounded-slice semantics).
-  # Data-only — never provider/model/endpoint/URL (ADR-013). The CLI does NOT
-  # evaluate these values yet; they are a documented pass-through placeholder.
+  # Declarative context-injection block (#1387, ADR-028 context-slice contract).
+  # Declares file-rooted content sources + a hard token budget; `zynax apply`
+  # binds each source into the Workflow member's {{ .ctx.<key> }} input template
+  # at apply time, applying the cap and overflow policy. STRICTLY DATA-ONLY
+  # (ADR-013/ADR-035) — never provider/model/endpoint/URL or any routing field;
+  # the CLI rejects such a field at compile time. One scenario's context never
+  # reaches another (strict isolation). See docs/scenarios/context-injection.md.
   context:
-    language: go
+    sources:
+      - key: diff
+        files:
+          - diff.patch
+    max_tokens: 8000
+    overflow: truncate-oldest

--- a/spec/scenarios/code-review/workflow.yaml
+++ b/spec/scenarios/code-review/workflow.yaml
@@ -6,8 +6,9 @@
 # member agent.yaml) over a git diff, then transitions to a terminal state.
 #
 # Never references the agent by name — only the capability (routing is the
-# platform's job, spec/AGENTS.md). The reserved scenario context slot (#1387)
-# will bind into this action's `input` Jinja2 templates once its semantics land.
+# platform's job, spec/AGENTS.md). The git diff under review is NOT pasted here:
+# it is injected declaratively via the scenario's context block (#1387) and bound
+# into this action's `input` through the {{ .ctx.diff }} template at apply time.
 # Validated by: make validate-spec (against spec/schemas/workflow.schema.json).
 
 kind: Workflow
@@ -35,23 +36,7 @@ spec:
               change looks risky, say why. End with an APPROVE or REQUEST-CHANGES verdict.
 
               ```diff
-              diff --git a/payments.go b/payments.go
-              --- a/payments.go
-              +++ b/payments.go
-              @@ -7,5 +7,12 @@ func Charge(balanceCents, amountCents int) (int, error) {
-               	if amountCents < 0 {
-               		return balanceCents, errors.New("amount must be non-negative")
-               	}
-              -	return balanceCents - amountCents, nil
-              +	// Apply a 2% loyalty discount before charging.
-              +	discounted := amountCents - (amountCents / 50)
-              +	return balanceCents - discounted, nil
-              +}
-              +
-              +// Refund credits amountCents back to the account.
-              +func Refund(balanceCents, amountCents int) int {
-              +	return balanceCents + amountCents
-               }
+              {{ .ctx.diff }}
               ```
       on:
         - event: codereview.completed

--- a/spec/schemas/context-injection.schema.json
+++ b/spec/schemas/context-injection.schema.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://zynax.io/schemas/context-injection/v1alpha1",
+  "title": "Zynax Context-Injection Block",
+  "description": "JSON Schema for a declarative context-injection block (issue #1387, ADR-028 context-slice contract). The block declares file-rooted content sources and a hard token budget; the CLI binds each source's content into a Workflow action's `input` through the EXISTING {{ .ctx.<key> }} Jinja2 template surface at apply/validate time. It is STRICTLY DATA-ONLY (ADR-013/ADR-035): it admits content sources and a budget only and MUST NEVER carry provider/model/endpoint/url or any field that redirects where or how a capability runs — those stay in AgentDef/overlay config and are never accepted from input_payload. This block fills the reserved `spec.context` slot of a Scenario index (#1385). See docs/scenarios/context-injection.md.",
+  "type": "object",
+  "required": ["sources", "max_tokens"],
+  "additionalProperties": false,
+  "properties": {
+    "sources": {
+      "type": "array",
+      "description": "The named content sources this block injects. Each source binds one context key to the concatenated contents of one or more files. The key is what a Workflow action references via {{ .ctx.<key> }}.",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/source"
+      }
+    },
+    "max_tokens": {
+      "type": "integer",
+      "description": "Hard cap on the total approximate token count of all injected sources combined. The CLI enforces this bound before binding; content beyond the cap is dropped per the overflow policy. Bounds the dispatched input_payload so injection can never be unbounded (ADR-028).",
+      "minimum": 1,
+      "maximum": 1000000
+    },
+    "overflow": {
+      "type": "string",
+      "description": "What the CLI does when the combined source content exceeds max_tokens. 'truncate-oldest' (default) drops content from the earliest-declared sources first until the budget is met. 'error' fails validation/apply instead of truncating.",
+      "enum": ["truncate-oldest", "error"],
+      "default": "truncate-oldest"
+    }
+  },
+  "$defs": {
+    "source": {
+      "type": "object",
+      "description": "One named context source: a key plus the file(s) whose contents become its value. Sources are file-rooted, not inline bodies, so injection is declarative and re-runnable.",
+      "required": ["key", "files"],
+      "additionalProperties": false,
+      "properties": {
+        "key": {
+          "type": "string",
+          "description": "The context key bound by this source. A Workflow action references it as {{ .ctx.<key> }}. Lowercase alphanumeric with single internal hyphens/underscores.",
+          "minLength": 1,
+          "maxLength": 128,
+          "pattern": "^[a-z0-9]([a-z0-9_-]*[a-z0-9])?$"
+        },
+        "files": {
+          "type": "array",
+          "description": "Paths to the files whose contents source this key, relative to the directory containing the scenario index. Multiple files are concatenated in declared order. A path MUST NOT be absolute or escape the scenario directory (enforced by the CLI).",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[^/].*$"
+          }
+        }
+      }
+    }
+  }
+}

--- a/spec/schemas/scenario.schema.json
+++ b/spec/schemas/scenario.schema.json
@@ -110,8 +110,56 @@
     },
     "context": {
       "type": "object",
-      "description": "RESERVED context-injection slot. #1385 provides only the wiring placeholder; the bounded {files[], max_tokens} slice semantics and strict isolation are owned by issue #1387 (ADR-028). The slot may carry DATA ONLY — never provider/model/endpoint/URL or any field that redirects where a capability runs (ADR-013). Values declared here are intended to bind into a Workflow action's `input` Jinja2 {{ .ctx.* }} templates once #1387 lands; until then they are a documented pass-through and are NOT evaluated by the CLI.",
-      "additionalProperties": true
+      "description": "Declarative context-injection block (#1387, ADR-028 context-slice contract). Declares file-rooted content sources and a hard token budget; the CLI binds each source into the scenario's Workflow action `input` through the EXISTING {{ .ctx.<key> }} Jinja2 template surface at apply/validate time, applying the max_tokens cap and the overflow policy. STRICTLY DATA-ONLY (ADR-013/ADR-035): it admits content sources and a budget only and MUST NEVER carry provider/model/endpoint/url or any routing-redirecting field. Shape mirrors spec/schemas/context-injection.schema.json. One scenario's context never reaches another (strict isolation).",
+      "required": ["sources", "max_tokens"],
+      "additionalProperties": false,
+      "properties": {
+        "sources": {
+          "type": "array",
+          "description": "The named content sources this block injects. Each binds one context key to the concatenated contents of one or more files referenced via {{ .ctx.<key> }}.",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/contextSource"
+          }
+        },
+        "max_tokens": {
+          "type": "integer",
+          "description": "Hard cap on the total approximate token count of all injected sources combined; bounds the dispatched input_payload (ADR-028).",
+          "minimum": 1,
+          "maximum": 1000000
+        },
+        "overflow": {
+          "type": "string",
+          "description": "Policy when combined content exceeds max_tokens: 'truncate-oldest' (default) drops earliest-declared sources first; 'error' fails apply.",
+          "enum": ["truncate-oldest", "error"],
+          "default": "truncate-oldest"
+        }
+      }
+    },
+    "contextSource": {
+      "type": "object",
+      "description": "One named context source: a key plus the file(s) whose contents become its value. File-rooted, not inline bodies.",
+      "required": ["key", "files"],
+      "additionalProperties": false,
+      "properties": {
+        "key": {
+          "type": "string",
+          "description": "The context key bound by this source, referenced as {{ .ctx.<key> }}.",
+          "minLength": 1,
+          "maxLength": 128,
+          "pattern": "^[a-z0-9]([a-z0-9_-]*[a-z0-9])?$"
+        },
+        "files": {
+          "type": "array",
+          "description": "Paths to the files sourcing this key, relative to the scenario directory; concatenated in declared order. Must not be absolute or escape the directory (CLI-enforced).",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[^/].*$"
+          }
+        }
+      }
     }
   }
 }

--- a/spec/tests/features/context_injection.feature
+++ b/spec/tests/features/context_injection.feature
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: Apache-2.0
+# Zynax — Declarative Context-Injection BDD Contract
+#
+# This file is the SPECIFICATION. It is written BEFORE the implementation
+# (ADR-016). It describes what the context-injection block must enforce and how
+# `zynax apply`/`zynax validate` bind a scenario's declared context into a
+# Workflow action's input through the EXISTING {{ .ctx.* }} template surface.
+# See spec/AGENTS.md for spec governance and
+# docs/spdd/1387-context-injection/canvas.md for the A2 approach.
+#
+# Business context: today a demo grounds itself by hand-pasting a git diff into a
+# workflow prompt — unbounded, mixed with instructions, re-pasted every run.
+# #1387 makes that injection DECLARATIVE: a scenario declares file-rooted content
+# sources and a token budget once; the CLI binds them into {{ .ctx.<key> }}
+# references, bounded and isolated. The block is STRICTLY DATA-ONLY (ADR-013/035)
+# — it can never carry provider/model/endpoint/URL or any routing-redirecting
+# field. It fills the reserved spec.context slot of a Scenario index (#1385).
+
+Feature: Declarative context-injection block for demo scenarios
+  As a scenario author
+  I want to declare the content my scenario injects, bounded and data-only
+  So that `zynax apply` grounds the run in real content with no prompt hand-edit
+
+  Background:
+    Given the JSON Schema at "spec/schemas/context-injection.schema.json" is loaded
+
+  # ─── Valid block + substitution ─────────────────────────────────────────────
+
+  Scenario: A valid context block compiles and substitutes into {{ .ctx.* }}
+    Given a scenario whose spec.context declares a source key "diff" sourced from "diff.patch"
+    And the block declares a max_tokens budget
+    And the scenario's Workflow action input references "{{ .ctx.diff }}"
+    When the scenario is validated and applied
+    Then the file content is bound into the action input in place of {{ .ctx.diff }}
+    And no template reference remains unresolved
+
+  Scenario: A reference the block does not supply fails fast
+    Given a scenario Workflow that references "{{ .ctx.absent }}"
+    And the context block declares no source with key "absent"
+    When the scenario is validated
+    Then validation fails because the {{ .ctx.absent }} reference is unresolved
+
+  # ─── Data-only safeguard (load-bearing) ─────────────────────────────────────
+
+  Scenario: A context block carrying a routing field is rejected at compile time
+    Given a context block whose source also declares a "provider" field
+    When the block is parsed
+    Then it is rejected because a context block is data-only and may never carry provider/model/endpoint/URL
+
+  Scenario Outline: Each routing-redirecting field is forbidden
+    Given a context block that declares a "<field>" field
+    When the block is parsed
+    Then the block is rejected citing the forbidden "<field>" field
+
+    Examples:
+      | field    |
+      | provider |
+      | model    |
+      | endpoint |
+      | url      |
+      | base_url |
+      | api_key  |
+
+  Scenario: An unknown top-level field is rejected
+    Given a context block that declares a "language" field
+    When the block is parsed
+    Then it is rejected because a context block carries sources/max_tokens/overflow only
+
+  # ─── Bounds enforcement ─────────────────────────────────────────────────────
+
+  Scenario: An over-budget block is truncated oldest-first deterministically
+    Given a context block whose combined sources exceed max_tokens
+    And the overflow policy is "truncate-oldest"
+    When the block is resolved
+    Then the earliest-declared sources are dropped first until the budget is met
+
+  Scenario: An over-budget block with overflow error fails resolution
+    Given a context block whose combined sources exceed max_tokens
+    And the overflow policy is "error"
+    When the block is resolved
+    Then resolution fails citing the exceeded max_tokens budget
+
+  # ─── Isolation & containment ────────────────────────────────────────────────
+
+  Scenario: One scenario's context never reaches another
+    Given two scenarios that each declare a context key "diff" from different files
+    When both blocks are resolved
+    Then each scenario sees only its own content and never the other's
+
+  Scenario: A source file that escapes the scenario directory is rejected
+    Given a context block whose source file is "../../etc/passwd"
+    When the block is resolved
+    Then resolution fails because source files must stay within the scenario directory

--- a/spec/workflows/examples/code-review-ollama.yaml
+++ b/spec/workflows/examples/code-review-ollama.yaml
@@ -14,6 +14,13 @@
 # Run:
 #   zynax apply spec/workflows/examples/code-review-ollama.yaml
 #   zynax logs <run-id> --follow
+#
+# This standalone example inlines the diff by hand (the pre-#1387 way). For the
+# DECLARATIVE alternative — inject your own diff from a file, bounded and
+# isolated, with no prompt hand-edit — apply the scenario instead:
+#   zynax apply spec/scenarios/code-review
+# which binds spec/scenarios/code-review/diff.patch into {{ .ctx.diff }} via the
+# scenario's context-injection block (docs/scenarios/context-injection.md).
 
 kind: Workflow
 apiVersion: zynax.io/v1


### PR DESCRIPTION
## feat(context): declarative context-injection (context: block)

Closes #1387
Part of #1370 (EPIC — awesome-quickstart / first-run UX), canvas O-steps O1–O5

### Why
Today the only way to ground a demo scenario in real content is to hand-paste it
into the workflow action — unbounded, mixed with instructions, re-pasted every
run. #1387 makes that injection **declarative**: a scenario declares file-rooted
content sources and a token budget once, and `zynax` binds them into the workflow
through the existing `{{ .ctx.* }}` template surface. This gives #1385's reserved
`spec.context` slot real, bounded semantics (approach A2).

### What you'll get  (deliverables ↔ what changed)
- A bounded, data-only `context:` block schema (`{sources[], max_tokens, overflow}`) ← `spec/schemas/context-injection.schema.json`
- The reserved `spec.context` slot now carries the real bounded shape (was pass-through) ← `spec/schemas/scenario.schema.json`
- `zynax apply`/`validate` read file sources, cap at `max_tokens`, reject routing fields, and bind into `{{ .ctx.<key> }}` ← `cmd/zynax/validate/context.go`, `cmd/zynax/cmd/apply.go`, `cmd/zynax/validate/scenario.go`
- The code-review scenario injects a real git diff from a file, no prompt hand-edit ← `spec/scenarios/code-review/{scenario,workflow}.yaml`, `diff.patch`
- BDD contract committed before impl (ADR-016) ← `spec/tests/features/context_injection.feature`
- Authoring guide + human-validation guide ← `docs/scenarios/context-injection.md`, `docs/scenarios/code-review.context.validation.md`

### Scope & boundaries
- **In scope:** the declarative `context:` block schema, its bounded `{sources[], max_tokens}` semantics + strict isolation, the data-only compile-time rejection of provider/model/endpoint/URL, client-side binding into the existing `{{ .ctx.* }}` surface at apply/validate, the code-review worked example, and docs.
- **Out of scope (deferred):** widening ADR-029 `input_bindings` for external context (A1, **REJECTED** in canvas) · any new proto field on the dispatch path (A2 is template-surface only) · a new template/expression language · the scenario manifest-set convention itself (#1385 owns it).

### Test plan & acceptance

| Acceptance criterion | How verified (command) | Result |
|----------------------|------------------------|--------|
| Valid `context:` compiles + substitutes into `{{ .ctx.* }}` | `GOWORK=off go -C cmd/zynax test ./validate/... -run ValidBlockSubstitutes\|CodeReviewFixture` | ✅ diff content bound into `{{ .ctx.diff }}`, no unresolved ref |
| A `context:` with provider/model/endpoint/URL is REJECTED at compile time | `... -run RejectsRoutingFields\|RoutingFieldInSource` | ✅ rejected, error cites the forbidden field |
| `max_tokens` cap enforced | `... -run TruncatesOldestOverBudget\|ErrorOverflow` | ✅ truncate-oldest drops earliest first; `error` policy fails |
| No imperative edits (declarative injection) | code-review scenario references `{{ .ctx.diff }}`; diff lives in `diff.patch` | ✅ swap `diff.patch`, re-apply, no `workflow.yaml` edit |
| Strict scenario isolation | `... -run IsolatesScenarios` | ✅ no cross-scenario leakage |
| Source path traversal rejected | `... -run RejectsPathTraversal` | ✅ `../../etc/passwd` rejected |
| Ships a human-validation guide | `docs/scenarios/code-review.context.validation.md` | ✅ added |

**Local gates:** `gofmt` ✅ · `golangci-lint` (pre-commit) ✅ · `GOWORK=off go -C cmd/zynax test ./... -race` ✅ · `zynax-ci validate schema spec/schemas/` ✅ (the exact check CI runs)

### Evidence
- **CI:** required checks expected green (conventional-commit, canvas-freshness, spec well-formedness, go tests for cmd/zynax).
- **Local output:** `ok github.com/zynax-io/zynax/cmd/zynax/validate 1.098s`; all 7 schemas pass `zynax-ci validate schema`, including the new `context-injection.schema.json` and updated `scenario.schema.json`.
- **Artifacts / images:** none — no platform service source changed (CLI + spec + docs only).
- **Post-merge digest sync → main:** _placeholder — post-merge verifier fills after the release pipeline runs._

### Risk & rollback
Low — additive and client-side. No proto/gRPC contract change, no api-gateway endpoint, no behaviour change to existing single-manifest applies. Binding only activates for scenarios that declare a `spec.context` block; absent a block, behaviour is unchanged. Rollback = revert this PR.

> **Note:** `make validate-spec`'s `validate-scenario-schema` step currently fails locally with `unknown flag: --schema-dir` — this is **pre-existing digest drift** (the pinned `tools:latest` image predates #1385/PR #1454 which added the flag) and is unrelated to this PR. The actual scenario/workflow validation passes with a source-built `zynax-ci` (verified). CI does not run `make validate-spec`; it runs `zynax-ci validate schema spec/schemas/`, which is green here.

### Review aids
Suggested reading order: (1) `spec/schemas/context-injection.schema.json` — the contract; (2) `cmd/zynax/validate/context.go` — the **one key file** (parse → data-only reject → resolve+cap → bind via the same `text/template` engine engine-adapter uses); (3) `cmd/zynax/validate/scenario.go` + `apply.go` — wiring; (4) the scenario fixtures. Subtlety: binding operates on the parsed YAML tree (per-scalar render), not raw bytes, so an injected multi-line diff stays valid YAML.

**SPDD:** Canvas `docs/spdd/1387-context-injection/canvas.md` Aligned (A2); security-review PASS (data-only safeguard enforced).
**AI:** `Assisted-by: Claude/Opus 4.8`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
