### PR TITLE
feat(infra): run the hero workflow on Argo via one flag on kind

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,6 +141,14 @@ CLUSTER_DOWN  := scripts/e2e/cluster-down.sh
 # or `lite` (lean laptop — 1 in-memory dev Temporal, no event-bus/NATS/memory-
 # service). Usage: `make demo PROFILE=lite` / `make kind-up PROFILE=lite`.
 PROFILE      ?= full
+# Workflow engine the kind demo deploys (#1500, the engine-portability wedge —
+# #1370 / ADR-041): `temporal` (default) or `argo`. The SAME workflow manifest
+# runs unchanged on either — selection flows through umbrella values only
+# (values-e2e-argo.yaml), never the workflow (ADR-015). `ENGINE` is the clean
+# alias; the underlying `E2E_ENGINE` env var (read by cluster-up.sh) still works
+# as an override, so `E2E_ENGINE=argo make demo` and `make demo ENGINE=argo` are
+# equivalent. Usage: `make demo ENGINE=argo` / `make kind-up ENGINE=argo`.
+ENGINE       ?= $(or $(E2E_ENGINE),temporal)
 DEMO_WORKFLOW ?= spec/workflows/examples/code-review-ollama.yaml
 ZYNAX        ?= zynax
 # Optional: run a declarative scenario manifest set instead of the single hero
