### PR TITLE
fix(infra): make the demo boot reliably and repeatably

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,14 +139,22 @@ ZYNAX        ?= zynax
 # in the index's apply_order) over the existing /api/v1/apply REST path.
 SCENARIO     ?=
 DEMO_TARGET   = $(if $(SCENARIO),spec/scenarios/$(SCENARIO),$(DEMO_WORKFLOW))
+# Services the demo needs; `up --wait` boots their depends_on closure (workflow-compiler,
+# engine-adapter, task-broker, agent-registry, temporal, event-bus, nats, postgres*, ollama).
+# Deliberately EXCLUDES the git/ci/langgraph adapters — they require GITHUB_TOKEN or are unused, and
+# `up --wait` (no service list) would otherwise gate the whole demo on their health — and the
+# standalone Temporal UI.
+DEMO_SERVICES := api-gateway llm-adapter
 
 demo: check-docker ## ★ One command: boot the Ollama stack + run the hero workflow (or a SCENARIO=<name> manifest set)
 	@command -v $(ZYNAX) >/dev/null 2>&1 || \
 	  (echo "❌ zynax CLI not found — run 'make install-cli' and ensure ~/bin is on your PATH" && exit 1)
 	@echo "🧠 Demo model: qwen2.5-coder:3b — pull it once on the host if you have not:"
 	@echo "     ollama pull qwen2.5-coder:3b"
-	@echo "🚀 Booting the minimal stack + Ollama overlay (waiting for health)..."
-	$(COMPOSE_DEMO) up -d --wait
+	@echo "🧹 Clean slate for a repeatable run (the agent-registry is persistent across runs)..."
+	@$(COMPOSE_DEMO) down -v --remove-orphans 2>/dev/null || true
+	@echo "🚀 Booting the demo services + Ollama overlay (waiting for health)..."
+	$(COMPOSE_DEMO) up -d --wait $(DEMO_SERVICES)
 	@export ZYNAX_API_URL=http://localhost:7080; \
 	  echo "▶  zynax apply $(DEMO_TARGET)"; \
 	  run_id=$$($(ZYNAX) apply $(DEMO_TARGET) | sed -n 's/^run_id: //p' | tail -n1); \
@@ -163,8 +171,8 @@ demo: check-docker ## ★ One command: boot the Ollama stack + run the hero work
 	@echo "   • Lighter Temporal: EVAL_TEMPORAL=1 make demo  (single in-memory start-dev, no Postgres/UI)"
 	@echo "   • Tear it all down: make demo-clean"
 
-demo-clean: ## Stop and remove the demo stack (base + Ollama overlay)
-	$(COMPOSE_DEMO) down --remove-orphans
+demo-clean: ## Stop and remove the demo stack + volumes (base + Ollama overlay)
+	$(COMPOSE_DEMO) down -v --remove-orphans
 	@echo "✅ Demo stack removed"
 
 install-cli: ## Build and install zynax CLI to ~/bin/zynax (requires Go 1.26.3)

--- a/infra/docker-compose/ollama/llm-adapter.config.yaml
+++ b/infra/docker-compose/ollama/llm-adapter.config.yaml
@@ -8,11 +8,13 @@
 agent_id: llm-adapter
 name: LLM Adapter (Ollama / local)
 description: Ollama-backed local LLM capabilities for the zero-cost quickstart.
-# Endpoint is used BOTH as the bind address AND the address advertised to the
-# registry (no bind/advertise split in the Go adapter). The shipped example's
-# ":50070" advertises an unreachable host — the broker then dials localhost and
-# gets connection refused. Use the resolvable compose service name instead.
-endpoint: llm-adapter:50070
+# `endpoint` is the gRPC BIND address; ":50070" binds all interfaces so the
+# in-container healthcheck (which dials localhost:50070) passes. `advertise_endpoint`
+# is the ROUTABLE address the task-broker dials — the compose service name. Binding
+# directly to "llm-adapter:50070" instead would listen only on that interface and the
+# localhost healthcheck would get connection refused → container unhealthy (#1371).
+endpoint: ":50070"
+advertise_endpoint: llm-adapter:50070
 registry_endpoint: agent-registry:50052
 
 provider:


### PR DESCRIPTION
## Why

`make demo` failed at boot (`container ... langgraph-adapter exited (1)`). Running it end-to-end (per the new runtime-smoke discipline) uncovered a chain of bugs:

1. **Over-broad `up --wait`** — `make demo` booted the whole base stack and waited on **every** service, so the git/ci adapters (hard-require `GITHUB_TOKEN`) and an unused langgraph adapter crashing failed the whole demo.
2. **Non-repeatable** — the Postgres-backed agent-registry persists across runs (`demo-clean` did `down`, not `down -v`), so a 2nd `make demo` hit `RegisterAgent` → `AlreadyExists` → adapter exit 1.
3. **llm-adapter unhealthy** — the Ollama overlay config bound directly to the routable name `llm-adapter:50070`, so the in-container healthcheck (`localhost:50070`) was refused → `unhealthy` → `up --wait` failed.

## What

- **Scope `make demo`** to the `api-gateway` + `llm-adapter` `depends_on` closure (`DEMO_SERVICES`). git/ci/langgraph adapters + the Temporal UI are no longer booted or waited on.
- **Repeatable clean slate** — `down -v` at demo start + `demo-clean -v`, so the persistent registry is reset and repeat runs no longer hit `AlreadyExists`.
- **ollama config** — bind `:50070` (localhost healthcheck passes) and advertise the routable `llm-adapter:50070` via `advertise_endpoint` (the code already supports the split, `client.go:86` / #1371), so the task-broker dials a reachable address.

## Verification (actually run, not just `config`)

A clean `make demo` boots the scoped stack **fully healthy** (12 containers), dispatches the `codereview` capability, and the workflow reaches **`WORKFLOW_STATUS_COMPLETED`**. (Verified with a locally-present model since this host lacks `qwen2.5-coder:3b`; the committed default stays `qwen2.5-coder:3b`, which requires the documented `ollama pull`.)

## Known-separate issues uncovered (NOT in this PR — follow-up)

- The config fix needs a **current** `llm-adapter` image; `make demo` uses local `:main` images and doesn't refresh them — a stale local image ignores `advertise_endpoint`.
- `zynax result` → api-gateway **HTTP 500 "streaming not supported"** (`handler.go:152`) — a real gateway SSE bug on the result/watch endpoint.
- The demo recipe **masks** a `zynax result` failure (exits 0 regardless).

Assisted-by: Claude/claude-opus-4-8