### PR TITLE
ci(test-go): auto-discover Go adapters from go.work

### DIFF
--- a/.github/workflows/_test-go.yml
+++ b/.github/workflows/_test-go.yml
@@ -29,7 +29,9 @@ defaults:
 
 env:
   SERVICE_LIST: "agent-registry task-broker api-gateway workflow-compiler engine-adapter"
-  GO_ADAPTER_LIST: "http git"
+  # Go adapter modules are auto-discovered from go.work at run time (see the
+  # adapter test/coverage steps) — single source of truth, mirrors the Makefile
+  # and tools/golangci-lint-precommit.sh. No manual list to keep in sync.
   GOPROXY: "https://proxy.golang.org,direct"
   GONOSUMDB: "*"
 
@@ -246,7 +248,11 @@ jobs:
         if: steps.go-detect.outputs.has_adapters != '0' && inputs.adapters_go == 'true'
         run: |
           failed=false
-          for adapter in ${{ env.GO_ADAPTER_LIST }}; do
+          # Auto-discover Go adapter modules from go.work (SoT) — mirrors the Makefile
+          # and tools/golangci-lint-precommit.sh, so a new adapter is tested without a
+          # manual list edit here.
+          mapfile -t adapters < <(grep -E '^[[:space:]]+\./agents/adapters/' go.work | sed 's|.*agents/adapters/||')
+          for adapter in "${adapters[@]}"; do
             if [ -f "agents/adapters/${adapter}/go.mod" ]; then
               echo "── test: agents/adapters/${adapter}"
               cd "agents/adapters/${adapter}"
@@ -266,7 +272,8 @@ jobs:
         if: steps.go-detect.outputs.has_adapters != '0' && inputs.adapters_go == 'true'
         run: |
           failed=false
-          for adapter in ${{ env.GO_ADAPTER_LIST }}; do
+          mapfile -t adapters < <(grep -E '^[[:space:]]+\./agents/adapters/' go.work | sed 's|.*agents/adapters/||')
+          for adapter in "${adapters[@]}"; do
             if [ -f "agents/adapters/${adapter}/coverage.out" ]; then
               cd "agents/adapters/${adapter}"
               total=$(GOWORK=off go tool cover -func=coverage.out 2>/dev/null \

--- a/agents/adapters/ci/internal/adapter/server_test.go
+++ b/agents/adapters/ci/internal/adapter/server_test.go
@@ -404,3 +404,11 @@ func TestGetRunStatus_APIError429(t *testing.T) {
 		t.Fatalf("want RESOURCE_EXHAUSTED, got %v", last)
 	}
 }
+
+func TestNewAgentServer(t *testing.T) {
+	// The production constructor wires a real CI handler from a resolved token;
+	// httptest paths use NewAgentServerWithURL, so cover the public ctor directly.
+	if adapter.NewAgentServer(minimalCfg(), "tok") == nil {
+		t.Fatal("NewAgentServer returned nil")
+	}
+}

--- a/agents/adapters/ci/internal/registry/client_test.go
+++ b/agents/adapters/ci/internal/registry/client_test.go
@@ -5,6 +5,7 @@ package registry_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/zynax-io/zynax/agents/adapters/ci/internal/config"
 	"github.com/zynax-io/zynax/agents/adapters/ci/internal/registry"
@@ -109,6 +110,22 @@ func TestRegisterAgent_NonTransientError(t *testing.T) {
 	// Non-transient: should fail on first attempt.
 	if stub.calls != 1 {
 		t.Errorf("expected 1 call (no retry on InvalidArgument), got %d", stub.calls)
+	}
+}
+
+func TestRegisterAgent_TransientRetriesUntilCancelled(t *testing.T) {
+	t.Parallel()
+	// Always-Unavailable forces a retry (isTransient → true); a short ctx deadline
+	// trips the backoff select's ctx.Done() branch instead of waiting the base delay.
+	stub := &stubRegistryClient{registerErr: status.Error(codes.Unavailable, "down")}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancel()
+	err := registry.RegisterAgent(ctx, stub, &zynaxv1.AgentDef{AgentId: "ci-adapter"})
+	if err == nil {
+		t.Fatal("expected cancellation error, got nil")
+	}
+	if stub.calls < 1 {
+		t.Errorf("expected at least one register attempt, got %d", stub.calls)
 	}
 }
 


### PR DESCRIPTION
## ci(test-go): auto-discover Go adapters from go.work

### Why
`.github/workflows/_test-go.yml` hardcoded `GO_ADAPTER_LIST: "http git"`, so the **adk / ci / llm** adapters were never unit-tested or coverage-gated in CI — a silent divergence from the **Makefile** (`GO_ADAPTERS := $(shell grep ... go.work ...)`) and **`tools/golangci-lint-precommit.sh`**, which both auto-discover adapter modules from `go.work`. The list drifted (and would keep drifting every time an adapter is added — e.g. adk in #1482).

### What changed
- **`_test-go.yml`** — both the *Go adapter unit tests* and *coverage-gate* steps now discover adapters from `go.work` via `mapfile` (same query as the Makefile/pre-commit), and the stale `GO_ADAPTER_LIST` env is removed. New adapters are tested automatically, no manual list edit.
- **`ci` adapter coverage 84.4% → 87.2%** — auto-discovery surfaced the `ci` adapter just under the 85% gate, so two previously-untested paths are now covered: the public `NewAgentServer` constructor and `RegisterAgent`'s transient-retry/cancellation branch.

### Verified locally
- `agents/adapters/ci`: `GOWORK=off go test ./... -race` passes; total coverage **87.2%** (≥85% gate); golangci-lint **0 issues**.
- `go.work` discovery yields exactly `adk ci git http llm` (5 distinct entries).
- `actionlint` on `_test-go.yml`: **no new findings vs main** (SC2086 info-count unchanged at 1, pre-existing).

### Scope note
Only the **test/coverage** matrix is switched to auto-discovery here; the lint job is unchanged. All five adapters now clear the 85% test-coverage gate (adk 86.4 / ci 87.2 / git 90.2 / http 85.2 / llm 91.0).

### Risk
Low — CI now runs more adapter tests (all currently green); no production code changed.

Signed-off-by: Oscar Gómez Manresa <ogomezmanresa@gmail.com>
Assisted-by: Claude/claude-opus-4-8