### PR TITLE
fix: surface the capability result in zynax result and logs

### DIFF
--- a/infra/docker-compose/docker-compose.yml
+++ b/infra/docker-compose/docker-compose.yml
@@ -172,10 +172,16 @@ services:
       ZYNAX_BROKER_LOG_LEVEL: info
       ZYNAX_BROKER_DB_ENABLED: "true"
       ZYNAX_BROKER_DB_DSN: "postgres://zynax:zynax@postgres-zynax:5432/task_broker?sslmode=disable"
+      # Publish task-lifecycle CloudEvents (incl. the capability result_payload) so
+      # `zynax result`/`logs` can stream the model's output. Without this the broker
+      # runs with no event publisher and the review is never emitted to the bus.
+      ZYNAX_BROKER_EVENTBUS_ADDR: "event-bus:50056"
     depends_on:
       agent-registry:
         condition: service_healthy
       postgres-zynax:
+        condition: service_healthy
+      event-bus:
         condition: service_healthy
     healthcheck:
       test: ["CMD", "/healthcheck", "tcp://localhost:50053"]
@@ -266,6 +272,10 @@ services:
       ZYNAX_GW_COMPILER_ADDR: workflow-compiler:50054
       ZYNAX_GW_ENGINE_ADDR: engine-adapter:50055
       ZYNAX_GW_REGISTRY_ADDR: "agent-registry:50052"
+      # Subscribe to task-broker capability CloudEvents so `zynax result`/`logs`
+      # stream the result_payload. The default localhost:50056 is unreachable
+      # in-container, so without this the gateway streams engine history only.
+      ZYNAX_GW_EVENT_BUS_ADDR: "event-bus:50056"
       ZYNAX_GW_LOG_LEVEL: info
       ZYNAX_GW_DEV_INSECURE: "1"
     ports:

--- a/services/api-gateway/internal/infrastructure/clients.go
+++ b/services/api-gateway/internal/infrastructure/clients.go
@@ -36,10 +36,14 @@ type GatewayClients struct {
 	callTimeout time.Duration
 }
 
-// capabilityEventPattern matches every CloudEvent type so the streaming /logs
-// endpoint receives all capability events for a workflow. The event-bus filters
-// further by the workflow_id scope passed on the SubscribeRequest.
-const capabilityEventPattern = "**"
+// capabilityEventPattern subscribes to the task-broker task-lifecycle stream,
+// whose ".completed" events carry the capability result_payload surfaced by
+// `zynax logs`/`zynax result`. It MUST resolve (via StreamSubjectFromPattern) to
+// the concrete JetStream stream that owns those events: a bare "**" collapses to
+// the subject "x" and lands on a nonexistent stream, so no capability event is
+// ever delivered. The event-bus filters further by the workflow_id scope on the
+// SubscribeRequest.
+const capabilityEventPattern = "zynax.v1.task-broker.task.**"
 
 // ConnectionsReady returns false if any downstream gRPC connection is in
 // TRANSIENT_FAILURE or SHUTDOWN state. Used by the /readyz probe handler.

--- a/services/engine-adapter/internal/infrastructure/temporal_workflow.go
+++ b/services/engine-adapter/internal/infrastructure/temporal_workflow.go
@@ -20,7 +20,15 @@ import (
 const (
 	dispatchCapabilityActivityName = "DispatchCapabilityActivity"
 	publishEventActivityName       = "PublishLifecycleEventActivity"
-	defaultActivityTimeout         = 30 * time.Second
+	// defaultActivityTimeout is the StartToClose timeout applied to a capability
+	// dispatch when the workflow action declares no explicit timeout. It must be
+	// agent-scale: real capabilities (LLM inference, CI runs, git ops) routinely
+	// take longer than a handful of seconds, and a too-short cap truncates the
+	// activity to a nil result — the capability's output never reaches the
+	// completion event, so `zynax result` reports "no result payload". 5 minutes
+	// covers the slowest shipped capability (codereview, timeout_seconds: 300)
+	// with headroom; capabilities needing more should declare an action timeout.
+	defaultActivityTimeout = 5 * time.Minute
 )
 
 // DefaultActivityMaxAttempts is the maximum number of retry attempts for


### PR DESCRIPTION
## Why

A completed demo workflow (`make demo`) returned **`no result payload`** — the model's review was generated but never reached `zynax result`/`zynax logs`. Tracing the capability-result streaming path end-to-end revealed three coordinated gaps.

## What

1. **api-gateway subscribed to a nonexistent JetStream stream.** It used `TypePattern = "**"`, but `StreamSubjectFromPattern("**")` collapses to the subject `"x"`, so the consumer was created on a stream that owns no events → **zero** capability events delivered. Now subscribes to the concrete task-broker stream `zynax.v1.task-broker.task.**` that actually carries the `result_payload` completion events. *(This is the core bug.)*
2. **The demo compose never wired the event-bus** into the **task-broker** (so it ran with no event publisher — the result was never emitted) nor the **api-gateway** (whose `EVENT_BUS_ADDR` defaulted to an unreachable `localhost:50056`). Both now point at `event-bus:50056`.
3. **The dispatch activity timed out at 30s** (the `defaultActivityTimeout`), too short for real agents — local LLM inference exceeded it and the activity returned a nil result, truncating the output. Raised to 5m.

## Verification (actually run)

A clean demo run — `apply` the code-review workflow, tail `zynax result` — now **prints the model's code review (exit 0)**, e.g. it flagged the `Refund` overpay risk and the integer-division truncation in the example diff. Full `api-gateway` and `engine-adapter` test suites pass (`-race`).

> Note: `make demo` uses local `:main` images, so a developer must refresh them (build/pull) to pick up the gateway/engine fixes; the compose wirings apply immediately. The image-refresh ergonomics + a `make demo PR=<N>` real-PR mode are tracked in #1463.

Assisted-by: Claude/claude-opus-4-8