### PR TITLE
feat(cli): persist last run id so bare logs/result target it

### DIFF
--- a/cmd/zynax/cmd/apply.go
+++ b/cmd/zynax/cmd/apply.go
@@ -111,6 +111,12 @@ func runApply(cmd *cobra.Command, gw *client.Gateway, body []byte) error {
 	}
 	if runID != "" {
 		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "run_id: %s\n", runID)
+		// Record the run id locally so a later bare `zynax logs` / `zynax result`
+		// (no id) defaults to this run (#1491, canvas O21). Persisting is a
+		// convenience: a failure here must not fail an otherwise-successful apply.
+		if sErr := saveLastRun(runID); sErr != nil {
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "warning: could not record last run id: %v\n", sErr)
+		}
 	}
 	if agentID != "" {
 		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "agent_id: %s\n", agentID)

--- a/cmd/zynax/cmd/cmd_test.go
+++ b/cmd/zynax/cmd/cmd_test.go
@@ -612,6 +612,168 @@ func TestResultCmd_NoResult_Errors(t *testing.T) {
 	}
 }
 
+// ── last-run state (#1491, canvas O21) ────────────────────────────────────────
+
+// TestRunApply_RecordsLastRunID asserts AC1: a successful apply that returns a
+// run id persists it to <config-dir>/last-run so bare logs/result can default
+// to it. The config dir is an isolated t.TempDir() via ZYNAX_CONFIG_DIR.
+func TestRunApply_RecordsLastRunID(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("ZYNAX_CONFIG_DIR", dir)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusAccepted)
+		_ = json.NewEncoder(w).Encode(map[string]any{"run_id": "wf-record"})
+	}))
+	defer srv.Close()
+	apiURL = srv.URL
+	applyEngine = ""
+
+	cmd := fakeCmd(t)
+	if err := runApply(cmd, newGateway(), []byte("kind: Workflow")); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	b, err := os.ReadFile(filepath.Join(dir, lastRunFile)) //nolint:gosec // test reads the file it just wrote into a temp dir
+	if err != nil {
+		t.Fatalf("last-run file not written: %v", err)
+	}
+	if got := strings.TrimSpace(string(b)); got != "wf-record" {
+		t.Errorf("last-run file = %q, want %q", got, "wf-record")
+	}
+}
+
+// TestRunApply_AgentDef_DoesNotRecord asserts an apply that yields only an
+// agent id (no run id) records nothing — last-run is for Workflow runs only.
+func TestRunApply_AgentDef_DoesNotRecord(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("ZYNAX_CONFIG_DIR", dir)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]string{"agent_id": "agent-xyz"})
+	}))
+	defer srv.Close()
+	apiURL = srv.URL
+
+	if err := runApply(fakeCmd(t), newGateway(), []byte("kind: AgentDef")); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, lastRunFile)); !os.IsNotExist(err) {
+		t.Errorf("expected no last-run file for AgentDef apply, stat err = %v", err)
+	}
+}
+
+// TestResolveRunID covers AC2/AC3: explicit id overrides the stored one, a bare
+// invocation falls back to the stored id, and no prior run yields a clear error.
+func TestResolveRunID(t *testing.T) {
+	tests := []struct {
+		name    string
+		stored  string // "" means do not write a state file
+		args    []string
+		want    string
+		wantErr bool
+	}{
+		{name: "explicit id with no stored", args: []string{"explicit-1"}, want: "explicit-1"},
+		{name: "explicit id overrides stored", stored: "stored-1", args: []string{"explicit-2"}, want: "explicit-2"},
+		{name: "bare falls back to stored", stored: "stored-2", args: nil, want: "stored-2"},
+		{name: "bare with no prior run errors", args: nil, wantErr: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			t.Setenv("ZYNAX_CONFIG_DIR", dir)
+			if tc.stored != "" {
+				if err := saveLastRun(tc.stored); err != nil {
+					t.Fatalf("seed saveLastRun: %v", err)
+				}
+			}
+			got, err := resolveRunID(tc.args)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %s, got id %q", tc.name, got)
+				}
+				if !strings.Contains(err.Error(), "no prior run") {
+					t.Errorf("error not actionable: %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("resolveRunID = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestLogsCmd_BareUsesStoredRun asserts AC2: bare `zynax logs` (no positional
+// id) streams the most recently recorded run.
+func TestLogsCmd_BareUsesStoredRun(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("ZYNAX_CONFIG_DIR", dir)
+	if err := saveLastRun("stored-run"); err != nil {
+		t.Fatal(err)
+	}
+	var seenPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenPath = r.URL.Path
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprintf(w, "data: %s\n\n",
+			`{"run_id":"stored-run","event_type":"workflow.completed","status":"WORKFLOW_STATUS_COMPLETED"}`)
+	}))
+	defer srv.Close()
+	apiURL = srv.URL
+	logsFormat = formatText
+	logsFollow = false
+
+	if _, err := runLogs(t, nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(seenPath, "stored-run") {
+		t.Errorf("bare logs targeted %q, want path containing stored-run", seenPath)
+	}
+}
+
+// TestLogsCmd_BareNoPriorRun asserts AC3: a bare logs with no recorded run
+// returns a clear, actionable error rather than calling the gateway.
+func TestLogsCmd_BareNoPriorRun(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("ZYNAX_CONFIG_DIR", dir)
+	logsFollow = false
+
+	if _, err := runLogs(t, nil); err == nil {
+		t.Error("expected error for bare logs with no prior run")
+	} else if !strings.Contains(err.Error(), "no prior run") {
+		t.Errorf("error not actionable: %v", err)
+	}
+}
+
+// TestResultCmd_BareUsesStoredRun asserts AC2 for `result`: a bare invocation
+// targets the stored run and prints its completion text.
+func TestResultCmd_BareUsesStoredRun(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("ZYNAX_CONFIG_DIR", dir)
+	if err := saveLastRun("stored-r"); err != nil {
+		t.Fatal(err)
+	}
+	srv := sseServer(t, []map[string]any{
+		{"run_id": "stored-r", "event_type": "task.completed", "status": "capability_event",
+			"payload": `{"result_payload":"{\"completion\":\"bare result text\"}"}`},
+		{"run_id": "stored-r", "event_type": "workflow.completed", "status": "WORKFLOW_STATUS_COMPLETED"},
+	})
+	apiURL = srv.URL
+
+	out, err := runResult(t, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.TrimSpace(out) != "bare result text" {
+		t.Errorf("result output = %q, want %q", strings.TrimSpace(out), "bare result text")
+	}
+}
+
 // ── scenario apply + validate ─────────────────────────────────────────────────
 
 // TestRunApplyScenario_AppliesMembersInOrder verifies that applying the shipped

--- a/cmd/zynax/cmd/lastrun.go
+++ b/cmd/zynax/cmd/lastrun.go
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// lastRunFile is the basename of the state file that records the most recent
+// run id. It lives under <config-dir>/zynax/ so that bare `zynax logs` /
+// `zynax result` (no id) can default to the user's latest run.
+const lastRunFile = "last-run"
+
+// zynaxConfigDir returns the directory that holds the CLI's local state. It
+// honors ZYNAX_CONFIG_DIR (used by tests to point at a t.TempDir()) and
+// otherwise falls back to <os.UserConfigDir()>/zynax. CLI-side only — no
+// server or chart involvement.
+func zynaxConfigDir() (string, error) {
+	if dir := os.Getenv("ZYNAX_CONFIG_DIR"); dir != "" {
+		return dir, nil
+	}
+	base, err := os.UserConfigDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve user config dir: %w", err)
+	}
+	return filepath.Join(base, "zynax"), nil
+}
+
+// saveLastRun records runID as the most recent run so a later bare logs/result
+// can target it. A failure to persist is non-fatal to the caller: recording the
+// id is a convenience, never a reason to fail an otherwise-successful apply.
+func saveLastRun(runID string) error {
+	runID = strings.TrimSpace(runID)
+	if runID == "" {
+		return nil
+	}
+	dir, err := zynaxConfigDir()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("create config dir %s: %w", dir, err)
+	}
+	path := filepath.Join(dir, lastRunFile)
+	//nolint:gosec // G703: path is a fixed basename joined to the confined CLI config dir, not user-tainted
+	if err := os.WriteFile(path, []byte(runID+"\n"), 0o600); err != nil {
+		return fmt.Errorf("write last-run file %s: %w", path, err)
+	}
+	return nil
+}
+
+// loadLastRun returns the most recently recorded run id, or an empty string
+// (no error) when none has been recorded yet. A missing state file is the
+// expected "no prior run" case, not a failure.
+func loadLastRun() (string, error) {
+	dir, err := zynaxConfigDir()
+	if err != nil {
+		return "", err
+	}
+	path := filepath.Join(dir, lastRunFile)
+	b, err := os.ReadFile(path) //nolint:gosec // path is confined to the CLI config dir
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", fmt.Errorf("read last-run file %s: %w", path, err)
+	}
+	return strings.TrimSpace(string(b)), nil
+}
+
+// resolveRunID picks the run id to act on: an explicit positional arg always
+// wins; otherwise it falls back to the last recorded run. When neither is
+// available it returns a clear, actionable error telling the user to start a
+// run or pass an id. Used by `zynax logs` and `zynax result` so a bare
+// invocation targets the user's most recent run (#1491, canvas O21).
+func resolveRunID(args []string) (string, error) {
+	if len(args) > 0 && strings.TrimSpace(args[0]) != "" {
+		return args[0], nil
+	}
+	last, err := loadLastRun()
+	if err != nil {
+		return "", err
+	}
+	if last == "" {
+		return "", fmt.Errorf(
+			"no run id given and no prior run recorded: start a run with " +
+				"`zynax apply <file>` (or `zynax workflow run <name>`), or pass a run id explicitly")
+	}
+	return last, nil
+}

--- a/cmd/zynax/cmd/logs.go
+++ b/cmd/zynax/cmd/logs.go
@@ -22,16 +22,22 @@ var (
 var errFollowDone = errors.New("follow: terminal state reached")
 
 var logsCmd = &cobra.Command{
-	Use:   "logs <run-id>",
+	Use:   "logs [run-id]",
 	Short: "Stream lifecycle events for a workflow run",
 	Long: "Stream lifecycle events (state transitions and capability events) for a " +
 		"workflow run from the api-gateway SSE endpoint.\n\n" +
+		"With no run id the command targets your most recent run (recorded by the " +
+		"last `zynax apply`/`run`). An explicit run id always overrides.\n\n" +
 		"With --follow the command tails the run live and exits once the workflow " +
 		"reaches a terminal state (completed, failed, or cancelled).",
-	Args: cobra.ExactArgs(1),
+	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		runID, err := resolveRunID(args)
+		if err != nil {
+			return err
+		}
 		gw := newGateway()
-		err := gw.WatchWorkflowLogs(cmd.Context(), args[0], func(ev client.LogEvent) error {
+		err = gw.WatchWorkflowLogs(cmd.Context(), runID, func(ev client.LogEvent) error {
 			if logsFormat == "json" {
 				b, mErr := json.Marshal(ev)
 				if mErr != nil {

--- a/cmd/zynax/cmd/result.go
+++ b/cmd/zynax/cmd/result.go
@@ -16,18 +16,24 @@ import (
 var errResultDone = errors.New("result: terminal state reached")
 
 var resultCmd = &cobra.Command{
-	Use:   "result <run-id>",
+	Use:   "result [run-id]",
 	Short: "Print the capability output (result payload) of a workflow run",
 	Long: "Stream a run's events and print the capability result payload — e.g. the " +
 		"model's review text from the code-review example — straight from the CLI.\n\n" +
+		"With no run id the command targets your most recent run (recorded by the " +
+		"last `zynax apply`/`run`). An explicit run id always overrides.\n\n" +
 		"The command tails the run until it reaches a terminal state and prints the " +
 		"last completion text it saw. Exits with an error if the run finishes with no " +
 		"result (e.g. a failed run).",
-	Args: cobra.ExactArgs(1),
+	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		runID, err := resolveRunID(args)
+		if err != nil {
+			return err
+		}
 		gw := newGateway()
 		var output string
-		err := gw.WatchWorkflowLogs(cmd.Context(), args[0], func(ev client.LogEvent) error {
+		err = gw.WatchWorkflowLogs(cmd.Context(), runID, func(ev client.LogEvent) error {
 			if text := client.CompletionText(ev.Payload); text != "" {
 				output = text
 			}
@@ -40,7 +46,7 @@ var resultCmd = &cobra.Command{
 			return err
 		}
 		if output == "" {
-			return fmt.Errorf("no result payload for run %s", args[0])
+			return fmt.Errorf("no result payload for run %s", runID)
 		}
 		_, _ = fmt.Fprintln(cmd.OutOrStdout(), output)
 		return nil

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -173,6 +173,11 @@ run_id: <run-id>
 
 Copy that `run_id` — the next step uses it.
 
+> **No need to shuttle the id around.** `apply` records your most recent run
+> locally, so a bare `zynax logs` / `zynax result` (no id) targets it. An
+> explicit id always overrides; delete `<user-config-dir>/zynax/last-run` to
+> reset.
+
 > **Starting from scratch?** `zynax init workflow my-pipeline -o my-pipeline.yaml`
 > scaffolds a valid, versioned manifest from a template. Run `zynax validate
 > my-pipeline.yaml` before applying.


### PR DESCRIPTION
## feat(cli): persist last run id so bare logs/result target it

Closes #1491
Part of #1370 (EPIC — awesome quickstart)

### Why  (problem & intent)
A new user has to copy the `run_id` printed by `apply` and paste it into every
`logs`/`result` call. Canvas O21 removes that friction: the CLI remembers the
most recent run locally so a bare `zynax logs` / `zynax result` just works.

### What you'll get  (deliverables ↔ what changed)
- `apply`/`run` records the last run id under the user config dir ← `cmd/zynax/cmd/lastrun.go`, `cmd/zynax/cmd/apply.go`
- bare `zynax logs` defaults to that run; explicit id overrides ← `cmd/zynax/cmd/logs.go`
- bare `zynax result` defaults to that run; explicit id overrides ← `cmd/zynax/cmd/result.go`
- a clear, actionable error when there is no prior run ← `resolveRunID` in `cmd/zynax/cmd/lastrun.go`
- one-line quickstart note (additive; overridable; delete file to reset) ← `docs/quickstart.md`

### Scope & boundaries
- **In scope:** CLI-side local state only — a `last-run` file under `os.UserConfigDir()/zynax` (overridable via `ZYNAX_CONFIG_DIR` for tests); optional-id fallback for `logs`/`result`.
- **Out of scope (deferred):** no server, proto, or chart change (runtime-agnostic per O21); golden-path README consolidation → #1494; `workflow run` alias verb → #1490 (its alias delegates to apply's RunE, so recording covers it for free).

### Test plan & acceptance
| Acceptance criterion | How verified (command) | Result |
|----------------------|------------------------|--------|
| 1. `run`/`apply` records the last run id under the user config dir | `GOWORK=off go test ./... -race` → `TestRunApply_RecordsLastRunID` (asserts file contents under a `t.TempDir()`) | ✅ pass |
| 2. Bare `logs`/`result` default to that id; explicit id overrides | `TestResolveRunID` (table: explicit-overrides / bare-falls-back), `TestLogsCmd_BareUsesStoredRun`, `TestResultCmd_BareUsesStoredRun` | ✅ pass |
| 3. Clear, actionable message when no prior run | `TestLogsCmd_BareNoPriorRun`, `TestResolveRunID/bare_with_no_prior_run_errors` (asserts "no prior run") | ✅ pass |
| 4. Documented in the quickstart; additive, explicit overrides, delete file to revert | review `docs/quickstart.md` one-line note after the `run_id` step | ✅ added |

**Local gates:** `GOWORK=off go build ./...` ✅ · `GOWORK=off go test ./... -race -timeout 60s` ✅ · `make lint-go` ✅

### Evidence
- **CI:** required checks green (see run on the PR).
- **Local output:** `ok github.com/zynax-io/zynax/cmd/zynax/cmd 1.114s` (with `-race`); build exit 0; `make lint-go` → `0 issues` for cmd/zynax.
- **Artifacts / images:** none — no service source changed (CLI-only; cmd/zynax is a standalone module not in any image).
- **Post-merge digest sync → main:** N/A — no image rebuild.

### Risk & rollback
Low — additive only. Existing explicit-id call sites are unchanged (positional id still wins). A failure to write the state file only emits a warning and never fails an apply. Roll back by reverting this PR or deleting `<user-config-dir>/zynax/last-run`.

### Review aids
Start at `cmd/zynax/cmd/lastrun.go` — `resolveRunID` is the one shared helper `logs`/`result` call; `apply.go` records at the single success point (where `run_id` is printed) so #1490's `workflow run` alias inherits it. The config dir is overridable via `ZYNAX_CONFIG_DIR` so tests stay hermetic with `t.TempDir()`.

**SPDD:** Canvas `docs/spdd/1370-awesome-quickstart/canvas.md` — Status: **Aligned** · O21 (runtime-agnostic — unchanged) · `/spdd-security-review` PASS
**AI:** `Assisted-by: Claude/claude-opus-4-8`  (label: ai-assisted)
