### PR TITLE
feat(cli): add zynax doctor platform + model health checklist

### DIFF
--- a/cmd/zynax/AGENTS.md
+++ b/cmd/zynax/AGENTS.md
@@ -28,6 +28,7 @@ cmd/zynax/
     mcp.go          zynax mcp git   (launch Git MCP server — execs `git-adapter mcp`, ADR-032)
     validate.go      zynax validate <file> [--schema-dir] [--format]  (local: schema + data-flow)
     init.go          zynax init workflow|expert [name] [-o file]  (scaffold from spec/templates)
+    doctor.go        zynax doctor   (read-only platform+model health checklist; shells out to kubectl/helm/ollama)
   validate/
     manifest.go     JSON Schema validation (validate.Manifest) + combined pipeline (validate.File)
     dataflow.go     Workflow state-machine checks (initial_state + transition goto targets)

--- a/cmd/zynax/client/gateway.go
+++ b/cmd/zynax/client/gateway.go
@@ -133,6 +133,57 @@ func (g *Gateway) ApplyDryRun(ctx context.Context, body []byte) ([]CompileError,
 	}
 }
 
+// Health probes the api-gateway liveness endpoint GET /healthz (issue #1380:
+// returns 200 + a {"status":"..."} JSON body when serving, 503 when not). It
+// returns the reported status string on success, or a descriptive error when
+// the gateway is unreachable or unhealthy. Used by `zynax doctor`.
+func (g *Gateway) Health(ctx context.Context) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, g.base+"/healthz", nil)
+	if err != nil {
+		return "", fmt.Errorf("zynax: build request: %w", err)
+	}
+	resp, err := g.client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("zynax: health: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	raw, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("zynax: health: HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(raw)))
+	}
+	// Body is {"status":"ok"} since #1380; tolerate an empty body too.
+	var s struct {
+		Status string `json:"status"`
+	}
+	_ = json.Unmarshal(raw, &s)
+	if s.Status == "" {
+		s.Status = "ok"
+	}
+	return s.Status, nil
+}
+
+// Ready probes the api-gateway readiness endpoint GET /readyz (200 when the
+// gateway's dependencies are reachable, 503 otherwise; no body either way).
+// Returns nil when ready, a descriptive error otherwise. Used by `zynax doctor`.
+func (g *Gateway) Ready(ctx context.Context) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, g.base+"/readyz", nil)
+	if err != nil {
+		return fmt.Errorf("zynax: build request: %w", err)
+	}
+	resp, err := g.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("zynax: ready: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		raw, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("zynax: ready: HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(raw)))
+	}
+	return nil
+}
+
 // GetWorkflow returns the current status of a workflow run.
 func (g *Gateway) GetWorkflow(ctx context.Context, runID string) (*WorkflowStatus, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, g.base+"/api/v1/workflows/"+runID, nil)

