### PR TITLE
chore(kind): lean (PROFILE=lite) local runtime profile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,6 +137,10 @@ logs-local: ## Tail all local stack logs
 KIND_DEMO     := scripts/demo/kind-demo.sh
 CLUSTER_UP    := scripts/e2e/cluster-up.sh
 CLUSTER_DOWN  := scripts/e2e/cluster-down.sh
+# Stack profile for the kind targets (ADR-041): `full` (default, prod-mirroring)
+# or `lite` (lean laptop — 1 in-memory dev Temporal, no event-bus/NATS/memory-
+# service). Usage: `make demo PROFILE=lite` / `make kind-up PROFILE=lite`.
+PROFILE      ?= full
 DEMO_WORKFLOW ?= spec/workflows/examples/code-review-ollama.yaml
 ZYNAX        ?= zynax
 # Optional: run a declarative scenario manifest set instead of the single hero
@@ -165,13 +169,13 @@ DEMO_MODEL   := $(shell awk '/^[[:space:]]*model:/{print $$2; exit}' infra/docke
 # standalone Temporal UI.
 DEMO_SERVICES := api-gateway llm-adapter
 
-demo: check-docker ## ★ One command (kind): create cluster → load images → install umbrella → wait rollout → "Platform ready" + run hero workflow
-	@echo "🧭 Zynax demo on kind (ADR-041) — one command, prod-mirroring charts."
-	$(KIND_DEMO)
+demo: check-docker ## ★ One command (kind): create cluster → load images → install umbrella → wait rollout → "Platform ready" + run hero workflow (PROFILE=lite for the lean stack)
+	@echo "🧭 Zynax demo on kind (ADR-041, profile: $(PROFILE)) — one command, prod-mirroring charts."
+	PROFILE=$(PROFILE) $(KIND_DEMO)
 
-kind-up: check-docker ## Create the kind cluster + install the zynax-umbrella chart (wraps scripts/e2e/cluster-up.sh, loads local images)
-	@echo "☸️  Bringing up the kind cluster + Zynax umbrella (loads local images)..."
-	KIND_LOAD_IMAGES=1 $(CLUSTER_UP)
+kind-up: check-docker ## Create the kind cluster + install the zynax-umbrella chart (wraps scripts/e2e/cluster-up.sh, loads local images; PROFILE=lite for the lean stack)
+	@echo "☸️  Bringing up the kind cluster + Zynax umbrella (profile: $(PROFILE), loads local images)..."
+	KIND_LOAD_IMAGES=1 PROFILE=$(PROFILE) $(CLUSTER_UP)
 
 kind-down: ## Tear down the kind cluster (wraps scripts/e2e/cluster-down.sh)
 	@echo "🧹 Tearing down the kind cluster..."

--- a/scripts/demo/kind-demo.sh
+++ b/scripts/demo/kind-demo.sh
@@ -50,6 +50,10 @@ CLUSTER_NAME="${CLUSTER_NAME:-zynax-e2e}"
 NAMESPACE="${NAMESPACE:-zynax}"
 API_GW_URL="${API_GW_URL:-http://localhost:8080}"
 WORKFLOW_FILE="${WORKFLOW_FILE:-${REPO_ROOT}/spec/workflows/examples/e2e-demo.yaml}"
+# Stack profile passed through to cluster-up.sh (ADR-041): "full" (default,
+# prod-mirroring) or "lite" (lean laptop — one in-memory dev Temporal, no
+# event-bus/NATS/memory-service). The hero echo workflow runs on both.
+PROFILE="${PROFILE:-full}"
 # Default reference model — read from the single source (the llm-adapter config),
 # so the pre-flight and the runtime config never drift. Override with DEMO_MODEL.
 MODEL_CONFIG="${REPO_ROOT}/infra/docker-compose/ollama/llm-adapter.config.yaml"
@@ -151,6 +155,7 @@ log "bringing up the kind cluster + Zynax umbrella (wraps scripts/e2e/cluster-up
 KIND_LOAD_IMAGES="${KIND_LOAD_IMAGES:-1}" \
 CLUSTER_NAME="${CLUSTER_NAME}" \
 NAMESPACE="${NAMESPACE}" \
+PROFILE="${PROFILE}" \
   "${REPO_ROOT}/scripts/e2e/cluster-up.sh"
 
 # Defence-in-depth: re-assert every Zynax Deployment is actually Available before
@@ -159,8 +164,13 @@ NAMESPACE="${NAMESPACE}" \
 log "verifying every Zynax Deployment reports a healthy rollout before signalling ready…"
 SERVICE_DEPLOYMENTS=(
   zynax-api-gateway zynax-workflow-compiler zynax-engine-adapter
-  zynax-task-broker zynax-agent-registry zynax-event-bus zynax-memory-service
+  zynax-task-broker zynax-agent-registry
 )
+# event-bus + memory-service exist in the full profile only (the lean profile
+# disables them via values-lite.yaml) — only assert them when PROFILE != lite.
+if [[ "${PROFILE}" != "lite" ]]; then
+  SERVICE_DEPLOYMENTS+=(zynax-event-bus zynax-memory-service)
+fi
 for dep in "${SERVICE_DEPLOYMENTS[@]}"; do
   kubectl -n "${NAMESPACE}" rollout status "deployment/${dep}" --timeout=120s \
     || die "deployment ${dep} is not ready — NOT printing the ready banner (platform still coming up)"

--- a/scripts/e2e/cluster-up.sh
+++ b/scripts/e2e/cluster-up.sh
@@ -33,6 +33,11 @@
 #   ARGO_WORKFLOWS_CHART_VERSION
 #                         argo-helm argo-workflows chart version pin
 #                         (default: 0.47.5 → Argo Workflows v3.7.11)
+#   PROFILE               stack profile: full|lite (default: full). lite is the
+#                         ADR-041 lean laptop profile — collapses Temporal to a
+#                         single in-memory start-dev pod (manifests/temporal-dev.
+#                         yaml) and drops event-bus + NATS + memory-service via
+#                         values-lite.yaml. CI uses full.
 #
 # Minimum host resources: 4 CPU, 8 GB RAM (see scripts/e2e/README.md).
 
@@ -55,6 +60,12 @@ WAIT_TIMEOUT="${WAIT_TIMEOUT:-600s}"
 # Selection flows through umbrella values only — never hardcoded (ADR-015).
 E2E_ENGINE="${E2E_ENGINE:-temporal}"
 ARGO_WORKFLOWS_CHART_VERSION="${ARGO_WORKFLOWS_CHART_VERSION:-0.47.5}"
+# Stack profile (ADR-041). "full" (default, == CI) deploys the production-
+# mirroring topology: the 5-pod Temporal chart, event-bus, memory-service.
+# "lite" is the lean laptop profile — it collapses Temporal to ONE in-memory
+# `start-dev` pod (manifests/temporal-dev.yaml) and drops event-bus + NATS +
+# memory-service via values-lite.yaml. Same charts, same images, lighter floor.
+PROFILE="${PROFILE:-full}"
 # When set to a non-empty value, side-load the locally-built service images into
 # the kind cluster with `kind load docker-image` before the Helm install, so the
 # cluster runs the images already on the host instead of pulling from GHCR. The
@@ -84,9 +95,12 @@ SERVICE_DEPLOYMENTS=(
   "zynax-engine-adapter"
   "zynax-task-broker"
   "zynax-agent-registry"
-  "zynax-event-bus"
-  "zynax-memory-service"
 )
+# event-bus + memory-service ship in the full profile only; the lean profile
+# (values-lite.yaml) disables them, so they have no Deployment to wait on.
+if [[ "${PROFILE:-full}" != "lite" ]]; then
+  SERVICE_DEPLOYMENTS+=("zynax-event-bus" "zynax-memory-service")
+fi
 
 # ── helpers ──────────────────────────────────────────────────────────────────────
 
@@ -108,6 +122,11 @@ require openssl
 case "${E2E_ENGINE}" in
   temporal|argo) ;;
   *) die "E2E_ENGINE must be 'temporal' or 'argo' (got: '${E2E_ENGINE}')" ;;
