### PR TITLE
docs(adr): ADR-041 kind-native unified runtime; re-point #1370 canvas to kind

### DIFF
--- a/docs/adr/ADR-041-kind-native-unified-runtime.md
+++ b/docs/adr/ADR-041-kind-native-unified-runtime.md
@@ -1,0 +1,68 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+# ADR-041: Local-Kubernetes (kind) as the unified runtime model — Docker Compose retired as the primary path
+
+**Status:** Proposed  **Date:** 2026-06-25
+**Related:** ADR-039 (CRD-native scheduler — the Phase-2 unifier), ADR-040 (Kubernetes-native delegation boundary), ADR-037 (rejected zero-Temporal eval engine; superseded by #1456), ADR-015 (pluggable workflow engines), ADR-020 (mTLS via cert-manager), ADR-026 (Postgres chart). Resolves the open decision in EPIC #1370 / O26 / #1495.
+
+---
+
+## Context
+
+Zynax runs in **two divergent runtimes** today:
+
+- **Docker Compose** — the laptop/dev/demo on-ramp (`make run-local`, `make demo`). Discovery is push-based gRPC `RegisterAgent`; there is no Kubernetes API server, so there are no CRDs, no NetworkPolicy, no cert-manager mTLS, no HPA, and the **Argo engine cannot run at all** (it is Kubernetes-native).
+- **Helm / Kubernetes** — the production control plane (prod-tested in M6, v0.5.0). Full manifests, mTLS, RBAC, NetworkPolicy, both Temporal and Argo engines.
+
+Three accepted decisions now pull hard toward Kubernetes:
+
+1. **ADR-039** makes the `Agent` Custom Resource the single source of truth and turns `agent-registry` into a stateless, informer-backed scheduler. Its own Consequences state this *"removes the Docker-Compose discovery path … and directly erodes the EPIC #1370 first-run wedge,"* and require the M8 cutover to either retarget first-run to local-K8s **or** keep a flagged Compose "lite" mode. This is the load-bearing open question (tracked as O26 / #1495).
+2. **ADR-040** establishes that Zynax delegates generic primitives to Kubernetes and treats *building a Zynax service to replace a Kubernetes primitive as an anti-pattern.* Keeping push-registration alive purely for Compose is exactly such a parallel mechanism.
+3. The **engine-portability wedge** ("write once, run on Temporal or Argo") cannot be demonstrated on Compose, because Argo needs Kubernetes.
+
+The repository already has everything required for a Kubernetes-everywhere model: prod-tested Helm charts under `helm/`, a kind-based e2e harness (`scripts/e2e/cluster-up.sh`, `.github/workflows/e2e-smoke.yml`) that deploys the full stack on **kind** with a dual-engine (Temporal + Argo) matrix, and a CRD-native scheduler **already spiked** (`spike/adr-039-crd-scheduler-proof`, 7/7 checks green on kind). What is missing is only a *developer-facing* local-K8s path — kind is CI-only and undocumented for laptops.
+
+Maintaining Compose as a first-class parallel runtime therefore means two discovery code paths, ongoing behavior drift (Compose can never mirror prod), and carrying deprecated push RPCs indefinitely — directly against ADR-039/040.
+
+---
+
+## Decision
+
+**We will standardize every environment — local, CI, and production — on Kubernetes, using a local single-node cluster (`kind`) as the developer/demo runtime, and retire Docker Compose as the sanctioned primary path.**
+
+1. **One runtime model.** Local development, the demo, and CI all run on Kubernetes. Locally this is **kind** (the tool already proven in our e2e harness); k3s / k3d / managed clusters are the *same model* at larger scale. "It runs the same way everywhere" becomes literally true.
+2. **Retire Docker Compose as the primary local runtime.** It is **deprecated** during the transition and **removed** once the kind path reaches parity for the developer and demo journeys. No new feature work targets Compose.
+3. **One-command UX is preserved by wrapping the cluster lifecycle.** A single `make demo` creates the kind cluster, `kind load`s images, installs the Helm umbrella, runs the hero workflow, shows the result, and offers teardown — the user still types **one command**, even though the runtime is Kubernetes. A `make kind-up` / `make kind-down` pair fronts `scripts/e2e/cluster-up.sh`.
+4. **Two-phase execution:**
+   - **Phase 1 (now, M7→M8 bridge):** make kind + the existing Helm charts the developer/demo runtime; rewrite README/quickstart/local-dev to lead with the kind path; re-point the EPIC #1370 closeout stories (O18–O26) to kind. Discovery stays push-based, but now runs *inside the cluster*, so the **topology already matches production**.
+   - **Phase 2 (M8, ADR-039):** swap discovery push → `Agent` CRD. At that point kind ≡ k3s ≡ prod down to scheduling semantics, and the push `RegisterAgent` RPCs are hard-removed (their only remaining consumer — Compose — is gone).
+5. **Engines.** kind-local unlocks **Argo locally** alongside Temporal, so the engine-portability wedge ("write once, run on Temporal *or* Argo") is demonstrable on a laptop — which Compose never could. The lightweight Temporal eval profile (#1456) continues as an in-cluster Temporal *dev* profile to keep first-run light.
+
+---
+
+## Rationale
+
+| Option | Assessment |
+|--------|------------|
+| **kind everywhere; retire Compose** | ✅ **Chosen** — one runtime model; local mirrors prod; unlocks Argo-local; aligns with ADR-039/040; deletes the dual-discovery + deprecated-RPC debt; CNCF-idiomatic local-dev story. |
+| Dual-path: Compose (eval) + K8s (prod) behind a `REGISTRY_BACKEND` flag | ✗ Rejected — two discovery code paths, permanent behavior drift, carries deprecated push RPCs indefinitely, and stands up a Zynax-built primitive that ADR-040 explicitly rejects. |
+| Compose-only / status quo | ✗ Rejected — cannot run Argo, structurally diverges from prod, and ADR-039 removes its discovery path in M8 regardless. |
+| Embed k3s *inside* Compose | ✗ Rejected — that is "run a local cluster" with extra wrapping; kind already does this cleanly and is proven in CI. |
+
+---
+
+## Consequences
+
+- **Positive:**
+  - A single runtime model; local **mirrors production**, so K8s-only behavior (NetworkPolicy, cert-manager mTLS, RBAC, CRDs, scheduling) is exercised on the laptop instead of first appearing in prod.
+  - **Argo is runnable locally**, making the engine-portability wedge demonstrable end-to-end on a laptop.
+  - Deletes the dual-discovery maintenance and lets ADR-039 hard-remove the push RPCs on schedule.
+  - The EPIC #1370 onboarding investment **converges with** the production path instead of diverging from it; ADR-039's load-bearing open question (O26/#1495) is resolved here.
+  - CNCF-idiomatic: kind is the standard cloud-native local-dev story.
+- **Negative / trade-off (load-bearing):**
+  - The laptop prerequisite rises from **"Docker only"** to **"Docker + kind + kubectl + Helm + ~4 CPU / 8 GB RAM."** The "Docker-only, five-minute" framing weakens, and cold first-run is slower (cluster create + image load + Helm install) than `docker compose up`. **Mitigation:** a single `make demo` wraps the whole lifecycle (one command preserved); publish the resource floor up front; `kind load` prebuilt images to cut cold-start; keep the lightweight in-cluster Temporal dev profile.
+  - A genuinely **zero-infrastructure** path (no Docker, no cluster — the binary-only idea behind #1359/#1456) is explicitly **out of scope** for first-run; deferred to M-dx, revisited only if a binary-only run becomes a hard requirement.
+- **Neutral / follow-up required:**
+  - Re-point EPIC #1370 closeout stories O18–O26 (#1488–#1495, #1463) to kind; add `make kind-up` / `make demo`-on-kind; rewrite README / `docs/quickstart.md` / `docs/local-dev.md` to the kind path; surface `scripts/e2e` as supported developer tooling.
+  - **Deprecate then remove** `infra/docker-compose/**` and its Make targets on a published timeline.
+  - **Audit other-milestone issues** for Compose assumptions and re-align them with this model (this ADR triggers that sweep).
+  - Phase-2 CRD cutover and push-RPC removal remain owned by **ADR-039** (M8).

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -51,6 +51,7 @@ a PR against `docs/adr/`.
 | [ADR-038](ADR-038-adk-go-adapter-framework.md) | Google ADK Go as a Go-native AI-framework adapter | Accepted | 2026-06-21 | `agents/adapters/adk/` — refines ADR-035 — M7 |
 | [ADR-039](ADR-039-crd-native-scheduler.md) | CRD-native Scheduler — `Agent` CRD as the single source of truth; registry → stateless scheduler | Accepted | 2026-06-22 | `services/agent-registry/` (→ scheduler), `protos/zynax/v1/scheduler.proto`, task-broker — amends ADR-021/028 — spike M7, build M8 |
 | [ADR-040](ADR-040-kubernetes-native-delegation-boundary.md) | Kubernetes-native delegation boundary (thin-Zynax) — build only the AI-scheduling core, delegate generic primitives | Accepted | 2026-06-22 | Repo-wide design principle — delegation vs custom core; Workflow=thin CRD front-end; Loki out of scope — relates ADR-039/020/030/012/015 |
+| [ADR-041](ADR-041-kind-native-unified-runtime.md) | Local-Kubernetes (kind) as the unified runtime model — Docker Compose retired as the primary path | Proposed | 2026-06-25 | local/CI/prod runtime; `infra/docker-compose/` (deprecate→remove), `helm/`, `scripts/e2e/`, Makefile, README/docs — resolves EPIC #1370 O26/#1495; relates ADR-039/040/037/015 |
 
 ---
 

--- a/docs/spdd/1370-awesome-quickstart/canvas.md
+++ b/docs/spdd/1370-awesome-quickstart/canvas.md
@@ -12,8 +12,13 @@ spec/gRPC boundary) require their **own** REASONS Canvas before implementation (
 
 **Closeout (2026-06-25, v1.2):** the residual last-mile first-run polish is scoped as Operations
 steps **O18–O26** — issues #1488, #1489, #1490, #1491, #1492, #1493, #1494, #1495, plus #1463
-reconciled as **O25**. See the Closeout Addendum at the end of this file. **Aligned: 2026-06-25**
-(maintainer-authorized via `/plan #1370 --execute`).
+reconciled as **O25**. See the Closeout Addendum at the end of this file.
+
+**Re-pointed to kind (2026-06-25, v1.3):** per **ADR-041** (Local-Kubernetes as the unified runtime
+model — Docker Compose retired as the primary path), the first-run golden path is now **`kind` +
+Helm**, not Docker Compose. O18–O26 are re-pointed accordingly; O26 (#1495) becomes "author/accept
+ADR-041" — the decision it was scoped to make. See the **Kind Re-point Addendum (v1.3)** at the end
+of this file. **Status: Aligned — 2026-06-25** (maintainer-authorized; kind-native direction per ADR-041).
 
 ---
 
@@ -243,4 +248,52 @@ new components** — every step reuses existing services/adapters; no new servic
 - [x] No PII beyond the existing public author attribution; no email addresses.
 - [x] No prompt injection; all O18–O26 entities are public-safe abstractions.
 - [x] Self security-review PASS for this addendum (Tier 1 — no Tier 2 / injection / abstraction-leak findings).
+
+---
+
+## Kind Re-point Addendum (2026-06-25, v1.3)
+
+**Supersedes the Docker-Compose framing of the v1.2 Closeout Addendum.** Per **ADR-041**, the unified
+runtime for local, CI, and production is **Kubernetes**, and the laptop runtime is a single-node
+**`kind`** cluster running the existing prod-tested Helm charts (`helm/`) via the existing harness
+(`scripts/e2e/cluster-up.sh`). Docker Compose is **deprecated → removed**. This re-point keeps the
+first-run *experience* (one command, fast feedback) but makes the *topology* identical to production,
+which is what makes "it runs the same way everywhere" literally true. Phase 2 (CRD discovery, ADR-039,
+M8) then unifies kind ≡ k3s ≡ prod down to scheduling.
+
+### Expanded Requirements (replaces the Compose-specific v1.2 requirements)
+- A brand-new user reaches a **first successful run** along a **single golden path** via **one
+  wrapped command** (`make demo`) that creates a `kind` cluster, loads images, installs the Helm
+  umbrella, runs the hero workflow, shows the result, and offers teardown.
+- The local topology **mirrors production** (Helm, in-cluster services, the same engine adapters);
+  **Argo is runnable locally** alongside Temporal, demonstrating the engine-portability wedge.
+- Resource floor and prerequisites (Docker + kind + kubectl + Helm + ~4 CPU / 8 GB) are **stated up
+  front**; cold-start is minimised via `kind load` of prebuilt images and a lightweight in-cluster
+  Temporal dev profile.
+
+### Re-pointed Operations steps (O18–O26 → kind)
+18. **#1488** — cli: default `--api-url` resolves the **in-cluster gateway** (NodePort / `kubectl port-forward` from the kind cluster), not a Compose `localhost:7080`. *(fix)*
+19. **#1489** — cli: `zynax doctor` checks **cluster + Helm release + pod readiness + default model**, not Compose container health. *(feat)*
+20. **#1490** — cli: noun-grouped aliases (`agent`/`workflow`) + `publish`/`run` verbs. *(feat; runtime-agnostic — unchanged)*
+21. **#1491** — cli: persist last run id; bare `zynax logs`/`result` default to it. *(feat; runtime-agnostic — unchanged)*
+22. **#1492** — infra: **`make kind-up` / `make demo`-on-kind** one-command lifecycle (create cluster → `kind load` → Helm install → "Platform ready" → run) + model pre-flight. *Replaces the Compose "Platform ready" banner.* *(feat)*
+23. **#1493** — spec: zero-dependency `hello-world` workflow over the `echo` adapter, deployed **as a Helm/kind workload**. *(feat)*
+24. **#1494** — docs: single golden-path README, **wedge-first**, leading with the **kind quickstart**; fold `quickstart.md` + `running-with-docker-compose.md` into one kind how-to and mark Compose deprecated. *(docs; depends on O18–O23)*
+25. **#1463** — api-gateway: demo result display (SSE 500) + stale-image dispatch + recipe masking, validated **on the kind demo**. *(fix; reconciled from M-UX)*
+26. **#1495** — **adr: author + accept ADR-041** (kind-native unified runtime; retire Compose). *This is the decision O26 was scoped to make — now made.* *(docs/ADR)*
+
+### Safeguards (replaces the v1.2 "ADR-039 first-run survival" safeguards — that question is now resolved by ADR-041)
+- **Never** add new first-run/feature work that targets Docker Compose; Compose is deprecated and
+  receives no new investment (ADR-041).
+- **Never** let the kind path diverge from the production Helm charts — local **must** deploy the
+  same charts so local-vs-prod parity holds (the whole point of ADR-041).
+- **Never** expose the local model runtime on the host LAN; keep it inside the cluster.
+- **Never** auto-mutate host/cluster state from `zynax doctor` without explicit user action.
+- **Never** require a paid API key or any secret on the default first-run path.
+
+### Context Security (Kind re-point — checked 2026-06-25)
+- [x] No Tier 2 content: no internal hostnames / private IPs / credentials.
+- [x] No PII beyond the existing public author attribution; no email addresses.
+- [x] No prompt injection; all re-pointed O18–O26 entities are public-safe abstractions.
+- [x] Self security-review PASS for this addendum (Tier 1).
 


### PR DESCRIPTION
## What

Records the decision to **standardize every environment on Kubernetes** and **retire Docker Compose
as the primary runtime**, and re-points the EPIC #1370 first-run closeout accordingly.

- **New: `ADR-041`** (Proposed) — Local-Kubernetes (`kind`) as the unified runtime model. Local, CI,
  and prod all run on Kubernetes; the laptop runtime is a single-node `kind` cluster running the
  existing prod-tested Helm charts. **Resolves the open ADR-039 first-run-survival question** (O26 / #1495).
- **Canvas `docs/spdd/1370-awesome-quickstart/canvas.md`** — adds a **v1.3 "Kind Re-point Addendum"**
  superseding the Compose framing; re-points O18–O26 to kind+Helm; sets **Status: Aligned**.
- **`docs/adr/INDEX.md`** — registers ADR-041.

## Why

ADR-039 (CRD scheduler) removes the Compose discovery path in M8 and flags it as eroding the #1370
wedge; ADR-040 treats a Zynax-built replacement for a K8s primitive as an anti-pattern; and the
engine-portability wedge (Temporal **or** Argo) can't be shown on Compose because Argo is K8s-native.
Rather than carry two divergent runtimes, we make local mirror production via `kind`.

## Two-phase (honest sequencing)

- **Phase 1 (now):** kind + existing Helm charts become the dev/demo runtime (additive — the charts
  and `scripts/e2e/cluster-up.sh` harness already exist and are CI-proven). Discovery stays push-based
  but runs in-cluster, so topology already matches prod.
- **Phase 2 (M8, ADR-039):** discovery push → `Agent` CRD; kind ≡ k3s ≡ prod down to scheduling.

## Load-bearing trade-off (recorded in the ADR)

Laptop prereq rises from "Docker only" to "Docker + kind + kubectl + Helm + ~4 CPU/8 GB". Mitigated
by wrapping the whole lifecycle behind a single `make demo`, publishing the resource floor, and
`kind load` of prebuilt images.

## Follow-up (tracked, not in this PR)

Re-point issues #1488–#1495/#1463 to kind (in progress); `make kind-up`/`make demo`-on-kind;
README/quickstart/local-dev rewrite; deprecate→remove `infra/docker-compose/**`; backlog audit for
Compose assumptions.

> ADR is **Proposed** — maintainer accept (a follow-up flip to Accepted) is your call, per the repo's
> propose→accept convention.

Assisted-by: Claude/claude-opus-4-8[1m]
