### PR TITLE
docs(kind): lean profile quickstart + measured resource comparison

### DIFF
--- a/docs/benchmarks/kind-lean-resources.md
+++ b/docs/benchmarks/kind-lean-resources.md
@@ -1,0 +1,99 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+# Lean kind resource comparison (ADR-041) — measured
+
+How much the local runtime shrinks once the stack goes kind-native and the lean
+profile drops the components Kubernetes makes redundant. ADR-041 retires Docker
+Compose as the primary path; this quantifies what the move costs and what the
+lean profile (`PROFILE=lite`) buys back.
+
+**Measured:** 2026-06-25, single host (16 CPU / 15 GiB RAM), `kind v0.23.0`
+(node `v1.29.2`), `helm v3.21.0`, Docker Compose. Workload = the deterministic
+`echo` hero workflow (`spec/workflows/examples/e2e-demo.yaml`) — no model, so the
+demo time reflects **stack/orchestration** latency, not LLM inference. Reproduce
+with `scripts/bench/stack-resources.sh` (see `scripts/bench/README.md`).
+
+## Results
+
+| Stack | Pods / containers | Workload CPU (idle) | Workload RAM (idle) | Whole-machine RAM¹ | Whole-machine CPU¹ | PVC reserved | Image/layer disk² | Demo echo (cold / warm) |
+|-------|-------------------|---------------------|---------------------|--------------------|--------------------|--------------|-------------------|-------------------------|
+| **Docker Compose** (base, `make run-local`) | 13 | ~0 (negligible) | ~520 MiB | **~0.52 GiB** (no control plane) | negligible | named vols (~0.14 GiB) | ~1.3 GiB (1.15 img + 0.14 vol) | 3s / 3s |
+| **full-kind** (3-node, `PROFILE=full`) | 18 | 35m | 369 MiB | **~2.50 GiB** (2497 MiB) | 195m | **11.0 GiB** | ~5.9 GiB | 3s / 4s |
+| **lean-kind** (3-node, `PROFILE=lite`) | 8 | 16m | 253 MiB | **~2.03 GiB** (2075 MiB) | 138m | 2.0 GiB | ~5.3 GiB | 3s / 3s |
+| **lean-kind** (1-node, `PROFILE=lite` today³) | 8 | 11m | 209 MiB | **~1.40 GiB** (1430 MiB) | 126m | 2.0 GiB | **~2.9 GiB** | 9s / 3s |
+
+¹ `kubectl top nodes` summed across the kind node containers — the true
+machine cost (control-plane + kube-system + workloads + per-node
+kubelet/containerd). Compose has no control plane, so its whole-machine figure is
+just `docker stats`.
+² kind: `du /var/lib/containerd` across every node (the same images load into
+each node). Compose: sum of unique image sizes (upper bound; shared layers
+dedupe on disk) + named-volume sizes.
+³ `PROFILE=lite` uses the single-node `kind-config-lite.yaml`; `PROFILE=full`
+keeps the 3-node `kind-config.yaml` it needs for headroom.
+
+## The reduction: full-kind → lean-kind (single-node)
+
+| Dimension | full-kind (before) | lean-kind 1-node (after) | Reduction |
+|-----------|--------------------|--------------------------|-----------|
+| Pods | 18 | 8 | **−56%** |
+| Whole-machine RAM | ~2.50 GiB | ~1.40 GiB | **−44%** |
+| Workload RAM | 369 MiB | 209 MiB | −43% |
+| Whole-machine CPU | 195m | 126m | −35% |
+| PVC reserved | 11.0 GiB | 2.0 GiB | **−82%** |
+| Image/layer disk | ~5.9 GiB | ~2.9 GiB | **−51%** |
+| Demo (echo, warm) | 4s | 3s | same (~3s) |
+
+## What changed, and the two levers
+
+The lean profile pulls on **two independent levers** — together they roughly
+**halve** the kind footprint:
+
+1. **Component removal** (`values-lite.yaml` + `temporal-dev.yaml`): the 5-pod
+   Temporal chart + admintools + Postgres-backed schema Job → **one** in-memory
+   `temporal server start-dev` pod; drop **memory-service + Redis** and
+   **event-bus + NATS**; trim the **Postgres PVC 10 GiB → 2 GiB**. This is most of
+   the pod cut (18→8) and the PVC cut (11→2 GiB, −82%).
+2. **Single-node topology** (`kind-config-lite.yaml`): the full profile needs
+   3 nodes for headroom; the lean stack fits on **one**. That removes two nodes'
+   worth of kubelet/containerd/kindnet/kube-proxy overhead **and** stops the
+   service images loading into three nodes' containerd. This lever alone takes
+   whole-machine RAM 2.03 → 1.40 GiB and disk 5.3 → 2.9 GiB (−45%).
+
+## Key findings (honest reading)
+
+- **The kind tax is real and irreducible.** Even lean single-node kind (~1.4 GiB)
+  sits **above** Docker Compose (~0.5 GiB). The gap (~0.9 GiB) is the Kubernetes
+  control-plane (kube-system ~0.45 GiB) plus per-node kubelet/containerd. No lean
+  profile escapes it — it is the deliberate price of "local mirrors production"
+  (ADR-041). Lean single-node kind roughly **halves the gap** vs full 3-node kind.
+- **The demo runs just as fast.** ~3s warm on every stack — trimming the stack
+  does not slow orchestration. (1-node cold-start is one-off higher at 9s:
+  port-forward + first dispatch on a cold single node.)
+- **At the app-workload level, Compose is actually the heaviest** (~520 MiB) — it
+  bundles durable Temporal (auto-setup, ~170 MiB), a *second* Postgres, the
+  Temporal UI, and extra adapters. Lean kind's app workload is **209 MiB**.
+  Compose only "wins" on the whole-machine number because it carries no
+  orchestration layer.
+- **The full e2e profile is already trimmed** (`values-e2e.yaml` caps Temporal
+  roles and `numHistoryShards`), so the workload-RAM deltas are smaller than a
+  naive "5 pods → 1 pod" estimate; the dominant wins are **pods, PVC, and disk**.
+
+## Caveats
+
+- `kubectl top` reports working-set (includes some page cache); `docker stats`
+  reports RSS-ish. Cross-runtime RAM is therefore approximate — hence both a
+  per-engine workload figure and a whole-machine figure.
+- Single measurement, at-rest + one warm demo run — directional, not a
+  statistical benchmark. Absolute numbers scale with the host (this one is well
+  above the 4 CPU / 8 GiB floor); the **ratios** are the takeaway.
+- agent-registry still runs Postgres here; ADR-039 (M8) makes it stateless and
+  drops that DB — a further cut not yet reflected.
+
+## Raw harness rows (auto-appended by `scripts/bench/stack-resources.sh`)
+
+| Profile | Pods/containers | CPU | Memory | PVC reserved | Image+layer disk | Demo (apply→done) |
+|---------|-----------------|-----|--------|--------------|------------------|-------------------|
+| full-kind | 18 | 35m (used) | 369Mi (used) | 11.0Gi | 5904MB | 3s cold / 4s warm |
+| lean-kind | 8 | 16m (used) | 253Mi (used) | 2.0Gi | 5328MB | 3s cold / 3s warm |
+| compose | 13 | ~0% (stats) | 516Mi (stats) | n/a (named vols) | ~1.3GB | 3s cold / 3s warm |
+| lean-kind-1node | 8 | 11m (used) | 209Mi (used) | 2.0Gi | 2929MB | 9s cold / 3s warm |

