### PR TITLE
fix(infra): make localhost:8080 reach the kind gateway out of the box

### DIFF
--- a/scripts/e2e/cluster-up.sh
+++ b/scripts/e2e/cluster-up.sh
@@ -275,13 +275,19 @@ fi
 
 # ── 3. deploy the full Zynax stack via the umbrella chart ────────────────────────
 
-# Build chart dependencies if the packaged subcharts are missing (e.g. a fresh
-# checkout where `helm dependency build` has not yet run). No-op if present.
-if [[ ! -d "${UMBRELLA_CHART}/charts" ]] || \
-   [[ -z "$(ls -A "${UMBRELLA_CHART}/charts" 2>/dev/null)" ]]; then
-  log "building umbrella chart dependencies…"
-  helm dependency build "${UMBRELLA_CHART}"
-fi
+# ALWAYS (re)build chart dependencies from the live subchart sources before the
+# install. The umbrella vendors its subcharts as packaged `.tgz` files under
+# charts/, and those committed artifacts can drift from the subchart source —
+# e.g. the api-gateway tgz once predated the template that renders
+# service.nodePort, so the deployed Service silently dropped the pinned NodePort
+# 30080 and fell back to a kube-proxy-random nodePort the kind extraPortMapping
+# (host 8080 → 30080) does not target, leaving http://localhost:8080 unreachable
+# out of the box (#1488). A prior guard only rebuilt when charts/ was EMPTY, so a
+# stale-but-present tgz was deployed verbatim. Rebuilding unconditionally makes
+# the subchart source the single source of truth — it is idempotent and fast
+# (file:// deps, no network), and CI's helm-lint already rebuilds the same way.
+log "building umbrella chart dependencies from source (subchart source is the SoT)…"
+helm dependency build "${UMBRELLA_CHART}"
 
 log "deploying zynax-umbrella as release '${RELEASE_NAME}' in namespace '${NAMESPACE}' (engine: ${E2E_ENGINE})…"
 # values-e2e.yaml carries the e2e-only overrides (shared with helm-upgrade.sh so
@@ -394,6 +400,35 @@ kubectl -n "${NAMESPACE}" rollout status deployment/echo-worker --timeout "${WAI
 log "echo-worker is healthy and registered."
 
 kubectl -n "${NAMESPACE}" get pods -o wide
+
+# ── 6. assert the host NodePort path (the actual first-run user contract) ─────────
+
+# #1488: a brand-new user's very first command is `zynax --api-url
+# http://localhost:8080 apply …`, which relies SOLELY on the kind extraPortMapping
+# (host 8080 → nodePort 30080) hitting the api-gateway Service's pinned nodePort
+# 30080. The e2e assertion scripts deliberately port-forward to 18080 (kube-proxy
+# can reset a NodePort on multi-node clusters), so NO existing test ever exercised
+# raw localhost:8080 — which is exactly why the stale-tgz nodePort regression
+# shipped undetected. Verify the host path here so cluster-up.sh proves the claim
+# it prints below, and any future Service/extraPortMapping/nodePort drift fails
+# bring-up loudly instead of silently breaking the first-run experience.
+HOST_GW_URL="${HOST_GW_URL:-http://localhost:8080}"
+if command -v curl >/dev/null 2>&1; then
+  log "asserting the host NodePort path is reachable: ${HOST_GW_URL}/healthz (the first-run user contract, #1488)…"
+  host_ok=""
+  for _ in $(seq 1 30); do
+    code="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 5 "${HOST_GW_URL}/healthz" 2>/dev/null || true)"
+    if [[ "${code}" == "200" ]]; then
+      host_ok="yes"
+      break
+    fi
+    sleep 2
+  done
+  [[ -n "${host_ok}" ]] || die "api-gateway is NOT reachable on the host port (${HOST_GW_URL}/healthz never returned 200) — the kind extraPortMapping (host 8080 → nodePort 30080) and the Service nodePort (must be 30080) are out of sync (#1488). Check: kubectl -n ${NAMESPACE} get svc zynax-api-gateway -o jsonpath='{.spec.ports[0].nodePort}'"
+  log "  ✓ host NodePort path verified — ${HOST_GW_URL} reaches the api-gateway (HTTP 200)."
+else
+  warn "curl not found — skipping the host NodePort reachability assertion (#1488)."
+fi
 
 log "cluster '${CLUSTER_NAME}' is up. api-gateway REST is reachable on host port 8080."
 log "tear down with: scripts/e2e/cluster-down.sh"


### PR DESCRIPTION
## fix(infra): make localhost:8080 reach the kind gateway out of the box

Closes #1488

### Why (symptom + root cause)

**Symptom:** on a fresh `make kind-up` / `make demo` cluster, a brand-new user's
very first command —
`zynax --api-url http://localhost:8080 apply spec/workflows/examples/hello-world.yaml` —
could not reach the gateway: `localhost:8080` returned *connection reset by peer*
on every attempt (measured 0/20).

**Root cause:** the api-gateway Service came up on a **kube-proxy-random
nodePort (31079)** instead of the **pinned 30080** that the kind extraPortMapping
(host 8080 → nodePort 30080) targets. The umbrella vendors its subcharts as
packaged `.tgz` files under `helm/zynax-umbrella/charts/`, and the committed
`zynax-api-gateway-0.1.0.tgz` was **stale** — its `service.yaml` predated the
template block that renders `service.nodePort`. `cluster-up.sh`'s dependency
guard only rebuilt subcharts when `charts/` was **empty**, so the stale-but-present
tgz was deployed verbatim and the `nodePort: 30080` override in `values-e2e.yaml`
was silently dropped.