+esac
+
+case "${PROFILE}" in
+  full|lite) ;;
+  *) die "PROFILE must be 'full' or 'lite' (got: '${PROFILE}')" ;;
 esac
 
 [[ -f "${KIND_CONFIG}" ]]   || die "kind config not found: ${KIND_CONFIG}"
@@ -274,6 +293,13 @@ ENGINE_VALUES=()
 if [[ "${E2E_ENGINE}" == "argo" ]]; then
   ENGINE_VALUES+=(-f "${SCRIPT_DIR}/values-e2e-argo.yaml")
 fi
+# Lean profile overlay (ADR-041): layered last so it wins — disables the
+# Temporal chart, event-bus, NATS, memory-service and trims the Postgres PVC.
+PROFILE_VALUES=()
+if [[ "${PROFILE}" == "lite" ]]; then
+  log "lean profile: layering values-lite.yaml (Temporal→dev pod; no event-bus/NATS/memory-service)…"
+  PROFILE_VALUES+=(-f "${SCRIPT_DIR}/values-lite.yaml")
+fi
 IMAGE_OVERRIDES=()
 if [[ -n "${E2E_IMAGE_TAG:-}" ]]; then
   E2E_IMAGE_PREFIX="${E2E_IMAGE_PREFIX:-ghcr.io/zynax-io/zynax/staging}"
