### PR TITLE
docs(adk): ADR-038 + REASONS Canvas for the ADK Go adapter

### DIFF
--- a/agents/AGENTS.md
+++ b/agents/AGENTS.md
@@ -13,6 +13,7 @@
 | Situation | Path |
 |-----------|------|
 | Wrapping an existing system (LangGraph app, REST API, CI, LLM provider) | **Adapter** — `agents/adapters/AGENTS.md` |
+| Building / wrapping a **Google ADK (Go)** agent — tools, sub-agents, multi-step reasoning | **ADK adapter** — `agents/adapters/adk/` (ADR-038) |
 | Building a new Python agent with LangGraph / AutoGen / CrewAI | **Python SDK** — `agents/sdk/AGENTS.md` |
 | Plain Python agent, no AI framework | **Python SDK** (`DirectRuntime`) |
 | Building an agent in Go, TypeScript, Java, Rust | **Raw stubs** — `protos/AGENTS.md §8` |

--- a/agents/adapters/adk/AGENTS.md
+++ b/agents/adapters/adk/AGENTS.md
@@ -1,0 +1,81 @@
+# agents/adapters/adk — ADK Go Adapter
+
+Go adapter service implementing `AgentService` by embedding the **Google Agent
+Development Kit (Go)** (`google.golang.org/adk`). It runs an ADK agent
+(`llmagent` + tools + optional sub-agents) per declared capability and bridges
+the ADK `Runner` event loop onto the Zynax `TaskEvent` stream.
+
+> First **Go-native AI-framework adapter** (ADR-038, refines ADR-035). Unlike the
+> single-shot `llm-adapter`, an ADK-backed capability can use tools, multiple
+> reasoning steps, and sub-agent delegation.
+
+## Module
+
+`github.com/zynax-io/zynax/agents/adapters/adk`
+
+## Capabilities
+
+Capabilities are **declared in config** — each maps to one ADK `llmagent`
+(instruction + tools). The shipped `agent-def.yaml.example` declares a starter
+capability; add more by adding `capabilities[]` entries, no code change.
+
+| Field per capability | Role |
+|----------------------|------|
+| `name` | Capability name routed on by the task broker (e.g. `triage`). |
+| `instruction` | The ADK agent's system instruction (`llmagent.Config.Instruction`). |
+| `input_schema_json` / `output_schema_json` | JSON Schema enforced at the adapter boundary (ADK itself is untyped text/tool-args). |
+| `timeout_seconds` | Wall-clock budget; exceeded → `FAILED` code `TIMEOUT`. |
+
+## Model backends (ADR-038 §3)
+
+| Backend | When | Secret? |
+|---------|------|---------|
+| **Ollama** (default) | `model.provider: ollama` — a custom `model.LLM` (`internal/model`) over Ollama `/api/chat` | **None** — keeps `make demo` secret-free |
+| Gemini (native ADK) | `model.provider: gemini` — ADK's `model/gemini` | `GOOGLE_API_KEY` required |
+
+The model name and host always come from config/env — never hardcoded (12-factor).
+
+## Environment Variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `ADAPTER_CONFIG` | ✓ | Path to the YAML config (see `agent-def.yaml.example`). |
+| `OLLAMA_HOST` | when `provider: ollama` | Ollama base URL (default `http://localhost:11434`). |
+| `GOOGLE_API_KEY` | when `provider: gemini` | Google API key for the native Gemini provider. |
+
+## Configuration
+
+YAML at the path in `ADAPTER_CONFIG`. Key fields:
+
+| Field | Description |
+|-------|-------------|
+| `agent_id` | Unique id registered with agent-registry. |
+| `endpoint` | gRPC bind address (default `:50080`). |
+| `registry_endpoint` | agent-registry address (e.g. `agent-registry:50052`). |
+| `model.provider` | `ollama` (default) or `gemini`. |
+| `model.name` | Model id (e.g. `qwen2.5-coder:3b`). |
+| `capabilities[]` | `name`, `instruction`, `input_schema_json`, `output_schema_json`, `timeout_seconds`. |
+
+## The bridge (`internal/adapter`)
+
+`ExecuteCapability` builds a `genai.Content` from the validated `input_payload`,
+gets/creates an ADK `session` keyed by `workflow_id`, runs `Runner.Run`, and maps
+each `*session.Event` → `PROGRESS`; the final non-`Partial` event → `COMPLETED`
+(coerced to `output_schema`); any error → a classified `CapabilityError`. The
+`AgentService` proto contract is unchanged — ADK use is an internal detail.
+
+## gRPC Port
+
+Default: **50080** (set via `endpoint` in config YAML).
+
+## Testing
+
+```bash
+GOWORK=off go test ./... -race -timeout 60s   # ADR-017: GOWORK=off required
+```
+
+BDD: `protos/tests/features/adk_adapter.feature` (committed before the bridge — ADR-016).
+
+## Reference
+
+Canvas: `docs/spdd/1476-adk-go-adapter/canvas.md` · Decision: `docs/adr/ADR-038-adk-go-adapter-framework.md` · Operator example: `agent-def.yaml.example`

