### PR TITLE
feat(infra): one-command kind demo lifecycle + Platform ready banner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,12 +125,18 @@ stop-local: ## Stop and remove local stack containers
 logs-local: ## Tail all local stack logs
 	$(COMPOSE) logs -f
 
-# ── One-command demo ────────────────────────────────────────────────────────
-# Boots the minimal stack + the zero-secret Ollama overlay, runs the hero
-# code-review workflow to a terminal state, and prints the model's review.
-# Prereq: pull the demo model once on the host — `ollama pull qwen2.5-coder:3b`
-# (the overlay reuses host-pulled models read-only; nothing is auto-downloaded).
-.PHONY: demo demo-clean
+# ── One-command kind demo (ADR-041 — kind is the unified runtime) ────────────
+# `make demo` creates a single-node kind cluster, side-loads the local images,
+# installs the zynax-umbrella Helm chart, waits for every Deployment's rollout,
+# runs the hero workflow against the gateway, and prints "Platform ready" with
+# the next command — ONE command, on the same charts that run in production.
+# `make kind-up` / `make kind-down` front the cluster lifecycle directly.
+# The legacy Docker-Compose demo is preserved as `demo-compose` (deprecated per
+# ADR-041 — Compose is retired as the primary path and receives no new work).
+.PHONY: demo kind-up kind-down demo-compose demo-clean
+KIND_DEMO     := scripts/demo/kind-demo.sh
+CLUSTER_UP    := scripts/e2e/cluster-up.sh
+CLUSTER_DOWN  := scripts/e2e/cluster-down.sh
 DEMO_WORKFLOW ?= spec/workflows/examples/code-review-ollama.yaml
 ZYNAX        ?= zynax
 # Optional: run a declarative scenario manifest set instead of the single hero
