### PR TITLE
chore(demo): bigger review example with issue types + STREAM=1 mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,6 +143,11 @@ SCENARIO     ?=
 PR           ?=
 DEMO_PR_FILE := /tmp/zynax-demo-pr-review.yaml
 DEMO_TARGET   = $(if $(PR),$(DEMO_PR_FILE),$(if $(SCENARIO),spec/scenarios/$(SCENARIO),$(DEMO_WORKFLOW)))
+# Optional: STREAM=1 prints EVERY step's output live via `zynax logs --follow`
+# instead of just the final result — useful for multi-step (data-flow) workflows.
+# Note: streaming is per-step, not per-token — the engine polls the broker for
+# each capability's final result, so a step's output appears once it completes.
+STREAM       ?=
 # Demo LLM model — read from the Ollama overlay config so the pre-flight check and
 # the config never drift. `make demo` ensures this is pulled on the host (the
 # ollama container reuses host models read-only), otherwise the codereview 404s.
@@ -181,12 +186,18 @@ demo: check-docker ## ★ One command: boot the Ollama stack + review code (hero
 	  run_id=$$($(ZYNAX) apply $(DEMO_TARGET) | sed -n 's/^run_id: //p' | tail -n1); \
 	  test -n "$$run_id" || (echo "❌ apply did not return a run_id" && exit 1); \
 	  echo "   run_id: $$run_id"; \
-	  echo "⏳ Streaming to terminal + printing the model's review..."; \
-	  echo "── review ──────────────────────────────────────────────"; \
-	  $(ZYNAX) result "$$run_id" || echo "(no review — the run did not complete; inspect: ZYNAX_API_URL=$$ZYNAX_API_URL $(ZYNAX) logs $$run_id)"; \
+	  echo "── output ──────────────────────────────────────────────"; \
+	  if [ -n "$(STREAM)" ]; then \
+	    echo "⏳ Streaming every step live (zynax logs --follow)..."; \
+	    $(ZYNAX) logs "$$run_id" --follow || echo "(stream ended early; inspect: ZYNAX_API_URL=$$ZYNAX_API_URL $(ZYNAX) logs $$run_id)"; \
+	  else \
+	    echo "⏳ Waiting for the final result (add STREAM=1 to see every step live)..."; \
+	    $(ZYNAX) result "$$run_id" || echo "(no result — the run did not complete; inspect: ZYNAX_API_URL=$$ZYNAX_API_URL $(ZYNAX) logs $$run_id)"; \
+	  fi; \
 	  echo "────────────────────────────────────────────────────────"
 	@echo ""
 	@echo "✅ Demo complete. Next steps:"
+	@echo "   • See every step:  make demo STREAM=1 DEMO_WORKFLOW=<file>  (live, all states)"
 	@echo "   • Inspect logs:    ZYNAX_API_URL=http://localhost:7080 zynax logs <run-id> --follow"
 	@echo "   • Run a scenario:  make demo SCENARIO=code-review  (see docs/scenarios/scenario-manifest.md)"
 	@echo "   • Review a real PR: make demo PR=<number>  (read-only — never changes the PR)"

--- a/spec/workflows/examples/code-review-rank-ollama.yaml
+++ b/spec/workflows/examples/code-review-rank-ollama.yaml
@@ -1,17 +1,19 @@
 # SPDX-License-Identifier: Apache-2.0
-# Two-step workflow with EPIC-W data-flow: code review, then summarize + rank.
+# Two-step workflow with EPIC-W data-flow: code review, then categorize + rank.
 #