--- a/docs/local-dev-kind.md
+++ b/docs/local-dev-kind.md
@@ -1,0 +1,70 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+# Local development on kind (ADR-041)
+
+ADR-041 makes a local **kind** cluster the unified developer/demo runtime —
+local runs on the same prod-mirroring Helm charts as CI and production, and
+Docker Compose is retired as the primary path. One command still does
+everything; the runtime underneath is now Kubernetes.
+
+> Prerequisites: Docker, `kind`, `kubectl`, `helm`. Resource floor ~4 CPU / 8 GB
+> RAM (the lean profile is lighter — see below).
+
+## One command
+
+```bash
+make demo                 # full prod-mirroring stack on kind, runs the hero workflow
+make demo PROFILE=lite    # the lean stack — same workflow, far lighter (see below)
+```
+
+`make demo` creates a kind cluster, side-loads the local service images,
+installs the `zynax-umbrella` chart, waits for every Deployment, runs the echo
+hero workflow against the gateway on `http://localhost:8080`, and prints
+**Platform ready**. Tear down with `make kind-down`.
+
+## Cluster lifecycle (without the hero run)
+
+```bash
+make kind-up                 # full profile (3-node, prod-mirroring)
+make kind-up PROFILE=lite    # lean profile (single-node, trimmed)
+make kind-down               # delete the cluster
+```
+
+## Two profiles
+
+| | `PROFILE=full` (default) | `PROFILE=lite` |
+|---|--------------------------|----------------|
+| Topology | 3-node (`kind-config.yaml`) | **single-node** (`kind-config-lite.yaml`) |
+| Temporal | 5-pod chart + admintools + schema Job | **1** in-memory `start-dev` pod (`scripts/e2e/manifests/temporal-dev.yaml`) |
+| event-bus + NATS | on | **off** |
+| memory-service + Redis | on | **off** |
+| Postgres PVC | 10 GiB | **2 GiB** |
+| Pods | 18 | **8** |
+| Whole-machine RAM | ~2.5 GiB | **~1.4 GiB** |
+| Image/layer disk | ~5.9 GiB | **~2.9 GiB** |
+
+`full` mirrors production and is what CI runs (it also unlocks
+`E2E_ENGINE=argo`). `lite` is the lean laptop profile: same charts and images,
+the components the hero `echo` workflow does not exercise removed, and one node
+instead of three. The hero workflow runs identically (~3s) on both. Measured
+before/after numbers and the methodology: **`docs/benchmarks/kind-lean-resources.md`**.
+
+## How it works
+
+`make demo` → `scripts/demo/kind-demo.sh` → `scripts/e2e/cluster-up.sh` (the
+single bring-up source of truth, shared with the CI e2e harness). The `PROFILE`
+env flows through all three. `lite` layers `scripts/e2e/values-lite.yaml` over
+`values-e2e.yaml`, applies the dev-Temporal manifest in place of the chart, and
+selects the single-node kind config.
+
+## Engine portability
+
+The same workflow runs on Temporal or Argo on the same cluster:
+
+```bash
+E2E_ENGINE=argo make demo     # installs the Argo Workflows control plane, same workflow
+```
+
+## Legacy Docker Compose (deprecated)
+
+`make demo-compose` still runs the old Compose Ollama demo, but Compose is
+deprecated under ADR-041 and receives no new feature work. Prefer `make demo`.


