### PR TITLE
feat(cli): noun-grouped aliases (agent/workflow) + publish/run verbs

### DIFF
--- a/cmd/zynax/cmd/agent.go
+++ b/cmd/zynax/cmd/agent.go
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// agentCmd is the noun-first parent for agent (expert) operations. Its
+// subcommands are thin aliases that DELEGATE to the existing verb commands'
+// RunE — no logic is duplicated (canvas O20). `zynax agent init <name>` is
+// `zynax init expert <name>`; `zynax agent publish <file>` is `zynax apply
+// <file>` with kind auto-detection.
+var agentCmd = &cobra.Command{
+	Use:     "agent",
+	Short:   "Create and publish agents (experts)",
+	Long:    "Noun-first aliases for agent (expert) operations.\n\n`agent init` scaffolds an AgentDef manifest (alias for `init expert`); `agent\npublish` submits it to the api-gateway (alias for `apply`). The underlying\n`init expert` and `apply` verbs remain available unchanged.",
+	GroupID: beginnerGroupID,
+}
+
+var agentInitCmd = &cobra.Command{
+	Use:   "init [name]",
+	Short: "Scaffold an agent (expert) manifest — alias for `init expert`",
+	Args:  cobra.MaximumNArgs(1),
+	RunE:  initExpertCmd.RunE,
+}
+
+var agentPublishCmd = &cobra.Command{
+	Use:   publishUse,
+	Short: "Publish an agent manifest — alias for `apply`",
+	Args:  cobra.ExactArgs(1),
+	RunE:  applyCmd.RunE,
+}
+
+func init() {
+	// `agent init` reuses runInit's package vars (initTemplateDir/initOutput);
+	// register the same flags with the same defaults so it behaves identically.
+	agentInitCmd.Flags().StringVar(&initTemplateDir, "template-dir", "spec/templates",
+		"directory containing <kind>/<kind>.template.yaml files")
+	agentInitCmd.Flags().StringVarP(&initOutput, "output", "o", "",
+		"write the manifest to this file instead of stdout")
+	// `agent publish` reuses apply's package vars (applyDryRun/applyEngine).
+	agentPublishCmd.Flags().BoolVar(&applyDryRun, "dry-run", false, "validate manifest without submitting")
+	agentPublishCmd.Flags().StringVar(&applyEngine, "engine", "", "engine hint forwarded to SubmitWorkflow (ADR-015)")
+
+	agentCmd.AddCommand(agentInitCmd)
+	agentCmd.AddCommand(agentPublishCmd)
+	rootCmd.AddCommand(agentCmd)
+}

