### PR TITLE
chore(claude): require runtime smoke before claiming a runtime change done

### DIFF
--- a/.claude/commands/deliver.md
+++ b/.claude/commands/deliver.md
@@ -39,6 +39,12 @@ procedure: repo-wide ready work by default, or the `--milestone` filter. Where a
   squash auto-merge (rebase blocked by `required_signatures`).
 - **Stops on blockers** (CI red it can't fix, context budget) and reports how to resume — recover
   with `/reconcile`.
+- **Runtime evidence, not config evidence:** for changes touching `infra/docker-compose/**`,
+  `infra/helm/**`, a Makefile `demo`/`run-local`/compose target, `services/*/cmd/**`,
+  `agents/adapters/**`, or `cmd/zynax*`, "done" requires actually booting the documented path and
+  observing the user-facing outcome — `docker compose config`, a build, or CI-green are **not**
+  runtime evidence. Re-run stateful paths **twice** on the same volumes (persistence bugs surface on
+  run #2). Claim "works end-to-end" only for what was executed; label config/build-only checks as such.
 
 ## Output
 Per issue: claim status, PR link, merge state, post-merge verification, and learnings recorded.

--- a/.claude/commands/experts/post-merge.md
+++ b/.claude/commands/experts/post-merge.md
@@ -146,6 +146,29 @@ done
 
 ---
 
+## Phase 3.5 — Runtime smoke (when INFRA_CHANGED or a service/adapter/CLI path changed)
+
+```bash
+[post-mrg PR#${PR_NUMBER} $(date +%H:%M:%S)] RUNTIME_SMOKE: booting documented path on merged images  [ctx: ~13K | compress=0 | msgs=5]
+```
+
+CI-green + image-published is **not** runtime evidence. If `INFRA_CHANGED` is true or the merge
+touched `agents/adapters/**`, `services/*/cmd/**`, or `cmd/zynax*`, boot the user-facing path on a
+clean slate, assert no container is Exited/unhealthy, then run it a **second** time (persistence /
+idempotency — a Postgres-backed registry/repo makes run #2 fail where run #1 passed):
+
+```bash
+make demo-clean 2>/dev/null || true
+docker compose -f infra/docker-compose/docker-compose.yml \
+  -f infra/docker-compose/docker-compose.ollama.yml down -v --remove-orphans 2>/dev/null || true
+make demo && make demo || { echo "RUNTIME SMOKE FAILED"; RUNTIME_SMOKE_STATUS="FAIL"; }
+```
+
+If the host cannot run the stack, emit `RUNTIME_SMOKE: SKIPPED (no docker host)` in the evidence
+block — never silently treat the absence of a smoke as a pass.
+
+---
+
 ## Phase 4a — Update service image digest pins in docker-compose
 
 ```bash

--- a/.claude/commands/lib/deliver-one.md
+++ b/.claude/commands/lib/deliver-one.md
@@ -477,6 +477,35 @@ git diff --name-only | grep -q '\.proto\|_pb2\|\.go.*grpc' && {
 echo "All local gates passed."
 ```
 
+### Runtime smoke — REQUIRED when the change affects a runtime path
+
+Build/test/lint/CI-green validate **structure**, not **runtime**. If `git diff --name-only` touches
+any of `infra/docker-compose/**`, `infra/helm/**`, a Makefile `demo`/`run-local`/compose target,
+`services/*/cmd/**`, `agents/adapters/**`, or `cmd/zynax*`, boot the affected path and observe the
+user-facing outcome BEFORE claiming the issue done:
+
+```bash
+# 1. Clean slate — persistent volumes (Postgres-backed registry/repos) hide re-run bugs.
+make demo-clean 2>/dev/null || true
+$(COMPOSE_DEMO) down -v --remove-orphans 2>/dev/null || true
+
+# 2. Boot the issue's DOCUMENTED path (the one in its acceptance criteria), e.g.
+#    `make demo` | `EVAL_TEMPORAL=1 make demo` | `make run-local`.
+#    `up --wait` gates on EVERY service it starts: any Exited/unhealthy container = FAIL,
+#    even one the feature does not use.
+<documented command>            # FAIL the gate on non-zero exit
+PS=$($(COMPOSE_DEMO) ps --format '{{.Name}} {{.State}}')
+echo "$PS" | grep -qiE 'exited|unhealthy' && { echo "RUNTIME SMOKE FAILED:"; echo "$PS"; exit 1; }
+
+# 3. Idempotency — run the documented path a SECOND time on the same volumes.
+#    Stateful services (registry/repos, Temporal) must survive a repeat run.
+<documented command again>      # FAIL on non-zero exit
+```
+
+Map every acceptance criterion that says "runs", "demo", "documented run", or "end-to-end" to an
+actual execution with captured output. Never mark such an AC met from `docker compose config`, a
+build, or CI-green alone.
+
 ---
 
 ## STEP 8 — Commit


### PR DESCRIPTION
## Why

A broken `make demo` (adapters crash on re-registration against the now-persistent Postgres-backed agent-registry, and git/ci adapters hard-require `GITHUB_TOKEN`) was reported as a safe smoke test. Root cause in the **process**: every delivery gate is structure/CI evidence (`go build`/`go test`/`make lint`/`make security`/BDD; CI-green; GHCR image published) — **none boots the user-facing path**. So "config-validated / CI-green" masqueraded as "works end-to-end."

## What

- **[deliver-one.md](.claude/commands/lib/deliver-one.md) STEP 7** — new **Runtime smoke** gate: when the diff touches `infra/docker-compose/**`, a Makefile `demo`/`run-local`/compose target, `services/*/cmd/**`, `agents/adapters/**`, or `cmd/zynax*`, boot the documented path on a **clean slate**, FAIL on any `Exited`/`unhealthy` container (even one the feature doesn't use — `up --wait` gates on all), and **re-run once** (persistence bugs surface on run #2).
- **[post-merge.md](.claude/commands/experts/post-merge.md)** — new **Phase 3.5 Runtime smoke** for `INFRA_CHANGED` / runtime paths; emits an explicit `SKIPPED (no docker host)` marker rather than a silent pass.
- **[deliver.md](.claude/commands/deliver.md)** — new guardrail: *runtime evidence, not config evidence*; claim "works end-to-end" only for what was executed.

Companion `fix(infra)` PR makes `make demo` itself robust (scope to required services + repeatable clean-slate).

Assisted-by: Claude/claude-opus-4-8