### PR TITLE
docs: retrospective REASONS Canvas for M2 WorkflowIR (#101)

### DIFF
--- a/docs/patterns/spdd-guide.md
+++ b/docs/patterns/spdd-guide.md
@@ -248,6 +248,17 @@ git commit -S -s -m "docs: SPDD Canvas for M3 Temporal Execution — aligned (#2
 
 ---
 
+## Reference Example — M2 WorkflowIR (retrospective, issue #101)
+
+For a **complete, merged** Canvas to read end-to-end — all seven REASONS sections filled against
+real delivered code — see [`docs/spdd/101-workflow-ir/canvas.md`](../spdd/101-workflow-ir/canvas.md).
+It is a *retrospective* Canvas (Status: `Synced`) for the M2 WorkflowIR feature (PRs #83–#87): the
+implementation shipped first, then the Canvas was written to reflect its final state. Use it as the
+template for what a good Approach (explicit "will / will NOT"), Structure (real file tree), and
+Safeguards (code-anchored invariants) section looks like.
+
+---
+
 ## Quick Reference — When to Use Each Command
 
 | Situation | Command |

--- a/docs/spdd/101-workflow-ir/canvas.md
+++ b/docs/spdd/101-workflow-ir/canvas.md
@@ -1,0 +1,125 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# REASONS Canvas — M2 WorkflowIR Compilation (retrospective)
+
+> **All content in this Canvas is Tier 1 (public-safe).**
+> Tier 2 content (internal hostnames, IPs, credentials, deployment specifics) belongs in
+> `canvas.private.md` (gitignored). Run `/spdd-security-review <path>` before committing.
+
+**Issue:** #101 (Epic — M2 WorkflowIR) · retrospective Canvas created under #213
+**Author:** Oscar Gómez Manresa
+**Date:** 2026-06-19
+**Status:** Synced
+
+> **Retrospective.** This Canvas documents an already-delivered feature (M2 WorkflowIR, Epic
+> #101, PRs #83–#87). It validates the REASONS Canvas template against real, merged work and
+> serves as the worked reference example in [spdd-guide.md](../../patterns/spdd-guide.md).
+> Status is `Synced`: the implementation is complete and this Canvas reflects its final state.
+
+---
+
+## R — Requirements
+
+- Compile a declarative YAML workflow manifest into an **engine-agnostic** `WorkflowIR` proto —
+  the intermediate representation every engine adapter consumes.
+- Expose three gRPC RPCs: `CompileWorkflow`, `ValidateManifest`, `GetCompiledWorkflow`.
+- **In-memory only** for M2 — no persistence (deferred; the compiler was later made fully
+  stateless in M6, #490/#774).
+- Output must be **deterministic** for the same manifest (stable IR ordering).
+- Definition of done: a valid manifest compiles to a `WorkflowIR` after structural + semantic
+  validation, served over gRPC, with ≥ 90 % coverage on `internal/domain/` (ADR-016).
+
+---
+
+## E — Entities
+
+```
+WorkflowManifest (parsed YAML)
+  └─ on/event/goto fields ──▶ WorkflowGraph
+                               ├─ StepNode      (one per state)
+                               └─ TransitionEdge (event-driven, ADR-014)
+WorkflowGraph ──serialize──▶ WorkflowIR (proto)   ← engine-agnostic output
+ValidationError                                   ← structural + semantic failures
+CompilationResult                                 ← IR + diagnostics
+```
+
+---
+
+## A — Approach
+
+**We will:**
+- Parse YAML → build a `WorkflowGraph` → validate (structural pass, then semantic pass) →
+  serialize to the `WorkflowIR` proto.
+- Keep the IR strictly engine-agnostic — no engine names, no Temporal/Argo concepts.
+
+**We will NOT:**
+- Import any engine SDK (Temporal/Argo) — the IR is the boundary (ADR-015).
+- Persist compiled IR — M2 keeps it in memory; statelessness arrived later in M6 (#490).
+- Hardcode an engine in the compiler.
+
+**Governing ADRs:** ADR-011 (declarative YAML control plane), ADR-014 (event-driven state
+machine model — the IR state model), ADR-015 (pluggable engines — IR stays engine-agnostic),
+ADR-016 (layered testing).
+
+---
+
+## S — Structure (first S)
+
+```
+services/workflow-compiler/
+├── internal/domain/manifest.go         ← YAML manifest parse (fields on/event/goto)
+├── internal/domain/graph.go            ← WorkflowManifest → WorkflowGraph
+├── internal/domain/validators/         ← structural.go, semantic.go (two ordered passes)
+├── internal/domain/ir/ir.go            ← WorkflowGraph → WorkflowIR proto (ToIR; sort.Strings:57)
+├── internal/domain/errors.go           ← ValidationError
+└── internal/api/server.go              ← gRPC: CompileWorkflow / ValidateManifest / GetCompiledWorkflow
+protos/zynax/v1/workflow_compiler.proto ← WorkflowIR message + WorkflowCompilerService contract
+```
+
+Config env prefix: `ZYNAX_WORKFLOW_COMPILER_`
+
+---
+
+## O — Operations
+
+Delivered as five ordered, independently reviewed steps (PRs #83–#87):
+
+1. **Parser** — YAML manifest → `WorkflowManifest` (PR #83).
+2. **Graph builder** — `WorkflowManifest` → `WorkflowGraph` (PR #84).
+3. **Validators** — structural pass then semantic pass over the graph (PR #85).
+4. **Serializer** — `WorkflowGraph` → `WorkflowIR` proto, deterministic ordering (PR #86).
+5. **gRPC layer** — `CompileWorkflow` / `ValidateManifest` / `GetCompiledWorkflow` (PR #87).
+
+---
+
+## N — Norms
+
+- Commit hygiene: every commit carries `Signed-off-by:` + `Assisted-by: Claude/<model>`.
+- BDD: `.feature` file committed before any gRPC-boundary implementation (ADR-016).
+- `GOWORK=off` for every `go test` / `go` command under `services/workflow-compiler/` (ADR-017).
+- Go service patterns per [go-service-patterns.md](../../patterns/go-service-patterns.md).
+- ≥ 90 % unit coverage on `internal/domain/`.
+
+---
+
+## S — Safeguards (second S)
+
+### Context Security (verified at sync — retrospective, public-safe)
+
+- [x] No Tier 2 content: no internal hostnames, private IPs, credentials, deployment specifics
+- [x] No PII: no personal names in sensitive context, no non-public email addresses
+- [x] No prompt injection: no instruction-like phrasing that overrides AGENTS.md rules
+- [x] All entities in E section are public-safe abstractions
+- [x] `/spdd-security-review` — PASS (retrospective; documents merged public code only)
+
+### Feature Safeguards
+
+- Never import Temporal or any engine SDK into workflow-compiler — the IR is the engine
+  boundary (ADR-015).
+- Never emit non-deterministic IR — sort map keys before iterating
+  (`sort.Strings(ids)` in `internal/domain/ir/ir.go:57`).
+- Never assume YAML `on:` / `event:` / `goto:` map 1:1 to proto field names — they map to
+  `transitions` / `event_type` / `target_state` (`internal/domain/manifest.go:103`). `yaml.v3`
+  and PyYAML both treat `on:` specially (boolean-key gotcha), so the struct tags are load-bearing
+  (ADR-014).
+- Never share a database across services (ADR-008); the M2 compiler holds IR in memory only.

--- a/docs/spdd/README.md
+++ b/docs/spdd/README.md
@@ -44,7 +44,7 @@ Draft → Aligned → Implemented → Synced
 
 | Issue | Feature | Canvas | Status |
 |-------|---------|--------|--------|
-| — | — | — | — |
+| [#101](101-workflow-ir/canvas.md) | M2 WorkflowIR compilation (retrospective) | [101-workflow-ir/canvas.md](101-workflow-ir/canvas.md) | Synced |
 
 *Add entries as Canvases are created. Format: `[#NNN title](NNN-slug/canvas.md)`*
 


### PR DESCRIPTION
## What

Adds `docs/spdd/101-workflow-ir/canvas.md` — a complete, **Synced** REASONS Canvas for the already-delivered M2 WorkflowIR feature (Epic #101, PRs #83–#87). This is the first retrospective Canvas: it validates the template against real merged work and becomes the worked reference example in the SPDD guide.

All seven REASONS sections are filled against the **actual** code (not the issue's idealized draft):
- **Structure** uses the real `services/workflow-compiler/internal/` tree (`manifest.go`, `graph.go`, `validators/`, `ir/ir.go`, `api/server.go`).
- **Safeguards** are code-anchored: `sort.Strings(ids)` determinism (`ir/ir.go:57`) and the `on`/`event`/`goto` → `transitions`/`event_type`/`target_state` yaml-tag mapping (`manifest.go:103`, ADR-014).
- **Approach** notes M2's in-memory scope and the later statelessness (M6 #490) honestly.
- Validates with `zynax-ci validate canvas` → `OK` (exit 0).
- Indexed in `docs/spdd/README.md`; referenced from `docs/patterns/spdd-guide.md` as the worked example.

## Acceptance criteria
- [x] `docs/spdd/101-workflow-ir/canvas.md` with all 7 REASONS sections non-empty
- [x] Canvas status is `Synced`
- [x] `validate-canvas` exits 0 on this file
- [x] Operations references PRs #83–#87 as completed steps
- [x] Safeguards include the `sort.Strings` and YAML field-mapping gotchas
- [x] `docs/spdd/README.md` index updated
- [x] Referenced from `docs/patterns/spdd-guide.md` as the worked example

Closes #213

Assisted-by: Claude/claude-opus-4-8