--- a/cmd/zynax/cmd/cmd_test.go
+++ b/cmd/zynax/cmd/cmd_test.go
@@ -786,12 +786,12 @@ func TestRunApplyScenario_AppliesMembersInOrder(t *testing.T) {
 		b, _ := io.ReadAll(r.Body)
 		body := string(b)
 		switch {
-		case strings.Contains(body, "kind: AgentDef"):
-			kinds = append(kinds, "AgentDef")
+		case strings.Contains(body, "kind: "+kindAgentDef):
+			kinds = append(kinds, kindAgentDef)
 			w.WriteHeader(http.StatusCreated)
 			_ = json.NewEncoder(w).Encode(map[string]string{"agent_id": "agent-xyz"})
 		default:
-			kinds = append(kinds, "Workflow")
+			kinds = append(kinds, kindWorkflow)
 			w.WriteHeader(http.StatusAccepted)
 			_ = json.NewEncoder(w).Encode(map[string]any{"run_id": "wf-001"})
 		}
@@ -808,7 +808,7 @@ func TestRunApplyScenario_AppliesMembersInOrder(t *testing.T) {
 	if err := runApplyScenario(cmd, newGateway(), idx); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(kinds) != 2 || kinds[0] != "AgentDef" || kinds[1] != "Workflow" {
+	if len(kinds) != 2 || kinds[0] != kindAgentDef || kinds[1] != kindWorkflow {
 		t.Errorf("server observed order %v, want [AgentDef Workflow]", kinds)
 	}
 	if !strings.Contains(out.String(), "run_id: wf-001") {

--- a/cmd/zynax/cmd/logs.go
+++ b/cmd/zynax/cmd/logs.go
@@ -22,8 +22,9 @@ var (
 var errFollowDone = errors.New("follow: terminal state reached")
 
 var logsCmd = &cobra.Command{
-	Use:   "logs [run-id]",
-	Short: "Stream lifecycle events for a workflow run",
+	Use:     "logs [run-id]",
+	GroupID: beginnerGroupID,
+	Short:   "Stream lifecycle events for a workflow run",
 	Long: "Stream lifecycle events (state transitions and capability events) for a " +
 		"workflow run from the api-gateway SSE endpoint.\n\n" +
 		"With no run id the command targets your most recent run (recorded by the " +

--- a/cmd/zynax/cmd/noun_aliases_test.go
+++ b/cmd/zynax/cmd/noun_aliases_test.go
@@ -1,0 +1,243 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Tests for the noun-first aliases (agent/workflow groups + publish verb).
+// They assert command resolution and RunE wiring (no network) plus one
+// behavioural round-trip per alias through httptest, mirroring cmd_test.go.
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// Manifest-kind literals shared across the CLI tests (satisfies goconst).
+const (
+	kindWorkflow = "Workflow"
+	kindAgentDef = "AgentDef"
+)
+
+// runEPtr returns the comparable pointer of a command's RunE for identity asserts.
+func runEPtr(c *cobra.Command) uintptr {
+	if c == nil || c.RunE == nil {
+		return 0
+	}
+	return reflect.ValueOf(c.RunE).Pointer()
+}
+
+// ── command resolution ────────────────────────────────────────────────────────
+
+// TestNounAliases_Resolve proves each new noun-verb form resolves to a real
+// command under rootCmd (back-compat verbs are covered separately below).
+func TestNounAliases_Resolve(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+		want *cobra.Command
+	}{
+		{"agent init", []string{"agent", "init"}, agentInitCmd},
+		{"agent publish", []string{"agent", "publish"}, agentPublishCmd},
+		{"workflow init", []string{"workflow", "init"}, workflowInitCmd},
+		{"workflow run", []string{"workflow", "run"}, workflowRunCmd},
+		{"workflow publish", []string{"workflow", "publish"}, workflowPublishCmd},
+		{"publish", []string{"publish"}, publishCmd},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c, _, err := rootCmd.Find(tc.args)
+			if err != nil {
+				t.Fatalf("Find(%v) error: %v", tc.args, err)
+			}
+			if c != tc.want {
+				t.Errorf("resolved %q, want %q", c.Use, tc.want.Use)
+			}
+		})
+	}
+}
+
+// TestNounAliases_DelegateToVerbRunE proves the aliases reuse the existing verb
+// commands' RunE (no duplicated logic), per canvas O20.
+func TestNounAliases_DelegateToVerbRunE(t *testing.T) {
+	cases := []struct {
+		name  string
+		alias *cobra.Command
+		verb  *cobra.Command
+	}{
+		{"agent init → init expert", agentInitCmd, initExpertCmd},
+		{"agent publish → apply", agentPublishCmd, applyCmd},
+		{"workflow init → init workflow", workflowInitCmd, initWorkflowCmd},
+		{"workflow run → apply", workflowRunCmd, applyCmd},
+		{"workflow publish → apply", workflowPublishCmd, applyCmd},
+		{"publish → apply", publishCmd, applyCmd},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if runEPtr(tc.alias) == 0 {
+				t.Fatalf("alias %q has nil RunE", tc.alias.Use)
+			}
+			if runEPtr(tc.alias) != runEPtr(tc.verb) {
+				t.Errorf("alias %q RunE does not delegate to verb %q", tc.alias.Use, tc.verb.Use)
+			}
+		})
+	}
+}
+
+// ── back-compat: existing verbs still registered ──────────────────────────────
+
+func TestBackCompat_VerbsStillResolve(t *testing.T) {
+	cases := [][]string{
+		{"apply"},
+		{"init"},
+		{"init", "workflow"},
+		{"init", "expert"},
+	}
+	for _, args := range cases {
+		c, _, err := rootCmd.Find(args)
+		if err != nil {
+			t.Fatalf("back-compat verb %v no longer resolves: %v", args, err)
+		}
+		if c == rootCmd {
+			t.Errorf("back-compat verb %v resolved to root (not registered)", args)
+		}
+	}
+}
+
+// ── beginner help group ───────────────────────────────────────────────────────
+
+// TestBeginnerGroup_Registered proves the beginner group exists and that the
+// existing beginner commands are tagged into it. `doctor` (#1489) is not
+// asserted — it joins the group only once that command is registered.
+func TestBeginnerGroup_Registered(t *testing.T) {
+	var found bool
+	for _, g := range rootCmd.Groups() {
+		if g.ID == beginnerGroupID {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("beginner group %q not registered on root", beginnerGroupID)
+	}
+
+	want := map[string]bool{"workflow": true, "agent": true, "publish": true, "logs": true, "result": true}
+	for _, c := range rootCmd.Commands() {
+		if want[c.Name()] && c.GroupID != beginnerGroupID {
+			t.Errorf("command %q GroupID = %q, want beginner group %q", c.Name(), c.GroupID, beginnerGroupID)
+		}
+	}
+}
+
+// TestRootHelp_ListsBeginnerCommands proves the noun-first commands appear in
+// `zynax --help` output under the beginner heading.
+func TestRootHelp_ListsBeginnerCommands(t *testing.T) {
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetArgs([]string{"--help"})
+	defer rootCmd.SetArgs(nil)
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("--help error: %v", err)
+	}
+	help := out.String()
+	for _, name := range []string{"agent", "workflow", "publish"} {
+		if !strings.Contains(help, name) {
+			t.Errorf("--help missing beginner command %q:\n%s", name, help)
+		}
+	}
+}
+
+// ── behavioural parity: aliases hit the same apply path ───────────────────────
+
+// applyAliasServer accepts an apply POST and records the kind it observed.
+func applyAliasServer(t *testing.T, gotKind *string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var b bytes.Buffer
+		_, _ = b.ReadFrom(r.Body)
+		body := b.String()
+		switch {
+		case strings.Contains(body, "kind: "+kindAgentDef):
+			*gotKind = kindAgentDef
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]string{"agent_id": "agent-1"})
+		default:
+			*gotKind = kindWorkflow
+			w.WriteHeader(http.StatusAccepted)
+			_ = json.NewEncoder(w).Encode(map[string]any{"run_id": "wf-1"})
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestPublishAlias_AutoDetectsKind(t *testing.T) {
+	cases := []struct {
+		name     string
+		cmd      *cobra.Command
+		manifest string
+		wantKind string
+	}{
+		{"publish workflow", publishCmd, "kind: " + kindWorkflow, kindWorkflow},
+		{"publish agentdef", publishCmd, "kind: " + kindAgentDef, kindAgentDef},
+		{"workflow run", workflowRunCmd, "kind: " + kindWorkflow, kindWorkflow},
+		{"agent publish", agentPublishCmd, "kind: " + kindAgentDef, kindAgentDef},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotKind string
+			srv := applyAliasServer(t, &gotKind)
+			apiURL = srv.URL
+			applyDryRun = false
+			applyEngine = ""
+
+			dir := t.TempDir()
+			f := filepath.Join(dir, "m.yaml")
+			if err := os.WriteFile(f, []byte(tc.manifest), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			cmd := fakeCmd(t)
+			if err := tc.cmd.RunE(cmd, []string{f}); err != nil {
+				t.Fatalf("alias RunE error: %v", err)
+			}
+			if gotKind != tc.wantKind {
+				t.Errorf("server observed kind %q, want %q", gotKind, tc.wantKind)
+			}
+		})
+	}
+}
+
+// TestNounInitAliases_ScaffoldSameAsVerb proves `agent init`/`workflow init`
+// emit the same manifest kind as the underlying `init expert`/`init workflow`.
+func TestNounInitAliases_ScaffoldSameAsVerb(t *testing.T) {
+	root := repoRoot(t)
+	initTemplateDir = filepath.Join(root, "spec/templates")
+	initOutput = ""
+
+	cases := []struct {
+		name     string
+		cmd      *cobra.Command
+		wantKind string
+	}{
+		{"workflow init", workflowInitCmd, "kind: Workflow"},
+		{"agent init", agentInitCmd, "kind: AgentDef"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := fakeCmd(t)
+			var out bytes.Buffer
+			cmd.SetOut(&out)
+			if err := tc.cmd.RunE(cmd, nil); err != nil {
+				t.Fatalf("alias init error: %v", err)
+			}
+			if !strings.Contains(out.String(), tc.wantKind) {
+				t.Errorf("scaffold missing %q, got:\n%s", tc.wantKind, out.String())
+			}
+		})
+	}
+}