@@ -169,13 +177,13 @@ DEMO_MODEL   := $(shell awk '/^[[:space:]]*model:/{print $$2; exit}' infra/docke
 # standalone Temporal UI.
 DEMO_SERVICES := api-gateway llm-adapter
 
-demo: check-docker ## ★ One command (kind): create cluster → load images → install umbrella → wait rollout → "Platform ready" + run hero workflow (PROFILE=lite for the lean stack)
-	@echo "🧭 Zynax demo on kind (ADR-041, profile: $(PROFILE)) — one command, prod-mirroring charts."
-	PROFILE=$(PROFILE) $(KIND_DEMO)
+demo: check-docker ## ★ One command (kind): create cluster → load images → install umbrella → wait rollout → "Platform ready" + run hero workflow (PROFILE=lite for the lean stack; ENGINE=argo for the Argo wedge)
+	@echo "🧭 Zynax demo on kind (ADR-041, profile: $(PROFILE), engine: $(ENGINE)) — one command, prod-mirroring charts."
+	PROFILE=$(PROFILE) E2E_ENGINE=$(ENGINE) $(KIND_DEMO)
 
-kind-up: check-docker ## Create the kind cluster + install the zynax-umbrella chart (wraps scripts/e2e/cluster-up.sh, loads local images; PROFILE=lite for the lean stack)
-	@echo "☸️  Bringing up the kind cluster + Zynax umbrella (profile: $(PROFILE), loads local images)..."
-	KIND_LOAD_IMAGES=1 PROFILE=$(PROFILE) $(CLUSTER_UP)
+kind-up: check-docker ## Create the kind cluster + install the zynax-umbrella chart (wraps scripts/e2e/cluster-up.sh, loads local images; PROFILE=lite for the lean stack; ENGINE=argo for Argo)
+	@echo "☸️  Bringing up the kind cluster + Zynax umbrella (profile: $(PROFILE), engine: $(ENGINE), loads local images)..."
+	KIND_LOAD_IMAGES=1 PROFILE=$(PROFILE) E2E_ENGINE=$(ENGINE) $(CLUSTER_UP)
 
 kind-down: ## Tear down the kind cluster (wraps scripts/e2e/cluster-down.sh)
 	@echo "🧹 Tearing down the kind cluster..."

--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ verdict, straight from the CLI. The only prerequisites are Docker and pulling th
 > `zynax --api-url http://localhost:8080 apply spec/workflows/examples/hello-world.yaml` (the built-in
 > `echo` capability, no Ollama, no API key).
 
+> **Switch engines, same workflow** — the demo runs on Temporal by default; run the *same*
+> manifest on Argo with one flag: `ENGINE=argo make demo` (or `E2E_ENGINE=argo make demo`). That
+> portability — write once, run on Temporal **or** Argo, no rewrite — is the wedge ([ADR-041](docs/adr/), [#1370](https://github.com/zynax-io/zynax/issues/1370)).
+
 <!-- asciinema cast — record locally with `make demo` and `asciinema rec docs/casts/make-demo.cast`.
      See docs/casts/README.md. Once recorded, replace the placeholder below with the upload embed. -->
 [![asciicast — make demo](https://asciinema.org/a/PLACEHOLDER.svg)](https://asciinema.org/a/PLACEHOLDER)

--- a/scripts/demo/kind-demo.sh
+++ b/scripts/demo/kind-demo.sh
@@ -54,6 +54,14 @@ WORKFLOW_FILE="${WORKFLOW_FILE:-${REPO_ROOT}/spec/workflows/examples/e2e-demo.ya
 # prod-mirroring) or "lite" (lean laptop — one in-memory dev Temporal, no
 # event-bus/NATS/memory-service). The hero echo workflow runs on both.
 PROFILE="${PROFILE:-full}"
+# Workflow engine passed through to cluster-up.sh (#1500, the engine-portability
+# wedge — #1370 / ADR-041): "temporal" (default) or "argo". argo additionally
+# installs the Argo Workflows control plane and deploys the umbrella with
+# values-e2e-argo.yaml (cluster-up.sh, ADR-015). The SAME hero workflow runs
+# unchanged on either — selection flows through umbrella values, never the
+# manifest. Forwarded EXPLICITLY to cluster-up.sh below (no silent env
+# inheritance) so `E2E_ENGINE=argo make demo` is a robust, documented contract.
+E2E_ENGINE="${E2E_ENGINE:-temporal}"
 # Default reference model — read from the single source (the llm-adapter config),
 # so the pre-flight and the runtime config never drift. Override with DEMO_MODEL.
 MODEL_CONFIG="${REPO_ROOT}/infra/docker-compose/ollama/llm-adapter.config.yaml"
@@ -151,11 +159,12 @@ fi
 # KIND_LOAD_IMAGES), installs cert-manager + the zynax-umbrella chart, and BLOCKS
 # on `kubectl rollout status` for every Zynax Deployment. Its success is the gate
 # for the "Platform ready" banner below — we never print it if this returns ≠ 0.
-log "bringing up the kind cluster + Zynax umbrella (wraps scripts/e2e/cluster-up.sh)…"
+log "bringing up the kind cluster + Zynax umbrella (engine: ${E2E_ENGINE}; wraps scripts/e2e/cluster-up.sh)…"
 KIND_LOAD_IMAGES="${KIND_LOAD_IMAGES:-1}" \
 CLUSTER_NAME="${CLUSTER_NAME}" \
 NAMESPACE="${NAMESPACE}" \
 PROFILE="${PROFILE}" \
+E2E_ENGINE="${E2E_ENGINE}" \
   "${REPO_ROOT}/scripts/e2e/cluster-up.sh"
 
 # Defence-in-depth: re-assert every Zynax Deployment is actually Available before
@@ -179,6 +188,15 @@ log "all Zynax Deployments are Available."
 
 # ── 3. run the hero workflow against the gateway (localhost:8080) ────────────────
 
+# The opposite engine, for the wedge-switch hint in the banner below: the SAME
+# workflow runs unchanged on the other engine — just re-run with E2E_ENGINE flipped
+# (the engine-portability wedge, #1500 / #1370). Always defined (even with SKIP_RUN).
+if [[ "${E2E_ENGINE}" == "argo" ]]; then
+  OTHER_ENGINE="temporal"
+else
+  OTHER_ENGINE="argo"
+fi
+
 RAN_RESULT=""
 if [[ -z "${SKIP_RUN:-}" ]]; then
   require curl
@@ -195,7 +213,7 @@ if [[ -z "${SKIP_RUN:-}" ]]; then
     port_forward "svc/zynax-api-gateway" "${GW_LOCAL_PORT}" 8080
     API_GW_URL="http://localhost:${GW_LOCAL_PORT}"
   fi
-  log "running the hero workflow (${WORKFLOW_FILE##*/}) via api-gateway at ${API_GW_URL}…"
+  log "running the hero workflow (${WORKFLOW_FILE##*/}) on the '${E2E_ENGINE}' engine via api-gateway at ${API_GW_URL}…"
   APPLY_RESPONSE="$(api_curl POST /api/v1/apply \
     -H "Content-Type: application/x-yaml" \
     --data-binary "@${WORKFLOW_FILE}" 2>&1)" \
@@ -219,7 +237,7 @@ if [[ -z "${SKIP_RUN:-}" ]]; then
   done
   [[ "${RAN_RESULT}" == "succeeded" ]] \
     || die "hero workflow did not reach success within ${POLL_TIMEOUT}s (last status: '${status:-unknown}')"
-  log "  ✓ hero workflow reached terminal success ('${status}', run_id=${RUN_ID})."
+  log "  ✓ hero workflow reached terminal success on the '${E2E_ENGINE}' engine ('${status}', run_id=${RUN_ID})."
 fi
 
 # ── 4. "Platform ready" banner — ONLY reached after rollout + (optional) run ─────
@@ -242,7 +260,7 @@ echo ""
 echo "      zynax --api-url http://localhost:8080 apply spec/workflows/examples/e2e-demo.yaml"
 echo ""
 echo "  More:"
-echo "    • Engine-portability:  E2E_ENGINE=argo make demo   (same workflow, Argo engine)"
+echo "    • Engine-portability:  E2E_ENGINE=${OTHER_ENGINE} make demo   (same workflow, ${OTHER_ENGINE} engine — the wedge)"
 echo "    • Inspect a run:        zynax --api-url http://localhost:8080 logs <run-id> --follow"
 echo "    • Tear it all down:     make kind-down"
 echo ""


### PR DESCRIPTION
## feat(infra): run the hero workflow on Argo via one flag on kind

Closes #1500
Part of #1370 (EPIC — first-run UX / engine-portability wedge)

### Why
The Argo bring-up assets already existed (`cluster-up.sh E2E_ENGINE=argo`, `values-e2e-argo.yaml`, `argo-ir-interpreter.yaml`), and the banner *advertised* `E2E_ENGINE=argo make demo` — but the contract relied on **silent env inheritance** through `make demo` → `kind-demo.sh` → `cluster-up.sh` and was never made explicit or documented. This wires the engine-portability wedge into a robust, documented **one-flag** option so a new user can run the *same* hero workflow on Argo instead of Temporal with no manifest edit (ADR-041 kind-native runtime; #1370 wedge).

### What you'll get
- a documented one-flag switch: `make demo ENGINE=argo` (and the equivalent `E2E_ENGINE=argo make demo`) deploys the umbrella with the Argo engine ← `Makefile` (`ENGINE ?= $(or $(E2E_ENGINE),temporal)`, forwarded as `E2E_ENGINE` through `demo` + `kind-up`)
- `E2E_ENGINE` forwarded **explicitly** to `cluster-up.sh` (no reliance on inheritance) + the active engine surfaced in the bring-up/hero-run logs ← `scripts/demo/kind-demo.sh`
- the "Platform ready" banner's wedge hint now points at the *other* engine (run on Argo → it suggests flipping back to Temporal, and vice-versa) ← `scripts/demo/kind-demo.sh`
- a one-line "Switch engines, same workflow" note in the README's "See it run" ← `README.md`

No engine-logic fork: reuses the existing Argo assets verbatim (AC3). No engine-adapter Go change — `ArgoEngine` already exists; the engine is selected via umbrella values only (ADR-015).

### Scope & boundaries
- **In scope:** the one-flag `ENGINE`/`E2E_ENGINE` wiring on the kind demo path + minimal README/help-text docs; the wedge proof (same manifest, both engines) on a real kind cluster.
- **Out of scope (deferred):** full README golden-path consolidation → #1494; Argo-side capability-dispatch parity with the Temporal `IRInterpreterWorkflow` (the Argo `zynax-ir-interpreter` template is the documented smoke interpreter) → tracked separately.

### Test plan & acceptance
All evidence captured on an **isolated** kind cluster `zynax-deliver-1500` (E2E_ENGINE=argo, full profile), CLI built `GOWORK=off`. Hero manifest sha256 `6546b985bc65ce3e23c4a2f2ec6c74716d8ad8c23eafd64464871748befa12b4` (`hello-world.yaml`), unchanged across both engines.

| Acceptance criterion | How verified (command) | Result |
|----------------------|------------------------|--------|
| AC1 — documented one-flag option runs the hero on Argo on kind | `make demo ENGINE=argo` resolves to `PROFILE=full E2E_ENGINE=argo scripts/demo/kind-demo.sh` (`make -n`); cluster booted `E2E_ENGINE=argo CLUSTER_NAME=zynax-deliver-1500 cluster-up.sh` → `engine: argo`; the `make demo` hero `e2e-demo.yaml` applied on Argo | ✅ run_id `wf-87c54f296047a171` → `WORKFLOW_STATUS_COMPLETED`; Argo Workflow object phase `Succeeded` |
| AC2 — SAME manifest runs unchanged on BOTH engines (wedge) | byte-identical `hello-world.yaml` (sha256 above) applied on Argo (default) and on Temporal (after flipping `activeEngine`) — no manifest/agent-def edit between runs | ✅ Argo: Workflow `Succeeded`; Temporal: engine-adapter ran `IRInterpreterWorkflow` + `DispatchCapabilityActivity` → `WORKFLOW_STATUS_COMPLETED` |
| AC3 — reuses `e2e-argo.sh`/`values-e2e-argo.yaml`, no engine-logic fork | diff touches only `Makefile`, `README.md`, `scripts/demo/kind-demo.sh`; Argo assets unchanged; `active-engine=argo` sourced from `values-e2e-argo.yaml` overlay | ✅ `git show --stat` (3 files); no Go/engine change |
| AC4 — README "Next steps" shows the Temporal ↔ Argo switch (minimal) | `README.md` "See it run" — one blockquote added, no restructure | ✅ "Switch engines, same workflow" line |

**Local gates:** `bash -n scripts/demo/kind-demo.sh` ✅ · shellcheck (koalaman/shellcheck:stable via Docker) on `kind-demo.sh` ✅ clean · `make -n demo` / `make -n demo ENGINE=argo` / `E2E_ENGINE=argo make -n demo` / `make -n kind-up ENGINE=argo` ✅ all forward the right `E2E_ENGINE`. No Helm charts touched → `helm lint` N/A. No Go/Python/proto changed.

### Evidence
- **CI:** required checks pending (will update); both e2e-smoke legs (temporal + argo) gate this.
- **Local output (runtime — the decisive lines):**
  - Argo bring-up: `[cluster-up] deploying zynax-umbrella … (engine: argo)` · `[cluster-up] installing Argo Workflows (argo-helm chart 0.47.5)` · all 7 service deployments healthy · `✓ host NodePort path verified`.
  - `kubectl -n zynax get workflows.argoproj.io`:
    ```
    NAME                             STATUS      AGE
    wf-67d8e8cf923af1b6              Succeeded   10m     (hello-world on Argo, run 1)
    wf-67d8e8cf923af1b6-1782431665   Succeeded   9m      (hello-world on Argo, run 2 — idempotency)
    wf-67d8e8cf923af1b6-1782431694   Succeeded   8m      (Argo object pre-dates the Temporal wedge run)
    wf-87c54f296047a171              Succeeded   42s     (e2e-demo — the literal `make demo` hero — on Argo)
    ```
  - Argo hero (e2e-demo) apply→COMPLETED: `run_id: wf-87c54f296047a171` → poll `WORKFLOW_STATUS_RUNNING → WORKFLOW_STATUS_COMPLETED`; `phase=Succeeded`.
  - Wedge (Temporal, byte-identical `hello-world.yaml`): engine-adapter log `selecting workflow engine active_engine=temporal` then `WorkflowType IRInterpreterWorkflow WorkflowID wf-67d8e8cf923af1b6 … ActivityType DispatchCapabilityActivity` → `WORKFLOW_STATUS_COMPLETED`.
  - 2× Argo `hello-world` runs both `Succeeded` (idempotency).
- **Artifacts / images:** none — no service source changed (infra/docs only).
- **Post-merge digest sync → main:** N/A — no image rebuild.

### Risk & rollback
Low — additive, infra/docs only. `ENGINE` defaults to `temporal`, so `make demo` and every existing `E2E_ENGINE=…` invocation behave exactly as before; the only new behaviour is when a user opts into `ENGINE=argo`/`E2E_ENGINE=argo`. No data/migration concern. Rollback = revert this PR (no state).

### Review aids
- The ONE key change is the Makefile `ENGINE ?= $(or $(E2E_ENGINE),temporal)` line — it makes `make demo ENGINE=argo` and `E2E_ENGINE=argo make demo` equivalent while keeping `temporal` the default.
- `kind-demo.sh` now forwards `E2E_ENGINE` explicitly to `cluster-up.sh` (was silently inherited) — the robustness fix behind AC1.
- The Argo `zynax-ir-interpreter` template is intentionally a smoke interpreter (asserts non-empty IR, exits 0); full Argo capability-dispatch parity is out of scope here.

**SPDD:** ADR-041 — no separate canvas gate (this wires existing assets, not a new boundary); #1370 wedge. Positioning: the new README/help copy leads with the engine-portability wedge ("write once, run on Temporal or Argo, no rewrite"), per docs/product/positioning.md.
**AI:** `Assisted-by: Claude/claude-opus-4-8` (set the `ai-assisted` label)
