### PR TITLE
fix(engine-adapter): JSON-escape data-flow template values

### DIFF
--- a/infra/docker-compose/ollama/llm-adapter.config.yaml
+++ b/infra/docker-compose/ollama/llm-adapter.config.yaml
@@ -47,3 +47,22 @@ capabilities:
         "type": "object",
         "properties": { "completion": { "type": "string" } }
       }
+  # A second generic-LLM capability used by the two-step data-flow example
+  # (spec/workflows/examples/code-review-rank-ollama.yaml): it consumes the
+  # codereview output and ranks the issues by importance. Same shape as
+  # codereview — the llm-adapter sends `prompt` to Ollama and returns `completion`.
+  - name: summarize
+    timeout_seconds: 300
+    description: Summarize text and rank the items it contains by importance.
+    input_schema_json: |
+      {
+        "type": "object",
+        "required": ["prompt"],
+        "properties": { "prompt": { "type": "string", "minLength": 1 } },
+        "additionalProperties": false
+      }
+    output_schema_json: |
+      {
+        "type": "object",
+        "properties": { "completion": { "type": "string" } }
+      }

--- a/services/engine-adapter/internal/domain/interpreter.go
+++ b/services/engine-adapter/internal/domain/interpreter.go
@@ -287,8 +287,24 @@ func resolveTemplate(tmpl string, ctx map[string]string) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("invalid template %q: %w", tmpl, err)
 	}
+	// Each ctx value is substituted INTO the input's JSON template, almost always
+	// inside a JSON string literal (e.g. {"prompt":"...{{ .ctx.review }}..."}).
+	// Data-context values are arbitrary capability outputs — LLM text is routinely
+	// multi-line and quoted — so substituting them raw produces invalid JSON
+	// ("input_payload must be valid JSON"). JSON-escape each value to its
+	// string-inner form (marshal, strip the surrounding quotes) so the rendered
+	// payload stays valid; for simple values this is a no-op (backward compatible).
+	esc := make(map[string]string, len(ctx))
+	for k, v := range ctx {
+		b, mErr := json.Marshal(v)
+		if mErr != nil { // string marshalling never fails, but stay defensive
+			esc[k] = v
+			continue
+		}
+		esc[k] = string(b[1 : len(b)-1])
+	}
 	var buf strings.Builder