@@ -159,7 +165,20 @@ DEMO_MODEL   := $(shell awk '/^[[:space:]]*model:/{print $$2; exit}' infra/docke
 # standalone Temporal UI.
 DEMO_SERVICES := api-gateway llm-adapter
 
-demo: check-docker ## ★ One command: boot the Ollama stack + review code (hero workflow, or SCENARIO=<name> / PR=<number>)
+demo: check-docker ## ★ One command (kind): create cluster → load images → install umbrella → wait rollout → "Platform ready" + run hero workflow
+	@echo "🧭 Zynax demo on kind (ADR-041) — one command, prod-mirroring charts."
+	$(KIND_DEMO)
+
+kind-up: check-docker ## Create the kind cluster + install the zynax-umbrella chart (wraps scripts/e2e/cluster-up.sh, loads local images)
+	@echo "☸️  Bringing up the kind cluster + Zynax umbrella (loads local images)..."
+	KIND_LOAD_IMAGES=1 $(CLUSTER_UP)
+
+kind-down: ## Tear down the kind cluster (wraps scripts/e2e/cluster-down.sh)
+	@echo "🧹 Tearing down the kind cluster..."
+	$(CLUSTER_DOWN)
+
+demo-compose: check-docker ## [DEPRECATED — ADR-041] Legacy Docker-Compose Ollama demo (use `make demo` on kind)
+	@echo "⚠️  demo-compose is DEPRECATED (ADR-041 — Compose is retired). Prefer: make demo (kind)."
 	@command -v $(ZYNAX) >/dev/null 2>&1 || \
 	  (echo "❌ zynax CLI not found — run 'make install-cli' and ensure ~/bin is on your PATH" && exit 1)
 	@echo "🧠 Demo model: $(DEMO_MODEL)"
@@ -204,9 +223,9 @@ demo: check-docker ## ★ One command: boot the Ollama stack + review code (hero
 	@echo "   • Lighter Temporal: EVAL_TEMPORAL=1 make demo  (single in-memory start-dev, no Postgres/UI)"
 	@echo "   • Tear it all down: make demo-clean"
 
-demo-clean: ## Stop and remove the demo stack + volumes (base + Ollama overlay)
+demo-clean: ## Stop the legacy Compose demo stack + volumes (for the kind demo use `make kind-down`)
 	$(COMPOSE_DEMO) down -v --remove-orphans
-	@echo "✅ Demo stack removed"
+	@echo "✅ Compose demo stack removed (kind demo: make kind-down)"
 
 install-cli: ## Build and install zynax CLI to ~/bin/zynax (requires Go 1.26.3)
 	cd cmd/zynax && GOWORK=off go build -trimpath -o ~/bin/zynax .

--- a/scripts/demo/kind-demo.sh
+++ b/scripts/demo/kind-demo.sh
@@ -1,0 +1,241 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# kind-demo.sh — one-command kind lifecycle for the first-run golden path.
+#
+# EPIC #1370 / O22 (#1492), governed by ADR-041 (kind-native unified runtime —
+# Docker Compose retired as the primary path). Wraps the existing kind + Helm
+# bring-up (scripts/e2e/cluster-up.sh — the single source of bring-up truth) so a
+# brand-new user types ONE command and gets, in order:
+#
+#   1. a kind cluster (create → `kind load` local images → cert-manager →
+#      `helm upgrade --install` the zynax-umbrella → wait every Deployment's
+#      rollout) — all delegated to cluster-up.sh;
+#   2. a default-model pre-flight that reports, with actionable remediation,
+#      whether the reference model is available — BEFORE any workflow can fail;
+#   3. the hero workflow run against the gateway on http://localhost:8080;
+#   4. a "Platform ready" banner — printed ONLY AFTER the rollout actually
+#      succeeded (it is gated on cluster-up.sh's rollout wait returning 0), with
+#      the gateway URL and the exact next command, wedge-first.
+#
+# The banner is NEVER a premature "go" signal: cluster-up.sh blocks on
+# `kubectl rollout status` for all 7 services (and Temporal / echo-worker), so if
+# any Deployment is still coming up this script exits non-zero before the banner.
+#
+# AC5 (no host-LAN exposure of the model runtime): the kind demo dispatches the
+# `echo` capability (echo-worker, in-cluster) — no model runtime is exposed on
+# the host. The model pre-flight is host-side and informational; it never opens a
+# port. Only the api-gateway NodePort (host 8080 → nodePort 30080) is mapped out.
+#
+# Usage:
+#   scripts/demo/kind-demo.sh                 # full lifecycle + hero run
+#   KIND_LOAD_IMAGES=1 scripts/demo/kind-demo.sh   # (set by `make demo`)
+#
+# Environment overrides (plus everything cluster-up.sh accepts):
+#   CLUSTER_NAME    kind cluster name                 (default: zynax-e2e)
+#   NAMESPACE       release namespace                 (default: zynax)
+#   API_GW_URL      gateway base URL                  (default: http://localhost:8080)
+#   DEMO_MODEL      default reference model to check  (default: from the llm-adapter config)
+#   WORKFLOW_FILE   hero workflow to run              (default: spec/workflows/examples/e2e-demo.yaml)
+#   SKIP_RUN        set to skip the hero run (banner only after bring-up)
+#
+# Minimum host resources: 4 CPU, 8 GB RAM (see scripts/e2e/README.md).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+CLUSTER_NAME="${CLUSTER_NAME:-zynax-e2e}"
+NAMESPACE="${NAMESPACE:-zynax}"
+API_GW_URL="${API_GW_URL:-http://localhost:8080}"
+WORKFLOW_FILE="${WORKFLOW_FILE:-${REPO_ROOT}/spec/workflows/examples/e2e-demo.yaml}"
+# Default reference model — read from the single source (the llm-adapter config),
+# so the pre-flight and the runtime config never drift. Override with DEMO_MODEL.
+MODEL_CONFIG="${REPO_ROOT}/infra/docker-compose/ollama/llm-adapter.config.yaml"
+DEMO_MODEL="${DEMO_MODEL:-$(awk '/^[[:space:]]*model:/{print $2; exit}' "${MODEL_CONFIG}" 2>/dev/null)}"
+DEMO_MODEL="${DEMO_MODEL:-qwen2.5-coder:3b}"
+# Local port the script tunnels the gateway on (a NodePort can be reset by
+# kube-proxy on multi-node clusters; a port-forward is environment-independent).
+GW_LOCAL_PORT="${GW_LOCAL_PORT:-18080}"
+POLL_TIMEOUT="${POLL_TIMEOUT:-120}"
+POLL_INTERVAL="${POLL_INTERVAL:-5}"
+
+_PF_PIDS=()
+
+# ── helpers ──────────────────────────────────────────────────────────────────────
+
+log()  { printf '\033[1;34m[demo]\033[0m %s\n' "$*"; }
+warn() { printf '\033[1;33m[demo]\033[0m %s\n' "$*" >&2; }
+die()  { printf '\033[1;31m[demo]\033[0m %s\n' "$*" >&2; exit 1; }
+
+require() {
+  command -v "$1" >/dev/null 2>&1 || die "required tool not found on PATH: $1"
+}
+
+cleanup() {
+  for pid in "${_PF_PIDS[@]+"${_PF_PIDS[@]}"}"; do
+    kill "$pid" 2>/dev/null || true
+  done
+}
+trap cleanup EXIT
+
+# port_forward <resource> <local_port> <remote_port> — background kubectl
+# port-forward, wait up to PF_TIMEOUT (default 30s) for the port to accept.
+PF_TIMEOUT="${PF_TIMEOUT:-30}"
+port_forward() {
+  local resource="$1" local_port="$2" remote_port="$3"
+  local pf_log; pf_log=$(mktemp)
+  kubectl -n "${NAMESPACE}" port-forward "${resource}" \
+    "${local_port}:${remote_port}" >"${pf_log}" 2>&1 &
+  local pf_pid=$!
+  _PF_PIDS+=("$pf_pid")
+  local i=0
+  while ! (echo >"/dev/tcp/127.0.0.1/${local_port}") 2>/dev/null; do
+    if ! kill -0 "${pf_pid}" 2>/dev/null; then
+      die "port-forward ${resource}:${remote_port} exited: $(cat "${pf_log}")"
+    fi
+    i=$((i + 1))
+    [[ $i -ge ${PF_TIMEOUT} ]] && die "port-forward ${resource}:${remote_port} not ready in ${PF_TIMEOUT}s"
+    sleep 1
+  done
+  rm -f "${pf_log}"
+}
+
+api_curl() {
+  local method="$1" path="$2"; shift 2
+  local auth_args=()
+  [[ -n "${ZYNAX_API_KEY:-}" ]] && auth_args=(-H "Authorization: Bearer ${ZYNAX_API_KEY}")
+  curl --silent --show-error --fail \
+    -X "${method}" "${auth_args[@]+"${auth_args[@]}"}" "$@" "${API_GW_URL}${path}"
+}
+
+# ── 0. preflight: tools ──────────────────────────────────────────────────────────
+
+require kind
+require kubectl
+require helm
+require docker
+
+# ── 1. default-model pre-flight (BEFORE bring-up / any workflow can fail, AC3) ───
+
+# Surface the model situation up front with actionable remediation. The kind hero
+# workflow uses the in-cluster `echo` capability (no model needed), so a missing
+# model never breaks THIS run — but model-backed workflows would 404 mid-run, so
+# we tell the user exactly how to make it available now, never as a cryptic later
+# failure. The runtime stays in-cluster (AC5): this check never opens a host port.
+log "default-model pre-flight: ${DEMO_MODEL}"
+if command -v ollama >/dev/null 2>&1; then
+  if ollama list 2>/dev/null | awk '{print $1}' | grep -qx "${DEMO_MODEL}"; then
+    log "  ✓ default model '${DEMO_MODEL}' is available on the host."
+  else
+    warn "  ⚠️  default model '${DEMO_MODEL}' is NOT present yet."
+    warn "      The kind hero workflow below uses the in-cluster 'echo' capability and runs"
+    warn "      WITHOUT a model, so this run is unaffected. To run a model-backed workflow"
+    warn "      (e.g. the code-review example) pull it once first — this avoids a mid-run 404:"
+    warn "          ollama pull ${DEMO_MODEL}"
+  fi
+else
+  warn "  ⚠️  'ollama' is not on PATH — the kind hero workflow ('echo' capability) needs NO model"
+  warn "      and will run fine. For a model-backed workflow, install Ollama and pull the model:"
+  warn "          https://ollama.com  →  ollama pull ${DEMO_MODEL}"
+fi
+
+# ── 2. bring up the cluster (delegated to the single bring-up source of truth) ───
+
+# cluster-up.sh creates the kind cluster, `kind load`s the local images (we pass
+# KIND_LOAD_IMAGES), installs cert-manager + the zynax-umbrella chart, and BLOCKS
+# on `kubectl rollout status` for every Zynax Deployment. Its success is the gate
+# for the "Platform ready" banner below — we never print it if this returns ≠ 0.
+log "bringing up the kind cluster + Zynax umbrella (wraps scripts/e2e/cluster-up.sh)…"
+KIND_LOAD_IMAGES="${KIND_LOAD_IMAGES:-1}" \
+CLUSTER_NAME="${CLUSTER_NAME}" \
+NAMESPACE="${NAMESPACE}" \
+  "${REPO_ROOT}/scripts/e2e/cluster-up.sh"
+
+# Defence-in-depth: re-assert every Zynax Deployment is actually Available before
+# the banner, so the banner can NEVER be a premature "go" signal (AC4). This is a
+# fast no-op when cluster-up.sh already waited, but it pins the contract here too.
+log "verifying every Zynax Deployment reports a healthy rollout before signalling ready…"
+SERVICE_DEPLOYMENTS=(
+  zynax-api-gateway zynax-workflow-compiler zynax-engine-adapter
+  zynax-task-broker zynax-agent-registry zynax-event-bus zynax-memory-service
+)
+for dep in "${SERVICE_DEPLOYMENTS[@]}"; do
+  kubectl -n "${NAMESPACE}" rollout status "deployment/${dep}" --timeout=120s \
+    || die "deployment ${dep} is not ready — NOT printing the ready banner (platform still coming up)"
+done
+log "all Zynax Deployments are Available."
+
+# ── 3. run the hero workflow against the gateway (localhost:8080) ────────────────
+
+RAN_RESULT=""
+if [[ -z "${SKIP_RUN:-}" ]]; then
+  require curl
+  require jq
+  # Resolve the gateway bearer key cluster-up.sh provisioned (avoids a 401).
+  if [[ -z "${ZYNAX_API_KEY:-}" ]]; then
+    ZYNAX_API_KEY="$(kubectl -n "${NAMESPACE}" get secret zynax-gw-api-key \
+      -o jsonpath='{.data.api-key}' 2>/dev/null | base64 -d || true)"
+  fi
+  # Tunnel the gateway. The kind NodePort maps host 8080 → 30080, but a
+  # port-forward is environment-independent (kube-proxy can reset the NodePort on
+  # a multi-node cluster). Honour a caller-supplied non-default API_GW_URL.
+  if [[ "${API_GW_URL}" == "http://localhost:8080" ]]; then
+    port_forward "svc/zynax-api-gateway" "${GW_LOCAL_PORT}" 8080
+    API_GW_URL="http://localhost:${GW_LOCAL_PORT}"
+  fi
+  log "running the hero workflow (${WORKFLOW_FILE##*/}) via api-gateway at ${API_GW_URL}…"
+  APPLY_RESPONSE="$(api_curl POST /api/v1/apply \
+    -H "Content-Type: application/x-yaml" \
+    --data-binary "@${WORKFLOW_FILE}" 2>&1)" \
+    || die "POST /api/v1/apply failed — is api-gateway reachable? Response: ${APPLY_RESPONSE}"
+  RUN_ID="$(printf '%s' "${APPLY_RESPONSE}" | jq -r '.run_id // empty')"
+  [[ -n "${RUN_ID}" ]] || die "apply response had no run_id: ${APPLY_RESPONSE}"
+  log "  submitted run_id=${RUN_ID} — polling for a terminal state (timeout ${POLL_TIMEOUT}s)…"
+  deadline=$(( $(date +%s) + POLL_TIMEOUT ))
+  status=""
+  while [[ $(date +%s) -lt ${deadline} ]]; do
+    # The api-gateway returns the WorkflowStatus proto enum under `.status`
+    # (e.g. WORKFLOW_STATUS_COMPLETED) and accepts lowercase aliases — match the
+    # same set as scripts/e2e/e2e-happy.sh so the two stay in lockstep.
+    status="$(api_curl GET "/api/v1/workflows/${RUN_ID}" 2>/dev/null | jq -r '.status // empty' || true)"
+    case "${status}" in
+      succeeded|completed|*COMPLETED|*SUCCEEDED) RAN_RESULT="succeeded"; break ;;
+      failed|error|*FAILED|*ERROR|*CANCELED|*TERMINATED|*TIMED_OUT)
+        die "hero workflow reached terminal failure state '${status}' (run_id=${RUN_ID})" ;;
+    esac
+    sleep "${POLL_INTERVAL}"
+  done
+  [[ "${RAN_RESULT}" == "succeeded" ]] \
+    || die "hero workflow did not reach success within ${POLL_TIMEOUT}s (last status: '${status:-unknown}')"
+  log "  ✓ hero workflow reached terminal success ('${status}', run_id=${RUN_ID})."
+fi
+
+# ── 4. "Platform ready" banner — ONLY reached after rollout + (optional) run ─────
+
+# wedge-first copy (ADR-041 / #1492 AC6): lead with engine portability.
+cat <<'BANNER'
+
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  ✅  Platform ready                                                           ║
+║                                                                              ║
+║  Write your workflow ONCE — run it on Temporal OR Argo, on the same kind     ║
+║  cluster that mirrors production. (Switch engines: E2E_ENGINE=argo make demo)║
+║                                                                              ║
+║  Gateway:  http://localhost:8080                                             ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+BANNER
+
+echo "  Next, run a workflow against the live platform:"
+echo ""
+echo "      zynax --api-url http://localhost:8080 apply spec/workflows/examples/e2e-demo.yaml"
+echo ""
+echo "  More:"
+echo "    • Engine-portability:  E2E_ENGINE=argo make demo   (same workflow, Argo engine)"
+echo "    • Inspect a run:        zynax --api-url http://localhost:8080 logs <run-id> --follow"
+echo "    • Tear it all down:     make kind-down"
+echo ""
+[[ "${RAN_RESULT}" == "succeeded" ]] \
+  && echo "  (the hero workflow already ran to 'succeeded' above — the platform is live.)"
+echo ""

