### PR TITLE
docs: repo truth-pass — reconcile status surfaces to live state

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,7 +408,7 @@ make test        # full suite (unit + BDD + coverage gate)
 
 ## Milestone Status
 
-Latest release: **v0.5.0 — K8s Production-Ready (M6 ✅)** · next milestone not yet open — live status in
+Latest release: **v0.5.0 — K8s Production-Ready (M6 ✅)** · active milestone: **M7 — Usable Workflows + Observability** 🚧 (target v0.6.0) — live status in
 [state/current-milestone.md](state/current-milestone.md) · milestone goals and sequence in
 [ROADMAP.md](ROADMAP.md).
 

--- a/state/current-milestone.md
+++ b/state/current-milestone.md
@@ -61,7 +61,7 @@ O / L / R respectively — and their issue titles were aligned to that scheme 20
 (#467 → M7.O, #469 → M7.R, #553 backref) to resolve the duplicate `M7.C` label with #1168.
 New ADRs: ADR-029…034 (Proposed).
 
-**Delivery (as of 2026-06-19):** GitHub milestone #7 — **~115 closed / ~10 open (~92% done)**.
+**Delivery (as of 2026-06-25):** GitHub milestone #7 — **132 closed / 16 open (~89% done)**.
 
 **EPIC #1370 (M7.K — First-run User Experience) cluster DELIVERED 2026-06-18/19:** 11 stories merged
 via PRs #1431–#1441 (foundation #1371/#1372/#1380 closed earlier) — api-gateway SSE-logs 500 fix,


### PR DESCRIPTION
Truth-pass per `/reconcile`. Drives every value from live `gh`/milestone state.

| Surface | Was | Now |
|---------|-----|-----|
| README.md | "next milestone not yet open" | M7 — Usable Workflows + Observability 🚧 Active (v0.6.0) |
| state/current-milestone.md | (as of 2026-06-19) ~115 closed / ~10 open (~92%) | (as of 2026-06-25) **132 closed / 16 open** (~89%) |

**Also checked, no change:** `make check-images` clean (no `images.yaml` drift); **0** open `[AUTO]` issues; canvas `Status:` lines all correct. **Deferred:** ARCHITECTURE.md M-dx/M-UX completeness rows (not a correctness error). **Not touched:** AGENTS.md, ADRs. Branch cleanup (36 merged-orphan local branches) handled separately.

Assisted-by: Claude/claude-opus-4-8[1m]