--- a/docs/adr/ADR-038-adk-go-adapter-framework.md
+++ b/docs/adr/ADR-038-adk-go-adapter-framework.md
@@ -1,0 +1,131 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# ADR-038 — Google ADK Go as a Go-native AI-framework adapter
+
+| Field | Value |
+|-------|-------|
+| **Status** | Accepted |
+| **Date** | 2026-06-21 |
+| **Deciders** | Oscar Gómez Manresa |
+| **Scope** | `agents/adapters/adk/` — a new capability adapter embedding the Google Agent Development Kit (Go); refines ADR-035 |
+| **Related** | ADR-013 (adapter-first, no mandatory SDK), ADR-035 (adapter language boundary), ADR-009 (Go for platform, Python for agents), ADR-010 (pluggable runtime), ADR-001 (gRPC inter-service contract), ADR-032 (git MCP shim) |
+
+---
+
+## Context
+
+ADR-035 drew the adapter language line by **what the adapter wraps**:
+
+- **Go** for *stateless provider/proxy* adapters (`http`, `git`, `ci`, `llm`).
+- **Python** for *AI-framework* adapters — "adapters that embed or wrap a
+  Python-only library (LangGraph, LangChain, AutoGen, CrewAI) **where no Go
+  equivalent exists**" (`langgraph`).
+
+That last clause assumed AI-agent frameworks are Python-only. That assumption no
+longer holds. **Google's Agent Development Kit ships a native Go SDK**
+(`google.golang.org/adk`, `go 1.25`) with a full agent-reasoning loop:
+`llmagent.New(cfg)` (instruction + tools + sub-agents), a `runner.Runner`, an
+in-memory `session.Service`, deterministic workflow agents
+(`agent/workflowagents`), `remoteagent` for A2A delegation, and A2A/REST servers
+(`server/adka2a`, `server/adkrest`). It is precisely the "Go equivalent" ADR-035
+presumed did not exist — an **AI-framework that is natively Go**.
+
+This matters because Zynax's whole adapter thesis (ADR-013) is that *any* system
+serving the `AgentService` gRPC contract becomes a first-class capability. ADK Go
+is a high-value thing to wrap: it brings tool-use, multi-step reasoning,
+sub-agent delegation, and A2A — none of which the single-shot `llm-adapter`
+offers — and it is the same runtime the competing kagent project builds on, so
+supporting it is also competitive parity.
+
+Two facts were verified against the ADK Go source before this ADR (not from docs):
+
+1. **The execution seam is near 1:1.**
+   `Runner.Run(ctx, userID, sessionID, *genai.Content, RunConfig) → iter.Seq2[*session.Event, error]`
+   maps directly onto Zynax's `AgentService.ExecuteCapability → stream TaskEvent`:
+   each ADK `session.Event` (it embeds `model.LLMResponse`) becomes a Zynax
+   `PROGRESS` event; the final non-`Partial` event becomes the terminal
+   `COMPLETED`. No engine, compiler, or workflow change is required.
+
+2. **ADK Go ships no Ollama/OpenAI model provider** — only `gemini` and `apigee`,
+   both built on `google.golang.org/genai` (Gemini wire format). Ollama does not
+   speak that format and there is no base-URL shortcut. The `model.LLM` interface
+   is, however, tiny:
+   `Name() string` + `GenerateContent(ctx, *LLMRequest, stream bool) iter.Seq2[*LLMResponse, error]`.
+
+Zynax's hero onboarding (EPIC #1370) is a **zero-secret** local-Ollama quickstart.
+A demo that needed a cloud `GOOGLE_API_KEY` would contradict that positioning.
+
+## Decision
+
+1. **Adopt Google ADK Go as a supported adapter framework.** Add
+   `agents/adapters/adk/`, a Go adapter implementing the `AgentService` gRPC
+   contract, mirroring the existing Go adapters (`git`/`http`/`ci`/`llm`):
+   `cmd/adk-adapter/main.go` (wiring + registry registration), `internal/config`,
+   `internal/adapter/server.go` (the bridge), `internal/adk` (builds the
+   `llmagent`), shipped as a single distroless binary.
+
+2. **Refine ADR-035: decouple the language axis from the "what it wraps" axis.**
+   Adapter language is now chosen by *whether a native-Go binding exists*, not by
+   whether the adapter embeds a framework:
+   - **Python** only when the framework is **Python-only** (LangGraph → `langgraph`).
+   - **Go** when the adapter is a proxy **or** embeds a framework with a native-Go
+     SDK (ADK → `adk`).
+   ADK is the first **Go AI-framework adapter**: it embeds an agent-reasoning
+   framework (so it is *not* a proxy) yet needs no Python.
+
+3. **Ship a custom `model.LLM` over Ollama inside the adapter** so ADK agents run
+   secret-free under the existing Ollama compose overlay. It translates
+   `[]*genai.Content` ↔ Ollama `/api/chat` messages and adapts responses back into
+   `*model.LLMResponse`. ADK's native `gemini` provider remains selectable by env
+   for users who supply a key — Ollama is the default, keeping the quickstart
+   secret-free.
+
+4. **Reasoning lives in the adapter; the manifest stays a thin capability surface.**
+   The ADK agent's `Instruction`, `Tools`, and sub-agents are wired in
+   `internal/adk`; the `AgentDef` manifest declares only the capability name,
+   JSON input/output schema, and runtime image. The wire contract is the unchanged
+   `AgentService` proto (ADR-001/ADR-013) — the adapter's use of ADK is invisible
+   to the platform and to the language-agnostic BDD `.feature`.
+
+## Consequences
+
+**Positive**
+
+- ADK's tool-use, multi-step reasoning, sub-agent delegation, and A2A reach become
+  dispatchable Zynax capabilities, referenced by name from any workflow state —
+  with **zero** engine/compiler/workflow change (the AgentService seam pays off).
+- Go-native: distroless static binary, no Python dependency tax, same lint/test/
+  build path as the other four Go adapters (ADR-035's uniformity benefit extends).
+- The custom Ollama `model.LLM` keeps `make demo` secret-free, preserving the
+  EPIC #1370 quickstart while adding ADK's capabilities.
+- Competitive parity: Zynax can host the same ADK-authored agents kagent runs,
+  but behind its declarative workflow engine.
+
+**Negative / accepted**
+
+- The custom `model.LLM` is maintenance we own: the `genai.Content` ↔ Ollama
+  translation, including tool-call round-trips, is non-trivial and must track ADK's
+  `model` package. Bounded by an adapter-level `.feature` parity oracle (ADR-016).
+- Small local models are weak at tool-calling, so the **first** demo agent stays
+  simple (single-tool or single-shot); richer tool-using demos may need a stronger
+  model (cloud, with a key) and are explicitly out of the zero-secret default.
+- ADK Go is young: pin the `google.golang.org/adk` version and re-verify the
+  `Runner`/`Session`/`model.LLM` signatures on each bump. Its `go 1.25` floor sets
+  the adapter module's toolchain.
+- Supply chain grows by `google.golang.org/adk` + `google.golang.org/genai`
+  (govulncheck-gated via `make security`).
+
+## Alternatives considered
+
+- **Wrap ADK through the Python adapter path (adk-python).** Rejected: ADK has a
+  first-class Go SDK; routing through Python would re-incur exactly the dependency/
+  CVE tax ADR-035 removed, for no capability gain.
+- **Reuse the existing `llm-adapter` instead of adding ADK.** Rejected: the
+  `llm-adapter` is a single-shot prompt→completion proxy with no agent loop, tools,
+  or sub-agents — it cannot express what ADK exists to provide.
+- **Gemini-only demo (skip the custom Ollama model).** Rejected: requires a cloud
+  `GOOGLE_API_KEY`, breaking the zero-secret #1370 quickstart and the local-first
+  positioning.
+- **An `AdkEngine` implementing `WorkflowEngine` (ADK workflow agents interpret
+  WorkflowIR).** Deferred, not rejected: a much larger, orthogonal effort behind
+  ADR-015's engine abstraction; recorded for a future milestone, not this adapter.

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -48,6 +48,7 @@ a PR against `docs/adr/`.
 | [ADR-035](ADR-035-adapter-language-boundary.md) | Adapter language boundary — Go for provider/proxy adapters, Python for AI-framework adapters | Accepted | 2026-06-16 | `agents/adapters/*` — refines ADR-009 — M7 EPIC P (#1276) |
 | [ADR-036](ADR-036-ci-logic-as-go-cli.md) | CI logic belongs in a tested Go CLI (zynax-ci), not inline workflow bash | Accepted | 2026-06-16 | `cmd/zynax-ci/`, `.github/workflows/*`, `scripts/`, `Makefile` — M7 EPIC S (#1285) |
 | [ADR-037](ADR-037-zero-temporal-evaluation-engine.md) | Zero-Temporal in-process evaluation engine (Day-0 onboarding) | Rejected | 2026-06-19 | `services/engine-adapter/` — third engine behind ADR-015 — M7 (#1359) (superseded by #1456) |
+| [ADR-038](ADR-038-adk-go-adapter-framework.md) | Google ADK Go as a Go-native AI-framework adapter | Accepted | 2026-06-21 | `agents/adapters/adk/` — refines ADR-035 — M7 |
 
 ---
 

--- a/docs/spdd/1476-adk-go-adapter/canvas.md
+++ b/docs/spdd/1476-adk-go-adapter/canvas.md
@@ -1,0 +1,116 @@
+# REASONS Canvas — ADK Go as a Go-native AI-framework adapter
+
+> **All content in this Canvas is Tier 1 (public-safe).**
+> Tier 2 content (internal hostnames, IPs, credentials, deployment specifics) belongs in
+> `canvas.private.md` (gitignored). Run `/spdd-security-review <path>` before committing.
+
+**Issue:** #1476
+**Author:** Oscar Gómez Manresa
+**Date:** 2026-06-21
+**Status:** Aligned
+
+---
+
+## R — Requirements
+
+- **Problem:** Zynax's only "agent" today is the single-shot `llm-adapter` (prompt → completion). There is no path to **tool-using, multi-step, or sub-agent** reasoning inside a workflow. Google ADK Go provides exactly that, but it speaks a different model (in-process `Runner`/`Session` over `genai`) and — verified against source — ships **no Ollama/OpenAI provider** (only `gemini`, `apigee`). So it can be dispatched neither as a Zynax capability nor secret-free, without an adapter.
+- **Done — observable outcomes:**
+  - `adk-adapter` serves `AgentService`, registers a capability with `agent-registry`, reports gRPC health `SERVING`.
+  - A workflow dispatches the ADK-backed capability **by name**; ADK `Runner` events surface as `PROGRESS`, the final non-`Partial` event as terminal `COMPLETED`; `timeout_seconds` → `FAILED` code `TIMEOUT`.
+  - The demo runs **secret-free** on local Ollama (existing compose overlay): `zynax apply` → `zynax logs --follow` → `zynax result` returns the agent's output. Verified by running the stateful path **twice**.
+  - `GOWORK=off go test ./... -race`, adapter `.feature`, `make lint` / `make security` / `make check-images` all green.
+
+---
+
+## E — Entities
+
+- **AdkAdapter** — implements `AgentService`; a `CapabilityRouter` maps `capability_name` → an ADK agent + instruction + JSON schema.
+- **AdkAgent** — `llmagent.New(cfg)`: instruction + tools (+ optional sub-agents).
+- **OllamaModel** — a custom `model.LLM` (the one real gap): translates `[]*genai.Content` ↔ Ollama `/api/chat`, response → `*model.LLMResponse`.
+- **AgentDef manifest** — declares the capability surface (name + input/output JSON Schema) + runtime image; the reasoning is *not* in the manifest.
+
+```
+TaskBroker
+  → AgentService.ExecuteCapability(capability_name, input_payload, workflow_id, timeout)
+     → AdkAdapter (router) → Runner.Run(AdkAgent over OllamaModel, session=workflow_id)
+        → iter.Seq2[*session.Event, error]  ─maps→  stream TaskEvent (PROGRESS… → COMPLETED/FAILED)
+```
+
+---
+
+## A — Approach
+
+**We will:**
+- Add `agents/adapters/adk/` as a **Go** adapter mirroring `git`/`llm`; implement `AgentService` and bridge `Runner.Run → iter.Seq2[*session.Event, error]` onto `ExecuteCapability → stream TaskEvent` (the verified near-1:1 seam).
+- Ship a custom **Ollama `model.LLM`** so ADK agents run secret-free under the existing Ollama overlay; ADK's native `gemini` provider stays selectable by env for users with a key.
+- Keep reasoning (instruction, tools, sub-agents) inside the adapter; keep `AgentDef` a thin capability surface; leave the `AgentService` wire contract unchanged.
+
+**We will NOT:**
+- Touch any engine / compiler / workflow / proto contract (the seam is unchanged — ADR-001/ADR-013).
+- Build an `AdkEngine` implementing `WorkflowEngine` via ADK workflow agents — deferred in ADR-038 (separate, larger, behind ADR-015).
+- Ship rich tool-using demos on weak local models (poor at tool-calling) — the first demo stays simple; richer demos need a stronger (cloud) model and are not the zero-secret default.
+
+**Positioning fit:** advances the **local-first / zero-secret** and **author-once-run-anywhere** wedge — an ADK-authored agent becomes a portable capability dispatched behind Zynax's declarative workflow engine (direct parity with kagent, which runs agents on ADK). User-facing surface: a new demo workflow + adapter docs/help; no change to the generic control-plane framing.
+
+**Governing ADRs:** ADR-038 (ADK Go adapter framework), ADR-035 (adapter language boundary), ADR-013 (adapter-first), ADR-001 (gRPC contract), ADR-010 (pluggable runtime), ADR-016 (BDD-first).
+
+---
+
+## S — Structure (first S)
+
+```
+agents/adapters/adk/
+├── go.mod / go.sum            ← module …/agents/adapters/adk (go 1.25; deps: adk, genai, protos, grpc)
+├── AGENTS.md                  ← adapter contract doc (shape from git/AGENTS.md)
+├── Dockerfile                 ← distroless adk-adapter binary (mirror git/Dockerfile)
+├── agent-def.yaml.example     ← AgentDef: capability + JSON schemas + runtime image
+├── cmd/adk-adapter/main.go    ← wiring only: ADAPTER_CONFIG → register → grpc+health → deregister
+└── internal/
+    ├── config/config.go       ← AdapterConfig{AgentID,Endpoint,RegistryEndpoint,Capabilities[]}
+    ├── adk/agent.go           ← llmagent.New(Config{Name,Description,Model,Instruction,Tools})
+    ├── model/ollama.go        ← custom model.LLM over Ollama /api/chat (genai.Content translation)
+    ├── adapter/server.go      ← AgentServiceServer: ExecuteCapability bridge + GetCapabilitySchema
+    └── registry/client.go     ← BuildAgentDef + RegisterAgent/DeregisterAgent (copy from git)
+```
+
+Config env prefix: `ADAPTER_CONFIG` (path) · `OLLAMA_HOST` (model endpoint) · Port: adapter gRPC `Endpoint` from config.
+
+---
+
+## O — Operations
+
+1. **S1 (#1477, docs):** ADR-038 + this Canvas + adapter `AGENTS.md`. *Verify:* Canvas passes security review and is set **Aligned**; `docs:` PR (size-excluded). *(ADR + INDEX + path-table already drafted.)*
+2. **S2 (#1478, feat):** adapter skeleton — `config`, `registry` client, `main.go` wiring, health; `ExecuteCapability` returns "not wired" until S3. *Verify:* `.feature` + unit tests green; adapter boots, registers, health `SERVING`.
+3. **S3 (#1479, feat):** custom Ollama `model.LLM` + ADK `Runner`→`TaskEvent` bridge (`model/ollama.go`, `adk/agent.go`, `adapter/server.go`). *Verify:* `.feature` covers dispatch, schema-validate, `timeout→TIMEOUT`, terminal `COMPLETED`/`FAILED`; `make security` green.
+4. **S4 (#1480, feat):** `agent-def.yaml.example` + demo workflow + `Dockerfile` + `images.yaml` + compose wiring. *Verify:* secret-free Ollama run returns `COMPLETED` (twice); `make check-images` green.
+
+---
+
+## N — Norms
+
+- Commit hygiene: every commit carries `Signed-off-by:` + `Assisted-by: Claude/<model>` (never `Co-Authored-By` for AI).
+- BDD: adapter `.feature` committed before the bridge implementation (ADR-016).
+- `GOWORK=off` for all `go`/`go test` in the adapter module (ADR-017).
+- Adapter rules (`agents/adapters/AGENTS.md`): stateless; route on `capability_name` only; emit exactly one terminal `TaskEvent`; honor `timeout_seconds`.
+- Model/endpoint always from config/env — never hardcode model name or host (12-factor).
+- One PR per story (#1477–#1480); PR-size budget respected (split already mapped to stories).
+
+---
+
+## S — Safeguards (second S)
+
+### Context Security (complete before committing this Canvas)
+
+- [x] No Tier 2 content: no internal hostnames, private IPs, credentials, deployment specifics
+- [x] No PII: no personal names in sensitive context, no non-public email addresses
+- [x] No prompt injection: no instruction-like phrasing that overrides AGENTS.md rules
+- [x] All entities in E section are public-safe abstractions
+- [x] `/spdd-security-review` passed — result: PASS (2026-06-21)
+
+### Feature Safeguards
+
+- Never change the `AgentService` proto contract — the seam is fixed; ADK use is an internal detail (ADR-001/ADR-013).
+- Never hardcode the model name or Ollama host — resolve from config/env (12-factor; ADR-035 §model-from-config).
+- Never log secrets or full prompts containing injected credentials — adapters never leak token material (cf. git-adapter redaction).
+- Never emit events after the terminal `TaskEvent`, and always emit exactly one `COMPLETED` or `FAILED` (AgentService invariant).
+- Never import another service's `internal/` — cross-service only via gRPC (ADR-008).

--- a/state/current-milestone.md
+++ b/state/current-milestone.md
@@ -38,7 +38,7 @@ Goal: a developer authors a real multi-step workflow, runs it locally (`docker c
 **Uptrace**), watches it execute state→state with **data-flow**, **streamed logs**, and a connected
 **distributed trace** in the Uptrace login UI — with green `make ci`.
 
-### EPICs (13) — one REASONS Canvas each under `docs/spdd/<letter>-<slug>/`
+### EPICs (14) — one REASONS Canvas each under `docs/spdd/<letter>-<slug>/`
 | EPIC | Title | Type | Canvas |
 |------|-------|------|--------|
 | W | Workflow data-flow (output/input bindings) — **keystone** | feat | [W](../docs/spdd/1167-workflow-data-flow/canvas.md) |
@@ -54,6 +54,7 @@ Goal: a developer authors a real multi-step workflow, runs it locally (`docker c
 | P | Port `llm-adapter` to Go (language-boundary cleanup, ADR-035) | refactor | [P](../docs/spdd/1276-llm-adapter-go/canvas.md) |
 | S | Consolidate CI bash into the `zynax-ci` Go CLI (ADR-036) | ci | [S](../docs/spdd/1285-ci-bash-to-go/canvas.md) |
 | K | First-run User Experience — zero-secret Ollama quickstart (clone → one command → result) | feat | [K](../docs/spdd/1370-awesome-quickstart/canvas.md) |
+| A | Google ADK Go adapter — Go-native AI-framework adapter (#1476, ADR-038) | feat | [A](../docs/spdd/1476-adk-go-adapter/canvas.md) |
 
 Pre-existing M7 EPICs #467 (OTel) / #468 (history streaming) / #469 (test rigor) are **absorbed** into
 O / L / R respectively — and their issue titles were aligned to that scheme 2026-06-17


### PR DESCRIPTION
## S1 of EPIC #1476 — ADK Go adapter (SPDD Step-0 docs)

The docs-only foundation for the Google ADK Go adapter. **No implementation code.**

### What's here
- **ADR-038** (Accepted) — ADK Go as the first **Go-native AI-framework adapter**; refines **ADR-035** by decoupling the language axis ("Go vs Python") from the "what it wraps" axis ("proxy vs AI-framework"). ADK ships a native Go SDK, so an AI-framework adapter need not be Python.
- **REASONS Canvas** (`docs/spdd/1476-adk-go-adapter/canvas.md`) — Status **Aligned**, `/spdd-security-review` **PASS**.
- **Adapter `AGENTS.md`** — the contract for `agents/adapters/adk/`.
- **`agents/AGENTS.md`** path-table row + **ADR INDEX** entry.
- **`state/current-milestone.md`** — EPIC **A** scoped into M7 (13 → 14).

### Two facts grounded against real `google.golang.org/adk` source
- The seam is near-1:1: `runner.Run → iter.Seq2[*session.Event, error]` maps onto `ExecuteCapability → stream TaskEvent`.
- ADK Go ships **no Ollama provider** (only `gemini`/`apigee`) → the adapter will ship a custom `model.LLM` over Ollama, keeping the demo **secret-free**.

### Follow-ups (one PR each)
- #1478 — adapter skeleton (config, registry, gRPC wiring, `.feature`)
- #1479 — custom Ollama `model.LLM` + ADK `Runner`→`TaskEvent` bridge
- #1480 — AgentDef manifest + demo workflow + image/compose wiring

🤖 Generated with [Claude Code](https://claude.com/claude-code)