--- a/scripts/e2e/cluster-up.sh
+++ b/scripts/e2e/cluster-up.sh
@@ -55,6 +55,19 @@ WAIT_TIMEOUT="${WAIT_TIMEOUT:-600s}"
 # Selection flows through umbrella values only — never hardcoded (ADR-015).
 E2E_ENGINE="${E2E_ENGINE:-temporal}"
 ARGO_WORKFLOWS_CHART_VERSION="${ARGO_WORKFLOWS_CHART_VERSION:-0.47.5}"
+# When set to a non-empty value, side-load the locally-built service images into
+# the kind cluster with `kind load docker-image` before the Helm install, so the
+# cluster runs the images already on the host instead of pulling from GHCR. The
+# laptop demo path (`make kind-up` / `make demo`) sets this to make cold-start
+# fast and offline-friendly; CI leaves it unset and lets the cluster pull the
+# pinned staging/`:main` lane from GHCR (existing behaviour, ADR-027).
+KIND_LOAD_IMAGES="${KIND_LOAD_IMAGES:-}"
+# Registry/tag the loaded images carry — must match what values-e2e.yaml asks the
+# chart to run (`:main`, the lane the chart's image.tag override pins). The echo
+# capability worker image (langgraph-adapter, manifests/echo-worker.yaml) is
+# loaded too so the dispatch chain round-trips with IfNotPresent.
+KIND_LOAD_REGISTRY="${KIND_LOAD_REGISTRY:-ghcr.io/zynax-io/zynax}"
+KIND_LOAD_TAG="${KIND_LOAD_TAG:-main}"
 
 KIND_CONFIG="${SCRIPT_DIR}/kind-config.yaml"
 UMBRELLA_CHART="${REPO_ROOT}/helm/zynax-umbrella"