-	if err := t.Execute(&buf, map[string]any{"ctx": ctx}); err != nil {
+	if err := t.Execute(&buf, map[string]any{"ctx": esc}); err != nil {
 		return nil, fmt.Errorf("template execution failed: %w", err)
 	}
 	return []byte(buf.String()), nil

--- a/services/engine-adapter/internal/domain/interpreter_test.go
+++ b/services/engine-adapter/internal/domain/interpreter_test.go
@@ -7,6 +7,7 @@ package domain
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"log/slog"
 	"strings"
@@ -403,6 +404,25 @@ func TestResolveTemplate(t *testing.T) {
 	}
 	if string(got) != `{"user":"alice"}` {
 		t.Errorf("resolveTemplate = %s; want %s", got, `{"user":"alice"}`)
+	}
+}
+
+// TestResolveTemplate_EscapesJSON guards EPIC-W data-flow: a ctx value carrying
+// newlines and quotes (e.g. an LLM review passed between steps) must be
+// JSON-escaped on substitution so the rendered input_payload stays valid JSON,
+// rather than failing dispatch with "input_payload must be valid JSON".
+func TestResolveTemplate_EscapesJSON(t *testing.T) {
+	ctx := map[string]string{"review": "line 1\n\"quoted\" line 2\tend"}
+	got, err := resolveTemplate(`{"prompt":"Rank:\n{{ .ctx.review }}"}`, ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var out map[string]string
+	if err := json.Unmarshal(got, &out); err != nil {
+		t.Fatalf("rendered payload is not valid JSON: %v\npayload=%s", err, got)
+	}
+	if out["prompt"] != "Rank:\nline 1\n\"quoted\" line 2\tend" {
+		t.Errorf("decoded prompt = %q; want the original review verbatim", out["prompt"])
 	}
 }
 

--- a/spec/workflows/examples/code-review-rank-ollama.yaml
+++ b/spec/workflows/examples/code-review-rank-ollama.yaml
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: Apache-2.0
+# Two-step workflow with EPIC-W data-flow: code review, then summarize + rank.
+#
+# State `review` runs the `codereview` capability on a diff and publishes the
+# review text into the workflow data context via an OUTPUT binding. State `rank`
+# consumes it via an INPUT binding ("$.states.review.output.review"), exposes it
+# to the prompt template as {{ .ctx.review }}, and asks the `summarize` capability
+# to count the issues and rank them by importance.
+#
+# Run it:
+#   make demo DEMO_WORKFLOW=spec/workflows/examples/code-review-rank-ollama.yaml
+#   # or:
+#   zynax apply spec/workflows/examples/code-review-rank-ollama.yaml
+#   zynax result <run-id>
+#
+# Requires the llm-adapter to register BOTH `codereview` and `summarize`
+# (see infra/docker-compose/ollama/llm-adapter.config.yaml).
+kind: Workflow
+apiVersion: zynax.io/v1
+
+metadata:
+  name: code-review-rank-ollama
+  namespace: demo
+  version: "1.0.0"
+  annotations:
+    description: "Code review, then summarize + rank the issues by importance (data-flow)."
+
+spec:
+  initial_state: review
+
+  states:
+    # ── 1) Review the diff ────────────────────────────────────────
+    review:
+      actions:
+        - capability: codereview
+          input:
+            prompt: |
+              You are a senior Go code reviewer. Review the following git diff and
+              reply with a numbered list of concrete issues (correctness, security,
+              edge cases). Cite the function. End with APPROVE or REQUEST-CHANGES.
+
+              ```diff
+              diff --git a/payments.go b/payments.go
+              --- a/payments.go
+              +++ b/payments.go
+              @@ -7,5 +7,12 @@ func Charge(balanceCents, amountCents int) (int, error) {
+               	if amountCents < 0 {
+               		return balanceCents, errors.New("amount must be non-negative")
+               	}
+              -	return balanceCents - amountCents, nil
+              +	// Apply a 2% loyalty discount before charging.
+              +	discounted := amountCents - (amountCents / 50)
+              +	return balanceCents - discounted, nil
+              +}
+              +
+              +// Refund credits amountCents back to the account.
+              +func Refund(balanceCents, amountCents int) int {
+              +	return balanceCents + amountCents
+               }
+              ```
+          # OUTPUT binding: publish the review text (result field `completion`)
+          # into the data context as states.review.output.review.
+          output:
+            review: completion
+      on:
+        - event: codereview.completed
+          goto: rank
+
+    # ── 2) Summarize + rank the issues ────────────────────────────
+    rank:
+      actions:
+        - capability: summarize
+          # `review` is an INPUT BINDING (a "$.states..." reference): it is
+          # resolved from the data context and exposed to the prompt template as
+          # {{ .ctx.review }}. Bindings are NOT sent to the capability — only the
+          # rendered `prompt` is.
+          input:
+            review: "$.states.review.output.review"
+            prompt: |
+              Below is a code review. First state the TOTAL number of issues, then
+              list each issue ranked by importance (High / Medium / Low) with a
+              one-line justification.
+
+              {{ .ctx.review }}
+          output:
+            ranking: completion
+      on:
+        - event: summarize.completed
+          goto: done
+
+    done:
+      type: terminal


### PR DESCRIPTION
## Why

Cross-state **data-flow** (EPIC W) is the keystone for multi-step workflows, but it was broken for the most common case: passing **LLM output** (multi-line, quoted) between steps. `resolveTemplate` substituted a context value into an action's JSON input template **raw**, so a multi-line review produced invalid JSON and the next dispatch failed with `input_payload must be valid JSON`.

## What

- **Fix**: `resolveTemplate` now JSON-escapes each `ctx` value to its string-inner form before substitution. No-op for simple values (existing tests unchanged), so backward compatible. Regression test `TestResolveTemplate_EscapesJSON` added.
- **Runnable example** that exercises it (also answers "how do I run a non-code-review workflow"):
  - a `summarize` capability on the Ollama llm-adapter (`infra/docker-compose/ollama/llm-adapter.config.yaml`), and
  - `spec/workflows/examples/code-review-rank-ollama.yaml`: state `review` runs `codereview` and **publishes** the review (`output: { review: completion }`); state `rank` **consumes** it (`input: { review: "$.states.review.output.review" }`, used as `{{ .ctx.review }}`) and asks `summarize` to count + rank the issues by importance.

## Verification (actually run)

Before the fix: the `rank` step failed 3× with `input_payload must be valid JSON` and the run `FAILED`. After: the workflow runs to completion and `zynax result` prints the **second** step's output — a ranked summary (`TOTAL NUMBER OF ISSUES: 4`, each ranked High/Medium/Low with a justification). Full `engine-adapter` suite passes with `-race`.

Run it:
```
make demo DEMO_WORKFLOW=spec/workflows/examples/code-review-rank-ollama.yaml
```

Assisted-by: Claude/claude-opus-4-8