### PR TITLE
docs(readme): wedge-first five-minute golden path on kind

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,25 +21,71 @@ _The engine-portability layer for agentic automation._
 
 ---
 
-## See it run — one command
+## See it run — the five-minute golden path
+
+**Write your workflow once — run it on Temporal *or* Argo, on a local Kubernetes cluster
+that mirrors production.** That engine portability is the wedge: a Kubernetes-locked agent
+platform cannot move one workflow across engines. This path proves it on your laptop, with
+**zero secrets and no model** for the first success.
+
+**Prerequisites:** Docker + [kind](https://kind.sigs.k8s.io/) + `kubectl` + [Helm](https://helm.sh/),
+and a host with **~4 CPU / 8 GB RAM**. ([ADR-041](docs/adr/ADR-041-kind-native-unified-runtime.md)
+makes local Kubernetes the one runtime model — see [why](#why-kind) below.)
+
+### 1. Boot the cluster — one command
 
 ```bash
 make demo
 ```
 
-`make demo` boots the minimal stack with a zero-secret local-LLM ([Ollama](https://ollama.com)) overlay
-and runs the hero code-review workflow end-to-end — a real model reviews a git diff and prints its
-verdict, straight from the CLI. The only prerequisites are Docker and pulling the demo model once
-(`ollama pull qwen2.5-coder:3b`). Tear it down with `make demo-clean`.
+`make demo` creates a [kind](https://kind.sigs.k8s.io/) cluster, loads the images, installs the
+**production Helm charts**, waits for every Deployment to roll out, then runs the hero workflow with
+the in-cluster **`echo`** capability — **no Ollama, no model, no API key needed for first success**.
+When it finishes it prints a **Platform ready** banner with the gateway URL
+(`http://localhost:8080`). Lean laptop? `PROFILE=lite make demo`.
 
-> **Zero-dependency first win** — want a success before any model or secret? Run the
-> [`hello-world`](spec/workflows/examples/hello-world.yaml) workflow on the same kind cluster:
-> `zynax --api-url http://localhost:8080 apply spec/workflows/examples/hello-world.yaml` (the built-in
-> `echo` capability, no Ollama, no API key).
+### 2. Reach the gateway and run your first workflow
 
-> **Switch engines, same workflow** — the demo runs on Temporal by default; run the *same*
-> manifest on Argo with one flag: `ENGINE=argo make demo` (or `E2E_ENGINE=argo make demo`). That
-> portability — write once, run on Temporal **or** Argo, no rewrite — is the wedge ([ADR-041](docs/adr/), [#1370](https://github.com/zynax-io/zynax/issues/1370)).
+The api-gateway is auth-enabled, so fetch the bearer key the cluster provisioned, then apply the
+zero-dependency [`hello-world`](spec/workflows/examples/hello-world.yaml) workflow (the built-in
+`echo` capability — no model, no external secret):
+
+```bash
+export ZYNAX_API_KEY=$(kubectl -n zynax get secret zynax-gw-api-key -o jsonpath='{.data.api-key}' | base64 -d)
+zynax apply spec/workflows/examples/hello-world.yaml
+# run_id: wf-<hex>
+
+zynax status workflow wf-<hex>
+# WORKFLOW_STATUS_COMPLETED
+```
+
+That `WORKFLOW_STATUS_COMPLETED` is your first success — the engine dispatched the in-cluster `echo`
+capability and ran to a terminal state with zero secrets. Inspect the run with
+`zynax logs wf-<hex>`.
+
+The CLI defaults to `--api-url http://localhost:8080` (mapped from the kind NodePort `30080`). The
+NodePort can be reset by kube-proxy on repeat runs; if `localhost:8080` is flaky, port-forward to a
+**different** local port (the NodePort already holds `8080`) and target it with `--api-url`:
+
+```bash
+kubectl -n zynax port-forward svc/zynax-api-gateway 18080:8080 &
+zynax --api-url http://localhost:18080 apply spec/workflows/examples/hello-world.yaml
+```
+
+### 3. Switch engines — same workflow, one flag
+
+```bash
+ENGINE=argo make demo     # (or E2E_ENGINE=argo make demo)
+```
+
+The *same* `hello-world.yaml` runs unchanged on Argo instead of Temporal — write once, run on
+either engine, no rewrite. That is the wedge ([ADR-041](docs/adr/ADR-041-kind-native-unified-runtime.md),
+[#1370](https://github.com/zynax-io/zynax/issues/1370)). Tear it all down with `make kind-down`.
+
+> **Next:** a real model reviews a git diff (the code-review demo), scaling onto k3s / managed
+> Kubernetes, and observability are covered in the **[kind how-to](docs/quickstart.md)** — not
+> inlined here. <a id="why-kind"></a>**Why kind?** One runtime for local, CI, and prod, and it is
+> the only way to run Argo locally — see [ADR-041](docs/adr/ADR-041-kind-native-unified-runtime.md).
 
 <!-- asciinema cast — record locally with `make demo` and `asciinema rec docs/casts/make-demo.cast`.
      See docs/casts/README.md. Once recorded, replace the placeholder below with the upload embed. -->
@@ -335,50 +381,15 @@ Layer 1 YAML is never imported by Go services. Cross-service reads always go thr
 
 ## Quickstart
 
-> **Prefer raw `docker compose` (no `make`)?** See
-> [docs/running-with-docker-compose.md](docs/running-with-docker-compose.md) — three commands to a
-> result, then optional depth (full platform, observability).
+The five-minute golden path lives in **[See it run](#see-it-run--the-five-minute-golden-path)**
+above (`make demo` on kind → fetch key → `zynax apply hello-world` → result). The full kind how-to —
+the code-review model demo, scaling onto k3s / managed Kubernetes, and observability — is
+**[docs/quickstart.md](docs/quickstart.md)**.
 
-### Try it with Docker
-
-**Prerequisites:** Docker Desktop + the `zynax` CLI (see [Install](#install-the-zynax-cli) above).
-
-> **M5 status note:** `make run-local` starts all five platform services: api-gateway,
-> workflow-compiler, engine-adapter, task-broker, and agent-registry, plus Temporal and NATS.
-> Workflows submit, dispatch capabilities to registered agents, and produce state-transition logs.
-> To exercise end-to-end capability dispatch, register an adapter (e.g. http-adapter) with the
-> agent-registry before running `zynax apply`.
-
-```bash
-git clone https://github.com/zynax-io/zynax.git
-cd zynax
-
-# Start the full local stack (all 5 platform services + Temporal + NATS)
-make run-local
-
-# Apply an example workflow manifest
-export ZYNAX_API_URL=http://localhost:7080
-zynax apply spec/workflows/examples/code-review.yaml
-# run_id: wf-<hex>
-
-zynax status workflow wf-<hex>
-# status: Running   current_state: review
-
-zynax logs wf-<hex>
-# streams state-transition events (capability dispatch pending M5.C)
-
-# Stop the stack when done
-make stop-local
-```
-
-Port map while the stack is running:
-
-| Endpoint | URL |
-|----------|-----|
-| api-gateway HTTP | http://localhost:7080 |
-| Temporal Web UI | http://localhost:7088 |
-| Temporal gRPC | localhost:7233 |
-| NATS | localhost:7422 |
+> **Docker Compose is deprecated** as the local runtime ([ADR-041](docs/adr/ADR-041-kind-native-unified-runtime.md)):
+> it cannot run the Argo engine and structurally diverges from production. Use the kind path above.
+> The legacy Compose runbook is kept for reference only at
+> [docs/running-with-docker-compose.md](docs/running-with-docker-compose.md).
 
 ### Develop locally
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,252 +1,164 @@
-# Quick Start
+<!-- SPDX-License-Identifier: Apache-2.0 -->
 
-> **In a hurry?** Run `make demo` for the one-command path: it boots a zero-secret local-LLM
-> stack and runs the hero code-review workflow end-to-end. Prereq: `ollama pull qwen2.5-coder:3b`.
-> The steps below walk through the same flow manually.
->
-> **Without `make`?** [running-with-docker-compose.md](running-with-docker-compose.md) is the raw
-> `docker compose` runbook — three commands to a result, then optional depth.
+# Quick Start — Zynax on kind
 
-Get from a fresh clone to a **traced workflow run** in minutes. Everything runs in
-Docker — the only prerequisite is Docker Desktop (or Docker Engine + the Compose plugin).
+The single how-to for running Zynax locally on a [kind](https://kind.sigs.k8s.io/) cluster that
+mirrors production. The **five-minute golden path** (boot → first workflow → switch engines) lives
+in the root [README "See it run"](../README.md#see-it-run--the-five-minute-golden-path); this page
+goes one level deeper — the real-model code-review demo, the engine-portability switch, scaling
+beyond kind, and observability.
 
-By the end you will have:
-
-1. A zero-secret local-LLM stack running (the base stack + the Ollama overlay).
-2. The hero `code-review-ollama` workflow applied with `zynax apply`.
-3. The run watched live with `zynax logs --follow` and its review printed with `zynax result`.
-4. (Optional) The trace and logs for that run visible in the Uptrace UI.
-
-Every command shown below maps to a real `zynax` subcommand — see
-[Command reference](#command-reference) at the end for the full list and how each was
-verified against the CLI source. Prefer watching it run first? See the recorded
-walkthroughs in [docs/casts/](casts/).
+> **Docker Compose is deprecated** as the local runtime ([ADR-041](adr/ADR-041-kind-native-unified-runtime.md)):
+> it cannot run the Argo engine and structurally diverges from production. The legacy Compose runbook
+> is kept for reference only at [running-with-docker-compose.md](running-with-docker-compose.md).
 
 ---
 
-## 1. Clone and bootstrap
+## Prerequisites
+
+- **Docker** Engine / Docker Desktop.
+- **[kind](https://kind.sigs.k8s.io/)**, **`kubectl`**, and **[Helm](https://helm.sh/)** on your PATH.
+- A host with **~4 CPU / 8 GB RAM** (the resource floor — see [ADR-041](adr/ADR-041-kind-native-unified-runtime.md)).
+- The **`zynax` CLI** — `make install-cli` (builds → `~/bin/zynax`; ensure `~/bin` is on PATH), or a
+  release binary (see the root [README § zynax CLI](../README.md#zynax-cli--user-facing-binary)).
+
+No Go, Python, or `buf` is needed locally — `make demo` builds and loads images inside containers.
+
+---
+
+## 1. Boot the cluster
 
 ```bash
 git clone https://github.com/zynax-io/zynax.git
 cd zynax
-make bootstrap    # one-time: pulls ghcr.io/zynax-io/zynax/tools:latest from GHCR
+
+make demo            # create kind cluster → load images → install Helm umbrella → wait rollout
 ```
 
-`make bootstrap` is only needed once after cloning. Nothing else needs Go, Python, or
-`buf` installed locally — they all run inside containers.
+`make demo` runs the full lifecycle and prints a **Platform ready** banner with the gateway URL
+(`http://localhost:8080`) once every Deployment is Available. The banner is never a premature "go"
+signal — it is gated on `kubectl rollout status` for all services.
+
+Lean laptop? `PROFILE=lite make demo` swaps the durable Temporal trio for a single in-cluster dev
+Temporal and disables the event-bus / memory-service.
 
 ---
 
-## 2. Install the `zynax` CLI
+## 2. Reach the gateway
 
-The CLI talks to the api-gateway over HTTP REST. Build it from source (requires the
-Go toolchain pinned in [go.work](../go.work)) or grab a release binary:
+The api-gateway is auth-enabled. Fetch the bearer key the cluster provisioned:
 
 ```bash
-make install-cli                       # builds → ~/bin/zynax (ensure ~/bin is on PATH)
-# or download a pre-built binary — see docs/local-dev.md
+export ZYNAX_API_KEY=$(kubectl -n zynax get secret zynax-gw-api-key -o jsonpath='{.data.api-key}' | base64 -d)
 ```
 
-Confirm it runs:
+The CLI defaults to `--api-url http://localhost:8080` (the kind NodePort `30080` mapped to host
+`8080`). The NodePort can be reset by kube-proxy on repeat runs; if `localhost:8080` is flaky,
+port-forward to a **different** local port (the NodePort already holds `8080`) and target it with
+`--api-url`:
 
 ```bash
-zynax --version
+kubectl -n zynax port-forward svc/zynax-api-gateway 18080:8080 &
+# then add --api-url http://localhost:18080 to the zynax commands below
 ```
 
 ---
 
-## 3. Start the stack with the zero-secret Ollama overlay
+## 3. First success — the zero-dependency workflow
 
-The fastest runnable path needs **no API keys and no cloud LLM**. A small Compose
-overlay ([docker-compose.ollama.yml](../infra/docker-compose/docker-compose.ollama.yml))
-adds an `ollama` service inside the network and repoints the llm-adapter at it via
-[ollama/llm-adapter.config.yaml](../infra/docker-compose/ollama/llm-adapter.config.yaml) —
-which registers a `codereview` capability against a local model. Pull the demo model
-once on the host (the overlay reuses host-pulled models read-only — nothing is
-re-downloaded), then layer the overlay on the base stack:
+[`hello-world.yaml`](../spec/workflows/examples/hello-world.yaml) dispatches the in-cluster `echo`
+capability and completes — **no model, no secret**. Validate it locally, then submit:
 
 ```bash
-ollama pull qwen2.5-coder:3b               # default model (see override note below)
+zynax validate spec/workflows/examples/hello-world.yaml   # static + data-flow checks (no gateway)
+zynax apply spec/workflows/examples/hello-world.yaml       # submit
+# run_id: wf-<hex>
 
-docker compose \
-  -f infra/docker-compose/docker-compose.yml \
-  -f infra/docker-compose/docker-compose.ollama.yml \
-  up -d --wait
+zynax status workflow wf-<hex>
+# WORKFLOW_STATUS_COMPLETED
+
+zynax logs wf-<hex>                                        # the lifecycle events for the run
 ```
 
-This starts the api-gateway, engine-adapter, workflow-compiler, Temporal, NATS, the
-`ollama` service, and the llm-adapter — all locally, with no secrets.
+`WORKFLOW_STATUS_COMPLETED` is your first success: the engine dispatched the in-cluster `echo`
+capability and ran to a terminal state with zero secrets.
 
-**Model / host-path overrides** (both optional):
-
-- The model lives in one line of `ollama/llm-adapter.config.yaml`
-  (`model: qwen2.5-coder:3b`). To switch, edit that line (e.g. `model: llama3.2:3b`) and
-  pull the new model on the host.
-- The overlay bind-mounts the host models dir read-only, defaulting to a systemd
-  install path. Override it for other setups:
-
-  ```bash
-  OLLAMA_HOST_MODELS=$HOME/.ollama/models docker compose \
-    -f infra/docker-compose/docker-compose.yml \
-    -f infra/docker-compose/docker-compose.ollama.yml up -d --wait
-  ```
-
-> **Cloud LLM instead?** Drop the `-f docker-compose.ollama.yml` overlay and run plain
-> `make run-local`; the baked llm-adapter config then expects an OpenAI key.
-
-When it finishes, the api-gateway is reachable on port `7080`. The CLI defaults to
-`http://localhost:8080`, so point it at the local gateway:
-
-```bash
-export ZYNAX_API_URL=http://localhost:7080
-```
-
-Verify the stack is healthy — `/healthz` returns a small JSON status body:
-
-```bash
-curl http://localhost:7080/healthz
-```
-
-Useful endpoints:
-
-| URL | What |
-|-----|------|
-| `http://localhost:7080` | api-gateway HTTP REST (`ZYNAX_API_URL`) |
-| `http://localhost:7088` | Temporal Web UI — inspect workflow executions |
-
-See [infra/docker-compose/README.md](../infra/docker-compose/README.md) for the full
-port map and startup order.
+> **No need to shuttle the id around.** `apply` records your most recent run locally, so a bare
+> `zynax status` / `zynax logs` (no id) targets it. An explicit id always overrides.
 
 ---
 
-## 4. (Optional) Start the observability stack
+## 4. The real-model code-review demo (optional)
 
-To see traces and logs in a UI, bring up the Uptrace overlay. Telemetry is **off by
-default** and env-gated, so this step is optional — the workflow run works without it.
+To run a workflow where a real model reviews a git diff, you need a model available to the
+llm-adapter. Pull it once on the host so the in-cluster adapter can reach it:
 
 ```bash
-cp infra/docker-compose/observability/.env.observability.example \
-   infra/docker-compose/observability/.env.observability
-# edit the file — set a login + token (there are no committed defaults)
-
-make obs-up    # Uptrace UI → http://localhost:7020
+ollama pull qwen2.5-coder:3b           # default model; see infra/docker-compose/ollama/llm-adapter.config.yaml
 ```
 
-Then point the platform services at the collector and restart the stack so they export
-telemetry:
+Then apply [`code-review-ollama.yaml`](../spec/workflows/examples/code-review-ollama.yaml) — it runs
+to completion from the CLI alone (its initial state dispatches the `codereview` capability over a
+real git diff, then transitions to a terminal state):
 
 ```bash
-export ZYNAX_OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:7017
-make run-local
-```
-
-The Uptrace login UI is at `http://localhost:7020` (use the login/token you set in the
-`.env.observability` file). For the full telemetry guide see
-[docs/observability/](observability/).
-
----
-
-## 5. Apply the runnable workflow
-
-The hero example is
-[code-review-ollama.yaml](../spec/workflows/examples/code-review-ollama.yaml) — it runs
-to completion from the CLI alone: its initial state dispatches the `codereview`
-capability (served by the llm-adapter pointed at your local Ollama model) over a real git
-diff, then transitions to a terminal state. Validate it, then submit:
-
-```bash
-zynax validate spec/workflows/examples/code-review-ollama.yaml      # static + data-flow checks
-zynax apply --dry-run spec/workflows/examples/code-review-ollama.yaml   # compile without submitting
-zynax apply spec/workflows/examples/code-review-ollama.yaml         # submit
+zynax apply spec/workflows/examples/code-review-ollama.yaml
+zynax logs <run-id> --follow            # stream every state + step output as it completes
+zynax result <run-id>                   # print just the model's review text
 ```
 
 > Other examples under [spec/workflows/examples/](../spec/workflows/examples/) (e.g.
-> `code-review.yaml`) are **reference specs** that wait on external GitHub/review events —
-> use them to learn the data-flow patterns, but they do not run to completion from the CLI
-> alone.
-
-`apply` prints the run identifier:
-
-```
-run_id: <run-id>
-```
-
-Copy that `run_id` — the next step uses it.
-
-> **No need to shuttle the id around.** `apply` records your most recent run
-> locally, so a bare `zynax logs` / `zynax result` (no id) targets it. An
-> explicit id always overrides; delete `<user-config-dir>/zynax/last-run` to
-> reset.
-
-> **Starting from scratch?** `zynax init workflow my-pipeline -o my-pipeline.yaml`
-> scaffolds a valid, versioned manifest from a template. Run `zynax validate
-> my-pipeline.yaml` before applying.
+> `code-review.yaml`) are **reference specs** that wait on external GitHub/review events — use them to
+> learn the data-flow patterns, but they do not run to completion from the CLI alone. Drive one
+> forward with `zynax events publish <run-id> review.approved --data reviewer=alice`.
 
 ---
 
-## 6. Watch the run
+## 5. Switch engines — the portability wedge
 
-Check the current status (exits `0` if terminal, `2` if still running):
-
-```bash
-zynax status workflow <run-id>
-```
-
-Tail the run live — the command follows lifecycle events (state transitions and
-capability events) and exits once the workflow reaches a terminal state (`-f` is the
-short flag; `--format json` emits one JSON object per event):
+The same manifest runs unchanged on Temporal **or** Argo — selection flows through the cluster, never
+the workflow file:
 
 ```bash
-zynax logs <run-id> --follow
+ENGINE=argo make demo     # (or E2E_ENGINE=argo make demo)
 ```
 
-Print just the capability output — the model's review text — straight from the CLI:
-
-```bash
-zynax result <run-id>
-```
-
-For a full snapshot of a run (id, workflow, status, current state, version):
-
-```bash
-zynax get workflow <run-id>
-```
-
-For event-driven workflows (the reference `code-review.yaml` waits on review events),
-inject an event from the CLI to drive the run forward:
-
-```bash
-zynax events publish <run-id> review.approved --data reviewer=alice
-```
+This is the wedge: write once, run on whichever engine your org already operates. Argo is only
+runnable locally because the runtime is Kubernetes ([ADR-041](adr/ADR-041-kind-native-unified-runtime.md),
+[#1370](https://github.com/zynax-io/zynax/issues/1370)).
 
 ---
 
-## 7. See the trace and logs (if observability is running)
+## 6. Scaling beyond kind
 
-Open the Uptrace UI at `http://localhost:7020`, log in, and find the trace for your run.
-Traces, metrics, logs, and APM are correlated by `trace_id`/`span_id`, so you can jump
-from a span to the matching log records for the same run.
+kind, k3s / k3d, and managed Kubernetes are the **same runtime model** at larger scale — the Helm
+umbrella `make demo` installs is the production chart. Point `kubectl` at any cluster and
+`helm upgrade --install` the same umbrella. See [docs/local-dev.md](local-dev.md) and the Helm chart
+README under `infra/helm/` for cluster targeting, values overrides, and multi-namespace deploys.
+
+---
+
+## 7. Observability (optional)
+
+Telemetry is **off by default** and env-gated. To see traces, metrics, logs, and APM correlated by
+`trace_id`/`span_id` in the Uptrace UI, follow [docs/observability/](observability/) (`opentelemetry.md`
+and `uptrace.md`) for the in-cluster OTel collector + Uptrace wiring. The golden path above works
+without it.
 
 ---
 
 ## 8. Tear down
 
 ```bash
-docker compose \
-  -f infra/docker-compose/docker-compose.yml \
-  -f infra/docker-compose/docker-compose.ollama.yml \
-  down --remove-orphans      # or: make demo-clean
-
-make obs-down                # stop the observability stack (if started)
+make kind-down       # delete the kind cluster (wraps scripts/e2e/cluster-down.sh)
 ```
 
 ---
 
 ## Command reference
 
-Every command this guide shows is a real `zynax` subcommand. Verify the surface yourself
-with `zynax --help` (and `zynax <cmd> --help`); the source of record is
-[cmd/zynax/cmd/](../cmd/zynax/cmd/).
+Every command this guide shows is a real `zynax` subcommand. Verify the surface yourself with
+`zynax --help` (and `zynax <cmd> --help`); the source of record is [cmd/zynax/cmd/](../cmd/zynax/cmd/).
 
 | Command | Purpose | Key flags |
 |---------|---------|-----------|
@@ -255,19 +167,24 @@ with `zynax --help` (and `zynax <cmd> --help`); the source of record is
 | `zynax apply <file>` | Submit a manifest to the gateway | `--dry-run`, `--engine` |
 | `zynax status workflow <run-id>` | Status (exit 0 terminal, 2 running) | — |
 | `zynax logs <run-id>` | Stream lifecycle events | `--follow/-f`, `--format text\|json` |
-| `zynax result <run-id>` | Print the capability output (review text) | — |
+| `zynax result <run-id>` | Print the capability output | — |
 | `zynax get workflow <run-id>` | Full run snapshot | — |
 | `zynax delete workflow <run-id>` | Cancel/remove a run | — |
 | `zynax events publish <run-id> <event-type>` | Inject an event into a running workflow | `--data key=value` (repeatable) |
+
+Global flags (any subcommand): `--api-url` (`$ZYNAX_API_URL`, default `http://localhost:8080`),
+`--api-key` (`$ZYNAX_API_KEY`, the gateway bearer token), `--insecure`.
 
 ---
 
 ## What next
 
 - **[Developer Guide](developer-guide.md)** — the Make targets and daily workflow.
-- **[Local Development Guide](local-dev.md)** — CLI install options and persona paths.
-- **[Human-validation guide](contributing/human-validation-guide.md)** — how to validate a
-  change actually runs (the standard the demo path is checked against).
+- **[Local Development Guide](local-dev.md)** — CLI install options and cluster targeting.
+- **[Human-validation guide](contributing/human-validation-guide.md)** — how to validate a change
+  actually runs (the standard the demo path is checked against).
 - **[docs/casts/](casts/)** — recorded terminal walkthroughs of these flows.
-- **[spec/workflows/examples/](../spec/workflows/examples/)** — the reference workflows and
-  their data-flow patterns.
+- **[spec/workflows/examples/](../spec/workflows/examples/)** — the reference workflows and their
+  data-flow patterns.
+</content>
+</invoke>

--- a/docs/running-with-docker-compose.md
+++ b/docs/running-with-docker-compose.md
@@ -1,12 +1,21 @@
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-# Running Zynax with raw `docker compose`
+# Running Zynax with raw `docker compose` — DEPRECATED
 
-Everything `make demo` does, as plain `docker compose` + `zynax` commands — no `make` required.
-Start with the simplest run; the rest is optional depth.
+> ## ⚠️ DEPRECATED — Docker Compose is no longer the sanctioned local runtime
+>
+> [**ADR-041**](adr/ADR-041-kind-native-unified-runtime.md) retires Docker Compose as the primary
+> local path. It cannot run the **Argo engine** (Argo is Kubernetes-native), so the
+> engine-portability wedge cannot be demonstrated on Compose, and it structurally diverges from
+> production. No new feature work targets Compose; it will be **removed** once the kind path reaches
+> parity.
+>
+> **Use the kind path instead:** the five-minute golden path in the root
+> [README "See it run"](../README.md#see-it-run--the-five-minute-golden-path), and the full
+> [Quick Start on kind](quickstart.md). This page is retained for reference only.
 
-> For the gentle, narrated walkthrough see [quickstart.md](quickstart.md). This page is the
-> no-`make` operator reference.
+The historical runbook below documents everything `make demo-compose` did, as plain `docker compose` +
+`zynax` commands — no `make` required.
 
 ---
 


### PR DESCRIPTION
Closes #1494

## Why

After ADR-041 (kind-native unified runtime, Compose retired as the primary path) and the EPIC #1370 closeout stories O18–O23 (#1488–#1493) merged, the README "See it run" was stale and **wrong**:

- It claimed `make demo` boots a Docker-Compose **"Ollama overlay"** — but `make demo` now boots a **kind** cluster running the prod Helm charts, and first success uses the in-cluster **echo** capability (no model).
- The documented `zynax apply` command was **missing `--api-key`** and would return **HTTP 401** — the gateway is auth-enabled (#1517 added `--api-key`/`ZYNAX_API_KEY`).

This PR makes the golden path **runnable verbatim** on a local kind cluster, wedge-first, ≤ 4 concepts to first success.

## What you'll get

- A wedge-first opening: "Write your workflow once — run it on Temporal *or* Argo, on a kind cluster that mirrors production."
- A verbatim-runnable golden path: `make demo` → `export ZYNAX_API_KEY=$(kubectl …)` → `zynax apply hello-world` → `zynax status workflow` returns `WORKFLOW_STATUS_COMPLETED`.
- kind prerequisites (Docker + kind + kubectl + Helm) and the **~4 CPU / 8 GB RAM** floor stated up front.
- The `ENGINE=argo make demo` engine switch (same manifest, other engine).
- Reaching the gateway documented for kind: host `8080` / NodePort `30080`, with a `kubectl port-forward` fallback (to a non-8080 local port, since the NodePort already holds 8080).
- The three onboarding docs consolidated into **one** kind how-to (`docs/quickstart.md`); advanced / scaling (k3s/managed k8s) / observability are **linked, not inlined**; `docs/running-with-docker-compose.md` is marked **DEPRECATED** (cites ADR-041).

## Test plan & acceptance

| AC | Acceptance criterion | Evidence |
|----|----------------------|----------|
| AC1 | README golden path runnable **verbatim** on kind (`make demo`), matches real CLI/cluster surface | **Verified verbatim** on an isolated kind cluster (`CLUSTER_NAME=zynax-deliver-1494 make kind-up PROFILE=lite`): the exact `export ZYNAX_API_KEY=$(kubectl -n zynax get secret zynax-gw-api-key -o jsonpath='{.data.api-key}' \| base64 -d)` + `zynax apply spec/workflows/examples/hello-world.yaml` returned a `run_id` (no 401), and `zynax status workflow` returned `WORKFLOW_STATUS_COMPLETED`. Output pasted in Evidence. |
| AC2 | Opening leads with the engine-portability wedge (Temporal OR Argo) | README "See it run" first line is the wedge; "control plane" framing removed from the hero. |
| AC3 | First success requires ONE doc page (README), ≤ 4 concepts | README-only: kind cluster → api-key → apply → status. The four concepts before first success. |
| AC4 | Advanced/scaling/observability LINKED not inlined; three onboarding docs consolidated into one kind how-to; Compose marked DEPRECATED | README links to `docs/quickstart.md` (the single kind how-to) for code-review/scaling/observability; `docs/quickstart.md` rewritten as Quick Start on kind; `docs/running-with-docker-compose.md` carries a DEPRECATED banner citing ADR-041. |
| AC5 | kind prerequisites + resource floor up front; gateway reach on kind documented (host 8080 / NodePort 30080 or port-forward) | README Prerequisites line: Docker + kind + kubectl + Helm + ~4 CPU / 8 GB RAM; gateway reach documented with the NodePort default and the verified port-forward fallback. |

## Evidence

Verbatim golden-path run on an isolated kind cluster (`zynax-deliver-1494`, lite profile), CLI built from this branch:

```
# cluster-up host NodePort assertion
[cluster-up]   ✓ host NodePort path verified — http://localhost:8080 reaches the api-gateway (HTTP 200).

$ kubectl -n zynax get secret zynax-gw-api-key -o jsonpath='{.data.api-key}' | base64 -d
f0bd7426…   (redacted)

$ ZYNAX_API_KEY=… zynax apply spec/workflows/examples/hello-world.yaml
run_id: wf-67d8e8cf923af1b6

$ ZYNAX_API_KEY=… zynax status workflow wf-67d8e8cf923af1b6
WORKFLOW_STATUS_COMPLETED

$ ZYNAX_API_KEY=… zynax logs wf-67d8e8cf923af1b6
… [2026-06-26T00:53:36Z] WorkflowExecutionCompleted  (WORKFLOW_STATUS_COMPLETED)
```

Port-forward fallback also verified (NodePort holds host 8080, so the forward must use a different local port):

```
$ kubectl -n zynax port-forward svc/zynax-api-gateway 18080:8080 &
$ ZYNAX_API_KEY=… zynax --api-url http://localhost:18080 apply spec/workflows/examples/hello-world.yaml
run_id: wf-67d8e8cf923af1b6-1782435307
$ ZYNAX_API_KEY=… zynax --api-url http://localhost:18080 status workflow wf-67d8e8cf923af1b6-1782435307
WORKFLOW_STATUS_COMPLETED
```

Note: `zynax result` for the echo capability returns "no result payload" in this build, so the golden path confirms success via `zynax status workflow` → `WORKFLOW_STATUS_COMPLETED` (the verified-truthful signal) rather than a result-payload echo.

## Review aids

- Three files changed: `README.md` (hero rewrite + Quickstart pointer), `docs/quickstart.md` (rewritten as the single kind how-to), `docs/running-with-docker-compose.md` (DEPRECATED banner).
- docs/ is exempt from the PR-size and REASONS-Canvas gates.
- Governing decision: [ADR-041](docs/adr/ADR-041-kind-native-unified-runtime.md).

Assisted-by: Claude/claude-opus-4-8