@@ -115,6 +128,30 @@ fi
 
 # Point kubectl/helm at the cluster regardless of how it was created.
 kubectl config use-context "kind-${CLUSTER_NAME}" >/dev/null
+
+# ── 1.5 [opt-in] side-load locally-built images into the cluster ─────────────────
+
+# When KIND_LOAD_IMAGES is set (the laptop demo path), copy the host's local
+# `<registry>/<svc>:<tag>` images straight into the kind nodes so the chart runs
+# them with IfNotPresent instead of pulling from GHCR — fast, offline-friendly
+# cold-start. Skipped silently in CI (unset), where the cluster pulls the pinned
+# staging/`:main` lane. Each `kind load` no-ops gracefully if the host image is
+# absent (warn, continue) — a missing image surfaces as an ImagePull later, with
+# the same diagnostics as the GHCR path.
+if [[ -n "${KIND_LOAD_IMAGES}" ]]; then
+  log "side-loading local images into kind cluster '${CLUSTER_NAME}' (tag: ${KIND_LOAD_TAG})…"
+  for svc in api-gateway workflow-compiler engine-adapter task-broker \
+             agent-registry event-bus memory-service langgraph-adapter; do
+    img="${KIND_LOAD_REGISTRY}/${svc}:${KIND_LOAD_TAG}"
+    if docker image inspect "${img}" >/dev/null 2>&1; then
+      log "  → loading ${img}"
+      kind load docker-image "${img}" --name "${CLUSTER_NAME}"
+    else
+      warn "  host image not found, skipping (will pull from registry): ${img}"
+    fi
+  done
+  log "image side-load complete."
+fi
 
 # ── 2. install cert-manager (CRDs + controllers) ─────────────────────────────────
 