--- a/cmd/zynax/cmd/doctor.go
+++ b/cmd/zynax/cmd/doctor.go
@@ -1,0 +1,253 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// doctorNamespace is the Helm release namespace the kind-native runtime deploys
+// the Zynax stack into (scripts/e2e/cluster-up.sh: NAMESPACE=zynax).
+const doctorNamespace = "zynax"
+
+// doctorRelease is the umbrella Helm release name (cluster-up.sh: RELEASE_NAME=zynax).
+const doctorRelease = "zynax"
+
+// defaultModel is the reference local model the quickstart pulls (DEMO_MODEL /
+// infra/docker-compose/ollama/llm-adapter.config.yaml). Kept in lockstep with
+// the demo script so the doctor pre-flight and runtime config never drift.
+const defaultModel = "qwen2.5-coder:3b"
+
+// doctorComponent names a platform Deployment/StatefulSet doctor checks for
+// readiness, paired with the user-facing label and a remediation hint.
+type doctorComponent struct {
+	label    string // user-facing component name (wedge/help copy)
+	workload string // kubectl workload, e.g. "deployment/zynax-api-gateway"
+	hint     string // one-line remediation shown when the component is not Ready
+}
+
+// doctorComponents are the platform workloads doctor asserts are Ready. Names
+// match scripts/e2e/cluster-up.sh (namespace zynax, release zynax) exactly:
+// the 5 Gherkin lines API/Registry/Runtime/Event Bus/Storage.
+var doctorComponents = []doctorComponent{
+	{"API gateway", "deployment/zynax-api-gateway", "kubectl -n " + doctorNamespace + " rollout status deployment/zynax-api-gateway"},
+	{"Agent registry", "deployment/zynax-agent-registry", "kubectl -n " + doctorNamespace + " rollout status deployment/zynax-agent-registry"},
+	{"Runtime (engine-adapter)", "deployment/zynax-engine-adapter", "kubectl -n " + doctorNamespace + " rollout status deployment/zynax-engine-adapter"},
+	{"Event bus", "deployment/zynax-event-bus", "kubectl -n " + doctorNamespace + " rollout status deployment/zynax-event-bus"},
+	{"Storage (Postgres)", "statefulset/zynax-postgresql", "kubectl -n " + doctorNamespace + " rollout status statefulset/zynax-postgresql"},
+}
+
+// commander runs an external command and returns its combined stdout. Injected
+// so unit tests run with a fake — no real kubectl/helm/ollama or cluster.
+type commander func(ctx context.Context, name string, args ...string) (string, error)
+
+// healthProber probes the api-gateway liveness endpoint. Injected so tests use
+// an httptest.Server (or a stub) instead of a real gateway.
+type healthProber func(ctx context.Context) (string, error)
+
+// execCommander is the production commander: shells out via os/exec and returns
+// combined output. Per cmd/zynax/AGENTS.md the CLI shells out to the user's
+// kubectl/helm/ollama binaries (no client-go/helm SDK deps).
+func execCommander(ctx context.Context, name string, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, name, args...) //nolint:gosec // G204: name is a fixed binary (kubectl/helm/ollama); args are static
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+// doctorDeps bundles the injectable collaborators so tests are hermetic.
+type doctorDeps struct {
+	run    commander
+	health healthProber
+	model  string
+}
+
+var doctorCmd = &cobra.Command{
+	Use:     "doctor",
+	GroupID: beginnerGroupID,
+	Short:   "Check the platform is healthy — write once, run on Temporal or Argo",
+	Long: `Confirm your local platform is ready before your first workflow.
+
+Write your workflow ONCE — it runs on Temporal OR Argo, on the same kind
+cluster that mirrors production. ` + "`zynax doctor`" + ` validates that runtime with
+one read-only checklist instead of hand-running kubectl, helm, and curl:
+
+  • Cluster      — the current kubecontext is reachable
+  • Helm release — the zynax umbrella deployed cleanly
+  • Pods         — API, Registry, Runtime, Event Bus and Storage are Ready
+  • API gateway  — /healthz answers on --api-url
+  • Model        — the default reference model is available (host-side)
+
+Exit 0 only when the cluster, release, pods and gateway are all healthy
+(scriptable); a missing local model is a warning, not a failure.`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		deps := doctorDeps{run: execCommander, health: newGateway().Health, model: defaultModel}
+		ok := runDoctor(cmd.Context(), cmd.OutOrStdout(), deps)
+		if !ok {
+			// Non-zero, scriptable exit (AC3). Mirrors status.go's os.Exit(2)
+			// precedent: a clean RunE return would exit 0 and hide the failure.
+			os.Exit(1)
+		}
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(doctorCmd)
+}
+
+// runDoctor runs every check, prints a ✓/✗ checklist, and returns true only
+// when the cluster, release, pods and gateway are all healthy. A missing model
+// prints a ⚠ warning line but does NOT flip the result (AC2/AC3): model-backed
+// workflows need it, but the kind hero workflow uses the in-cluster echo
+// capability, so a missing host model must not block a healthy platform.
+func runDoctor(ctx context.Context, w io.Writer, deps doctorDeps) bool {
+	// Wedge-first header (AC4): lead with engine portability, never "control plane".
+	_, _ = fmt.Fprintln(w, "zynax doctor — write your workflow once, run it on Temporal or Argo.")
+	_, _ = fmt.Fprintln(w, "Checking the kind runtime that mirrors production:")
+	_, _ = fmt.Fprintln(w)
+
+	healthy := true
+
+	// 1. Cluster reachability.
+	if err := checkCluster(ctx, deps.run); err != nil {
+		printFail(w, "Cluster", "kubecontext not reachable — start it with `make kind-up` (or `kubectl config use-context kind-zynax-e2e`)")
+		healthy = false
+	} else {
+		printOK(w, "Cluster")
+	}
+
+	// 2. Helm release status.
+	if err := checkRelease(ctx, deps.run); err != nil {
+		printFail(w, "Helm release", "umbrella not deployed — run `make kind-up` to `helm upgrade --install` it")
+		healthy = false
+	} else {
+		printOK(w, "Helm release")
+	}
+
+	// 3. Pod/Deployment readiness, per component.
+	for _, c := range doctorComponents {
+		if err := checkWorkloadReady(ctx, deps.run, c.workload); err != nil {
+			printFail(w, "Pods: "+c.label, c.hint)
+			healthy = false
+		} else {
+			printOK(w, "Pods: "+c.label)
+		}
+	}
+
+	// 4. api-gateway liveness over the configured --api-url.
+	if _, err := deps.health(ctx); err != nil {
+		printFail(w, "API gateway", "/healthz did not answer — check --api-url and `kubectl -n "+doctorNamespace+" port-forward svc/zynax-api-gateway 8080:8080`")
+		healthy = false
+	} else {
+		printOK(w, "API gateway")
+	}
+
+	// 5. Default reference model (host-side, informational — AC2). Missing model
+	// warns with remediation but never flips `healthy`.
+	if checkModel(ctx, deps.run, deps.model) {
+		printOK(w, "Model ("+deps.model+")")
+	} else {
+		printWarn(w, "Model ("+deps.model+")", "not found on host — `ollama pull "+deps.model+"` to run model-backed workflows (the kind demo's echo capability needs no model)")
+	}
+
+	_, _ = fmt.Fprintln(w)
+	if healthy {
+		_, _ = fmt.Fprintln(w, "✅  Platform healthy — run: zynax apply spec/workflows/examples/e2e-demo.yaml")
+	} else {
+		_, _ = fmt.Fprintln(w, "❌  Platform not ready — fix the ✗ lines above, then re-run `zynax doctor`.")
+	}
+	return healthy
+}
+
+// checkCluster verifies the current kubecontext is reachable.
+func checkCluster(ctx context.Context, run commander) error {
+	_, err := run(ctx, "kubectl", "cluster-info")
+	return err
+}
+
+// checkRelease verifies the umbrella Helm release is deployed and its last
+// operation succeeded (status "deployed").
+func checkRelease(ctx context.Context, run commander) error {
+	out, err := run(ctx, "helm", "-n", doctorNamespace, "status", doctorRelease, "-o", "json")
+	if err != nil {
+		return fmt.Errorf("helm status: %w", err)
+	}
+	var st struct {
+		Info struct {
+			Status string `json:"status"`
+		} `json:"info"`
+	}
+	if err := json.Unmarshal([]byte(out), &st); err != nil {
+		return fmt.Errorf("decode helm status: %w", err)
+	}
+	if st.Info.Status != "deployed" {
+		return fmt.Errorf("release status %q (want deployed)", st.Info.Status)
+	}
+	return nil
+}
+
+// checkWorkloadReady verifies a Deployment/StatefulSet has all replicas Ready by
+// parsing `kubectl get <workload> -o json` status counters.
+func checkWorkloadReady(ctx context.Context, run commander, workload string) error {
+	out, err := run(ctx, "kubectl", "-n", doctorNamespace, "get", workload, "-o", "json")
+	if err != nil {
+		return fmt.Errorf("kubectl get %s: %w", workload, err)
+	}
+	var obj struct {
+		Spec struct {
+			Replicas *int `json:"replicas"`
+		} `json:"spec"`
+		Status struct {
+			ReadyReplicas int `json:"readyReplicas"`
+		} `json:"status"`
+	}
+	if err := json.Unmarshal([]byte(out), &obj); err != nil {
+		return fmt.Errorf("decode %s: %w", workload, err)
+	}
+	want := 1
+	if obj.Spec.Replicas != nil {
+		want = *obj.Spec.Replicas
+	}
+	if obj.Status.ReadyReplicas < want {
+		return fmt.Errorf("%d/%d replicas ready", obj.Status.ReadyReplicas, want)
+	}
+	return nil
+}
+
+// checkModel reports whether the default reference model is present on the host.
+// Host-side and informational: a missing `ollama` binary or model is not fatal.
+func checkModel(ctx context.Context, run commander, model string) bool {
+	out, err := run(ctx, "ollama", "list")
+	if err != nil {
+		return false
+	}
+	// `ollama list` first column is NAME (e.g. "qwen2.5-coder:3b").
+	for _, line := range strings.Split(out, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) > 0 && fields[0] == model {
+			return true
+		}
+	}
+	return false
+}
+
+func printOK(w io.Writer, label string) {
+	_, _ = fmt.Fprintf(w, "  ✓ %s\n", label)
+}
+
+func printFail(w io.Writer, label, hint string) {
+	_, _ = fmt.Fprintf(w, "  ✗ %s — %s\n", label, hint)
+}
+
+func printWarn(w io.Writer, label, hint string) {
+	_, _ = fmt.Fprintf(w, "  ⚠ %s — %s\n", label, hint)
+}