-# State `review` runs the `codereview` capability on a diff and publishes the
-# review text into the workflow data context via an OUTPUT binding. State `rank`
-# consumes it via an INPUT binding ("$.states.review.output.review"), exposes it
-# to the prompt template as {{ .ctx.review }}, and asks the `summarize` capability
-# to count the issues and rank them by importance.
+# State `review` runs the `codereview` capability on a deliberately-flawed diff
+# (issues spanning every category below) and publishes the review into the
+# workflow data context via an OUTPUT binding. State `rank` consumes it via an
+# INPUT binding ("$.states.review.output.review"), exposes it to the prompt as
+# {{ .ctx.review }}, and asks `summarize` to tag each issue with a formal TYPE
+# (category) and SEVERITY (importance) and rank them.
+#
+# Note: TYPE is the category of the issue (security, correctness, ...), NOT its
+# severity. Severity (High/Medium/Low) is a separate field.
 #
 # Run it:
-#   make demo DEMO_WORKFLOW=spec/workflows/examples/code-review-rank-ollama.yaml
-#   # or:
-#   zynax apply spec/workflows/examples/code-review-rank-ollama.yaml
-#   zynax result <run-id>
+#   make demo            DEMO_WORKFLOW=spec/workflows/examples/code-review-rank-ollama.yaml
+#   make demo STREAM=1   DEMO_WORKFLOW=spec/workflows/examples/code-review-rank-ollama.yaml   # live, all steps
 #
 # Requires the llm-adapter to register BOTH `codereview` and `summarize`
 # (see infra/docker-compose/ollama/llm-adapter.config.yaml).
@@ -23,40 +25,84 @@ metadata:
   namespace: demo
   version: "1.0.0"
   annotations:
-    description: "Code review, then summarize + rank the issues by importance (data-flow)."
+    description: "Code review, then categorize (type) + rank (severity) the issues (data-flow)."
 
 spec:
   initial_state: review
 
   states:
-    # ── 1) Review the diff ────────────────────────────────────────
+    # ── 1) Review a deliberately-flawed diff ──────────────────────
     review:
       actions:
         - capability: codereview
           input:
             prompt: |
-              You are a senior Go code reviewer. Review the following git diff and
-              reply with a numbered list of concrete issues (correctness, security,
-              edge cases). Cite the function. End with APPROVE or REQUEST-CHANGES.
+              You are a senior Go code reviewer. Review the git diff below and
+              report EVERY issue you find as a numbered list. For each issue give,
+              on its own lines:
+                - Type: exactly one category from this set —
+                  security | correctness | concurrency | error-handling |
+                  resource-leak | performance | style | documentation
+                  (Type is the CATEGORY of the issue, never its severity.)
+                - Severity: one of High | Medium | Low
+                - Function: the function name it occurs in
+                - Detail: a one-sentence explanation
+              End with a single line: "VERDICT: APPROVE" or "VERDICT: REQUEST-CHANGES".
 
               ```diff
               diff --git a/payments.go b/payments.go
               --- a/payments.go
               +++ b/payments.go
-              @@ -7,5 +7,12 @@ func Charge(balanceCents, amountCents int) (int, error) {
-               	if amountCents < 0 {
-               		return balanceCents, errors.New("amount must be non-negative")
-               	}
-              -	return balanceCents - amountCents, nil
+              @@ -1,4 +1,60 @@
+               package payments
+              +
+              +import (
+              +	"database/sql"
+              +	"os"
+              +)
+              +
+              +// dbPassword is the production database password.
+              +var dbPassword = "S3cr3t-Prod-Pa55!"
+              +
+              +var totalCharged int
+              +
+              +func Charge(balanceCents, amountCents int) (int, error) {
+              +	if amountCents < 0 {
+              +		return balanceCents, nil
+              +	}
               +	// Apply a 2% loyalty discount before charging.
               +	discounted := amountCents - (amountCents / 50)
+              +	totalCharged += discounted
               +	return balanceCents - discounted, nil
               +}
               +
-              +// Refund credits amountCents back to the account.
               +func Refund(balanceCents, amountCents int) int {
               +	return balanceCents + amountCents
-               }
+              +}
+              +
+              +func UserByName(db *sql.DB, name string) *sql.Row {
+              +	q := "SELECT id, email FROM users WHERE name = '" + name + "'"
+              +	return db.QueryRow(q)
+              +}
+              +
+              +func ReadConfig(path string) []byte {
+              +	f, _ := os.Open(path)
+              +	buf := make([]byte, 4096)
+              +	n, _ := f.Read(buf)
+              +	return buf[:n]
+              +}
+              +
+              +func CountMatches(items []string, target string) int {
+              +	count := 0
+              +	for i := 0; i < len(items); i++ {
+              +		for j := 0; j < len(items); j++ {
+              +			if items[i] == target {
+              +				count++
+              +			}
+              +		}
+              +	}
+              +	return count
+              +}
               ```
           # OUTPUT binding: publish the review text (result field `completion`)
           # into the data context as states.review.output.review.
