### PR TITLE
docs(adr): accept ADR-040 (thin-Zynax delegation boundary)

### DIFF
--- a/docs/adr/ADR-040-kubernetes-native-delegation-boundary.md
+++ b/docs/adr/ADR-040-kubernetes-native-delegation-boundary.md
@@ -1,6 +1,6 @@
 # ADR-040: Kubernetes-native delegation boundary (thin-Zynax)
 
-**Status:** Proposed  **Date:** 2026-06-22
+**Status:** Accepted  **Date:** 2026-06-22
 **Related:** ADR-039 (the first concrete migration under this principle — agent-registry → `Agent` CRD), ADR-020 (mTLS via cert-manager — auth already delegated), ADR-030 (OpenTelemetry + Uptrace — metrics/tracing/logging already delegated), ADR-026 (Postgres distribution), ADR-012 (engine-agnostic Workflow IR — bounds the Workflow-CRD decision), ADR-015 (pluggable workflow engines), ADR-011 (declarative YAML / CRD control surface), ADR-016/017 (testing · `GOWORK=off`)
 
 > **Sequencing:** This is a governing **principle** ADR. It records the delegation boundary and the

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -50,7 +50,7 @@ a PR against `docs/adr/`.
 | [ADR-037](ADR-037-zero-temporal-evaluation-engine.md) | Zero-Temporal in-process evaluation engine (Day-0 onboarding) | Rejected | 2026-06-19 | `services/engine-adapter/` — third engine behind ADR-015 — M7 (#1359) (superseded by #1456) |
 | [ADR-038](ADR-038-adk-go-adapter-framework.md) | Google ADK Go as a Go-native AI-framework adapter | Accepted | 2026-06-21 | `agents/adapters/adk/` — refines ADR-035 — M7 |
 | [ADR-039](ADR-039-crd-native-scheduler.md) | CRD-native Scheduler — `Agent` CRD as the single source of truth; registry → stateless scheduler | Accepted | 2026-06-22 | `services/agent-registry/` (→ scheduler), `protos/zynax/v1/scheduler.proto`, task-broker — amends ADR-021/028 — spike M7, build M8 |
-| [ADR-040](ADR-040-kubernetes-native-delegation-boundary.md) | Kubernetes-native delegation boundary (thin-Zynax) — build only the AI-scheduling core, delegate generic primitives | Proposed | 2026-06-22 | Repo-wide design principle — delegation vs custom core; Workflow=thin CRD front-end; Loki out of scope — relates ADR-039/020/030/012/015 |
+| [ADR-040](ADR-040-kubernetes-native-delegation-boundary.md) | Kubernetes-native delegation boundary (thin-Zynax) — build only the AI-scheduling core, delegate generic primitives | Accepted | 2026-06-22 | Repo-wide design principle — delegation vs custom core; Workflow=thin CRD front-end; Loki out of scope — relates ADR-039/020/030/012/015 |
 
 ---
 


### PR DESCRIPTION
Flip ADR-040 status Proposed → Accepted (file + INDEX). The Kubernetes-native delegation boundary is now binding. No content change beyond status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)