--- a/cmd/zynax/cmd/publish.go
+++ b/cmd/zynax/cmd/publish.go
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// publishUse is the shared Use string for the publish-style aliases (publish,
+// workflow publish, agent publish) — they all submit a file or scenario dir.
+const publishUse = "publish <file|scenario-dir>"
+
+// publishCmd is a thin, top-level alias over `apply`. It submits a YAML manifest
+// (Workflow or AgentDef) to the api-gateway; the manifest kind is auto-detected
+// on the apply path exactly as `zynax apply` does, so `publish` adds no behaviour
+// of its own — it only gives the quickstart a noun-free "ship it" verb (canvas O20).
+var publishCmd = &cobra.Command{
+	Use:     publishUse,
+	Short:   "Publish a manifest (Workflow or AgentDef) — alias for apply",
+	Long:    "Publish a YAML manifest to the api-gateway. The manifest kind is\nauto-detected, exactly like `zynax apply`. This is a thin alias kept for the\nquickstart's noun-first mental model; `apply` remains available unchanged.",
+	Args:    cobra.ExactArgs(1),
+	GroupID: beginnerGroupID,
+	RunE:    applyCmd.RunE,
+}
+
+func init() {
+	// Re-register apply's flags so `publish --dry-run/--engine` behave identically;
+	// the RunE reads the same package-level vars (applyDryRun/applyEngine).
+	publishCmd.Flags().BoolVar(&applyDryRun, "dry-run", false, "validate manifest without submitting")
+	publishCmd.Flags().StringVar(&applyEngine, "engine", "", "engine hint forwarded to SubmitWorkflow (ADR-015)")
+	rootCmd.AddCommand(publishCmd)
+}