### PR DESCRIPTION
## docs(kind): lean profile quickstart + measured resource comparison

Part of #1370 (EPIC — Awesome Quickstart) · documents **ADR-041** (kind-native unified runtime).
Pairs with the lean profile (branch `chore/kind-lean-profile`) and the harness (branch `chore/kind-stack-benchmark`) — best merged after both so the doc's repo-relative links resolve.

### Why  (problem & intent)
ADR-041 retires Compose and asks for the resource floor to be "published up front." This adds the kind-native local-dev quickstart and a measured before/after, so the cost of the move — and what the lean profile buys back — is documented with **real numbers**, not estimates.

### What you'll get  (deliverables ↔ what changed)
- `docs/local-dev-kind.md` — kind-native quickstart (`make demo` / `kind-up` / `kind-down`, full vs `PROFILE=lite`, engine portability, deprecated `demo-compose`) ← new
- `docs/benchmarks/kind-lean-resources.md` — measured compose vs full-kind vs lean-kind footprint (CPU, memory, disk, demo wall-clock), the two reduction levers (component removal + single-node), and an honest "irreducible kind tax" reading ← new

### Scope & boundaries
- **In scope:** two docs (PR-size-exempt). No code.
- **Out of scope:** ADR-041 itself (already accepted); the lean-profile code and the harness (separate PRs).

### Test plan & acceptance
All numbers are **measured** (not estimated) on this host; full methodology + caveats live in the doc. Headline reduction, full-kind → lean-kind (single-node):

| Dimension | before | after | Δ |
|---|---|---|---|
| Pods | 18 | 8 | −56% |
| Whole-machine RAM | ~2.5 GiB | ~1.4 GiB | −44% |
| PVC reserved | 11.0 GiB | 2.0 GiB | −82% |
| Image/layer disk | ~5.9 GiB | ~2.9 GiB | −51% |
| Demo (echo, warm) | 4s | 3s | same |

**Local gates:** repo-relative links only ✅ · measured figures cross-checked against raw `kubectl top` / `docker stats` ✅ · no literal emails / skip-ci tokens ✅

### Evidence
The doc records the honest tradeoff, not just the win:
> Even lean single-node kind (~1.4 GiB) sits **above** Docker Compose (~0.5 GiB). The gap (~0.9 GiB) is the Kubernetes control-plane + per-node kubelet/containerd — the deliberate price of "local mirrors production." Lean single-node kind roughly **halves the gap** vs full 3-node kind, and the demo runs ~3s on every stack.
