### PR TITLE
fix(cli): send Authorization bearer token to auth-enabled gateway

### DIFF
--- a/cmd/zynax/AGENTS.md
+++ b/cmd/zynax/AGENTS.md
@@ -11,6 +11,7 @@ from any service, no imports from `services/*/internal/`.
 - This module is **not** in `go.work`. Always use `GOWORK=off` for every `go` command here.
 - Depends only on `github.com/spf13/cobra` and the standard library.
 - The api-gateway base URL comes from `ZYNAX_API_URL` or `--api-url` flag; default `http://localhost:8080`.
+- The bearer token for an auth-enabled gateway comes from `ZYNAX_API_KEY` or `--api-key` flag; when set it is sent as `Authorization: Bearer <key>` on every request, when empty no header is sent (auth-disabled gateways still work). Must match the gateway's `ZYNAX_API_KEY` (issue #1517).
 
 ## Layout
 

--- a/cmd/zynax/client/gateway.go
+++ b/cmd/zynax/client/gateway.go
@@ -41,12 +41,17 @@ type CompileError struct {
 // Gateway is an HTTP client for the Zynax api-gateway REST API.
 type Gateway struct {
 	base   string
+	apiKey string
 	client *http.Client
 }
 
 // New creates a Gateway pointing at baseURL.
 // When insecure is true TLS certificate verification is skipped (local dev only).
-func New(baseURL string, insecure bool) *Gateway {
+// When apiKey is non-empty every request carries an "Authorization: Bearer <apiKey>"
+// header to satisfy the gateway's bearer-token auth (ZYNAX_API_KEY); an empty
+// apiKey sends no header, preserving the unauthenticated behaviour for
+// auth-disabled gateways.
+func New(baseURL string, insecure bool, apiKey string) *Gateway {
 	tr := http.DefaultTransport
 	if insecure {
 		tr = &http.Transport{
@@ -55,8 +60,23 @@ func New(baseURL string, insecure bool) *Gateway {
 	}
 	return &Gateway{
 		base:   strings.TrimRight(baseURL, "/"),
+		apiKey: apiKey,
 		client: &http.Client{Transport: tr},
 	}
+}
+
+// newRequest builds an *http.Request and applies the bearer-token Authorization
+// header when an API key is configured. Every gateway call funnels through here
+// so authentication is set in exactly one place (issue #1517).
+func (g *Gateway) newRequest(ctx context.Context, method, url string, body io.Reader) (*http.Request, error) {
+	req, err := http.NewRequestWithContext(ctx, method, url, body)
+	if err != nil {
+		return nil, fmt.Errorf("zynax: build request: %w", err)
+	}
+	if g.apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+g.apiKey)
+	}
+	return req, nil
 }
 
 // Apply submits a manifest for execution. Returns run_id (Workflow) or
@@ -138,9 +158,9 @@ func (g *Gateway) ApplyDryRun(ctx context.Context, body []byte) ([]CompileError,
 // returns the reported status string on success, or a descriptive error when
 // the gateway is unreachable or unhealthy. Used by `zynax doctor`.
 func (g *Gateway) Health(ctx context.Context) (string, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, g.base+"/healthz", nil)
+	req, err := g.newRequest(ctx, http.MethodGet, g.base+"/healthz", nil)
 	if err != nil {
-		return "", fmt.Errorf("zynax: build request: %w", err)
+		return "", err
 	}
 	resp, err := g.client.Do(req)
 	if err != nil {
@@ -167,9 +187,9 @@ func (g *Gateway) Health(ctx context.Context) (string, error) {
 // gateway's dependencies are reachable, 503 otherwise; no body either way).
 // Returns nil when ready, a descriptive error otherwise. Used by `zynax doctor`.
 func (g *Gateway) Ready(ctx context.Context) error {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, g.base+"/readyz", nil)
+	req, err := g.newRequest(ctx, http.MethodGet, g.base+"/readyz", nil)
 	if err != nil {
-		return fmt.Errorf("zynax: build request: %w", err)
+		return err
 	}
 	resp, err := g.client.Do(req)
 	if err != nil {
@@ -186,9 +206,9 @@ func (g *Gateway) Ready(ctx context.Context) error {
 
 // GetWorkflow returns the current status of a workflow run.
 func (g *Gateway) GetWorkflow(ctx context.Context, runID string) (*WorkflowStatus, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, g.base+"/api/v1/workflows/"+runID, nil)
+	req, err := g.newRequest(ctx, http.MethodGet, g.base+"/api/v1/workflows/"+runID, nil)
 	if err != nil {
-		return nil, fmt.Errorf("zynax: build request: %w", err)
+		return nil, err
 	}
 	resp, err := g.client.Do(req)
 	if err != nil {
@@ -213,9 +233,9 @@ func (g *Gateway) GetWorkflow(ctx context.Context, runID string) (*WorkflowStatu
 
 // DeleteWorkflow cancels a running workflow run.
 func (g *Gateway) DeleteWorkflow(ctx context.Context, runID string) error {
-	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, g.base+"/api/v1/workflows/"+runID, nil)
+	req, err := g.newRequest(ctx, http.MethodDelete, g.base+"/api/v1/workflows/"+runID, nil)
 	if err != nil {
-		return fmt.Errorf("zynax: build request: %w", err)
+		return err
 	}
 	resp, err := g.client.Do(req)
 	if err != nil {
@@ -246,9 +266,9 @@ func (g *Gateway) PublishEvent(ctx context.Context, runID, eventType string, dat
 	if err != nil {
 		return "", fmt.Errorf("zynax: encode event: %w", err)
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, g.base+"/api/v1/workflows/"+runID+"/events", bytes.NewReader(body))
+	req, err := g.newRequest(ctx, http.MethodPost, g.base+"/api/v1/workflows/"+runID+"/events", bytes.NewReader(body))
 	if err != nil {
-		return "", fmt.Errorf("zynax: build request: %w", err)
+		return "", err
 	}
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := g.client.Do(req)
@@ -328,9 +348,9 @@ func completionField(s string) string {
 // WatchWorkflowLogs streams SSE events from GET /api/v1/workflows/{id}/logs,
 // calling send for each event. Returns when the stream closes or ctx is cancelled.
 func (g *Gateway) WatchWorkflowLogs(ctx context.Context, runID string, send func(LogEvent) error) error {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, g.base+"/api/v1/workflows/"+runID+"/logs", nil)
+	req, err := g.newRequest(ctx, http.MethodGet, g.base+"/api/v1/workflows/"+runID+"/logs", nil)
 	if err != nil {
-		return fmt.Errorf("zynax: build request: %w", err)
+		return err
 	}
 	req.Header.Set("Accept", "text/event-stream")
 	resp, err := g.client.Do(req)
@@ -372,9 +392,9 @@ func (g *Gateway) post(ctx context.Context, path string, q url.Values, body []by
 	if len(q) > 0 {
 		u += "?" + q.Encode()
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u, bytes.NewReader(body))
+	req, err := g.newRequest(ctx, http.MethodPost, u, bytes.NewReader(body))
 	if err != nil {
-		return nil, fmt.Errorf("zynax: build request: %w", err)
+		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/yaml")
 	resp, err := g.client.Do(req)

--- a/cmd/zynax/client/gateway_test.go
+++ b/cmd/zynax/client/gateway_test.go
@@ -18,7 +18,15 @@ func newGW(t *testing.T, handler http.HandlerFunc) *client.Gateway {
 	t.Helper()
 	srv := httptest.NewServer(handler)
 	t.Cleanup(srv.Close)
-	return client.New(srv.URL, false)
+	return client.New(srv.URL, false, "")
+}
+
+// newGWKey is newGW with a configured bearer API key (issue #1517).
+func newGWKey(t *testing.T, apiKey string, handler http.HandlerFunc) *client.Gateway {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	return client.New(srv.URL, false, apiKey)
 }
 
 func TestApply_Workflow_Returns202(t *testing.T) {
@@ -257,6 +265,83 @@ func TestPublishEvent_ServerError(t *testing.T) {
 	_, err := gw.PublishEvent(context.Background(), "run-7", "review.approved", nil)
 	if err == nil {
 		t.Fatal("expected error on 500, got nil")
+	}
+}
+
+// TestAuthorizationHeader_WithKey asserts every verb sends the bearer token when
+// an API key is configured (issue #1517 — AC2: key on all gateway calls). The
+// handler writes a permissive response so each verb completes without error; the
+// assertion is only on the captured Authorization header.
+func TestAuthorizationHeader_WithKey(t *testing.T) {
+	const key = "s3cr3t-token"
+	want := "Bearer " + key
+
+	cases := []struct {
+		name   string
+		status int
+		call   func(*client.Gateway) error
+	}{
+		{"apply POST", http.StatusAccepted, func(g *client.Gateway) error {
+			_, _, _, err := g.Apply(context.Background(), []byte("kind: Workflow"), "")
+			return err
+		}},
+		{"get workflow GET", http.StatusOK, func(g *client.Gateway) error {
+			_, err := g.GetWorkflow(context.Background(), "run-1")
+			return err
+		}},
+		{"delete workflow DELETE", http.StatusNoContent, func(g *client.Gateway) error {
+			return g.DeleteWorkflow(context.Background(), "run-1")
+		}},
+		{"publish event POST", http.StatusAccepted, func(g *client.Gateway) error {
+			_, err := g.PublishEvent(context.Background(), "run-1", "approved", nil)
+			return err
+		}},
+		{"watch logs SSE GET", http.StatusOK, func(g *client.Gateway) error {
+			return g.WatchWorkflowLogs(context.Background(), "run-1", func(client.LogEvent) error { return nil })
+		}},
+		{"health GET", http.StatusOK, func(g *client.Gateway) error {
+			_, err := g.Health(context.Background())
+			return err
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var got string
+			gw := newGWKey(t, key, func(w http.ResponseWriter, r *http.Request) {
+				got = r.Header.Get("Authorization")
+				w.WriteHeader(tc.status)
+				_ = json.NewEncoder(w).Encode(map[string]string{
+					"run_id": "run-1", "status": "ok", "event_id": "e1",
+				})
+			})
+			if err := tc.call(gw); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != want {
+				t.Errorf("Authorization = %q; want %q", got, want)
+			}
+		})
+	}
+}
+
+// TestAuthorizationHeader_NoKey asserts no Authorization header is sent when no
+// API key is configured (issue #1517 — AC3: backward compatible, auth-disabled
+// gateways keep working).
+func TestAuthorizationHeader_NoKey(t *testing.T) {
+	var got string
+	var seen bool
+	gw := newGW(t, func(w http.ResponseWriter, r *http.Request) {
+		_, seen = r.Header["Authorization"]
+		got = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusAccepted)
+		_ = json.NewEncoder(w).Encode(map[string]any{"run_id": "wf-1"})
+	})
+	if _, _, _, err := gw.Apply(context.Background(), []byte("kind: Workflow"), ""); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if seen || got != "" {
+		t.Errorf("Authorization header present (%q) without an API key; want none", got)
 	}
 }
 

--- a/cmd/zynax/cmd/root.go
+++ b/cmd/zynax/cmd/root.go
@@ -30,6 +30,7 @@ var rootCmd = &cobra.Command{
 
 var (
 	apiURL   string
+	apiKey   string
 	insecure bool
 )
 
@@ -46,10 +47,11 @@ func init() {
 		defaultURL = "http://localhost:8080"
 	}
 	rootCmd.PersistentFlags().StringVar(&apiURL, "api-url", defaultURL, "api-gateway base URL ($ZYNAX_API_URL)")
+	rootCmd.PersistentFlags().StringVar(&apiKey, "api-key", os.Getenv("ZYNAX_API_KEY"), "api-gateway bearer token sent as Authorization header ($ZYNAX_API_KEY)")
 	rootCmd.PersistentFlags().BoolVar(&insecure, "insecure", false, "skip TLS certificate verification")
 	rootCmd.AddGroup(&cobra.Group{ID: beginnerGroupID, Title: "Getting started:"})
 }
 
 func newGateway() *client.Gateway {
-	return client.New(apiURL, insecure)
+	return client.New(apiURL, insecure, apiKey)
 }


### PR DESCRIPTION
## fix(cli): send Authorization bearer token to auth-enabled gateway

Closes #1517

### Why  (problem & intent)
The `zynax` CLI sent no `Authorization` header, so every request returned `401 unauthorized` against a gateway with `ZYNAX_API_KEY` set (mutating routes `POST /apply`, `POST /events`, `DELETE /workflows/{id}` are gated by the gateway's `requireBearer`). This blocked the CLI on any auth-enabled deployment. Surfaced while delivering #1493.

### What you'll get  (deliverables ↔ what changed)
- A `--api-key` flag and `ZYNAX_API_KEY` env var on every command ← `cmd/zynax/cmd/root.go`
- `Authorization: Bearer <key>` on **every** gateway request (apply, get, status, logs, result, delete, events, health, ready) ← `cmd/zynax/client/gateway.go` (single `newRequest` choke point)
- Backward compatibility: no key → no header → auth-disabled gateways unchanged ← `cmd/zynax/client/gateway.go`
- Module docs for the new flag/env ← `cmd/zynax/AGENTS.md`

### Scope & boundaries
- **In scope:** CLI-side bearer auth (`cmd/zynax` only). HTTP REST client, no gRPC.
- **Out of scope (deferred):** No gateway-side changes — the gateway auth contract (`requireBearer` on mutating routes) is unchanged. Read-only GET routes remain unauthenticated by gateway design (`handler.go`), so the CLI sends the header on them too but the gateway does not require it.

### Test plan & acceptance

Verified live on an isolated kind cluster (`zynax-deliver-1517`, `PROFILE=lite`) with `ZYNAX_API_KEY` auth enabled (gateway secret `zynax-gw-api-key` present). Port-forward on host `18080`.

| Acceptance criterion | How verified (command) | Result |
|----------------------|------------------------|--------|
| AC1: `--api-key` apply succeeds (no 401) | `zynax --api-key <key> --api-url http://localhost:18080 apply spec/workflows/examples/hello-world.yaml` | ✅ `run_id: wf-67d8e8cf923af1b6` |
| AC1: `ZYNAX_API_KEY` env apply/get succeeds | `ZYNAX_API_KEY=<key> ZYNAX_API_URL=http://localhost:18080 zynax get workflow <run>` | ✅ `status: WORKFLOW_STATUS_COMPLETED` |
| AC2: key sent on ALL gateway calls | `GOWORK=off go test ./client/... -run TestAuthorizationHeader_WithKey -v` (apply/get/delete/events/logs/health) | ✅ all 6 subtests PASS |
| AC3: no key → no header → unchanged | `zynax --api-url http://localhost:18080 apply hello-world.yaml` (no key) | ✅ `HTTP 401: {"error":"unauthorized"}` (gateway gate fires; old broken behaviour reproduced) + `TestAuthorizationHeader_NoKey` PASS |
| AC4: hello-world reaches COMPLETED via CLI, both runs | `zynax --api-key <key> ... status workflow <run>` (run #1 and run #2) | ✅ `WORKFLOW_STATUS_COMPLETED` both runs |

**Local gates:** `GOWORK=off go build ./...` ✅ · `GOWORK=off go test ./... -race -timeout 60s` ✅ · `golangci-lint` (repo config) ✅ 0 issues · pre-commit hooks ✅

### Evidence
- **CI:** pending — see checks below.
- **Local output:**
  - `go test ./... -race`: `ok github.com/zynax-io/zynax/cmd/zynax/client 1.019s` (+ cmd, gitops, validate all ok)
  - `golangci-lint run --config tools/golangci-lint.yml ./...`: `0 issues.`
  - 401-without-key: `Error: zynax: apply: HTTP 401: {"error":"unauthorized","code":"UNAUTHORIZED"}`
  - COMPLETED-with-key, run #1 (`wf-67d8e8cf923af1b6`): `WORKFLOW_STATUS_COMPLETED`
  - COMPLETED-with-key, run #2 (`wf-67d8e8cf923af1b6-1782428538`, idempotency): `WORKFLOW_STATUS_COMPLETED`
  - env-var path (`ZYNAX_API_KEY` + `ZYNAX_API_URL`, `get workflow`): `status: WORKFLOW_STATUS_COMPLETED`
- **Artifacts / images:** none — no service source changed (CLI module only, not in go.work).
- **Post-merge digest sync → main:** N/A — no image rebuild.

### Risk & rollback
Low — additive only. Empty key preserves the exact prior request shape (no header), so auth-disabled gateways are unaffected. Revert this PR to restore prior behaviour. No data/migration concern.

### Review aids
- The ONE key file: `cmd/zynax/client/gateway.go` — the new `newRequest` helper is the single choke point; all 7 `http.NewRequestWithContext` call sites were routed through it so no verb can miss the header.
- Note: `zynax result hello-world` reports `no result payload` — that is a property of the echo capability (it emits no `completion` text), not an auth failure; the `result`/SSE path authenticated fine (no 401) and tailed to terminal. AC4 ("reaches COMPLETED through the CLI") is confirmed via authenticated `status`/`get`.
- Gateway contract matched exactly: `requireBearer` compares `Authorization` against `"Bearer " + ZYNAX_API_KEY`.

**AI:** `Assisted-by: Claude/claude-opus-4-8`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