It shipped undetected because **no test ever exercised the raw `localhost:8080`
host path**: every e2e assertion script (`e2e-happy.sh`, `kind-demo.sh`)
deliberately `port-forward`s to `18080`, so the NodePort that the banner
advertises to users was never validated.

This is NOT a NodePort-vs-port-forward exposure decision — the exposure design
(pinned NodePort 30080 + kind extraPortMapping) is correct. The only defect was a
vendored artifact drifting from its source.

### What you'll get

- `scripts/e2e/cluster-up.sh` now **always** `helm dependency build`s the umbrella
  from the live subchart **source** before install, so source is the single
  source of truth and committed-tgz drift can never silently ship again
  (idempotent, `file://` deps, no network; CI's `helm-lint.yml` already rebuilds
  the same way). ← removes the "rebuild only when charts/ is empty" guard.
- A **host-NodePort reachability assertion** at the end of bring-up: polls
  `localhost:8080/healthz` for HTTP 200 (the real first-run user contract) and
  fails bring-up loudly on any Service / extraPortMapping / nodePort drift —
  this is the regression guard that would have caught the bug.

### Scope & boundaries

- In scope: kind bring-up path (`cluster-up.sh`), used by `make kind-up`,
  `make demo`, and CI's `e2e-smoke.yml`.
- Out of scope: the exposure design (unchanged), the `PROFILE ?= full` default
  (unchanged), CLI defaults (`--api-url` is already `http://localhost:8080`),
  and the committed `.tgz` blobs (now runtime-regenerated from source — not
  committed to avoid binary churn / merge races).

### Test plan & acceptance

All measured on an **isolated** cluster `zynax-deliver-1488` (never touches a user
`zynax-e2e`). CLI built from `cmd/zynax` (`GOWORK=off go build`).

| Acceptance criterion | How verified | Result |
|---|---|---|
| Repro: before fix, `localhost:8080` is dead | `seq 1 20 \| xargs … curl … :8080/healthz` on the stale-tgz deploy | ❌ 0/20 (reset); Service nodePort=**31079** ≠ 30080 |
| After fix (lite, single-node): host path reliable | same 20× curl | ✅ **20/20 → 200**; nodePort=**30080** |
| After fix (lite): first command works out of the box | `zynax --api-key … --api-url http://localhost:8080 apply hello-world.yaml` ×2 | ✅ **COMPLETED** ×2 |
| After fix (**full, multi-node — default**): host path reliable, gateway pod on a **worker** node (cross-node routing) | same 20× curl | ✅ **20/20 → 200**; nodePort=**30080** |
| After fix (full, default): first command works out of the box | `zynax … apply hello-world.yaml` ×2 (persistence-safe, run twice) | ✅ **COMPLETED** ×2 |
| Regression guard fires on drift | new `cluster-up.sh` assertion polls `:8080/healthz`, `die`s if never 200 | ✅ ran & **passed** on full bring-up; would have failed the stale deploy |

**Local gates:** `shellcheck scripts/e2e/cluster-up.sh` ✅ (clean) · `bash -n` ✅ ·
`make -n kind-up demo` ✅ (targets intact).

### Evidence

Before (stale tgz, full deploy) — Service got a random nodePort, host path dead:
```
$ kubectl -n zynax get svc zynax-api-gateway -o jsonpath='{.spec.ports[0].nodePort}'
31079
$ seq 1 20 | xargs -I{} curl -sS -o /dev/null -w '%{http_code}\n' --max-time 5 http://localhost:8080/healthz
curl: (56) Recv failure: Connection reset by peer        # ×20  → 000 ×20
```

After (default full multi-node, gateway pod on `zynax-deliver-1488-worker`):
```
[cluster-up]   ✓ host NodePort path verified — http://localhost:8080 reaches the api-gateway (HTTP 200).
$ kubectl -n zynax get svc zynax-api-gateway -o jsonpath='{.spec.ports[0].nodePort}'
30080
$ seq 1 20 | xargs … curl … http://localhost:8080/healthz   →  200 ×20

$ zynax --api-url http://localhost:8080 apply hello-world.yaml   →  run_id: wf-…           (run 1)
   status →  WORKFLOW_STATUS_COMPLETED
$ zynax --api-url http://localhost:8080 apply hello-world.yaml   →  run_id: wf-…-1782430397 (run 2)
   status →  WORKFLOW_STATUS_COMPLETED
```

### Risk & rollback

- **Risk:** the new always-rebuild adds ~2s to bring-up (`file://` deps, no
  network) and the assertion adds a ≤60s bounded poll only when `curl` is present.
  Low. The assertion runs in CI's `e2e-smoke.yml` too — verified to pass on a
  multi-node cluster with the gateway pod on a worker (cross-node host routing
  holds once the nodePort is pinned).
- **Rollback:** revert this commit — restores the prior `charts/`-empty guard and
  drops the host-path assertion. The committed subchart `.tgz` blobs are
  untouched by this PR.

---

> Post-merge digest-sync: _<placeholder — fill after squash-merge>_

🤖 Generated with [Claude Code](https://claude.com/claude-code)
