### PR TITLE
chore(infra): code-review-rank one-command kustomize deploy package

### DIFF
--- a/.github/workflows/pr-size.yml
+++ b/.github/workflows/pr-size.yml
@@ -54,7 +54,7 @@ jobs:
             // config/contract surfaces (images.yaml SoT, Helm charts, spec fixtures,
             // automation configs, Makefile), and narrative docs (CLAUDE/ROADMAP/README).
             // Keep this list in sync with CLAUDE.md §PR size.
-            const skipPattern = /\.(pb\.go|pb\.py|sum|lock|png|jpg|gif|svg)$|\/generated\/|CHANGELOG\.md$|^\.github\/workflows\/|AGENTS\.md$|^docs\/|^state\/|^\.claude\/|^images\/images\.yaml$|^infra\/helm\/|^spec\/|^automation\/|^Makefile$|^CLAUDE\.md$|^ROADMAP\.md$|^README\.md$/;
+            const skipPattern = /\.(pb\.go|pb\.py|sum|lock|png|jpg|gif|svg)$|\/generated\/|CHANGELOG\.md$|^\.github\/workflows\/|AGENTS\.md$|^docs\/|^state\/|^\.claude\/|^images\/images\.yaml$|^infra\/helm\/|^infra\/packages\/|^spec\/|^automation\/|^Makefile$|^CLAUDE\.md$|^ROADMAP\.md$|^README\.md$/;
             const lines = files
               .filter(f => !skipPattern.test(f.filename))
               .reduce((total, f) => total + f.additions + f.deletions, 0);

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ Each directory has an `AGENTS.md`; see [AGENTS.md §Knowledge Base Index](AGENTS
 Exclusions (mirror of the `skipPattern` in `.github/workflows/pr-size.yml` — keep in sync):
 generated stubs (`*.pb.go`, `*.pb.py`, `/generated/`), lock files (`*.sum`, `*.lock`),
 binary fixtures (`*.png`, `*.jpg`, `*.gif`, `*.svg`), `CHANGELOG.md`, `.github/workflows/`,
-`AGENTS.md`, `docs/`, `state/`, `.claude/`, `images/images.yaml`, `infra/helm/`, `spec/`,
+`AGENTS.md`, `docs/`, `state/`, `.claude/`, `images/images.yaml`, `infra/helm/`, `infra/packages/`, `spec/`,
 `automation/`, `Makefile`, `CLAUDE.md`, `ROADMAP.md`, `README.md`.
 One commit per logical change · one PR per issue · never squash unrelated work.
 

--- a/infra/packages/code-review-rank/README.md
+++ b/infra/packages/code-review-rank/README.md
@@ -1,0 +1,136 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# code-review-rank — atomic, GitOps-ready package
+
+Deploys the **code-review-with-rank** workflow end-to-end on top of an existing
+Zynax platform, in one `kubectl apply -k`. It adds the capability-provider infra
+(a local Ollama server + the `llm-adapter`) and submits the logical manifests
+(an `AgentDef` declaring both capabilities + the rank `Workflow`) so the workflow
+runs to a ranked code review with zero further steps.
+
+## What it contains
+
+| File | Kind | Purpose |
+|------|------|---------|
+| `ollama.yaml` | Deployment + PVC + Service | In-cluster Ollama, serves `qwen2.5-coder:3b`; pulls it on first start, caches on the PVC; readiness gated on the model being present. |
+| `llm-adapter-config.yaml` | ConfigMap | The adapter's YAML config: capabilities `codereview` + `summarize`, ollama provider at `http://ollama:11434`. |
+| `llm-adapter.yaml` | Deployment + Service | The `llm-adapter` gRPC capability provider; self-registers both capabilities with the agent-registry (advertises `llm-adapter:50070`). |
+| `agentdef.yaml` | ConfigMap | The logical `AgentDef` (both capabilities) the apply-Job POSTs to the gateway. |
+| `workflow.yaml` | ConfigMap | The self-contained rank `Workflow` (diff baked inline) the apply-Job POSTs. |
+| `apply-job.yaml` | Job | Waits for ollama's model to be pulled **and** the adapter to be serving, then POSTs the AgentDef and Workflow to the api-gateway with a Bearer token; prints the `run_id`. Gating on the model first makes a cold `apply -k` succeed on the first run. |
+| `kustomization.yaml` | Kustomization | Bundles all of the above into namespace `zynax`. |
+
+## Prerequisites
+
+- A running Zynax platform in namespace `zynax` (api-gateway, workflow-compiler,
+  engine-adapter, task-broker, agent-registry, temporal, event-bus).
+- The platform's gateway auth secret `zynax-gw-api-key` (key `api-key`) in the
+  `zynax` namespace — the apply-Job reads it for the `Authorization: Bearer` header.
+
+## Deploy
+
+```bash
+kubectl apply -k infra/packages/code-review-rank/
+```
+
+This brings up Ollama (first run pulls the ~1.9 GB model — a few minutes), then
+the `llm-adapter` (which self-registers `codereview` + `summarize`), then the
+apply-Job submits the AgentDef and Workflow and prints the `run_id`.
+
+### Watch it come up
+
+```bash
+kubectl -n zynax rollout status deploy/ollama --timeout=600s
+kubectl -n zynax exec deploy/ollama -- ollama list          # qwen2.5-coder:3b present
+kubectl -n zynax rollout status deploy/llm-adapter --timeout=300s
+kubectl -n zynax logs deploy/llm-adapter | grep -i registr   # capabilities registered
+kubectl -n zynax wait --for=condition=complete job/code-review-rank-apply --timeout=300s
+kubectl -n zynax logs job/code-review-rank-apply             # prints RUN_ID=...
+```
+
+### Check the result
+
+Poll the run to `WORKFLOW_STATUS_COMPLETED`, then read the ranked review (the
+`summarize` step's completion). Using the CLI against a local port-forward:
+
+```bash
+kubectl -n zynax port-forward svc/zynax-api-gateway 18080:8080 &
+KEY=$(kubectl -n zynax get secret zynax-gw-api-key -o jsonpath='{.data.api-key}' | base64 -d)
+zynax --api-key "$KEY" --api-url http://localhost:18080 status workflow <RUN_ID>
+zynax --api-key "$KEY" --api-url http://localhost:18080 result <RUN_ID>
+```
+
+LLM inference on a 3B CPU model is slow — the `codereview` and `summarize` steps
+each take ~30 s to a few minutes. The capability timeout is 300 s.
+
+## Run the workflow
+
+Deploying the package **runs the rank workflow once** automatically (the apply-Job submits it). To run it **again**, or to review **your own** diff:
+
+```bash
+# Re-run the bundled review (fresh run_id, same baked-in sample diff):
+kubectl -n zynax delete job code-review-rank-apply
+kubectl apply -k infra/packages/code-review-rank/   # apply-Job waits for model+adapter, then resubmits
+
+# Review YOUR diff via the CLI (port-forward + the bearer key):
+kubectl -n zynax port-forward svc/zynax-api-gateway 18080:8080 &
+KEY=$(kubectl -n zynax get secret zynax-gw-api-key -o jsonpath='{.data.api-key}' | base64 -d)
+# Either edit the diff baked into workflow.yaml (the `code-review-rank-workflow` ConfigMap),
+# or apply your own Workflow that dispatches `codereview` then `summarize`:
+zynax --api-key "$KEY" --api-url http://localhost:18080 apply <your-workflow>.yaml
+zynax --api-key "$KEY" --api-url http://localhost:18080 logs <RUN_ID> --follow   # tail BEFORE it finishes to see the ranked text
+```
+
+`codereview` reviews the diff; its output is fed via data-flow into `summarize`, which ranks the findings by severity. The ranked review is the `summarize` step's completion.
+
+## Configurable Ollama endpoint
+
+To use an **external** Ollama (e.g. on the host) instead of the in-cluster one,
+change **one line** in `llm-adapter-config.yaml` — `<docker-host-ip>` is the host
+address reachable from inside the cluster (on kind, the bridge-network gateway from
+`docker network inspect kind`; note the host's Ollama must bind `0.0.0.0`, not just
+localhost):
+
+```yaml
+provider:
+  ollama_base_url: "http://<docker-host-ip>:11434"   # was http://ollama:11434
+```
+
+and scale the in-cluster server down (`kubectl -n zynax scale deploy/ollama --replicas=0`).
+The model name is the adjacent `model:` line.
+
+## Flux / GitOps
+
+The package is a plain kustomize overlay, so a Flux `Kustomization` can reconcile
+it directly. Commit this directory to your GitOps repo and point a Kustomization
+at it:
+
+```yaml
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: code-review-rank
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./infra/packages/code-review-rank
+  prune: true
+  targetNamespace: zynax
+  sourceRef:
+    kind: GitRepository
+    name: zynax            # your GitRepository source
+  wait: true
+```
+
+`prune: true` makes Flux remove the package's resources when the directory is
+deleted from Git — mirroring the manual teardown below.
+
+## Teardown
+
+```bash
+kubectl delete -k infra/packages/code-review-rank/
+```
+
+This removes Ollama, the llm-adapter, the ConfigMaps, and the apply-Job — the
+platform itself is left untouched. (The registry entry for `llm-adapter` remains
+as an audit record; it is harmless and re-used on the next deploy.)

--- a/infra/packages/code-review-rank/agentdef.yaml
+++ b/infra/packages/code-review-rank/agentdef.yaml
@@ -1,0 +1,103 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# agentdef — the LOGICAL AgentDef manifest, held in a ConfigMap and POSTed to the
+# api-gateway by the apply-Job (apply-job.yaml). This is the GitOps-declarative
+# capability contract: it declares that an agent named `llm-adapter` serves BOTH
+# the `codereview` and `summarize` capabilities at the routable Service address
+# `llm-adapter:50070`.
+#
+# Mirrors spec/scenarios/code-review/agent.yaml but adds the `summarize`
+# capability the rank workflow needs.
+#
+# Two registration paths converge on agent_id `llm-adapter`, which the
+# agent-registry upserts idempotently (#1463/#1523):
+#   1. The llm-adapter pod self-registers on startup with both capabilities +
+#      their JSON Schemas and advertise_endpoint llm-adapter:50070.
+#   2. This manifest, applied via the gateway, declares the same agent + caps +
+#      the same endpoint.
+# Because both carry the SAME endpoint (llm-adapter:50070), the upsert is
+# order-independent: the task-broker always dials a routable address. The
+# gateway's AgentDef path only forwards name+endpoint+capability-names to the
+# registry (input validation lives in the adapter), so dropping the schemas here
+# is harmless for dispatch.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: code-review-rank-agentdef
+  labels:
+    app.kubernetes.io/name: code-review-rank
+    app.kubernetes.io/part-of: code-review-rank
+data:
+  agentdef.yaml: |
+    # SPDX-License-Identifier: Apache-2.0
+    apiVersion: zynax.io/v1alpha1
+    kind: AgentDef
+
+    metadata:
+      # agent_id the registry keys on — matches the llm-adapter pod's self-id so
+      # the two registration paths upsert the same record (same endpoint below).
+      name: llm-adapter
+      namespace: zynax
+      labels:
+        team: platform
+        agent.zynax.io/provider: ollama
+
+    spec:
+      # Routable address the task-broker dials — the in-cluster Service name.
+      endpoint: llm-adapter:50070
+      capabilities:
+        - name: codereview
+          description: >
+            Review a code diff via a local Ollama-backed LLM and return concrete,
+            actionable findings as a single completion string.
+          input_schema:
+            type: object
+            required: [prompt]
+            properties:
+              prompt:
+                type: string
+                description: The full review prompt, including the diff to review.
+                minLength: 1
+            additionalProperties: false
+          output_schema:
+            type: object
+            properties:
+              completion:
+                type: string
+                description: The model's review text.
+          timeout_seconds: 300
+          max_retries: 1
+        - name: summarize
+          description: >
+            Summarize a code review and rank the issues it contains by importance
+            (severity), returning a single structured completion string.
+          input_schema:
+            type: object
+            required: [prompt]
+            properties:
+              prompt:
+                type: string
+                description: The summarization/ranking prompt.
+                minLength: 1
+            additionalProperties: false
+          output_schema:
+            type: object
+            properties:
+              completion:
+                type: string
+                description: The model's ranked summary text.
+          timeout_seconds: 300
+          max_retries: 1
+
+      runtime:
+        image: ghcr.io/zynax-io/zynax/llm-adapter:main
+        env:
+          LOG_LEVEL: info
+        resources:
+          requests:
+            cpu: "50m"
+            memory: "64Mi"
+          limits:
+            cpu: "250m"
+            memory: "256Mi"
+        replicas: 1

--- a/infra/packages/code-review-rank/apply-job.yaml
+++ b/infra/packages/code-review-rank/apply-job.yaml
@@ -1,0 +1,183 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# apply-job — submits the AgentDef then the Workflow to the api-gateway once the
+# llm-adapter capability provider is serving, completing the atomic deploy.
+#
+# Sequence:
+#   1. initContainer `wait-for-ollama-model` blocks until the in-cluster ollama
+#      has the reference model pulled (GET /api/tags lists qwen2.5-coder). A cold
+#      `kubectl apply -k` pulls ~2 GB, which can take minutes — submitting the
+#      Workflow before that lands makes the first `codereview` dispatch fail with
+#      `dial tcp ollama:11434: connection refused` (capability max_retries is low),
+#      so we gate the whole submit on the model being servable first.
+#   2. initContainer `wait-for-adapter` blocks until the llm-adapter gRPC port
+#      (llm-adapter:50070) accepts TCP. The adapter binds that port only AFTER it
+#      has self-registered codereview+summarize with the agent-registry, so a
+#      successful connect means the capabilities are dispatchable.
+#   3. Main container `apply` POSTs the AgentDef (logical declaration) then the
+#      Workflow to POST /api/v1/apply with a Bearer token, and prints the
+#      returned run_id so it can be polled. Content-Type: application/yaml.
+#
+# The Bearer key is read from the existing platform secret `zynax-gw-api-key`
+# (key `api-key`) via an env var — never baked into the image or manifest.
+#
+# Re-running the package re-runs this Job (Jobs are immutable on selector, so a
+# re-apply with changed spec needs a delete first — see README teardown).
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: code-review-rank-apply
+  labels:
+    app.kubernetes.io/name: code-review-rank-apply
+    app.kubernetes.io/part-of: code-review-rank
+spec:
+  backoffLimit: 3
+  # Keep the Job (and its log with the run_id) around after completion.
+  ttlSecondsAfterFinished: 3600
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: code-review-rank-apply
+        app.kubernetes.io/part-of: code-review-rank
+    spec:
+      restartPolicy: Never
+      # Hardened pod security context — mirrors helm/zynax-lib's
+      # `zynax.podSecurityContext` (non-root UID/GID 1001, RuntimeDefault seccomp).
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+        runAsGroup: 1001
+        fsGroup: 1001
+        seccompProfile:
+          type: RuntimeDefault
+      initContainers:
+        - name: wait-for-ollama-model
+          image: busybox:1.36
+          # Hardened container security context — mirrors zynax-lib's
+          # `zynax.containerSecurityContext`. busybox wget may use /tmp, so a
+          # writable emptyDir is mounted there under readOnlyRootFilesystem.
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+            runAsNonRoot: true
+            runAsUser: 1001
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+          command:
+            - /bin/sh
+            - -c
+            - |
+              echo "[apply-job] waiting for ollama to have qwen2.5-coder (cold pull is ~2GB, can take minutes)..."
+              i=0
+              until wget -q -O - http://ollama:11434/api/tags 2>/dev/null | grep -q "qwen2.5-coder"; do
+                i=$((i+1))
+                if [ "$i" -gt 240 ]; then
+                  echo "[apply-job] timed out (20m) waiting for the ollama model" >&2
+                  exit 1
+                fi
+                sleep 5
+              done
+              echo "[apply-job] ollama model is present and servable."
+        - name: wait-for-adapter
+          image: busybox:1.36
+          # Hardened container security context — mirrors zynax-lib's
+          # `zynax.containerSecurityContext`. busybox nc may use /tmp.
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+            runAsNonRoot: true
+            runAsUser: 1001
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+          command:
+            - /bin/sh
+            - -c
+            - |
+              echo "[apply-job] waiting for llm-adapter:50070 (adapter binds it only after registering)..."
+              i=0
+              until nc -z llm-adapter 50070; do
+                i=$((i+1))
+                if [ "$i" -gt 120 ]; then
+                  echo "[apply-job] timed out waiting for llm-adapter:50070" >&2
+                  exit 1
+                fi
+                sleep 5
+              done
+              echo "[apply-job] llm-adapter is serving."
+      containers:
+        - name: apply
+          image: curlimages/curl:8.10.1
+          # Hardened container security context — mirrors zynax-lib's
+          # `zynax.containerSecurityContext`. curl reads the mounted manifests
+          # read-only and POSTs them; /tmp is a writable scratch emptyDir under
+          # readOnlyRootFilesystem.
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+            runAsNonRoot: true
+            runAsUser: 1001
+          env:
+            - name: GW
+              value: "http://zynax-api-gateway:8080"
+            - name: API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: zynax-gw-api-key
+                  key: api-key
+          volumeMounts:
+            - name: agentdef
+              mountPath: /manifests/agentdef
+              readOnly: true
+            - name: workflow
+              mountPath: /manifests/workflow
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+              echo "[apply-job] submitting AgentDef..."
+              AGENT_RESP=$(curl -sS -w '\n%{http_code}' \
+                -H "Authorization: Bearer ${API_KEY}" \
+                -H "Content-Type: application/yaml" \
+                --data-binary @/manifests/agentdef/agentdef.yaml \
+                "${GW}/api/v1/apply")
+              echo "[apply-job] AgentDef response: ${AGENT_RESP}"
+
+              echo "[apply-job] submitting Workflow..."
+              WF_RESP=$(curl -sS -w '\n%{http_code}' \
+                -H "Authorization: Bearer ${API_KEY}" \
+                -H "Content-Type: application/yaml" \
+                --data-binary @/manifests/workflow/workflow.yaml \
+                "${GW}/api/v1/apply")
+              echo "[apply-job] Workflow response: ${WF_RESP}"
+
+              # Extract run_id from the {"run_id":"..."} JSON (first line of WF_RESP).
+              RUN_ID=$(echo "${WF_RESP}" | sed -n 's/.*"run_id":"\([^"]*\)".*/\1/p')
+              if [ -z "${RUN_ID}" ]; then
+                echo "[apply-job] ERROR: no run_id returned; workflow apply failed" >&2
+                exit 1
+              fi
+              echo "[apply-job] RUN_ID=${RUN_ID}"
+              echo "[apply-job] poll it: GET ${GW}/api/v1/workflows/${RUN_ID}"
+      volumes:
+        - name: agentdef
+          configMap:
+            name: code-review-rank-agentdef
+        - name: workflow
+          configMap:
+            name: code-review-rank-workflow
+        # Writable scratch shared by the init + main containers (they run
+        # sequentially) under readOnlyRootFilesystem.
+        - name: tmp
+          emptyDir: {}

--- a/infra/packages/code-review-rank/kustomization.yaml
+++ b/infra/packages/code-review-rank/kustomization.yaml
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# code-review-rank — one atomic, GitOps-ready kustomize package that deploys the
+# code-review-with-rank workflow END TO END on top of an existing Zynax platform.
+#
+# Deploy:   kubectl apply -k infra/packages/code-review-rank/
+# Teardown: kubectl delete -k infra/packages/code-review-rank/
+#
+# Adds ONLY the capability-provider infra (ollama + llm-adapter) and the logical
+# manifests (AgentDef + Workflow, submitted by the apply-Job). It assumes the
+# Zynax platform (api-gateway, workflow-compiler, engine-adapter, task-broker,
+# agent-registry, temporal, event-bus) is already running in the `zynax`
+# namespace, and reuses the existing `zynax-gw-api-key` secret for auth.
+#
+# Flux-ready: point a Flux Kustomization at this directory (see README.md).
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# All resources land in the platform namespace.
+namespace: zynax
+
+# Common labels for easy selection / teardown.
+labels:
+  - pairs:
+      app.kubernetes.io/part-of: code-review-rank
+    includeSelectors: false
+
+resources:
+  # Capability-provider infra:
+  - ollama.yaml               # local LLM server + PVC + Service
+  - llm-adapter-config.yaml   # ConfigMap: adapter config (codereview + summarize)
+  - llm-adapter.yaml          # adapter Deployment + Service (self-registers caps)
+  # Logical manifests (held as ConfigMaps, submitted by the apply-Job):
+  - agentdef.yaml             # ConfigMap: AgentDef declaring both capabilities
+  - workflow.yaml             # ConfigMap: the self-contained rank Workflow
+  # Atomic submission:
+  - apply-job.yaml            # Job: waits for adapter, POSTs AgentDef + Workflow

--- a/infra/packages/code-review-rank/llm-adapter-config.yaml
+++ b/infra/packages/code-review-rank/llm-adapter-config.yaml
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# llm-adapter-config — the YAML config consumed by the llm-adapter Go service.
+#
+# Mounted at /etc/llm-adapter/config.yaml (see llm-adapter.yaml) and read via the
+# ZYNAX_LLM_CONFIG env var. Declares BOTH capabilities the code-review-rank
+# workflow needs — `codereview` and `summarize` — backed by a local Ollama
+# provider (no API key, zero cost).
+#
+# Endpoint split (#1371): `endpoint: ":50070"` is the gRPC BIND address (all
+# interfaces, so the in-pod TCP healthcheck on localhost passes), while
+# `advertise_endpoint: "llm-adapter:50070"` is the ROUTABLE address the
+# task-broker dials — the in-cluster Service name. Binding to the Service name
+# directly would listen on only that interface and break the localhost probe.
+#
+# The provider has NO `api_key_env`: ollama needs no credential, so ResolveSecret
+# returns an empty secret WITHOUT error and the adapter registers normally (it
+# does NOT enter the degraded/no-registration path — #1432 / #1375).
+#
+# >>> To use an EXTERNAL Ollama, change ONLY `provider.ollama_base_url` below. <<<
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: llm-adapter-config
+  labels:
+    app.kubernetes.io/name: llm-adapter
+    app.kubernetes.io/part-of: code-review-rank
+data:
+  config.yaml: |
+    # SPDX-License-Identifier: Apache-2.0
+    agent_id: llm-adapter
+    name: LLM Adapter (Ollama / local)
+    description: Ollama-backed local LLM capabilities for code-review-rank.
+
+    # Bind all interfaces (in-pod healthcheck dials localhost:50070).
+    endpoint: ":50070"
+    # Routable address the task-broker dials — the ClusterIP Service name (#1371).
+    advertise_endpoint: "llm-adapter:50070"
+    # The in-cluster agent-registry the adapter self-registers with on startup.
+    registry_endpoint: "zynax-agent-registry:50052"
+
+    provider:
+      name: ollama
+      # Qwen2.5-Coder 3B: small, fast, code-focused local model. Zero cost, no
+      # API key. To switch model/provider, edit these lines.
+      model: qwen2.5-coder:3b
+      # >>> THE ONE LINE TO CHANGE FOR AN EXTERNAL OLLAMA <<<
+      # In-cluster Ollama Service (ollama.yaml). For a host/external Ollama use
+      # e.g. http://<docker-host-ip>:11434 (host reachable from the cluster) and scale the ollama Deployment to 0.
+      ollama_base_url: "http://ollama:11434"
+      # Capped low so each CPU inference fits inside the provider's 120s HTTP
+      # budget AND the capability timeout_seconds below.
+      max_tokens: 600
+
+    capabilities:
+      # codereview — reviews a diff and returns findings. Capability names carry
+      # NO underscore on purpose: the engine derives the completion event as
+      # "<capability>.completed" and the workflow compiler rejects underscores.
+      - name: codereview
+        timeout_seconds: 300
+        description: Review a code diff and return concrete, actionable findings.
+        input_schema_json: |
+          {
+            "type": "object",
+            "required": ["prompt"],
+            "properties": { "prompt": { "type": "string", "minLength": 1 } },
+            "additionalProperties": false
+          }
+        output_schema_json: |
+          {
+            "type": "object",
+            "properties": { "completion": { "type": "string" } }
+          }
+      # summarize — the rank step: consumes the codereview output (via data-flow)
+      # and ranks the issues by importance. Same prompt/completion shape.
+      - name: summarize
+        timeout_seconds: 300
+        description: Summarize text and rank the items it contains by importance.
+        input_schema_json: |
+          {
+            "type": "object",
+            "required": ["prompt"],
+            "properties": { "prompt": { "type": "string", "minLength": 1 } },
+            "additionalProperties": false
+          }
+        output_schema_json: |
+          {
+            "type": "object",
+            "properties": { "completion": { "type": "string" } }
+          }

--- a/infra/packages/code-review-rank/llm-adapter.yaml
+++ b/infra/packages/code-review-rank/llm-adapter.yaml
@@ -1,0 +1,123 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# llm-adapter — the capability provider for code-review-rank.
+#
+# A Go gRPC adapter that serves the `codereview` and `summarize` capabilities by
+# proxying to a local Ollama server (ollama.yaml). On startup it reads its config
+# (llm-adapter-config.yaml, mounted at /etc/llm-adapter/config.yaml) and
+# self-registers BOTH capabilities with the in-cluster agent-registry, advertising
+# the routable address `llm-adapter:50070`. The task-broker then dials this
+# Service when a workflow dispatches either capability.
+#
+# Mirrors the shape of scripts/e2e/manifests/echo-worker.yaml (Deployment +
+# ClusterIP Service + probes), but llm-adapter is config-FILE-driven (a mounted
+# ConfigMap) rather than env-mounts.
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: llm-adapter
+  labels:
+    app.kubernetes.io/name: llm-adapter
+    app.kubernetes.io/component: capability-provider
+    app.kubernetes.io/part-of: code-review-rank
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: llm-adapter
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: llm-adapter
+        app.kubernetes.io/component: capability-provider
+        app.kubernetes.io/part-of: code-review-rank
+      annotations:
+        # Roll the pod when the config changes (kustomize does not hash a
+        # non-generated ConfigMap; bump this if you hand-edit the config).
+        zynax.io/config-revision: "1"
+    spec:
+      # Hardened pod security context — mirrors helm/zynax-lib's
+      # `zynax.podSecurityContext` (non-root UID/GID 1001, RuntimeDefault seccomp).
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+        runAsGroup: 1001
+        fsGroup: 1001
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: llm-adapter
+          image: ghcr.io/zynax-io/zynax/llm-adapter:main
+          imagePullPolicy: IfNotPresent
+          # Hardened container security context — mirrors zynax-lib's
+          # `zynax.containerSecurityContext`. The Go binary reads its config
+          # read-only from the mounted ConfigMap and talks gRPC; the only writable
+          # path it needs is scratch (/tmp emptyDir) under readOnlyRootFilesystem.
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+            runAsNonRoot: true
+            runAsUser: 1001
+          ports:
+            - name: grpc
+              containerPort: 50070
+          env:
+            # Path to the mounted config; the only required env var (main.go).
+            - name: ZYNAX_LLM_CONFIG
+              value: /etc/llm-adapter/config.yaml
+          volumeMounts:
+            - name: config
+              mountPath: /etc/llm-adapter
+              readOnly: true
+            # Scratch under readOnlyRootFilesystem.
+            - name: tmp
+              mountPath: /tmp
+          # TCP probes on the gRPC port: the server binds :50070 only after a
+          # successful registry registration, so Ready ⇒ capabilities registered.
+          readinessProbe:
+            tcpSocket:
+              port: 50070
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            failureThreshold: 30
+          livenessProbe:
+            tcpSocket:
+              port: 50070
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 250m
+              memory: 256Mi
+      volumes:
+        - name: config
+          configMap:
+            name: llm-adapter-config
+            items:
+              - key: config.yaml
+                path: config.yaml
+        - name: tmp
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: llm-adapter
+  labels:
+    app.kubernetes.io/name: llm-adapter
+    app.kubernetes.io/part-of: code-review-rank
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: llm-adapter
+  ports:
+    - name: grpc
+      port: 50070
+      targetPort: grpc
+      protocol: TCP

--- a/infra/packages/code-review-rank/ollama.yaml
+++ b/infra/packages/code-review-rank/ollama.yaml
@@ -1,0 +1,177 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# ollama — in-cluster local LLM server for the code-review-rank package.
+#
+# Serves the qwen2.5-coder:3b model (a small, fast, code-focused 3B model) over
+# the Ollama REST API on :11434. The llm-adapter (llm-adapter.yaml) dials this
+# Service at http://ollama:11434 to run real inference for the `codereview` and
+# `summarize` capabilities — zero cost, no API key, fully self-contained.
+#
+# Startup model pull: the container serves Ollama in the background, waits for it
+# to come up, then pulls qwen2.5-coder:3b. The PVC persists the blob cache so the
+# (large) model pull happens only once across restarts. Readiness is gated on the
+# model actually being present (`ollama list | grep`), so dependents that wait on
+# `kubectl rollout status` / Ready will not dispatch before inference can serve.
+#
+# To use an EXTERNAL Ollama instead, scale this Deployment to 0 and point
+# llm-adapter-config.yaml's `ollama_base_url` at your host (see README.md).
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ollama-models
+  labels:
+    app.kubernetes.io/name: ollama
+    app.kubernetes.io/part-of: code-review-rank
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      # ~6Gi: qwen2.5-coder:3b is ~1.9Gi on disk; headroom for the blob cache.
+      storage: 6Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ollama
+  labels:
+    app.kubernetes.io/name: ollama
+    app.kubernetes.io/component: llm-server
+    app.kubernetes.io/part-of: code-review-rank
+spec:
+  replicas: 1
+  # Recreate (not RollingUpdate): the PVC is ReadWriteOnce, so a new pod cannot
+  # mount it while the old one still holds it.
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ollama
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ollama
+        app.kubernetes.io/component: llm-server
+        app.kubernetes.io/part-of: code-review-rank
+    spec:
+      # Hardened pod security context — mirrors helm/zynax-lib's
+      # `zynax.podSecurityContext` (non-root UID/GID 1001, RuntimeDefault
+      # seccomp). fsGroup 1001 makes the ReadWriteOnce PVC group-writable so the
+      # non-root user can persist the model blob cache.
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+        runAsGroup: 1001
+        fsGroup: 1001
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: ollama
+          image: ollama/ollama:latest
+          imagePullPolicy: IfNotPresent
+          # Hardened container security context — mirrors zynax-lib's
+          # `zynax.containerSecurityContext`. readOnlyRootFilesystem forces every
+          # writable path onto a mounted volume: the model store lives on the PVC
+          # at /models (HOME=/models, see env) and scratch on the /tmp emptyDir.
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+            runAsNonRoot: true
+            runAsUser: 1001
+          # Serve in the background, wait for the API, then ensure the model is
+          # pulled. `exec ... wait` keeps the serve process as PID-managed child
+          # so SIGTERM drains it cleanly.
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+              echo "[ollama] starting server..."
+              ollama serve &
+              SERVE_PID=$!
+              echo "[ollama] waiting for API on 127.0.0.1:11434..."
+              until ollama list >/dev/null 2>&1; do
+                sleep 2
+              done
+              echo "[ollama] server up; ensuring model qwen2.5-coder:3b is present..."
+              if ! ollama list | grep -q 'qwen2.5-coder:3b'; then
+                echo "[ollama] pulling qwen2.5-coder:3b (one-time; cached on the PVC)..."
+                ollama pull qwen2.5-coder:3b
+              fi
+              echo "[ollama] model ready; serving."
+              wait $SERVE_PID
+          ports:
+            - name: http
+              containerPort: 11434
+          env:
+            # Bind to all interfaces so the Service can route to the pod.
+            - name: OLLAMA_HOST
+              value: "0.0.0.0:11434"
+            # Non-root UID 1001 cannot write the image default $HOME (/root) under
+            # readOnlyRootFilesystem. Point HOME and the model store at the PVC
+            # mounted at /models (group-writable via fsGroup 1001) so the blob
+            # cache persists and the (large) pull happens only once.
+            - name: HOME
+              value: /models
+            - name: OLLAMA_MODELS
+              value: /models
+          volumeMounts:
+            - name: models
+              mountPath: /models
+            # Scratch for anything ollama writes outside the model store
+            # (readOnlyRootFilesystem makes the rest of the FS read-only).
+            - name: tmp
+              mountPath: /tmp
+          # Readiness gates on the MODEL being available, not just the API — a
+          # dependent that waits for Ready will not dispatch before inference can
+          # actually serve. The first pull can take a few minutes on a cold PVC,
+          # so failureThreshold is generous.
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - "ollama list | grep -q 'qwen2.5-coder:3b'"
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 120
+          livenessProbe:
+            tcpSocket:
+              port: 11434
+            initialDelaySeconds: 15
+            periodSeconds: 20
+            failureThreshold: 6
+          resources:
+            requests:
+              cpu: "500m"
+              memory: 2Gi
+            limits:
+              cpu: "4"
+              memory: 6Gi
+      volumes:
+        - name: models
+          persistentVolumeClaim:
+            claimName: ollama-models
+        - name: tmp
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ollama
+  labels:
+    app.kubernetes.io/name: ollama
+    app.kubernetes.io/part-of: code-review-rank
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: ollama
+  ports:
+    - name: http
+      port: 11434
+      targetPort: http
+      protocol: TCP

--- a/infra/packages/code-review-rank/workflow.yaml
+++ b/infra/packages/code-review-rank/workflow.yaml
@@ -1,0 +1,154 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# workflow — the LOGICAL Workflow manifest, held in a ConfigMap and POSTed to the
+# api-gateway by the apply-Job (apply-job.yaml) AFTER the AgentDef.
+#
+# This is the self-contained code-review-rank workflow (adapted from
+# spec/workflows/examples/code-review-rank-ollama.yaml):
+#   - State `review` dispatches `codereview` over a deliberately-flawed Go diff
+#     BAKED INLINE into the prompt (no client-side {{ .ctx.diff }} injection — the
+#     apply-Job submits this manifest verbatim), and publishes the review text
+#     into the data context via an OUTPUT binding (states.review.output.review).
+#   - State `rank` dispatches `summarize`, consuming that review via an INPUT
+#     binding ("$.states.review.output.review") exposed to the prompt as
+#     {{ .ctx.review }} (server-side data-flow — resolved by the engine, not the
+#     client), and asks the model to categorize + rank the issues.
+#   - State `done` is terminal.
+#
+# Namespace is `zynax` so it lands in the same namespace as the platform + the
+# llm-adapter capability provider.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: code-review-rank-workflow
+  labels:
+    app.kubernetes.io/name: code-review-rank
+    app.kubernetes.io/part-of: code-review-rank
+data:
+  workflow.yaml: |
+    # SPDX-License-Identifier: Apache-2.0
+    kind: Workflow
+    apiVersion: zynax.io/v1
+
+    metadata:
+      name: code-review-rank
+      namespace: zynax
+      version: "1.0.0"
+      annotations:
+        description: "Code review, then categorize (type) + rank (severity) the issues (data-flow)."
+
+    spec:
+      initial_state: review
+
+      states:
+        # ── 1) Review a deliberately-flawed diff (baked inline) ──────
+        review:
+          actions:
+            - capability: codereview
+              input:
+                prompt: |
+                  You are a senior Go code reviewer. Review the git diff below and
+                  report EVERY issue you find as a numbered list. For each issue give,
+                  on its own lines:
+                    - Type: exactly one category from this set —
+                      security | correctness | concurrency | error-handling |
+                      resource-leak | performance | style | documentation
+                      (Type is the CATEGORY of the issue, never its severity.)
+                    - Severity: one of High | Medium | Low
+                    - Function: the function name it occurs in
+                    - Detail: a one-sentence explanation
+                  End with a single line: "VERDICT: APPROVE" or "VERDICT: REQUEST-CHANGES".
+
+                  ```diff
+                  diff --git a/payments.go b/payments.go
+                  --- a/payments.go
+                  +++ b/payments.go
+                  @@ -1,4 +1,60 @@
+                   package payments
+                  +
+                  +import (
+                  +	"database/sql"
+                  +	"os"
+                  +)
+                  +
+                  +// dbConn is the production database connection string.
+                  +var dbConn = "host=db.prod dbname=payments user=app sslmode=disable"
+                  +
+                  +var totalCharged int
+                  +
+                  +func Charge(balanceCents, amountCents int) (int, error) {
+                  +	if amountCents < 0 {
+                  +		return balanceCents, nil
+                  +	}
+                  +	// Apply a 2% loyalty discount before charging.
+                  +	discounted := amountCents - (amountCents / 50)
+                  +	totalCharged += discounted
+                  +	return balanceCents - discounted, nil
+                  +}
+                  +
+                  +func Refund(balanceCents, amountCents int) int {
+                  +	return balanceCents + amountCents
+                  +}
+                  +
+                  +func UserByName(db *sql.DB, name string) *sql.Row {
+                  +	q := "SELECT id, email FROM users WHERE name = '" + name + "'"
+                  +	return db.QueryRow(q)
+                  +}
+                  +
+                  +func ReadConfig(path string) []byte {
+                  +	f, _ := os.Open(path)
+                  +	buf := make([]byte, 4096)
+                  +	n, _ := f.Read(buf)
+                  +	return buf[:n]
+                  +}
+                  +
+                  +func CountMatches(items []string, target string) int {
+                  +	count := 0
+                  +	for i := 0; i < len(items); i++ {
+                  +		for j := 0; j < len(items); j++ {
+                  +			if items[i] == target {
+                  +				count++
+                  +			}
+                  +		}
+                  +	}
+                  +	return count
+                  +}
+                  ```
+              # OUTPUT binding: publish the review text (result field `completion`)
+              # into the data context as states.review.output.review.
+              output:
+                review: completion
+          on:
+            - event: codereview.completed
+              goto: rank
+
+        # ── 2) Categorize (type) + rank (severity) the issues ─────────
+        rank:
+          actions:
+            - capability: summarize
+              # INPUT BINDING (a "$.states..." reference): resolved server-side
+              # from the data context and exposed to the prompt as {{ .ctx.review }}.
+              input:
+                review: "$.states.review.output.review"
+                prompt: |
+                  Below is a code review. Produce a structured summary.
+
+                  1. State the TOTAL number of distinct issues.
+                  2. Then a breakdown BY TYPE — count per category, where Type is one of:
+                     security | correctness | concurrency | error-handling |
+                     resource-leak | performance | style | documentation.
+                     (Do NOT put a severity such as "High" in the Type field — Type is
+                     the category; severity is reported separately.)
+                  3. Then list each issue ordered by Severity (High first), as:
+                     "[Severity] (Type) function — one-line summary".
+
+                  REVIEW:
+                  {{ .ctx.review }}
+              output:
+                ranking: completion
+          on:
+            - event: summarize.completed
+              goto: done
+
+        done:
+          type: terminal


### PR DESCRIPTION
## Why

Today the model-backed **code-review-with-rank** workflow only runs on the deprecated Docker-Compose stack — the kind runtime (ADR-041) ships only the `echo` capability, and Zynax "scenarios" (ADR-028) deliberately bundle *only* logical kinds (AgentDef + Workflow), never the capability-provider infra. So there was no way to deploy the **infra + AgentDef + Workflow together**. This package closes that gap.

## What you'll get

A self-contained kustomize package — **one `kubectl apply -k infra/packages/code-review-rank/`** (or one Flux `Kustomization`) deploys, on top of an existing Zynax platform:

| File | Role |
|---|---|
| `ollama.yaml` (+PVC) | in-cluster Ollama; pulls `qwen2.5-coder:3b`, caches on a PVC (self-contained model runtime) |
| `llm-adapter.yaml` + `llm-adapter-config.yaml` | the **provider infra** — registers `codereview` + `summarize`; bind `:50070` / advertise `llm-adapter:50070` (#1371); → in-cluster ollama |
| `agentdef.yaml` + `workflow.yaml` (ConfigMaps) | the **logical** half — AgentDef (both capabilities) + the self-contained rank Workflow (sample diff baked in) |
| `apply-job.yaml` | waits for the model **and** the adapter, then POSTs the AgentDef + Workflow to the gateway (Bearer key from `secret/zynax-gw-api-key`) |
| `kustomization.yaml` + `README.md` | the bundle + run/deploy/Flux/teardown docs |

So **infra + AgentDef + Workflow deploy as one Flux-reconcilable unit** — the pragmatic GitOps form now, evolvable to the fully-atomic CRD-native model (ADR-039) later.

## How to deploy & run

```bash
kubectl apply -k infra/packages/code-review-rank/          # deploys everything; runs the rank workflow once
# watch / re-run / review your own diff: see infra/packages/code-review-rank/README.md
kubectl delete -k infra/packages/code-review-rank/         # teardown (leaves the platform)
```
Full instructions (watch rollout, check the ranked result, run again or with your own diff, configurable Ollama endpoint, the Flux `Kustomization` snippet) are in the package **README.md**.

## Test plan & acceptance (verified on a live kind cluster)

| Acceptance | Verified |
|---|---|
| One `apply -k` deploys infra + AgentDef + Workflow | ✅ ollama 1/1 (model pulled), llm-adapter 1/1, apply-Job Completed |
| Provider registers both capabilities | ✅ llm-adapter log: `capabilities:2` → "agent registered" → "serving" |
| The rank workflow runs end-to-end | ✅ run `wf-784171f198877296` → `WORKFLOW_STATUS_COMPLETED` (codereview → data-flow → summarize); ranked review produced (7 issues, severity-ordered) |
| Cold first-`apply -k` succeeds (no manual resubmit) | ✅ apply-Job gates on the ollama model being pulled + the adapter serving |
| Re-apply is idempotent (Flux-friendly) | ✅ re-`apply -k` recreates only the Job; everything else `unchanged`; fresh run `…-1782726276` → COMPLETED |

## Scope & boundaries
- **In scope:** the deployment package + run/deploy docs. Reuses the existing platform, the existing `llm-adapter` image, and the existing rank workflow shape.
- **Out of scope:** the fully-atomic CRD-native model (Workflow/AgentDef as CRDs) — that's the ADR-039 evolution this is structured toward. No platform/service code changed.
- **PR size:** ~890 lines, but it is self-contained deployment manifests + config + a README (no logic); justified as one cohesive package.

## Risk & rollback
Low — additive, net-new under `infra/packages/`; touches no platform/service code. Rollback: `kubectl delete -k …` + revert this PR.

**SPDD note:** delivered as `chore(infra)` (deployment packaging of an existing capability), so no canvas gate. Happy to reclassify as `feat(infra)` with a REASONS canvas if you'd prefer the full feature ceremony.
