### PR TITLE
test(task-broker): deflake TestDispatchTask_HappyPath

### DIFF
--- a/services/task-broker/internal/domain/service_test.go
+++ b/services/task-broker/internal/domain/service_test.go
@@ -134,15 +134,14 @@ func TestDispatchTask_HappyPath(t *testing.T) {
 		t.Fatalf("DispatchTask: err=%v taskID=%q", err, taskID)
 	}
 
-	// Immediately after dispatch the task must be PENDING.
-	task, _ := repo.GetByID(context.Background(), taskID)
-	if task.Status != domain.TaskStatusPending {
-		t.Errorf("want PENDING, got %s", task.Status)
-	}
-
+	// Execution runs on a background goroutine, so the in-flight PENDING/DISPATCHED
+	// states are not deterministically observable here (an instant executor can reach
+	// COMPLETED before this goroutine reads the status back). Mid-flight observability
+	// is covered deterministically by TestDispatchTask_NonBlocking (blockingExecutor);
+	// the happy path asserts the terminal state once background work drains.
 	svc.WaitBackground()
 
-	task, _ = repo.GetByID(context.Background(), taskID)
+	task, _ := repo.GetByID(context.Background(), taskID)
 	if task.Status != domain.TaskStatusCompleted {
 		t.Errorf("want COMPLETED, got %s", task.Status)
 	}


### PR DESCRIPTION
## Why

The post-merge CI on `main` ([run 28187743016](https://github.com/zynax-io/zynax/actions/runs/28187743016), sha `669b0ae`) failed in `test-integration`:

```
--- FAIL: TestDispatchTask_HappyPath (0.00s)
    service_test.go:140: want PENDING, got COMPLETED
```

This is a **test-only race**, not a product bug and **unrelated to the CLI PR (#1505)** whose merge commit it landed on — `cmd/zynax` is a separate module that cannot touch `task-broker`. `DispatchTask` persists the task as `PENDING`, then runs `executeAsync` on a background `sync.WaitGroup` goroutine. The test then read the status back and asserted it was *still* `PENDING` — but with the instant `fakeExecutor`, the goroutine can run `PENDING → DISPATCHED → COMPLETED` before that read. The CI runner's load is what opens the window; the same suite was green on the prior commit `d1dea5b`.

## What you'll get

| Deliverable | Change |
|---|---|
| Deterministic `TestDispatchTask_HappyPath` | Drop the racy intermediate "must be PENDING immediately" read; assert only the terminal `COMPLETED` state after `WaitBackground()` drains the goroutine, with a comment explaining why. |

No coverage is lost: mid-flight observability is already asserted **deterministically** by `TestDispatchTask_NonBlocking` (uses `blockingExecutor` + `<-started` to hold the task at `DISPATCHED`), and the failure path by `TestDispatchTask_ExecutorFailure`.

## Scope & boundaries

- Touches **one test function** in `services/task-broker/internal/domain/service_test.go`. No production code change. No proto/chart/image impact.

## Test plan & acceptance

| Acceptance | Verify command | Result |
|---|---|---|
| Test is deterministic under load/scheduling perturbation | `GOWORK=off go -C services/task-broker test ./internal/domain/ -run TestDispatchTask -count=500 -race` | ✅ `ok` (500 iterations) |
| Full domain suite green | `GOWORK=off go -C services/task-broker test ./internal/domain/ -race` | ✅ `ok` |
| Domain coverage gate (≥90%, ADR-016) holds | `go test ./internal/domain/... -coverprofile … -covermode=atomic` → `tool cover -func` | ✅ `92.1%` (unchanged) |
| Lint clean | `make lint-go` | ✅ task-broker: 0 issues (all services 0) |

## Evidence

```
$ GOWORK=off go -C services/task-broker test ./internal/domain/ -run TestDispatchTask -count=500 -race -timeout 240s
ok  github.com/zynax-io/zynax/services/task-broker/internal/domain  1.999s

$ go tool cover -func /tmp/cov.out | tail -1
total:  (statements)  92.1%

$ make lint-go
🔍 task-broker
0 issues.
✅ Go lint passed
```

Local pre-commit `golangci-lint` + `gofmt`: passed. Commit DCO-signed + SSH-signed (status G).

## Risk & rollback

- **Risk:** negligible — removes a non-deterministic assertion; the property it nominally checked (initial `PENDING` persist) is not a publicly observable contract and is implicitly exercised by the surviving asserts. Rollback: revert this one commit.

## Review aids

- Sibling deterministic test for mid-flight state: `TestDispatchTask_NonBlocking` (same file, just below).
- `executeAsync` sets `DISPATCHED` *before* invoking the executor, so there is no executor hook that can deterministically freeze the task at `PENDING` — hence asserting the terminal state is the correct happy-path check.