### PR DESCRIPTION
## feat(infra): one-command kind demo lifecycle + Platform ready banner

Closes #1492
Part of #1370 (EPIC — Awesome Quickstart, canvas O22)

### Why  (problem & intent)
Per ADR-041 the laptop/demo runtime is now a single-node **kind** cluster on the prod-tested Helm charts, but that path was CI-only: `scripts/e2e/cluster-up.sh` finishes with no user-facing orientation, and the local model pull is a hidden, blocking prerequisite that only surfaced as a cryptic mid-run 404. Canvas **O22** re-points #1492 to a one-command kind lifecycle that ends with a definitive "Platform ready" signal and a model pre-flight — *before* anything can fail.

### What you'll get  (deliverables ↔ what changed)
- `make demo` = one command: create kind cluster → `kind load` local images → `helm upgrade --install` umbrella → wait every Deployment's rollout → run hero workflow → "Platform ready" banner ← `scripts/demo/kind-demo.sh`, `Makefile`
- `make kind-up` / `make kind-down` front the cluster lifecycle directly ← `Makefile`
- opt-in `kind load` of local images into the cluster (fast, offline-friendly cold-start; CI path unchanged) ← `scripts/e2e/cluster-up.sh`
- host-side default-model pre-flight with actionable `ollama pull` remediation, printed BEFORE any run, opening no host port ← `scripts/demo/kind-demo.sh`
- wedge-first "Platform ready" banner (Temporal OR Argo) gated strictly on rollout + hero success ← `scripts/demo/kind-demo.sh`
- legacy Compose demo preserved as `demo-compose` (deprecated per ADR-041) ← `Makefile`