@@ -293,38 +319,52 @@ helm upgrade --install "${RELEASE_NAME}" "${UMBRELLA_CHART}" \
   --create-namespace \
   -f "${SCRIPT_DIR}/values-e2e.yaml" \
   "${ENGINE_VALUES[@]}" \
+  "${PROFILE_VALUES[@]}" \
   --set zynax-cert-manager.enabled=true \
   "${IMAGE_OVERRIDES[@]}"
 
-# ── 3.5 register the Temporal 'default' namespace ────────────────────────────────
+# ── 3.5 bring Temporal up + ensure the 'default' namespace exists ────────────────
 
-# The temporalio/temporal chart does NOT auto-register a namespace, but
-# engine-adapter connects to namespace 'default' on startup and crash-loops with
-# "Namespace default is not found" until it exists. Wait for the Temporal frontend
-# to roll out, then register it via the admintools pod. Idempotent: skip if it is
-# already present (e.g. a re-run against a reused cluster).
-log "waiting for Temporal frontend, then registering the 'default' namespace…"
-kubectl -n "${NAMESPACE}" rollout status \
-  "deployment/${RELEASE_NAME}-temporal-frontend" --timeout "${WAIT_TIMEOUT}"
+if [[ "${PROFILE}" == "lite" ]]; then
+  # Lean profile: the chart is off (values-lite.yaml). Deploy the single-binary
+  # in-memory dev Temporal, which auto-registers the 'default' namespace at boot
+  # — so there is no admintools pod and no namespace-registration loop. Its
+  # Service is named zynax-temporal-frontend (the exact address engine-adapter
+  # dials), so the swap needs no engine-adapter override.
+  log "lean profile: deploying single-binary dev Temporal (in-memory)…"
+  kubectl -n "${NAMESPACE}" apply -f "${SCRIPT_DIR}/manifests/temporal-dev.yaml"
+  kubectl -n "${NAMESPACE}" rollout status deployment/zynax-temporal-dev \
+    --timeout "${WAIT_TIMEOUT}"
+  log "dev Temporal is up ('default' namespace auto-registered by start-dev)."
+else
+  # The temporalio/temporal chart does NOT auto-register a namespace, but
+  # engine-adapter connects to namespace 'default' on startup and crash-loops with
+  # "Namespace default is not found" until it exists. Wait for the Temporal frontend
+  # to roll out, then register it via the admintools pod. Idempotent: skip if it is
+  # already present (e.g. a re-run against a reused cluster).
+  log "waiting for Temporal frontend, then registering the 'default' namespace…"
+  kubectl -n "${NAMESPACE}" rollout status \
+    "deployment/${RELEASE_NAME}-temporal-frontend" --timeout "${WAIT_TIMEOUT}"
 
