### PR TITLE
ci(zynax-ci): accept Superseded and Rejected canvas statuses

### DIFF
--- a/cmd/zynax-ci/cmd/validate_canvas.go
+++ b/cmd/zynax-ci/cmd/validate_canvas.go
@@ -24,7 +24,7 @@ var validateCanvasCmd = &cobra.Command{
 Checks per canvas:
   • Seven REASONS sections (R, E, A, S-structure, O, N, S-safeguards)
   • Header fields: **Issue:**, **Author:**, **Date:**, **Status:**
-  • Status value one of: Draft, Aligned, Implemented, Synced
+  • Status value one of: Draft, Aligned, Implemented, Synced, Superseded, Rejected
   • Context Security checklist marker present
 
 Status: Draft emits a warning but does not fail.

--- a/cmd/zynax-ci/validate/canvas.go
+++ b/cmd/zynax-ci/validate/canvas.go
@@ -33,8 +33,14 @@ type ValidationWarning struct {
 	Message string `json:"message"`
 }
 
+// validStatuses is the closed set of canvas lifecycle statuses. Draft → Aligned →
+// Implemented → Synced is the active path; Superseded and Rejected are terminal
+// states for a canvas whose design was abandoned or replaced (e.g. its ADR was
+// Rejected), which must remain valid so a closed/superseded canvas does not fail
+// the repo-wide canvas validation.
 var validStatuses = map[string]bool{
 	"Draft": true, "Aligned": true, "Implemented": true, "Synced": true,
+	"Superseded": true, "Rejected": true,
 }
 
 type sectionCheck struct {
@@ -66,7 +72,7 @@ var statusRe = regexp.MustCompile(`\*\*Status:\*\*\s*(\w+)`)
 // Checks (full parity with tools/validate_canvas.py):
 //   - Seven REASONS sections present
 //   - **Issue:**, **Author:**, **Date:**, **Status:** header fields present
-//   - Status value is one of Draft, Aligned, Implemented, Synced
+//   - Status value is one of Draft, Aligned, Implemented, Synced, Superseded, Rejected
 //   - Context Security checklist marker present
 //   - canvas.private.md not committed alongside canvas.md
 //
@@ -117,7 +123,7 @@ func checkStatus(filePath, text string, errs *[]ValidationError, warns *[]Valida
 	if !validStatuses[status] {
 		*errs = append(*errs, ValidationError{
 			File:    filePath,
-			Message: fmt.Sprintf("invalid Status %q — must be one of: Aligned, Draft, Implemented, Synced", status),
+			Message: fmt.Sprintf("invalid Status %q — must be one of: Aligned, Draft, Implemented, Synced, Superseded, Rejected", status),
 		})
 		return
 	}

--- a/cmd/zynax-ci/validate/canvas_test.go
+++ b/cmd/zynax-ci/validate/canvas_test.go
@@ -75,6 +75,27 @@ func TestCanvas_DraftStatus_IsWarning(t *testing.T) {
 	}
 }
 
+func TestCanvas_TerminalStatuses_AreValid(t *testing.T) {
+	// Superseded/Rejected are terminal states for an abandoned or replaced canvas
+	// (e.g. its ADR was Rejected) and must validate without errors or warnings.
+	for _, status := range []string{"Superseded", "Rejected"} {
+		t.Run(status, func(t *testing.T) {
+			content := strings.ReplaceAll(fullCanvas, "**Status:** Aligned", "**Status:** "+status)
+			f := writeTempCanvas(t, content)
+			errs, warns, err := validate.Canvas(f)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(errs) != 0 {
+				t.Errorf("expected no errors for %s status, got: %v", status, errs)
+			}
+			if len(warns) != 0 {
+				t.Errorf("expected no warnings for %s status, got: %v", status, warns)
+			}
+		})
+	}
+}
+
 func TestCanvas_InvalidStatus(t *testing.T) {
 	content := strings.ReplaceAll(fullCanvas, "**Status:** Aligned", "**Status:** InProgress")
 	f := writeTempCanvas(t, content)


### PR DESCRIPTION
## ci(zynax-ci): accept Superseded and Rejected canvas statuses

### Why
The canvas validator (`cmd/zynax-ci/validate/canvas.go`) accepted only `Draft/Aligned/Implemented/Synced`. A closed canvas whose design was **superseded** or whose ADR was **Rejected** — e.g. `docs/spdd/1359-zero-temporal-engine` (superseded by #1456, ADR-037 Rejected) — therefore failed the repo-wide **"SPDD Canvas freshness"** validate-all pass on every `feat:` PR (it ran red on PR #1482 for exactly this reason). The non-required check isn't a merge blocker, but it's persistent red noise.

### What changed
- `validStatuses` gains the two terminal states `Superseded` + `Rejected` (with a doc comment explaining the lifecycle).
- Error message + CLI help + package doc updated to list them.
- Added `TestCanvas_TerminalStatuses_AreValid` (both validate with no errors/warnings).

### Verified
`GOWORK=off go run . validate canvas docs/spdd/` now reports **#1359 OK** (exit 0). validate-pkg tests pass `-race`; golangci-lint **0 issues**; cmd/zynax-ci coverage **86%** (≥80% gate).

### ⚠️ Follow-up required for full CI effect
The "SPDD Canvas freshness" check runs the **baked `zynax-ci`** from the ci-runner image (pinned by digest in `pr-checks.yml`), not from source. So the check stays red until the **ci-runner image is rebuilt and its digest re-pinned**. This PR is the source fix; the image bump is the second step (or switch that one check to `go run`-from-source like the milestone/images checks already do).

### Risk
Low — additive: widens an allow-list, no existing canvas changes status.

Signed-off-by: Oscar Gómez Manresa <ogomezmanresa@gmail.com>
Assisted-by: Claude/claude-opus-4-8