### PR TITLE
fix(agent-registry): make RegisterAgent idempotent on agent ID

### DIFF
--- a/services/agent-registry/internal/api/handler.go
+++ b/services/agent-registry/internal/api/handler.go
@@ -151,9 +151,6 @@ func grpcErr(err error) error {
 	if errors.Is(err, domain.ErrAgentNotFound) {
 		return status.Errorf(codes.NotFound, "%v", err)
 	}
-	if errors.Is(err, domain.ErrAgentAlreadyExists) {
-		return status.Errorf(codes.AlreadyExists, "%v", err)
-	}
 	if errors.Is(err, domain.ErrInvalidArgument) {
 		return status.Errorf(codes.InvalidArgument, "%v", err)
 	}

--- a/services/agent-registry/internal/api/handler_test.go
+++ b/services/agent-registry/internal/api/handler_test.go
@@ -78,7 +78,10 @@ func TestRegisterAgent_HappyPath(t *testing.T) {
 	}
 }
 
-func TestRegisterAgent_AlreadyExists(t *testing.T) {
+// TestRegisterAgent_IsIdempotent covers issue #1463: a restarted capability adapter
+// pod re-registers the same agent_id; this must return OK (not ALREADY_EXISTS) so the
+// pod does not crash-loop. The latest endpoint is upserted.
+func TestRegisterAgent_IsIdempotent(t *testing.T) {
 	client := newTestClient(t)
 
 	req := &zynaxv1.RegisterAgentRequest{Agent: validAgentDef("dup-01", "summarize")}
@@ -86,9 +89,23 @@ func TestRegisterAgent_AlreadyExists(t *testing.T) {
 		t.Fatalf("first RegisterAgent: %v", err)
 	}
 
-	_, err := client.RegisterAgent(context.Background(), req)
-	if code := status.Code(err); code != codes.AlreadyExists {
-		t.Errorf("want AlreadyExists, got %v", code)
+	// Simulate the adapter pod restarting and re-registering with a fresh endpoint.
+	updated := validAgentDef("dup-01", "summarize")
+	updated.Endpoint = "new-host:9100"
+	resp, err := client.RegisterAgent(context.Background(), &zynaxv1.RegisterAgentRequest{Agent: updated})
+	if err != nil {
+		t.Fatalf("re-RegisterAgent: want OK, got %v", err)
+	}
+	if resp.AgentId != "dup-01" {
+		t.Errorf("agent_id = %q, want %q", resp.AgentId, "dup-01")
+	}
+
+	def, err := client.GetAgent(context.Background(), &zynaxv1.GetAgentRequest{AgentId: "dup-01"})
+	if err != nil {
+		t.Fatalf("GetAgent: %v", err)
+	}
+	if def.Endpoint != "new-host:9100" {
+		t.Errorf("endpoint = %q, want upserted endpoint", def.Endpoint)
 	}
 }
 

--- a/services/agent-registry/internal/domain/errors.go
+++ b/services/agent-registry/internal/domain/errors.go
@@ -8,8 +8,6 @@ import "errors"
 var (
 	// ErrAgentNotFound is returned when an agent_id is unknown.
 	ErrAgentNotFound = errors.New("agent not found")
-	// ErrAgentAlreadyExists is returned when a REGISTERED agent with the same ID already exists.
-	ErrAgentAlreadyExists = errors.New("agent already exists")
 	// ErrInvalidArgument is returned when a request field fails validation.
 	ErrInvalidArgument = errors.New("invalid argument")
 )

--- a/services/agent-registry/internal/domain/service.go
+++ b/services/agent-registry/internal/domain/service.go
@@ -27,23 +27,27 @@ func NewAgentRegistryService(repo AgentRepository) *AgentRegistryService {
 	return &AgentRegistryService{repo: repo}
 }
 
-// Register validates and persists a new agent.
-// Returns ErrAgentAlreadyExists if a REGISTERED agent with the same ID already exists.
+// Register validates and persists an agent. Registration is idempotent on agent ID:
+// re-registering an existing agent (regardless of its current status) succeeds and
+// upserts the latest endpoint, capabilities, and metadata, preserving the original
+// RegisteredAt timestamp. This lets a restarted capability adapter pod re-register
+// cleanly instead of crash-looping on a non-existent conflict (issue #1463).
 // Returns ErrInvalidArgument if required fields are missing or invalid.
 func (s *AgentRegistryService) Register(ctx context.Context, agent Agent) (Agent, error) {
 	if err := validateAgent(agent); err != nil {
 		return Agent{}, err
 	}
 
-	existing, err := s.repo.FindByID(ctx, agent.ID)
-	if err == nil && existing.Status == AgentStatusRegistered {
-		return Agent{}, fmt.Errorf("%w: %q", ErrAgentAlreadyExists, agent.ID)
-	}
-
 	now := time.Now()
 	agent.Status = AgentStatusRegistered
-	agent.RegisteredAt = now
 	agent.UpdatedAt = now
+	// Preserve the original registration time on re-register; the durable repo
+	// upserts (ON CONFLICT DO UPDATE) so the record's identity stays stable.
+	if existing, err := s.repo.FindByID(ctx, agent.ID); err == nil {
+		agent.RegisteredAt = existing.RegisteredAt
+	} else {
+		agent.RegisteredAt = now
+	}
 
 	if err := s.repo.Save(ctx, agent); err != nil {
 		return Agent{}, fmt.Errorf("agent-registry: save: %w", err)

--- a/services/agent-registry/internal/domain/service_test.go
+++ b/services/agent-registry/internal/domain/service_test.go
@@ -157,13 +157,34 @@ func TestRegister_TooManyCapabilities(t *testing.T) {
 	}
 }
 
-func TestRegister_AlreadyExists(t *testing.T) {
+// TestRegister_IsIdempotent covers issue #1463: re-registering an already-REGISTERED
+// agent must succeed (not error), upsert the endpoint/capabilities, and preserve the
+// original RegisteredAt so a restarted adapter pod re-registers without crash-looping.
+func TestRegister_IsIdempotent(t *testing.T) {
 	svc := domain.NewAgentRegistryService(newFakeRepo())
-	seed(t, svc, validAgent("dup-01"))
+	first := seed(t, svc, validAgent("dup-01"))
 
-	_, err := svc.Register(context.Background(), validAgent("dup-01"))
-	if !errors.Is(err, domain.ErrAgentAlreadyExists) {
-		t.Errorf("err = %v, want ErrAgentAlreadyExists", err)
+	updated := validAgent("dup-01", "summarize", "translate")
+	updated.Endpoint = "new-host:9100"
+
+	second, err := svc.Register(context.Background(), updated)
+	if err != nil {
+		t.Fatalf("re-Register: %v", err)
+	}
+	if second.Status != domain.AgentStatusRegistered {
+		t.Errorf("status = %s, want REGISTERED", second.Status)
+	}
+	if second.Endpoint != "new-host:9100" {
+		t.Errorf("endpoint = %q, want updated endpoint", second.Endpoint)
+	}
+	if len(second.Capabilities) != 2 {
+		t.Errorf("capabilities = %d, want 2 (updated set)", len(second.Capabilities))
+	}
+	if !second.RegisteredAt.Equal(first.RegisteredAt) {
+		t.Errorf("RegisteredAt = %v, want preserved %v", second.RegisteredAt, first.RegisteredAt)
+	}
+	if !second.UpdatedAt.After(first.UpdatedAt) && !second.UpdatedAt.Equal(first.UpdatedAt) {
+		t.Errorf("UpdatedAt = %v, want >= %v", second.UpdatedAt, first.UpdatedAt)
 	}
 }
 

--- a/services/agent-registry/tests/features/agent_registry.feature
+++ b/services/agent-registry/tests/features/agent_registry.feature
@@ -29,13 +29,15 @@ Feature: Agent Registration
     When the agent is registered
     Then the metadata is persisted and retrievable via GetAgent
 
-  # ─── Validation failures ─────────────────────────────────────────────────
+  # ─── Idempotent re-registration (issue #1463) ────────────────────────────
 
-  Scenario: Reject duplicate agent_id
+  Scenario: Re-registering an existing agent_id is idempotent
     Given an agent with id "existing-agent-01" is already registered
     When a new agent registration is attempted with id "existing-agent-01"
-    Then the response status is ALREADY_EXISTS
-    And the error message contains "existing-agent-01"
+    Then the response status is OK (not NOT_FOUND)
+    And the agent_id matches the requested id "existing-agent-01"
+
+  # ─── Validation failures ─────────────────────────────────────────────────
 
   Scenario: Reject agent with no capabilities
     Given an agent spec with id "empty-agent" and capabilities []

--- a/services/agent-registry/tests/steps_test.go
+++ b/services/agent-registry/tests/steps_test.go
@@ -187,13 +187,6 @@ func TestFeatures(t *testing.T) {
 			})
 
 			// ── Error assertions ──────────────────────────────────────────────
-			sc.Step(`^the response status is ALREADY_EXISTS$`, func(ctx context.Context) (context.Context, error) {
-				st, _ := status.FromError(env.lastErr)
-				if st.Code() != codes.AlreadyExists {
-					return ctx, fmt.Errorf("expected ALREADY_EXISTS, got %w", env.lastErr)
-				}
-				return ctx, nil
-			})
 			sc.Step(`^the response status is INVALID_ARGUMENT$`, func(ctx context.Context) (context.Context, error) {
 				st, _ := status.FromError(env.lastErr)
 				if st.Code() != codes.InvalidArgument {


### PR DESCRIPTION
## fix(agent-registry): make RegisterAgent idempotent on agent ID

Closes #1463

### Why  (symptom + root cause)
**Symptom:** in the kind demo, a capability adapter pod that restarts (crash, rollout) without a graceful deregister crash-loops, so the hero workflow never reaches a result.
**Root cause:** `domain.Register` returned `ErrAgentAlreadyExists` when a `Registered` agent with the same ID re-registered (service.go ~L38-41), and both adapters treat `codes.AlreadyExists` as a non-transient failure → exit 1. The Postgres repo already upserts (`ON CONFLICT (id) DO UPDATE`), so the durable fix is registry-side idempotency.

### What you'll get  (deliverables ↔ what changed)
- Re-registering an already-REGISTERED agent ID **succeeds** (upserts endpoint/capabilities/metadata, preserves the original `RegisteredAt`) ← `services/agent-registry/internal/domain/service.go`
- The dead `codes.AlreadyExists` mapping and the now-unreferenced `ErrAgentAlreadyExists` sentinel are removed ← `internal/api/handler.go`, `internal/domain/errors.go`
- Regression tests at the domain, gRPC-handler, and BDD layers now assert idempotent success (not `ALREADY_EXISTS`) ← `internal/domain/service_test.go`, `internal/api/handler_test.go`, `tests/features/agent_registry.feature`, `tests/steps_test.go`

### Scope & boundaries
- **In scope:** the genuinely-remaining **sub-issue 4** of #1463 — registry-side idempotent `RegisterAgent` + its regression tests + the adapter-pod-restart runtime proof.
- **Confirmed-resolved by intervening PRs (verified live here, not just trusted):**
  - **Sub-issue 1** — SSE 500 "streaming not supported" → fixed in **#1431** (Flush forwarded); status/`/logs` path served with no 500 during the demo.
  - **Sub-issue 2** — stale images → **#1462 / #1492** (`KIND_LOAD_IMAGES=1` side-loads current local `:main` images); confirmed my locally-built `agent-registry:main` ran in-cluster.
  - **Sub-issue 3** — recipe masks failure → **#1492** (`scripts/demo/kind-demo.sh` now `die`s on any hero-run failure and gates the "Platform ready" banner on COMPLETED); directly observed the script `die` on a FAILED run instead of printing the banner.
- **Out of scope (deferred):** the langgraph-adapter deregisters on SIGTERM, so a `rollout restart` can race the new pod's register against the old pod's deregister (same `AGENT_ID`), transiently leaving the agent DEREGISTERED until the next register. This is a pre-existing rollout-ordering concern independent of this fix — N/A here (it does not affect re-register survival, which is what #1463 sub-issue 4 asks for).

### Test plan & acceptance

| Acceptance criterion | How verified (command) | Result |
|----------------------|------------------------|--------|
| Sub-issue 4: re-registering an already-REGISTERED agent succeeds (domain) | `GOWORK=off go test ./internal/domain/... -race` | ✅ `TestRegister_IsIdempotent` — endpoint upserted, `RegisteredAt` preserved |
| Sub-issue 4: re-register returns OK over gRPC (not ALREADY_EXISTS) | `GOWORK=off go test ./internal/api/... -race` | ✅ `TestRegisterAgent_IsIdempotent` — OK + upserted endpoint |
| Sub-issue 4: BDD duplicate-registration is idempotent | `GOWORK=off go test ./tests/... -race` | ✅ "Re-registering an existing agent_id is idempotent" → OK |
| Sub-issue 4: adapter pod survives restart (no crash-loop) | `kubectl -n zynax rollout restart deployment/echo-worker` ×2 | ✅ Ready both times, RESTARTS=0, "agent registered" each restart |
| Sub-issue 1: no SSE 500 on the demo path | `make demo` (status poll + `/logs`) | ✅ no 500 (#1431) |
| Sub-issue 2: current local images in-cluster | `make kind-up` `KIND_LOAD_IMAGES=1` side-load | ✅ `agent-registry:main` sha256:3310d31 loaded (#1462/#1492) |
| Sub-issue 3: recipe dies on failure, no false banner | first `make demo` hero run | ✅ `die`d on `WORKFLOW_STATUS_FAILED`, no "Platform ready" (#1492) |
| End-to-end: hero workflow reaches COMPLETED | apply `e2e-demo` via gateway, poll | ✅ `wf-6854420f656b23d7` → `WORKFLOW_STATUS_COMPLETED` |

**Local gates:** `make lint-go` ✅ (0 issues) · local `golangci-lint run` ✅ (0 issues) · `GOWORK=off go build ./...` ✅ · `GOWORK=off go test ./... -race` ✅ · domain coverage **93.9%** (≥90%)

### Evidence
- **CI:** pending — see checks on this PR.
- **Local output:** domain `coverage: 93.9% of statements`; domain/api/BDD tests all `ok` with `-race`.
- **Runtime (isolated kind, PROFILE=lite, cluster `zynax-deliver-1463`):** my `agent-registry:main` (sha256:3310d31) side-loaded; `echo-worker` re-registered cleanly across **2** `rollout restart`s (Ready, RESTARTS=0, "agent registered" each time) — with the OLD code this crash-loops on `AlreadyExists`; a fresh hero workflow then dispatched `echo` and reached `WORKFLOW_STATUS_COMPLETED`.
- **Artifacts / images:** `agent-registry` source changed → image rebuild expected on merge.
- **Post-merge digest sync → main:** _placeholder — to be filled by the post-merge verifier after the release pipeline runs._

### Risk & rollback
Low. Behaviour change is confined to the `RegisterAgent` happy path (an error case becomes a success-upsert); all other RPCs are untouched. The Postgres repo already upserted, so this only aligns the domain layer with the durable store. Rollback = revert this PR (restores the `ErrAgentAlreadyExists` sentinel, mapping, and the old tests).

### Review aids
Start at `internal/domain/service.go` `Register` — the one behavioural change (the `FindByID` lookup now preserves `RegisteredAt` on upsert instead of erroring). Everything else (handler mapping removal, sentinel removal, three test layers) is a consequence of that. The lite-profile `zynax-event-bus` DNS WARNs in the engine-adapter logs are expected (event-bus disabled in lite) and non-fatal.

**AI:** `Assisted-by: Claude/claude-opus-4-8`  (label: ai-assisted)