-ADMINTOOLS="deployment/${RELEASE_NAME}-temporal-admintools"
-namespace_ready=""
-for _ in $(seq 1 30); do
-  if kubectl -n "${NAMESPACE}" exec "${ADMINTOOLS}" -- \
-       temporal operator namespace describe default >/dev/null 2>&1; then
-    namespace_ready="yes"
-    break
-  fi
-  kubectl -n "${NAMESPACE}" exec "${ADMINTOOLS}" -- \
-    temporal operator namespace create default >/dev/null 2>&1 || true
-  sleep 5
-done
-[[ -n "${namespace_ready}" ]] || die "Temporal 'default' namespace did not register"
-log "Temporal 'default' namespace is registered."
+  ADMINTOOLS="deployment/${RELEASE_NAME}-temporal-admintools"
+  namespace_ready=""
+  for _ in $(seq 1 30); do
+    if kubectl -n "${NAMESPACE}" exec "${ADMINTOOLS}" -- \
+         temporal operator namespace describe default >/dev/null 2>&1; then
+      namespace_ready="yes"
+      break
+    fi
+    kubectl -n "${NAMESPACE}" exec "${ADMINTOOLS}" -- \
+      temporal operator namespace create default >/dev/null 2>&1 || true
+    sleep 5
+  done
+  [[ -n "${namespace_ready}" ]] || die "Temporal 'default' namespace did not register"
+  log "Temporal 'default' namespace is registered."
+fi
 
-# ── 4. wait for all 7 service deployments to become healthy ──────────────────────
+# ── 4. wait for the profile's service deployments to become healthy ──────────────
 
-log "waiting for all 7 service deployments to roll out…"
+log "waiting for ${#SERVICE_DEPLOYMENTS[@]} service deployments to roll out (profile: ${PROFILE})…"
 for dep in "${SERVICE_DEPLOYMENTS[@]}"; do
   if ! kubectl -n "${NAMESPACE}" get deployment "${dep}" >/dev/null 2>&1; then
     die "expected deployment not found: ${dep} (umbrella values out of sync?)"
@@ -334,7 +374,7 @@ for dep in "${SERVICE_DEPLOYMENTS[@]}"; do
     --timeout "${WAIT_TIMEOUT}"
 done
 
-log "all 7 service deployments are healthy."
+log "all ${#SERVICE_DEPLOYMENTS[@]} service deployments are healthy."
 
 # ── 5. deploy the echo capability worker (#1088) ────────────────────────────────
 

--- a/scripts/e2e/cluster-up.sh
+++ b/scripts/e2e/cluster-up.sh
@@ -81,6 +81,11 @@ KIND_LOAD_REGISTRY="${KIND_LOAD_REGISTRY:-ghcr.io/zynax-io/zynax}"
 KIND_LOAD_TAG="${KIND_LOAD_TAG:-main}"
 
 KIND_CONFIG="${SCRIPT_DIR}/kind-config.yaml"
+# The lean profile fits on ONE node — use the single-node config, which removes
+# two nodes' kubelet/containerd/kindnet tax and avoids loading the service images
+# into three nodes' containerd (the dominant laptop cost; see
+# docs/benchmarks/kind-lean-resources.md).
+[[ "${PROFILE}" == "lite" ]] && KIND_CONFIG="${SCRIPT_DIR}/kind-config-lite.yaml"
 UMBRELLA_CHART="${REPO_ROOT}/helm/zynax-umbrella"
 
 # The Zynax service Deployments that must reach a healthy rollout. All 7

