### PR TITLE
chore(infra): lightweight Temporal eval profile (in-memory start-dev)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,11 @@ BENCH_BASELINE := tools/bench-baseline.txt
 AGENTS        := $(shell find agents/examples -maxdepth 2 -name pyproject.toml -exec dirname {} \; 2>/dev/null | xargs -rI{} basename {} | sort)
 COMPOSE          := docker compose -f infra/docker-compose/docker-compose.yml
 COMPOSE_DEMO     := docker compose -f infra/docker-compose/docker-compose.yml -f infra/docker-compose/docker-compose.ollama.yml
+# Opt-in lightweight Temporal for the demo: `EVAL_TEMPORAL=1 make demo` swaps the durable
+# Temporal trio for a single in-memory `temporal server start-dev`. See infra/docker-compose/README.md.
+ifeq ($(EVAL_TEMPORAL),1)
+COMPOSE_DEMO     += -f infra/docker-compose/docker-compose.eval-temporal.yml
+endif
 COMPOSE_SERVICES := docker compose -f infra/docker-compose/docker-compose.services.yml
 COMPOSE_TOOLS    := docker compose -f infra/docker-compose/docker-compose.tools.yml
 COMPOSE_OBS      := docker compose --env-file infra/docker-compose/observability/.env.observability -f infra/docker-compose/docker-compose.observability.yml
@@ -155,6 +160,7 @@ demo: check-docker ## ★ One command: boot the Ollama stack + run the hero work
 	@echo "✅ Demo complete. Next steps:"
 	@echo "   • Inspect logs:    ZYNAX_API_URL=http://localhost:7080 zynax logs <run-id> --follow"
 	@echo "   • Run a scenario:  make demo SCENARIO=code-review  (see docs/scenarios/scenario-manifest.md)"
+	@echo "   • Lighter Temporal: EVAL_TEMPORAL=1 make demo  (single in-memory start-dev, no Postgres/UI)"
 	@echo "   • Tear it all down: make demo-clean"
 
 demo-clean: ## Stop and remove the demo stack (base + Ollama overlay)

--- a/infra/docker-compose/README.md
+++ b/infra/docker-compose/README.md
@@ -11,6 +11,7 @@ All Compose files live in this directory:
 | `docker-compose.test.yml` | CI overlay — disables persistent volumes for ephemeral test runs |
 | `docker-compose.observability.yml` | Local Uptrace stack — traces/metrics/logs/APM with a login UI |
 | `docker-compose.ollama.yml` | Zero-cost local LLM overlay — bundles `ollama` and repoints `llm-adapter` at it (no API key) |
+| `docker-compose.eval-temporal.yml` | Day-0 overlay — swaps the durable Temporal trio for a single in-memory `temporal server start-dev` (no Postgres/UI container) |
 
 ## Local dev stack
 
@@ -118,6 +119,41 @@ point `provider.name` / `provider.ollama_base_url` at a different provider. The
 model/provider is config-only and never travels in the workflow input payload
 (ADR-013 / ADR-035), so any workflow stays portable across models. A full
 human-validation guide standard is tracked in #1388.
+
+## Eval-Temporal overlay (single in-memory binary)
+
+By default the stack runs Temporal as **three containers** — `temporalio/auto-setup`,
+a dedicated Postgres, and `temporalio/ui`. For a Day-0 evaluation that is overkill.
+The `docker-compose.eval-temporal.yml` overlay replaces all three with **one**
+self-contained binary, `temporal server start-dev` (embedded in-memory SQLite, no
+external DB), and makes activities **fail fast** (`ZYNAX_ENGINE_MAX_ACTIVITY_ATTEMPTS=1`,
+no durable retry loops). It reuses the proven `TemporalEngine` — no new engine to own
+(this supersedes the rejected in-process `EvalEngine` of ADR-037 / #1359 for the compose
+path).
+
+```bash
+# Bring the whole stack up on the lightweight Temporal:
+docker compose \
+  -f infra/docker-compose/docker-compose.yml \
+  -f infra/docker-compose/docker-compose.eval-temporal.yml \
+  up -d
+
+# Or via the demo (one opt-in flag):
+EVAL_TEMPORAL=1 make demo
+```
+
+The single binary's built-in Web UI is on the same host port as before — http://localhost:7088.
+
+**Graduate to durable production Temporal — one flag, no edits:** simply drop the overlay
+(use the base `docker-compose.yml` alone). That restores `auto-setup` + Postgres + the
+standalone UI and the engine-adapter's default 3 retry attempts. If you need to run the
+durable trio while the overlay is layered on, opt in by profile:
+
+```bash
+docker compose -f infra/docker-compose/docker-compose.yml \
+  -f infra/docker-compose/docker-compose.eval-temporal.yml \
+  --profile durable-temporal up -d
+```
 
 ## Not included
 