### Scope & boundaries
- **In scope:** Makefile targets (`demo` re-pointed to kind, `kind-up`, `kind-down`, `demo-compose`), the kind-demo wrapper script, and an opt-in `kind load` step in the existing bring-up script. Wraps the existing bring-up (single source of truth) — no new chart/proto/event-schema changes.
- **Out of scope (deferred):** `zynax doctor` health checklist → #1489 · golden-path README rewrite → #1494 · in-cluster model runtime (the kind hero path uses the in-cluster `echo` capability; a model-backed in-cluster workflow is a separate follow-up).

### Test plan & acceptance
All booted on this host (Docker + kind v0.23.0 + kubectl v1.29.2 + helm v3.21.0). Two runs on the same cluster (run 1 = cold create; run 2 = idempotent reuse).

| Acceptance criterion | How verified (command) | Result |
|----------------------|------------------------|--------|
| 1. One `make demo` runs the full lifecycle (create → `kind load` → `helm upgrade --install` → wait rollout → banner) | `make demo` | ✅ cluster created, 8 images side-loaded across 3 nodes, umbrella installed (rev 1→2), all 7 Deployments + echo-worker rolled out |
| 2. Banner prints gateway URL `localhost:8080` + exact next command | `make demo` (banner block) | ✅ banner shows `Gateway: http://localhost:8080` and `zynax --api-url http://localhost:8080 apply spec/workflows/examples/e2e-demo.yaml` |
| 3. Missing default model → actionable remediation BEFORE a run | `DEMO_MODEL=nonexistent-model:99b` preflight | ✅ prints `ollama pull nonexistent-model:99b`, notes the kind hero path needs no model, opens no port |
| 4. Banner ONLY after rollout succeeds (never premature) | run 1 (stale poll) timed out at the hero step → banner NOT printed; run 2 printed banner only after `WORKFLOW_STATUS_COMPLETED` | ✅ banner is strictly gated on rollout + hero success |
| 5. No host-LAN exposure of the model runtime | review: kind hero uses in-cluster `echo` capability; only api-gateway NodePort (host 8080 → 30080) mapped; preflight is host-side and opens no port | ✅ |
| 6. Banner copy leads with the engine-portability wedge | banner first line | ✅ "Write your workflow ONCE — run it on Temporal OR Argo…" |