--- a/scripts/e2e/kind-config-lite.yaml
+++ b/scripts/e2e/kind-config-lite.yaml
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Single-node kind cluster for the LEAN laptop profile (ADR-041 — "a local
+# single-node cluster (kind)").
+#
+# The default kind-config.yaml runs 1 control-plane + 2 workers because the FULL
+# stack (5-pod Temporal + NATS + memory-service + 7 services) needs headroom and
+# a single node evicts under CI memory pressure. The lean profile is far lighter
+# (1 in-memory dev Temporal, no event-bus/NATS/memory-service), so it fits on ONE
+# node — which removes two nodes' worth of kubelet/containerd/kindnet/kube-proxy
+# overhead AND avoids loading the service images into three nodes' containerd.
+# That node + image-triplication tax is the dominant cost on a laptop, so this is
+# the single biggest lean win (see docs/benchmarks/kind-lean-resources.md).
+#
+# kind does not taint the control-plane node, so workloads schedule on it.
+# extraPortMappings expose the api-gateway REST port (8080) on the host exactly
+# as the multi-node config does, so `zynax apply` / the demo reach it unchanged.
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+name: zynax-e2e
+nodes:
+  - role: control-plane
+    kubeadmConfigPatches:
+      - |
+        kind: InitConfiguration
+        nodeRegistration:
+          kubeletExtraArgs:
+            node-labels: "ingress-ready=true"
+    extraPortMappings:
+      # api-gateway REST — host 8080 -> nodePort 30080
+      - containerPort: 30080
+        hostPort: 8080
+        protocol: TCP

--- a/scripts/e2e/manifests/temporal-dev.yaml
+++ b/scripts/e2e/manifests/temporal-dev.yaml
@@ -1,0 +1,99 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# temporal-dev — single-binary, in-memory Temporal for the LEAN kind profile.
+#
+# ADR-041 (kind-native unified runtime) keeps a lightweight in-cluster Temporal
+# *dev* profile so first-run stays light. This is the kind analogue of the
+# compose eval overlay (infra/docker-compose/docker-compose.eval-temporal.yml):
+# it replaces the chart's 5-pod Temporal topology (frontend/history/matching/
+# worker + admintools + the Postgres-backed schema Job) with ONE pod running
+# `temporal server start-dev` — embedded in-memory SQLite, no external Postgres,
+# and the `default` namespace auto-registered at boot (so cluster-up.sh skips the
+# admintools registration step it runs for the full chart).
+#
+# Applied by `scripts/e2e/cluster-up.sh` ONLY when PROFILE=lite (which also sets
+# `zynax-temporal.enabled=false` via values-lite.yaml so the chart is off). The
+# Service is named `zynax-temporal-frontend` on purpose: engine-adapter dials
+# `zynax-temporal-frontend:7233` (values-e2e.yaml), so the lean swap needs ZERO
+# engine-adapter env override — the dev pod simply answers on that name.
+#
+# Reuses the proven TemporalEngine — no new engine to own (see ADR-037 update).
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: zynax-temporal-dev
+  labels:
+    app.kubernetes.io/name: zynax-temporal-dev
+    app.kubernetes.io/component: workflow-engine
+    app.kubernetes.io/part-of: zynax-e2e
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: zynax-temporal-dev
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: zynax-temporal-dev
+        app.kubernetes.io/component: workflow-engine
+        app.kubernetes.io/part-of: zynax-e2e
+    spec:
+      containers:
+        - name: temporal
+          # Single self-contained binary — matches the compose eval overlay pin.
+          image: temporalio/temporal:1.7.2
+          imagePullPolicy: IfNotPresent
+          args:
+            - server
+            - start-dev
+            - --ip
+            - 0.0.0.0          # bind all interfaces so the Service can reach it
+            - --namespace
+            - default          # auto-create the namespace engine-adapter dials
+            - --log-level
+            - warn
+          ports:
+            - name: grpc
+              containerPort: 7233   # frontend gRPC (engine-adapter target)
+            - name: web
+              containerPort: 8233   # built-in dev Web UI
+          readinessProbe:
+            tcpSocket:
+              port: 7233
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          livenessProbe:
+            tcpSocket:
+              port: 7233
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          # One process carries every Temporal role + the in-memory store, so it
+          # sits a little above a single chart role (50m/96Mi) but well under the
+          # 5-pod chart total it replaces.
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  # Named to match engine-adapter's temporalHostPort (values-e2e.yaml) so the
+  # lean swap needs no env override — same address, dev backend.
+  name: zynax-temporal-frontend
+  labels:
+    app.kubernetes.io/name: zynax-temporal-dev
+    app.kubernetes.io/part-of: zynax-e2e
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: zynax-temporal-dev
+  ports:
+    - name: grpc
+      port: 7233
+      targetPort: grpc
+      protocol: TCP

--- a/scripts/e2e/values-lite.yaml
+++ b/scripts/e2e/values-lite.yaml
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# values-lite.yaml — LEAN kind profile overrides (ADR-041).
+#
+# Layered ON TOP of values-e2e.yaml (cluster-up.sh PROFILE=lite passes both with
+# `-f`, lite last → lite wins). It carries ONLY the deltas that strip the stack
+# down to what the hero `echo` workflow (spec/workflows/examples/e2e-demo.yaml)
+# actually exercises, so a laptop first-run is as light as possible while still
+# running on the SAME prod-mirroring charts.
+#
+# What it removes vs the full e2e profile:
+#   • Temporal chart (5 pods: frontend/history/matching/worker + admintools +
+#     the Postgres-backed schema Job) → replaced by ONE in-memory `start-dev`
+#     pod from scripts/e2e/manifests/temporal-dev.yaml, which cluster-up.sh
+#     applies when PROFILE=lite. engine-adapter still dials
+#     `zynax-temporal-frontend:7233` (values-e2e.yaml) — the dev Service owns
+#     that name, so NO engine-adapter override is needed here.
+#   • memory-service + its Redis — the echo workflow uses no agent memory.
+#   • event-bus + NATS — the echo workflow asserts no CloudEvents. (If a future
+#     workload needs completion events, re-enable these two; the Temporal cut is
+#     the dominant saving regardless.)
+#
+# What it keeps: the 5 core services (api-gateway, workflow-compiler,
+# engine-adapter, task-broker, agent-registry), Postgres (still backs
+# task-broker + agent-registry until ADR-039/M8 makes agent-registry stateless),
+# cert-manager, and the echo capability worker.
+
+# ── Collapse Temporal to the single-binary dev pod ───────────────────────────
+zynax-temporal:
+  enabled: false
+
+# ── Drop services the echo hero workflow does not use ────────────────────────
+zynax-memory-service:
+  enabled: false
+zynax-event-bus:
+  enabled: false
+# Only event-bus consumes NATS; drop the broker with it.
+zynax-nats:
+  enabled: false
+
+# ── Trim Postgres ────────────────────────────────────────────────────────────
+# Temporal no longer uses this Postgres (it ran the heaviest schema, default +
+# visibility stores). Only task-broker + agent-registry remain, which store
+# little, so shrink the reserved PVC from the 10Gi chart default to 2Gi.
+zynax-postgres:
+  postgresql:
+    primary:
+      persistence:
+        size: 2Gi


### PR DESCRIPTION
## chore(kind): lean (PROFILE=lite) local runtime profile

Part of #1370 (EPIC — Awesome Quickstart) · governed by **ADR-041** (kind-native unified runtime). Follow-up to #1508 (one-command kind demo).

### Why  (problem & intent)
ADR-041 makes kind the local/demo runtime, but the only profile is the production-mirroring full stack: a 5-pod Temporal chart + admintools + a Postgres-backed schema Job, event-bus + NATS, memory-service + Redis, a 10 GiB Postgres PVC — across a 3-node cluster. That is heavier than a laptop first-run needs. ADR-041 explicitly calls for a *single-node* cluster and keeps a lightweight in-cluster Temporal dev profile. This adds that lean profile so `make demo` / `make kind-up` can run a far lighter stack on the **same charts and images**.

### What you'll get  (deliverables ↔ what changed)
- `PROFILE=lite` threaded through the whole kind lifecycle — `make demo PROFILE=lite` / `make kind-up PROFILE=lite` ← `Makefile`, `scripts/demo/kind-demo.sh`, `scripts/e2e/cluster-up.sh`
- single-binary in-memory dev Temporal (1 pod) replacing the 5-pod chart + admintools + schema Job; its Service is named `zynax-temporal-frontend` so engine-adapter dials it with **no** override ← `scripts/e2e/manifests/temporal-dev.yaml`, `scripts/e2e/cluster-up.sh`
- lean Helm overlay: Temporal chart off, event-bus + NATS off, memory-service + Redis off, Postgres PVC 10 GiB → 2 GiB ← `scripts/e2e/values-lite.yaml`
- single-node cluster for the lean profile — removes two nodes' kubelet/containerd/kindnet tax and the image triplication ← `scripts/e2e/kind-config-lite.yaml`, `scripts/e2e/cluster-up.sh`
- `PROFILE=full` (default) is unchanged — exactly what CI's e2e-smoke runs

### Scope & boundaries
- **In scope:** a new `PROFILE=lite` path layered on the existing bring-up (the single source of truth). No chart/proto/event-schema changes; `values-e2e.yaml` and the full profile are untouched.
- **Out of scope (deferred):** agent-registry → stateless / no-Postgres is **ADR-039 / M8** (lean still runs Postgres for task-broker + agent-registry); the zero-Docker binary-only run (#1359, M-dx).

### Test plan & acceptance
Booted on this host (Docker + kind v0.23.0 + kubectl v1.29.2 + helm v3.21.0). Each profile brought up, the echo hero workflow run, then torn down.

| Criterion | How verified | Result |
|---|---|---|
| Lean bring-up succeeds end-to-end | `make kind-up PROFILE=lite` (cluster-up exit 0) | ✅ 8 pods, single node, dev-Temporal 1 pod, no event-bus/NATS/memory-service |
| Lean demo reaches terminal success | echo `e2e-demo.yaml` apply → status | ✅ `WORKFLOW_STATUS_COMPLETED` (~3s) |
| Full profile unchanged | `make kind-up PROFILE=full` | ✅ 18 pods (5-pod Temporal + event-bus + memory-service), demo ✅ |
| Lean renders only the intended subcharts | `helm template … -f values-lite.yaml` | ✅ 7 subcharts (no temporal/event-bus/memory-service/nats); Postgres PVC 2Gi |
| Single-node topology | `kind get nodes` (lite) | ✅ one node (`zynax-e2e-control-plane`) |

**Local gates:** `bash -n` on `cluster-up.sh` + `kind-demo.sh` ✅ · `helm lint`/`helm template` with `values-lite.yaml` ✅ (0 failed) · `make -n demo kind-up PROFILE=lite` ✅

### Evidence
Lean bring-up (single node, exit 0):
```
[cluster-up] lean profile: layering values-lite.yaml (Temporal→dev pod; no event-bus/NATS/memory-service)…
[cluster-up] lean profile: deploying single-binary dev Temporal (in-memory)…
[cluster-up] dev Temporal is up ('default' namespace auto-registered by start-dev).
[cluster-up] waiting for 5 service deployments to roll out (profile: lite)…
[cluster-up] all 5 service deployments are healthy.
[cluster-up] cluster 'zynax-e2e' is up. api-gateway REST is reachable on host port 8080.
```
Helm render — full 11 subcharts → lean 7:
```
full: agent-registry api-gateway cert-manager engine-adapter event-bus memory-service nats postgres task-broker temporal workflow-compiler
lean: agent-registry api-gateway cert-manager engine-adapter                          postgres task-broker          workflow-compiler
```

> **PR size:** ~280 non-excluded lines (201–400 acceptable band) — one coherent feature (the lean profile); splitting further would separate the dev-Temporal manifest from the wiring that activates it.