@@ -66,21 +112,27 @@ spec:
         - event: codereview.completed
           goto: rank
 
-    # ── 2) Summarize + rank the issues ────────────────────────────
+    # ── 2) Categorize (type) + rank (severity) the issues ─────────
     rank:
       actions:
         - capability: summarize
-          # `review` is an INPUT BINDING (a "$.states..." reference): it is
-          # resolved from the data context and exposed to the prompt template as
-          # {{ .ctx.review }}. Bindings are NOT sent to the capability — only the
-          # rendered `prompt` is.
+          # `review` is an INPUT BINDING (a "$.states..." reference): resolved from
+          # the data context and exposed to the prompt as {{ .ctx.review }}.
           input:
             review: "$.states.review.output.review"
             prompt: |
-              Below is a code review. First state the TOTAL number of issues, then
-              list each issue ranked by importance (High / Medium / Low) with a
-              one-line justification.
+              Below is a code review. Produce a structured summary.
 
+              1. State the TOTAL number of distinct issues.
+              2. Then a breakdown BY TYPE — count per category, where Type is one of:
+                 security | correctness | concurrency | error-handling |
+                 resource-leak | performance | style | documentation.
+                 (Do NOT put a severity such as "High" in the Type field — Type is
+                 the category; severity is reported separately.)
+              3. Then list each issue ordered by Severity (High first), as:
+                 "[Severity] (Type) function — one-line summary".
+
+              REVIEW:
               {{ .ctx.review }}
           output:
             ranking: completion


### PR DESCRIPTION
## What

Three improvements to the two-step code-review/rank demo:

1. **Bigger, all-types diff** — `code-review-rank-ollama.yaml` now reviews a larger deliberately-flawed Go diff (hardcoded credential, SQL injection, integer-division discount bug, no-op `Refund`, ignored errors, unclosed file, O(n²) loop, unsynchronized shared counter, missing docs) so the review surfaces issues across **every** category.
2. **Formal `Type` taxonomy, separate from `Severity`** — the prompts now require a `Type` from a fixed set (`security | correctness | concurrency | error-handling | resource-leak | performance | style | documentation`) **and** a separate `Severity` (High/Medium/Low). Fixes the earlier output where the model put `Type: High` (a severity) in the type field.
3. **`STREAM=1` mode** — `make demo STREAM=1 …` prints **every step's** output live via `zynax logs --follow`, instead of only the final result. Useful for multi-step data-flow workflows.

## Honest note on streaming

`STREAM=1` is **per-step**, not per-token: the engine *polls* the task-broker for each capability's final result, so a step's full output appears when that step completes. True token-by-token streaming would require plumbing the adapter's stream through broker→engine→gateway→CLI (a separate, larger change).

## Verification (actually run)

`make demo STREAM=1 DEMO_WORKFLOW=spec/workflows/examples/code-review-rank-ollama.yaml`: streamed **both** steps live (review's `VERDICT`, then the rank step's by-type breakdown), and the rank output categorized **8 issues** with `Type` (category) + `Severity` (importance) — e.g. `Concurrency / Low`, `Resource-Leak / Medium`, `Security / High`. Workflow + Makefile validate; `spec/` and Makefile are PR-size-excluded.

Assisted-by: Claude/claude-opus-4-8