**Local gates:** `shellcheck scripts/demo/kind-demo.sh scripts/e2e/cluster-up.sh` ✅ (clean) · `helm lint helm/zynax-umbrella -f scripts/e2e/values-e2e.yaml` ✅ (0 failed) · `make -n demo kind-up kind-down` ✅ (Makefile syntax valid)

### Evidence
- **Run 2 banner + hero result (idempotent reuse, exit 0):**
```
[demo]   ✓ hero workflow reached terminal success ('WORKFLOW_STATUS_COMPLETED', run_id=wf-87c54f296047a171-1782412251).

╔══════════════════════════════════════════════════════════════════════════════╗
║  ✅  Platform ready                                                           ║
║                                                                              ║
║  Write your workflow ONCE — run it on Temporal OR Argo, on the same kind     ║
║  cluster that mirrors production. (Switch engines: E2E_ENGINE=argo make demo)║
║                                                                              ║
║  Gateway:  http://localhost:8080                                             ║
╚══════════════════════════════════════════════════════════════════════════════╝
  Next, run a workflow against the live platform:

      zynax --api-url http://localhost:8080 apply spec/workflows/examples/e2e-demo.yaml
```
- **`kubectl -n zynax get deploy` (all Available, both runs):**
```
NAME                        READY   UP-TO-DATE   AVAILABLE
echo-worker                 1/1     1            1
zynax-agent-registry        1/1     1            1
zynax-api-gateway           1/1     1            1
zynax-engine-adapter        1/1     1            1
zynax-event-bus             1/1     1            1
zynax-memory-service        1/1     1            1
zynax-task-broker           1/1     1            1
zynax-workflow-compiler     1/1     1            1
(+ temporal-frontend/history/matching/worker/admintools, nats, postgres — all 1/1)
```
- **Run 1 (cold create):** kind cluster created, 8 images `kind load`ed across 3 nodes, umbrella rev 1, Temporal `default` namespace registered, all 7 + echo-worker rolled out; hero workflow `wf-87c54f296047a171` confirmed `WORKFLOW_STATUS_COMPLETED` server-side (`GET /api/v1/workflows/...`). Banner correctly withheld (the cold run's poll used a stale field — fixed in this PR; the fixed run 2 prints the banner).
- **Run 2 (idempotent reuse):** cluster reused, `helm upgrade` → rev 2, Postgres creds Secret reused, all 7 re-rolled, **fresh** hero workflow `…-1782412251` reached `WORKFLOW_STATUS_COMPLETED`, banner printed. `make demo` exit 0.
- **Artifacts / images:** none — no service source changed (infra/Makefile/scripts only).
- **Post-merge digest sync → main:** _placeholder — filled by the post-merge verifier (N/A expected: no image rebuild)._

### Risk & rollback
Low — additive/UX over the existing kind path. `make demo` now wraps the same `scripts/e2e/cluster-up.sh` (unchanged in CI: the `kind load` step is opt-in via `KIND_LOAD_IMAGES`, unset in CI). Revert: remove the banner/wrapper and `make kind-up`/`make demo` call `scripts/e2e/cluster-up.sh` directly; the Compose path remains as `demo-compose`. No data/migration concern.

### Review aids
Start at `scripts/demo/kind-demo.sh` (the one new file: model pre-flight → delegate bring-up → re-assert rollout → run hero → gated banner). `cluster-up.sh` gains only the opt-in `kind load` block (step 1.5). The Makefile change re-points `demo` to the script, adds `kind-up`/`kind-down`, and renames the old Compose demo to `demo-compose`. The banner is reached ONLY after `kubectl rollout status` for all 7 services returns 0 AND the hero workflow reaches a terminal success — never a premature "go".

**SPDD:** Canvas `docs/spdd/1370-awesome-quickstart/canvas.md` — O22, Status: **Aligned** (2026-06-25, kind-native per ADR-041) · `/spdd-security-review` **PASS** (no Tier 2 content; model runtime stays in-cluster; no secret on the default path).
**AI:** `Assisted-by: Claude/claude-opus-4-8`
