### PR TITLE
docs(adr): accept ADR-041 (kind-native unified runtime)

### DIFF
--- a/docs/adr/ADR-041-kind-native-unified-runtime.md
+++ b/docs/adr/ADR-041-kind-native-unified-runtime.md
@@ -1,7 +1,7 @@
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 # ADR-041: Local-Kubernetes (kind) as the unified runtime model — Docker Compose retired as the primary path
 
-**Status:** Proposed  **Date:** 2026-06-25
+**Status:** Accepted  **Date:** 2026-06-25
 **Related:** ADR-039 (CRD-native scheduler — the Phase-2 unifier), ADR-040 (Kubernetes-native delegation boundary), ADR-037 (rejected zero-Temporal eval engine; superseded by #1456), ADR-015 (pluggable workflow engines), ADR-020 (mTLS via cert-manager), ADR-026 (Postgres chart). Resolves the open decision in EPIC #1370 / O26 / #1495.
 
 ---

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -51,7 +51,7 @@ a PR against `docs/adr/`.
 | [ADR-038](ADR-038-adk-go-adapter-framework.md) | Google ADK Go as a Go-native AI-framework adapter | Accepted | 2026-06-21 | `agents/adapters/adk/` — refines ADR-035 — M7 |
 | [ADR-039](ADR-039-crd-native-scheduler.md) | CRD-native Scheduler — `Agent` CRD as the single source of truth; registry → stateless scheduler | Accepted | 2026-06-22 | `services/agent-registry/` (→ scheduler), `protos/zynax/v1/scheduler.proto`, task-broker — amends ADR-021/028 — spike M7, build M8 |
 | [ADR-040](ADR-040-kubernetes-native-delegation-boundary.md) | Kubernetes-native delegation boundary (thin-Zynax) — build only the AI-scheduling core, delegate generic primitives | Accepted | 2026-06-22 | Repo-wide design principle — delegation vs custom core; Workflow=thin CRD front-end; Loki out of scope — relates ADR-039/020/030/012/015 |
-| [ADR-041](ADR-041-kind-native-unified-runtime.md) | Local-Kubernetes (kind) as the unified runtime model — Docker Compose retired as the primary path | Proposed | 2026-06-25 | local/CI/prod runtime; `infra/docker-compose/` (deprecate→remove), `helm/`, `scripts/e2e/`, Makefile, README/docs — resolves EPIC #1370 O26/#1495; relates ADR-039/040/037/015 |
+| [ADR-041](ADR-041-kind-native-unified-runtime.md) | Local-Kubernetes (kind) as the unified runtime model — Docker Compose retired as the primary path | Accepted | 2026-06-25 | local/CI/prod runtime; `infra/docker-compose/` (deprecate→remove), `helm/`, `scripts/e2e/`, Makefile, README/docs — resolves EPIC #1370 O26/#1495; relates ADR-039/040/037/015 |
 
 ---
 


### PR DESCRIPTION
Flip ADR-041 Proposed → Accepted per maintainer direction. Kubernetes is now the binding unified runtime model (kind for local/dev/demo on the prod Helm charts; Docker Compose retired as the primary path). The #1370 canvas is already Aligned. Follows the repo's propose→accept convention (cf. ADR-039 #1485/#1486, ADR-040 #1486/#1487).

Refs #1370 #1495

Assisted-by: Claude/claude-opus-4-8[1m]