### PR TITLE
docs(adr): reject ADR-037; lightweight Temporal eval profile (#1456)

### DIFF
--- a/docs/adr/ADR-037-zero-temporal-evaluation-engine.md
+++ b/docs/adr/ADR-037-zero-temporal-evaluation-engine.md
@@ -1,6 +1,7 @@
 # ADR-037: Zero-Temporal in-process evaluation engine
 
-**Status:** Proposed  **Date:** 2026-06-19
+**Status:** Rejected  **Date:** 2026-06-19
+**Rejected:** 2026-06-19 — superseded by #1456 (lightweight Temporal eval profile); see Update below.
 **Related:** ADR-015 (pluggable workflow engines — this adds a third engine behind the same
 port), ADR-012 (Workflow IR — the engine-agnostic IR this engine interprets), ADR-014
 (event-driven state machine), ADR-034 (deterministic ManifestWorkflowID), ADR-022 (EventBusService)
@@ -59,7 +60,8 @@ compiled `WorkflowIR` **in-process** for evaluation, selectable via
 
 | Option | Assessment |
 |--------|------------|
-| **In-process eval engine behind `WorkflowEngine`** | ✅ **Chosen** — reuses the already-pure `IRInterpreter` and the existing capability path; minimal new code; respects ADR-015; removes the heaviest Day-0 prerequisite while keeping a clean graduation path to durable engines. |
+| **In-process eval engine behind `WorkflowEngine`** | ✗ **Deferred** — Sound, but only strictly needed for a *zero-Docker, zynax-binary-only* run. For the compose Day-0 path a stripped Temporal profile (next row) achieves the same with no new engine to maintain. |
+| Lightweight Temporal profile — `temporal server start-dev` (in-memory, no external DB) + retries off (`ZYNAX_ENGINE_MAX_ACTIVITY_ATTEMPTS=1`) | ✅ **Chosen (#1456)** — Config-only: a compose overlay + 2 existing env vars, ZERO new engine code, reuses the proven `TemporalEngine`. Removes the database (the real Day-0 weight: today Temporal = auto-setup + dedicated Postgres + UI) and gives eval-grade fail-fast behavior. No semantic-drift risk. |
 | Embedded Temporal / Templite (in-process Temporal-lite) | ✗ Rejected — heavier dependency surface, replay/persistence semantics we explicitly do not want for an evaluation engine, and a larger maintenance burden than the few hundred lines this engine needs. |
 | Require Temporal (status quo — "do nothing") | ✗ Rejected — leaves the top adoption barrier in place; evaluators bounce before the first workflow runs. |
 | Shell out to an external lightweight runner | ✗ Rejected — adds a process/IPC boundary and a new artifact to ship and version, for no benefit over an in-process Go implementation behind the existing port. |
@@ -80,3 +82,23 @@ compiled `WorkflowIR` **in-process** for evaluation, selectable via
 - **Neutral / follow-up required:** add an `eval` reference leg to the e2e-smoke matrix (no
   Temporal/Argo control plane), update the unsupported-engine error to list `eval`, and document
   the evaluation-vs-production boundary. No proto, YAML, or persistence-schema changes.
+
+---
+
+## Update — 2026-06-19 (Rejected)
+
+This ADR's original alternatives analysis omitted a **stripped Temporal profile**: Temporal's
+official `temporal server start-dev` runs an embedded in-memory database (no external Postgres),
+and retries are already a config knob (`ZYNAX_ENGINE_MAX_ACTIVITY_ATTEMPTS=1`,
+`services/engine-adapter/cmd/engine-adapter/main.go:80`). The engine-adapter is a Temporal *client*
+that simply dials `ZYNAX_ENGINE_ADAPTER_TEMPORAL_HOST_PORT` (`main.go:68`), so pointing it at a
+dev-server is a compose change, not code.
+
+That option (tracked as **#1456**) achieves the Day-0 goal — no external database, evaluation-grade
+fail-fast behavior — by **reusing the proven `TemporalEngine` with ~zero new code and nothing new to
+maintain**, and with no eval-vs-production semantic-drift risk. It therefore dominates a third
+in-process engine for the Docker/compose path.
+
+**Decision:** Rejected. The in-process `EvalEngine` is **deferred** — revisit only if a truly
+zero-Docker, `zynax`-binary-only run (no container at all) becomes a requirement. Issues #1359 and
+its stories #1449–#1452 are closed as superseded by #1456.

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -47,7 +47,7 @@ a PR against `docs/adr/`.
 | [ADR-034](ADR-034-manifest-workflow-id-collision-domain.md) | ManifestWorkflowID 64-bit collision domain + canonicalization stability | Proposed | 2026-06-15 | workflow-compiler — M7 EPIC Q (#583) |
 | [ADR-035](ADR-035-adapter-language-boundary.md) | Adapter language boundary — Go for provider/proxy adapters, Python for AI-framework adapters | Accepted | 2026-06-16 | `agents/adapters/*` — refines ADR-009 — M7 EPIC P (#1276) |
 | [ADR-036](ADR-036-ci-logic-as-go-cli.md) | CI logic belongs in a tested Go CLI (zynax-ci), not inline workflow bash | Accepted | 2026-06-16 | `cmd/zynax-ci/`, `.github/workflows/*`, `scripts/`, `Makefile` — M7 EPIC S (#1285) |
-| [ADR-037](ADR-037-zero-temporal-evaluation-engine.md) | Zero-Temporal in-process evaluation engine (Day-0 onboarding) | Proposed | 2026-06-19 | `services/engine-adapter/` — third engine behind ADR-015 — M7 (#1359) |
+| [ADR-037](ADR-037-zero-temporal-evaluation-engine.md) | Zero-Temporal in-process evaluation engine (Day-0 onboarding) | Rejected | 2026-06-19 | `services/engine-adapter/` — third engine behind ADR-015 — M7 (#1359) (superseded by #1456) |
 
 ---
 

--- a/docs/spdd/1359-zero-temporal-engine/canvas.md
+++ b/docs/spdd/1359-zero-temporal-engine/canvas.md
@@ -7,7 +7,7 @@
 **Issue:** #1359
 **Author:** Oscar Gómez Manresa
 **Date:** 2026-06-19
-**Status:** Aligned (v1 — maintainer-authorized 2026-06-19; scoped into M7 per operator decision)
+**Status:** Superseded (2026-06-19) — by #1456 (lightweight Temporal eval profile); ADR-037 Rejected. In-process EvalEngine deferred to a zero-Docker path.
 **Aligned:** 2026-06-19 (maintainer-authorized; grounded in the live engine-adapter code at `services/engine-adapter/`)
 **ADR:** [ADR-037](../../adr/ADR-037-zero-temporal-evaluation-engine.md) (Proposed — awaits maintainer Accept before `/deliver`)
 


### PR DESCRIPTION
## Summary

ADR-037 (in-process EvalEngine for Day-0) is **Rejected** in favor of **#1456**: a
stripped Temporal profile that runs `temporal server start-dev` (in-memory, no
external Postgres) with retries off (`ZYNAX_ENGINE_MAX_ACTIVITY_ATTEMPTS=1`). That
option is config-only — a compose overlay plus 2 existing env vars — with ZERO new
engine code, reusing the proven `TemporalEngine`. It removes the real Day-0 weight
(the database) and gives eval-grade fail-fast behavior with no semantic-drift risk.

## Changes (docs-only, 3 files)

- `docs/adr/ADR-037-...md` — Status -> Rejected; rationale table updated (in-process
  engine deferred, lightweight Temporal profile chosen); Update section added.
- `docs/adr/INDEX.md` — ADR-037 row Proposed -> Rejected (superseded by #1456).
- `docs/spdd/1359-zero-temporal-engine/canvas.md` — Status -> Superseded; body kept
  as historical record.

#1359 and its stories #1449-#1452 are closed as superseded by #1456. The in-process
EvalEngine is deferred to a future zero-Docker, `zynax`-binary-only path.

Refs #1456 #1359