--- a/cmd/zynax/cmd/doctor_test.go
+++ b/cmd/zynax/cmd/doctor_test.go
@@ -1,0 +1,237 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// fakeCommander builds a commander that returns canned output keyed by the
+// command + first arg pattern, so doctor's checks run with no real binaries.
+// Each rule maps a substring of the full command line to (output, err).
+type cmdRule struct {
+	match string // substring of "<name> <args...>"
+	out   string
+	err   error
+}
+
+func fakeCommander(rules []cmdRule) commander {
+	return func(_ context.Context, name string, args ...string) (string, error) {
+		full := name + " " + strings.Join(args, " ")
+		for _, r := range rules {
+			if strings.Contains(full, r.match) {
+				return r.out, r.err
+			}
+		}
+		return "", errors.New("fakeCommander: no rule for: " + full)
+	}
+}
+
+// healthyRules returns commander rules where every kubectl/helm/ollama call
+// reports a healthy platform with the default model present.
+func healthyRules() []cmdRule {
+	return []cmdRule{
+		{match: "kubectl cluster-info", out: "Kubernetes control plane is running\n"},
+		{match: "helm -n zynax status zynax", out: `{"info":{"status":"deployed"}}`},
+		{match: "get deployment/", out: `{"spec":{"replicas":1},"status":{"readyReplicas":1}}`},
+		{match: "get statefulset/", out: `{"spec":{"replicas":1},"status":{"readyReplicas":1}}`},
+		{match: "ollama list", out: "NAME\t\t\tID\nqwen2.5-coder:3b\tabc123\n"},
+	}
+}
+
+// okHealth is a healthProber stub reporting a healthy gateway.
+func okHealth(_ context.Context) (string, error) { return "ok", nil }
+
+// failHealth is a healthProber stub reporting an unreachable gateway.
+func failHealth(_ context.Context) (string, error) { return "", errors.New("connection refused") }
+
+func runDoctorTest(deps doctorDeps) (string, bool) {
+	var out bytes.Buffer
+	ok := runDoctor(context.Background(), &out, deps)
+	return out.String(), ok
+}
+
+// TestDoctor_AllOK asserts AC1/AC3/AC4: a fully healthy platform prints every
+// component OK and returns true (→ exit 0), and the output leads with the
+// engine-portability wedge.
+func TestDoctor_AllOK(t *testing.T) {
+	out, ok := runDoctorTest(doctorDeps{run: fakeCommander(healthyRules()), health: okHealth, model: defaultModel})
+	if !ok {
+		t.Fatalf("expected healthy=true, got false; output:\n%s", out)
+	}
+	// AC4: wedge-first framing.
+	if !strings.Contains(out, "Temporal or Argo") {
+		t.Errorf("output missing engine-portability wedge:\n%s", out)
+	}
+	// AC1: every component line present and OK.
+	for _, want := range []string{
+		"✓ Cluster", "✓ Helm release",
+		"✓ Pods: API gateway", "✓ Pods: Agent registry", "✓ Pods: Runtime (engine-adapter)",
+		"✓ Pods: Event bus", "✓ Pods: Storage (Postgres)",
+		"✓ API gateway", "✓ Model (" + defaultModel + ")",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+	if !strings.Contains(out, "Platform healthy") {
+		t.Errorf("expected healthy summary, got:\n%s", out)
+	}
+}
+
+// TestDoctor_PodNotReady asserts the Gherkin failing path: a required pod not
+// Ready flips the line to ✗ with a one-line hint and returns false (→ non-zero).
+func TestDoctor_PodNotReady(t *testing.T) {
+	rules := healthyRules()
+	// engine-adapter reports 0/1 replicas ready.
+	rules = append([]cmdRule{
+		{match: "get deployment/zynax-engine-adapter", out: `{"spec":{"replicas":1},"status":{"readyReplicas":0}}`},
+	}, rules...)
+
+	out, ok := runDoctorTest(doctorDeps{run: fakeCommander(rules), health: okHealth, model: defaultModel})
+	if ok {
+		t.Fatalf("expected healthy=false for not-ready pod, got true; output:\n%s", out)
+	}
+	if !strings.Contains(out, "✗ Pods: Runtime (engine-adapter)") {
+		t.Errorf("expected failing runtime line, got:\n%s", out)
+	}
+	// One-line hint present (remediation).
+	if !strings.Contains(out, "rollout status deployment/zynax-engine-adapter") {
+		t.Errorf("expected remediation hint, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Platform not ready") {
+		t.Errorf("expected not-ready summary, got:\n%s", out)
+	}
+}
+
+// TestDoctor_ModelMissing asserts AC2: a missing default model warns with a
+// remediation hint but does NOT flip the platform to unhealthy (exit stays 0).
+func TestDoctor_ModelMissing(t *testing.T) {
+	rules := healthyRules()
+	rules = append([]cmdRule{
+		{match: "ollama list", out: "NAME\tID\nllama3.2:3b\txyz\n"},
+	}, rules...)
+
+	out, ok := runDoctorTest(doctorDeps{run: fakeCommander(rules), health: okHealth, model: defaultModel})
+	if !ok {
+		t.Fatalf("expected healthy=true with model missing (warning only), got false:\n%s", out)
+	}
+	if !strings.Contains(out, "⚠ Model ("+defaultModel+")") {
+		t.Errorf("expected model warning line, got:\n%s", out)
+	}
+	if !strings.Contains(out, "ollama pull "+defaultModel) {
+		t.Errorf("expected ollama pull remediation hint, got:\n%s", out)
+	}
+}
+
+// TestDoctor_ModelBinaryMissing asserts a missing `ollama` binary (commander
+// error) is treated as model-absent: a warning, not a hard failure.
+func TestDoctor_ModelBinaryMissing(t *testing.T) {
+	rules := healthyRules()
+	rules = append([]cmdRule{
+		{match: "ollama list", err: errors.New("exec: ollama not found")},
+	}, rules...)
+
+	out, ok := runDoctorTest(doctorDeps{run: fakeCommander(rules), health: okHealth, model: defaultModel})
+	if !ok {
+		t.Fatalf("expected healthy=true when ollama binary absent, got false:\n%s", out)
+	}
+	if !strings.Contains(out, "⚠ Model (") {
+		t.Errorf("expected model warning when ollama absent, got:\n%s", out)
+	}
+}
+
+// TestDoctor_GatewayUnreachable asserts an unreachable api-gateway fails the
+// gateway line with a hint and flips the platform to unhealthy.
+func TestDoctor_GatewayUnreachable(t *testing.T) {
+	out, ok := runDoctorTest(doctorDeps{run: fakeCommander(healthyRules()), health: failHealth, model: defaultModel})
+	if ok {
+		t.Fatalf("expected healthy=false for unreachable gateway, got true:\n%s", out)
+	}
+	if !strings.Contains(out, "✗ API gateway") {
+		t.Errorf("expected failing gateway line, got:\n%s", out)
+	}
+	if !strings.Contains(out, "--api-url") {
+		t.Errorf("expected gateway remediation hint, got:\n%s", out)
+	}
+}
+
+// TestDoctor_ClusterUnreachable asserts an unreachable cluster fails the Cluster
+// line and the whole command.
+func TestDoctor_ClusterUnreachable(t *testing.T) {
+	rules := []cmdRule{
+		{match: "kubectl cluster-info", err: errors.New("connection refused")},
+		{match: "helm -n zynax status zynax", out: `{"info":{"status":"deployed"}}`},
+		{match: "get deployment/", out: `{"spec":{"replicas":1},"status":{"readyReplicas":1}}`},
+		{match: "get statefulset/", out: `{"spec":{"replicas":1},"status":{"readyReplicas":1}}`},
+		{match: "ollama list", out: "qwen2.5-coder:3b\tabc\n"},
+	}
+	out, ok := runDoctorTest(doctorDeps{run: fakeCommander(rules), health: okHealth, model: defaultModel})
+	if ok {
+		t.Fatalf("expected healthy=false for unreachable cluster, got true:\n%s", out)
+	}
+	if !strings.Contains(out, "✗ Cluster") {
+		t.Errorf("expected failing cluster line, got:\n%s", out)
+	}
+}
+
+// TestDoctor_ReleaseNotDeployed asserts a Helm release in a non-"deployed"
+// state (e.g. failed/pending) fails the release line.
+func TestDoctor_ReleaseNotDeployed(t *testing.T) {
+	rules := healthyRules()
+	rules = append([]cmdRule{
+		{match: "helm -n zynax status zynax", out: `{"info":{"status":"failed"}}`},
+	}, rules...)
+
+	out, ok := runDoctorTest(doctorDeps{run: fakeCommander(rules), health: okHealth, model: defaultModel})
+	if ok {
+		t.Fatalf("expected healthy=false for failed release, got true:\n%s", out)
+	}
+	if !strings.Contains(out, "✗ Helm release") {
+		t.Errorf("expected failing release line, got:\n%s", out)
+	}
+}
+
+// TestDoctor_GatewayHealth_RealProbe wires the real Gateway.Health against an
+// httptest.Server so the client probe path is covered end-to-end (no cluster).
+func TestDoctor_GatewayHealth_RealProbe(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/healthz" {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"status":"ok"}`))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+	apiURL = srv.URL
+
+	out, ok := runDoctorTest(doctorDeps{run: fakeCommander(healthyRules()), health: newGateway().Health, model: defaultModel})
+	if !ok {
+		t.Fatalf("expected healthy=true with live healthz probe, got false:\n%s", out)
+	}
+	if !strings.Contains(out, "✓ API gateway") {
+		t.Errorf("expected gateway OK from live probe, got:\n%s", out)
+	}
+}
+
+// TestDoctor_Registered asserts the doctor command is wired under root in the
+// beginner group (canvas O19/O20).
+func TestDoctor_Registered(t *testing.T) {
+	c, _, err := rootCmd.Find([]string{"doctor"})
+	if err != nil {
+		t.Fatalf("doctor command does not resolve: %v", err)
+	}
+	if c != doctorCmd {
+		t.Fatalf("resolved %q, want doctorCmd", c.Use)
+	}
+	if c.GroupID != beginnerGroupID {
+		t.Errorf("doctor GroupID = %q, want beginner group %q", c.GroupID, beginnerGroupID)
+	}
+}


### PR DESCRIPTION
## feat(cli): add `zynax doctor` platform + model health checklist

Closes #1489
Part of #1370 (EPIC — awesome quickstart, M7.K closeout)

### Why  (problem & intent)
Under the kind-native runtime (ADR-041) a new user has no single way to confirm the platform is ready before their first workflow — they must hand-run `kubectl get pods`, `helm status`, `curl …/healthz`, and only discover a missing local model as a cryptic mid-run 404. Canvas **O19** adds one read-only command that answers "is it safe to run a workflow?" and leads with the engine-portability wedge.

### What you'll get  (deliverables ↔ what changed)
- `zynax doctor` checklist: Cluster, Helm release, Pods (API/Registry/Runtime/Event Bus/Storage), API gateway, Model ← `cmd/zynax/cmd/doctor.go`
- engine-portability wedge framing in the command help + output header (write once, run on Temporal or Argo) ← `cmd/zynax/cmd/doctor.go` (`Short`/`Long`/`runDoctor` header)
- scriptable exit code: 0 only when cluster+release+pods+gateway healthy; non-zero otherwise ← `runDoctor` return + `os.Exit(1)` in `RunE`
- a model warning (not a hard fail) with `ollama pull` remediation ← `checkModel` + `printWarn`
- gateway liveness probe over `--api-url` ← `client/gateway.go` `Health` / `Ready`
- hermetic table-driven tests (no cluster/network) ← `cmd/zynax/cmd/doctor_test.go`

### Scope & boundaries
- **In scope:** read-only `zynax doctor` that shells out to the user's `kubectl`/`helm`/`ollama` (no client-go/helm SDK deps, per `cmd/zynax/AGENTS.md`) against the current kubecontext, plus an api-gateway `/healthz` probe.
- **Out of scope (deferred):** auto-remediation / `--fix` (read-only by design); per-pod log tailing; non-kind runtimes. N/A.

### Test plan & acceptance

| Acceptance criterion | How verified (command) | Result |
|----------------------|------------------------|--------|
| AC1 — lists each component with OK/failing status (cluster, release, pods, model) | `/tmp/zynax-doctor-1489 doctor` on a healthy kind cluster (`make kind-up`) | ✅ full green checklist (below), exit 0 |
| AC2 — checks default model (Qwen2.5-Coder 3B), warns + remediation if absent | unit `TestDoctor_ModelMissing` / `TestDoctor_ModelBinaryMissing`; runtime: model present → `✓ Model (qwen2.5-coder:3b)` | ✅ unit (warn + `ollama pull` hint), runtime ✓ |
| AC3 — exit 0 only when cluster+release+pods+gateway healthy; non-zero otherwise | healthy run `EXIT=0`; broken run (`kubectl -n zynax scale deploy zynax-api-gateway --replicas=0/1`) `EXIT=1` | ✅ 0 healthy / 1 broken (below) |
| AC4 — output leads with the engine-portability wedge | `/tmp/zynax-doctor-1489 doctor --help` + output header | ✅ "write your workflow once, run it on Temporal or Argo" |
| Gherkin — required pod not Ready → that line fails with a one-line hint, exit non-zero | broken-path run below (pod 0/1 Ready) | ✅ `✗ Pods: API gateway — kubectl -n zynax rollout status deployment/zynax-api-gateway`, exit 1 |

**Local gates:** `GOWORK=off go -C cmd/zynax build ./...` ✅ · `GOWORK=off go -C cmd/zynax test ./... -race` ✅ (client + cmd packages) · `golangci-lint` (tools/golangci-lint.yml, module-scoped) ✅ 0 issues

### Evidence
- **CI:** all required checks green (see the PR checks).
- **Local output:** real healthy + broken `zynax doctor` runs against a live 3-node kind cluster (`make kind-up`: 7 services + Postgres + Temporal + echo-worker all rolled out). Live `kubectl get deploy,statefulset` confirmed every workload name doctor checks.
- **Artifacts / images:** none — no service source changed (CLI-only; the standalone `cmd/zynax` module).
- **Post-merge digest sync → main:** N/A — no image rebuild.

**HEALTHY path** — `make kind-up`, then `/tmp/zynax-doctor-1489 doctor --api-url http://localhost:18080` (gateway port-forwarded; the kind host-8080 NodePort mapping is environment-flaky — exactly why kind-demo.sh port-forwards):

```text
zynax doctor — write your workflow once, run it on Temporal or Argo.
Checking the kind runtime that mirrors production:

  ✓ Cluster
  ✓ Helm release
  ✓ Pods: API gateway
  ✓ Pods: Agent registry
  ✓ Pods: Runtime (engine-adapter)
  ✓ Pods: Event bus
  ✓ Pods: Storage (Postgres)
  ✓ API gateway
  ✓ Model (qwen2.5-coder:3b)

✅  Platform healthy — run: zynax apply spec/workflows/examples/e2e-demo.yaml
EXIT=0
```

**BROKEN path (Gherkin)** — `kubectl -n zynax scale deploy zynax-api-gateway --replicas=0` then `--replicas=1`, doctor re-run while the pod is still rolling (0/1 Ready):

```text
zynax doctor — write your workflow once, run it on Temporal or Argo.
Checking the kind runtime that mirrors production:

  ✓ Cluster
  ✓ Helm release
  ✗ Pods: API gateway — kubectl -n zynax rollout status deployment/zynax-api-gateway
  ✓ Pods: Agent registry
  ✓ Pods: Runtime (engine-adapter)
  ✓ Pods: Event bus
  ✓ Pods: Storage (Postgres)
  ✗ API gateway — /healthz did not answer — check --api-url and `kubectl -n zynax port-forward svc/zynax-api-gateway 8080:8080`
  ✓ Model (qwen2.5-coder:3b)

❌  Platform not ready — fix the ✗ lines above, then re-run `zynax doctor`.
EXIT=1
```

After `kubectl -n zynax rollout status deployment/zynax-api-gateway` (restore), a re-run returns to the full green checklist with `EXIT=0` — the platform self-heals, confirming the command tracks live state, not a snapshot.

### Risk & rollback
Low — additive, read-only new command in the standalone CLI module. No behaviour change to any existing command or to any service. Revert this PR to remove. No data/migration concern. Exit-code policy is deliberate: a missing host model warns (the kind hero workflow uses the in-cluster echo capability and needs no model); cluster/release/pods/gateway failures are non-zero so the command is scriptable.

### Review aids
Start at `cmd/zynax/cmd/doctor.go` — `runDoctor` is the orchestrator and encodes the exit policy; the `doctorComponents` table pins the exact workload names from `scripts/e2e/cluster-up.sh` (namespace `zynax`, release `zynax`) — verified against live `kubectl get deploy,statefulset`. `commander`/`healthProber` are the injection seams that make the tests hermetic. `client/gateway.go` adds only the `Health`/`Ready` probes.

**SPDD:** Canvas `docs/spdd/1370-awesome-quickstart/canvas.md` — Status: **Aligned** (O19) · `/spdd-security-review` **PASS**
**AI:** `Assisted-by: Claude/claude-opus-4-8`  (label: ai-assisted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