--- a/cmd/zynax/cmd/result.go
+++ b/cmd/zynax/cmd/result.go
@@ -16,8 +16,9 @@ import (
 var errResultDone = errors.New("result: terminal state reached")
 
 var resultCmd = &cobra.Command{
-	Use:   "result [run-id]",
-	Short: "Print the capability output (result payload) of a workflow run",
+	Use:     "result [run-id]",
+	GroupID: beginnerGroupID,
+	Short:   "Print the capability output (result payload) of a workflow run",
 	Long: "Stream a run's events and print the capability result payload — e.g. the " +
 		"model's review text from the code-review example — straight from the CLI.\n\n" +
 		"With no run id the command targets your most recent run (recorded by the " +

--- a/cmd/zynax/cmd/root.go
+++ b/cmd/zynax/cmd/root.go
@@ -15,6 +15,12 @@ var Version = "dev"
 
 const workflowRunIDUse = "workflow <run-id>"
 
+// beginnerGroupID groups the small noun-first command set surfaced first in
+// `zynax --help` for new users (canvas O20). Advanced verbs (apply, get, status,
+// validate, …) stay available but fall under cobra's default "Additional
+// Commands" heading. `doctor` (issue #1489) joins this group when it lands.
+const beginnerGroupID = "beginner"
+
 var rootCmd = &cobra.Command{
 	Use:          "zynax",
 	Short:        "Zynax CLI — apply, manage, and monitor Zynax workflows",
@@ -41,6 +47,7 @@ func init() {
 	}
 	rootCmd.PersistentFlags().StringVar(&apiURL, "api-url", defaultURL, "api-gateway base URL ($ZYNAX_API_URL)")
 	rootCmd.PersistentFlags().BoolVar(&insecure, "insecure", false, "skip TLS certificate verification")
+	rootCmd.AddGroup(&cobra.Group{ID: beginnerGroupID, Title: "Getting started:"})
 }
 
 func newGateway() *client.Gateway {

--- a/cmd/zynax/cmd/workflow.go
+++ b/cmd/zynax/cmd/workflow.go
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// workflowCmd is the noun-first parent for workflow operations. Its subcommands
+// are thin aliases that DELEGATE to the existing verb commands' RunE — no logic
+// is duplicated (canvas O20). `zynax workflow init <name>` is `zynax init
+// workflow <name>`; `zynax workflow run|publish <file>` is `zynax apply <file>`
+// with kind auto-detection. The underlying `init workflow` and `apply` verbs
+// remain available unchanged.
+var workflowCmd = &cobra.Command{
+	Use:     "workflow",
+	Short:   "Create, run, and publish workflows",
+	Long:    "Noun-first aliases for workflow operations.\n\n`workflow init` scaffolds a Workflow manifest (alias for `init workflow`);\n`workflow run` and `workflow publish` submit it to the api-gateway (aliases for\n`apply`). The underlying `init workflow` and `apply` verbs remain available.",
+	GroupID: beginnerGroupID,
+}
+
+var workflowInitCmd = &cobra.Command{
+	Use:   "init [name]",
+	Short: "Scaffold a Workflow manifest — alias for `init workflow`",
+	Args:  cobra.MaximumNArgs(1),
+	RunE:  initWorkflowCmd.RunE,
+}
+
+var workflowRunCmd = &cobra.Command{
+	Use:   "run <file|scenario-dir>",
+	Short: "Run a Workflow manifest — alias for `apply`",
+	Args:  cobra.ExactArgs(1),
+	RunE:  applyCmd.RunE,
+}
+
+var workflowPublishCmd = &cobra.Command{
+	Use:   publishUse,
+	Short: "Publish a Workflow manifest — alias for `apply`",
+	Args:  cobra.ExactArgs(1),
+	RunE:  applyCmd.RunE,
+}
+
+func init() {
+	// `workflow init` reuses runInit's package vars (initTemplateDir/initOutput);
+	// register the same flags with the same defaults so it behaves identically.
+	workflowInitCmd.Flags().StringVar(&initTemplateDir, "template-dir", "spec/templates",
+		"directory containing <kind>/<kind>.template.yaml files")
+	workflowInitCmd.Flags().StringVarP(&initOutput, "output", "o", "",
+		"write the manifest to this file instead of stdout")
+	// `workflow run|publish` reuse apply's package vars (applyDryRun/applyEngine).
+	for _, c := range []*cobra.Command{workflowRunCmd, workflowPublishCmd} {
+		c.Flags().BoolVar(&applyDryRun, "dry-run", false, "validate manifest without submitting")
+		c.Flags().StringVar(&applyEngine, "engine", "", "engine hint forwarded to SubmitWorkflow (ADR-015)")
+	}
+
+	workflowCmd.AddCommand(workflowInitCmd)
+	workflowCmd.AddCommand(workflowRunCmd)
+	workflowCmd.AddCommand(workflowPublishCmd)
+	rootCmd.AddCommand(workflowCmd)
+}


### PR DESCRIPTION
## feat(cli): noun-grouped aliases (agent/workflow) + publish/run verbs

Closes #1490
Part of #1370 (EPIC — awesome quickstart)

### Why  (problem & intent)
A new user reaches for `zynax agent init` / `zynax workflow run` / `zynax publish` — a noun-first mental model the quickstart teaches — but the CLI only exposed verb-first commands (`init expert`, `apply`). Canvas O20 ("runtime-agnostic — unchanged") adds thin aliases so the CLI matches that mental model without changing any runtime behaviour.

### What you'll get  (deliverables ↔ what changed)
- `zynax agent init|publish` (alias of `init expert` / `apply`) ← `cmd/zynax/cmd/agent.go`
- `zynax workflow init|run|publish` (alias of `init workflow` / `apply`) ← `cmd/zynax/cmd/workflow.go`
- `zynax publish <file>` top-level verb with kind auto-detection (alias of `apply`) ← `cmd/zynax/cmd/publish.go`
- a "Getting started:" help group surfacing the beginner set (workflow, agent, publish, logs, result) ← `cmd/zynax/cmd/root.go`, `logs.go`, `result.go`
- table-driven parity tests proving each alias delegates to the same verb RunE ← `cmd/zynax/cmd/noun_aliases_test.go`

### Scope & boundaries
- **In scope:** additive Cobra aliases that DELEGATE to existing verb commands' `RunE` (no logic duplicated); a beginner help group.
- **Out of scope (deferred):** `doctor` joins the beginner group when #1489 lands; last-run tracking is #1491. No runtime behaviour change, no api-gateway endpoint change.

### Test plan & acceptance
| Acceptance criterion | How verified (command) | Result |
|----------------------|------------------------|--------|
| `agent init/publish`, `workflow init/run/publish`, `publish` work as thin aliases (publish auto-detects kind) | `GOWORK=off go -C cmd/zynax test ./cmd/... -race` (TestNounAliases_Resolve, TestNounAliases_DelegateToVerbRunE, TestPublishAlias_AutoDetectsKind, TestNounInitAliases_ScaffoldSameAsVerb) | ✅ ok 1.115s |
| Existing `apply` / `init` verbs still work (back-compat) | same suite (TestBackCompat_VerbsStillResolve) | ✅ pass |
| `zynax --help` groups a beginner set and keeps advanced verbs available | same suite (TestBeginnerGroup_Registered, TestRootHelp_ListsBeginnerCommands) | ✅ pass |
| No behaviour change beyond naming/help; additive aliases | aliases set `RunE = <verb>.RunE` (pointer-identity asserted); diff is new files + group tags only | ✅ pass |

**Local gates:** `make lint-go` ✅ (0 issues) · `GOWORK=off go -C cmd/zynax test ./... -race` ✅ · `GOWORK=off go -C cmd/zynax build ./...` ✅ · pre-commit golangci-lint (cmd/zynax) ✅

### Evidence
- **CI:** all required checks green (see run).
- **Local output:**
  - `make lint-go` → `✅ Go lint passed` (0 issues)
  - `go test ./... -race` → `ok github.com/zynax-io/zynax/cmd/zynax/cmd 1.115s` (all packages ok)
  - `go build ./...` → exit 0
- **Artifacts / images:** none — CLI module only, no service source changed.
- **Post-merge digest sync → main:** N/A — no image rebuild.

### Risk & rollback
Low — additive only. New commands delegate to existing verb `RunE`; existing `apply`/`init` paths are untouched. Revert this PR to remove the aliases. No data/migration concern. Edits to `apply.go` were avoided entirely to keep the sibling #1491 diff conflict-free; only test-file constants and two `GroupID` tags touch existing files.

### Review aids
Start at `cmd/zynax/cmd/publish.go` (the simplest alias — one `RunE` delegation), then `agent.go` / `workflow.go` (same pattern with init/apply). `root.go` registers the beginner group. The `goconst` refactor in `cmd_test.go` only swaps two repeated string literals for shared `kindWorkflow`/`kindAgentDef` constants — no logic change. User-facing help copy is task-oriented ("Create and publish agents", "Getting started:") and does not contradict the engine-portability positioning.

**SPDD:** Canvas `docs/spdd/1370-awesome-quickstart/canvas.md` — Status: **Aligned** (O20, runtime-agnostic) · `/lib:spdd-security-review` PASS
**AI:** `Assisted-by: Claude/claude-opus-4-8`  (label: ai-assisted)
