### PR TITLE
docs(automation): apply expert learnings — 2026-06-25

### DIFF
--- a/.claude/commands/experts/go-services.md
+++ b/.claude/commands/experts/go-services.md
@@ -192,6 +192,21 @@ func (h *Handler) Submit(ctx context.Context, req *pb.SubmitRequest) (*pb.Submit
   `status.FromContextError(ctx.Err()).Err()`, which the wrapcheck grpc glob exempts and which
   maps cancellation/deadline to the correct gRPC code. Seen in: #824, #797 (2 sessions).
 
+- **Capability adapters must register a RESOLVABLE advertised endpoint, not a bind-only `:PORT`.**
+  One field reused for both `net.Listen` and the registry-advertised address is the recurring root
+  cause of "task-broker dials localhost → connection refused". Add an `advertise_endpoint` + a
+  resolver + fail-fast validation that rejects a hostless bind (`:50070`, empty host via
+  `net.SplitHostPort`) when no advertise is set; mirror the langgraph-adapter bind-vs-advertise
+  split. The example YAML is baked into the container as the shipped default config, so fixing the
+  example also fixes the runtime default in one edit. Seen in: #1371, #1116 (2 sessions).
+
+- **A `snake_case` capability yields a `<name>.completed` event the workflow-compiler REJECTS.**
+  `agents/adapters/AGENTS.md` mandates `snake_case` capability names, but the compiler's `event_type`
+  rule is dot-separated lowercase (no underscores) — so `summarize_feedback.completed` cannot be a
+  transition target. When widening an `event_type`/capability regex, reuse the repo's underscore
+  sub-pattern `(_[a-z0-9]+)*` (grep the sibling `capabilityNameRe`), never `[a-z0-9_]+` (which wrongly
+  accepts leading/trailing/double underscores). Seen in: #1372, #1376 (2 sessions).
+
 ---
 
 ## Postgres / pgx v5 patterns (ADR-008 + M6.H canvas)

--- a/.claude/commands/experts/infra-helm.md
+++ b/.claude/commands/experts/infra-helm.md
@@ -251,6 +251,17 @@ helm upgrade --install zynax-<service> helm/zynax-<service>/ --dry-run
   files only, so a literal email in an infra `.env.example` IS flagged. Validate overlays with
   `docker compose config --quiet` against a throwaway gitignored `.env`. (#1190, #807)
 
+- **`docker compose config` does NOT surface values inside a BIND-MOUNTED config file** — it renders
+  the mount, not the file the consuming Go service reads literally. Grep the actual value out of the
+  mounted file as a SEPARATE piece of PR evidence, and never put `${ENV:-default}` tokens inside a
+  config file the service reads literally (no shell interpolation happens — document a one-line file
+  edit instead). Seen in: #1386, #1360 (2 sessions).
+
+- **Third-party / dev-compose runtime images stay direct pinned refs — only first-party + base/
+  toolchain images go in `images/images.yaml`.** A dev compose overlay (ollama / postgres / nats /
+  clickhouse) is not an `images.yaml` consumer, so keep plain pinned tags (`postgres:16-alpine`) and
+  it stays out of the digest-alignment gate while still passing it. Seen in: #1190, #1374 (2 sessions).
+
 ---
 
 ## Commit format

--- a/.claude/commands/experts/python-adapters.md
+++ b/.claude/commands/experts/python-adapters.md
@@ -118,6 +118,15 @@ cat docs/patterns/python-agent-guide.md  # code examples
 
 Never add business logic to an adapter — adapters are translation layers only.
 
+- **`agents/adapters/*` are GO modules (ADR-035), not Python.** A "python-adapter" task frequently
+  lands on a Go adapter (`cmd/<name>/main.go` + `internal/config`, its own `go.mod`) — locate the
+  module and confirm the language BEFORE assuming Python. When it is Go, switch to go-services
+  discipline: build/test with `GOWORK=off go -C <moduledir>`; pre-empt golangci-lint G706 (slog with
+  config args) / G101 (env-var-NAME literals) with `//nolint:gosec` matching the sibling adapters'
+  suppressions; for missing-secret graceful degradation use a typed sentinel + `errors.Is` branch in
+  `main` (start + warn + skip registry registration + health `NOT_SERVING`), keeping non-sentinel
+  errors fatal. Seen in: #1375, #1371 (2 sessions).
+
 ---
 
 ## Adapter structure

--- a/docs/ai-learnings/APPLY_LOG.md
+++ b/docs/ai-learnings/APPLY_LOG.md
@@ -97,3 +97,17 @@
 | 2 | go-services | gh projectCards deprecation: read via --json, label via REST API | domain | #1206, #1183 | pending | — |
 
 **Summary:** 2 proposed | 0 applied | 0 rejected (structural) | 2 pending
+
+## Run 2026-06-25 16:00 — domains: go-services, python-adapters, infra-helm
+
+| # | Domain | Pattern | Category | Source sessions | Status | Delta |
+|---|--------|---------|----------|-----------------|--------|-------|
+| 1 | go-services | Capability adapter: advertise-vs-bind resolvable endpoint | domain | #1371, #1116 | committed | go-services.md +9L |
+| 2 | go-services | snake_case capability → underscored event rejected by compiler | domain | #1372, #1376 | committed | go-services.md +8L |
+| 3 | go-services | golangci-lint can't take abs/`...` path under no-cd sandbox | env-constraint | #1185, #1198, #1371 | pending | manual orchestrator-preamble edit (outside --apply scope) |
+| 4 | python-adapters | agents/adapters/* are Go (ADR-035), not Python; locate module first | domain | #1375, #1371 | committed | python-adapters.md +9L |
+| 5 | infra-helm | docker compose config hides bind-mounted config file values | domain | #1386, #1360 | committed | infra-helm.md +5L |
+| 6 | infra-helm | Third-party/dev-compose images stay direct refs, not images.yaml | domain | #1190, #1374 | committed | infra-helm.md +4L |
+| 7 | python-adapters | RUFF_CACHE_DIR prefix vs root-owned .ruff_cache | structural-workaround | #808, #1189 | rejected | — |
+
+**Summary:** 7 proposed | 5 committed | 1 rejected (structural) | 1 pending (env-constraint)


### PR DESCRIPTION
Synthesized from 221 session learnings via `/learn`. Folds **5 domain patterns** (recurrence ≥2, deduped vs 25 already-committed) into the expert guides:

| Domain | Pattern |
|--------|---------|
| go-services | Capability adapter advertise-vs-bind resolvable endpoint (#1371,#1116) |
| go-services | snake_case capability → underscored `.completed` event rejected by compiler (#1372,#1376) |
| python-adapters | `agents/adapters/*` are Go (ADR-035), not Python — locate module first (#1375,#1371) |
| infra-helm | `docker compose config` hides bind-mounted config file values (#1386,#1360) |
| infra-helm | Third-party/dev-compose images stay direct refs, not `images.yaml` (#1190,#1374) |

1 env-constraint (golangci-lint no-cd) left **pending** — belongs in the orchestrator dispatch preamble, a manual edit outside `/learn --apply` scope. 1 structural-workaround **rejected** (worktree isolation). Ledger: `docs/ai-learnings/APPLY_LOG.md`.

Assisted-by: Claude/claude-opus-4-8[1m]