--- a/infra/docker-compose/docker-compose.eval-temporal.yml
+++ b/infra/docker-compose/docker-compose.eval-temporal.yml
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: Apache-2.0
+# Eval-Temporal overlay — Day-0 friction reducer for evaluators.
+#
+# Replaces the durable Temporal trio (temporalio/auto-setup + a dedicated
+# Postgres + temporalio/ui) with a SINGLE self-contained binary:
+# `temporal server start-dev` (embedded in-memory SQLite, no external DB).
+# Reuses the proven TemporalEngine — no new engine to own (supersedes #1359 /
+# ADR-037 for the compose path; see docs/adr/ADR-037).
+#
+# It also makes activities fail fast (no durable retry loops) via
+# ZYNAX_ENGINE_MAX_ACTIVITY_ATTEMPTS=1 — evaluation-grade semantics.
+#
+# Usage (layered on top of the base stack):
+#   docker compose \
+#     -f infra/docker-compose/docker-compose.yml \
+#     -f infra/docker-compose/docker-compose.eval-temporal.yml \
+#     up -d
+#   # the demo path: EVAL_TEMPORAL=1 make demo
+#
+# Graduate to durable production Temporal — drop this overlay and use the base
+# file alone (auto-setup + Postgres + the standalone UI come back, and the
+# engine-adapter's default ZYNAX_ENGINE_MAX_ACTIVITY_ATTEMPTS=3 retries return).
+# To run the durable trio while this overlay is present, opt in by name:
+#   docker compose -f ...yml -f ...eval-temporal.yml --profile durable-temporal up -d
+#
+# The single binary's built-in Web UI is published on the same host port the
+# standalone UI used (7088 → container 8233).
+services:
+
+  # Durable-only services — excluded from the default `up` under this overlay
+  # (a profile gates them; nothing references them once `temporal` is swapped).
+  postgres:
+    profiles: ["durable-temporal"]
+  temporal-ui:
+    profiles: ["durable-temporal"]
+
+  # Swap auto-setup + Postgres for Temporal's official single binary.
+  temporal:
+    image: temporalio/temporal:1.7.2
+    command:
+      - server
+      - start-dev
+      - --ip
+      - 0.0.0.0
+      - --namespace
+      - default
+      - --log-level
+      - warn
+    environment: !reset null   # drop the auto-setup DB env; start-dev is self-contained
+    depends_on: !reset null     # no Postgres dependency
+    ports: !override
+      - "7233:7233"            # Temporal frontend gRPC (engine-adapter dials temporal:7233)
+      - "7088:8233"            # built-in dev Web UI (replaces the temporal-ui container)
+    healthcheck:
+      test: ["CMD", "temporal", "operator", "namespace", "describe", "--namespace", "default", "--address", "127.0.0.1:7233"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+      start_period: 5s
+
+  engine-adapter:
+    environment:
+      ZYNAX_ENGINE_MAX_ACTIVITY_ATTEMPTS: "1"   # fail fast — no durable retry loops


### PR DESCRIPTION
## What

Adds `infra/docker-compose/docker-compose.eval-temporal.yml` — a Day-0 overlay that replaces the durable Temporal **trio** (`temporalio/auto-setup` + a dedicated Postgres + `temporalio/ui`) with **one** self-contained binary: `temporal server start-dev` (embedded in-memory SQLite, no external DB). Reuses the proven `TemporalEngine` — no new engine to own. This is the compose-path answer to Day-0 friction that supersedes the rejected in-process `EvalEngine` (ADR-037 / #1359).

- `postgres` + `temporal-ui` are gated behind a `durable-temporal` Compose profile, so the default `up` runs just the one binary. The engine-adapter still dials `temporal:7233` and gets `ZYNAX_ENGINE_MAX_ACTIVITY_ATTEMPTS=1` (fail-fast, evaluation-grade — no durable retry loops).
- The binary's built-in Web UI is published on the existing `7088` host port (no separate UI container).
- `EVAL_TEMPORAL=1 make demo` opt-in flag layers the overlay; **default demo behavior is unchanged**.
- `infra/docker-compose/README.md` documents usage + the one-flag graduation back to durable Temporal.

## Validation
- `docker compose -f docker-compose.yml -f docker-compose.eval-temporal.yml config` → exit 0; `--services` shows only `temporal` for Temporal (Postgres/UI excluded), `temporal` has no Postgres dependency.
- Three-way merge with the Ollama demo overlay also validates.
- **Live smoke:** `temporalio/temporal:1.7.2 server start-dev` came up healthy in ~1s; the `default` namespace is Registered and the overlay healthcheck command returns 0.
- Image `temporalio/temporal:1.7.2` is a third-party pinned tag, outside the `images.yaml` banner-managed regions (no SoT-drift gate impact).

## Acceptance
- [x] `docker compose -f ...yml -f ...eval-temporal.yml up -d` brings the stack up with no Temporal Postgres / auto-setup / UI
- [x] Fail-fast retry semantics (`ZYNAX_ENGINE_MAX_ACTIVITY_ATTEMPTS=1`)
- [x] Validated via `docker compose config` + a documented run; graduation to full Temporal documented

Closes #1456

Assisted-by: Claude/claude-opus-4-8