### PR TITLE
chore(infra): code-review-rank use tiny qwen2.5-coder:0.5b model

### DIFF
--- a/infra/packages/code-review-rank/README.md
+++ b/infra/packages/code-review-rank/README.md
@@ -12,7 +12,7 @@ runs to a ranked code review with zero further steps.
 
 | File | Kind | Purpose |
 |------|------|---------|
-| `ollama.yaml` | Deployment + PVC + Service | In-cluster Ollama, serves `qwen2.5-coder:3b`; pulls it on first start, caches on the PVC; readiness gated on the model being present. |
+| `ollama.yaml` | Deployment + PVC + Service | In-cluster Ollama, serves `qwen2.5-coder:0.5b`; pulls it on first start, caches on the PVC; readiness gated on the model being present. |
 | `llm-adapter-config.yaml` | ConfigMap | The adapter's YAML config: capabilities `codereview` + `summarize`, ollama provider at `http://ollama:11434`. |
 | `llm-adapter.yaml` | Deployment + Service | The `llm-adapter` gRPC capability provider; self-registers both capabilities with the agent-registry (advertises `llm-adapter:50070`). |
 | `agentdef.yaml` | ConfigMap | The logical `AgentDef` (both capabilities) the apply-Job POSTs to the gateway. |
@@ -33,7 +33,7 @@ runs to a ranked code review with zero further steps.
 kubectl apply -k infra/packages/code-review-rank/
 ```
 
-This brings up Ollama (first run pulls the ~1.9 GB model — a few minutes), then
+This brings up Ollama (first run pulls the ~398 MB model — under a minute), then
 the `llm-adapter` (which self-registers `codereview` + `summarize`), then the
 apply-Job submits the AgentDef and Workflow and prints the `run_id`.
 
@@ -41,7 +41,7 @@ apply-Job submits the AgentDef and Workflow and prints the `run_id`.
 
 ```bash
 kubectl -n zynax rollout status deploy/ollama --timeout=600s
-kubectl -n zynax exec deploy/ollama -- ollama list          # qwen2.5-coder:3b present
+kubectl -n zynax exec deploy/ollama -- ollama list          # qwen2.5-coder:0.5b present
 kubectl -n zynax rollout status deploy/llm-adapter --timeout=300s
 kubectl -n zynax logs deploy/llm-adapter | grep -i registr   # capabilities registered
 kubectl -n zynax wait --for=condition=complete job/code-review-rank-apply --timeout=300s

--- a/infra/packages/code-review-rank/apply-job.yaml
+++ b/infra/packages/code-review-rank/apply-job.yaml
@@ -6,7 +6,7 @@
 # Sequence:
 #   1. initContainer `wait-for-ollama-model` blocks until the in-cluster ollama
 #      has the reference model pulled (GET /api/tags lists qwen2.5-coder). A cold
-#      `kubectl apply -k` pulls ~2 GB, which can take minutes — submitting the
+#      `kubectl apply -k` pulls ~398 MB, which can take ~a minute — submitting the
 #      Workflow before that lands makes the first `codereview` dispatch fail with
 #      `dial tcp ollama:11434: connection refused` (capability max_retries is low),
 #      so we gate the whole submit on the model being servable first.
@@ -70,7 +70,7 @@ spec:
             - /bin/sh
             - -c
             - |
-              echo "[apply-job] waiting for ollama to have qwen2.5-coder (cold pull is ~2GB, can take minutes)..."
+              echo "[apply-job] waiting for ollama to have qwen2.5-coder (cold pull is ~398 MB, can take ~a minute)..."
               i=0
               until wget -q -O - http://ollama:11434/api/tags 2>/dev/null | grep -q "qwen2.5-coder"; do
                 i=$((i+1))

--- a/infra/packages/code-review-rank/llm-adapter-config.yaml
+++ b/infra/packages/code-review-rank/llm-adapter-config.yaml
@@ -41,9 +41,11 @@ data:
 
     provider:
       name: ollama
-      # Qwen2.5-Coder 3B: small, fast, code-focused local model. Zero cost, no
-      # API key. To switch model/provider, edit these lines.
-      model: qwen2.5-coder:3b
+      # Qwen2.5-Coder 0.5B: tiny (~398 MB), fast, code-focused local model — small
+      # enough to test the pipeline without a big download. Raise to
+      # qwen2.5-coder:3b (~1.9 GB) for higher-quality reviews. To switch model,
+      # edit this line AND the pull tag + readiness grep in ollama.yaml.
+      model: qwen2.5-coder:0.5b
       # >>> THE ONE LINE TO CHANGE FOR AN EXTERNAL OLLAMA <<<
       # In-cluster Ollama Service (ollama.yaml). For a host/external Ollama use
       # e.g. http://<docker-host-ip>:11434 (host reachable from the cluster) and scale the ollama Deployment to 0.

--- a/infra/packages/code-review-rank/ollama.yaml
+++ b/infra/packages/code-review-rank/ollama.yaml
@@ -2,13 +2,15 @@
 #
 # ollama — in-cluster local LLM server for the code-review-rank package.
 #
-# Serves the qwen2.5-coder:3b model (a small, fast, code-focused 3B model) over
-# the Ollama REST API on :11434. The llm-adapter (llm-adapter.yaml) dials this
+# Serves the qwen2.5-coder:0.5b model (a tiny, fast, code-focused 0.5B model —
+# ~398 MB, vs ~1.9 GB for the 3B; ideal for testing the pipeline without a big
+# download — raise the tag/model to qwen2.5-coder:3b for higher-quality reviews)
+# over the Ollama REST API on :11434. The llm-adapter (llm-adapter.yaml) dials this
 # Service at http://ollama:11434 to run real inference for the `codereview` and
 # `summarize` capabilities — zero cost, no API key, fully self-contained.
 #
 # Startup model pull: the container serves Ollama in the background, waits for it
-# to come up, then pulls qwen2.5-coder:3b. The PVC persists the blob cache so the
+# to come up, then pulls qwen2.5-coder:0.5b. The PVC persists the blob cache so the
 # (large) model pull happens only once across restarts. Readiness is gated on the
 # model actually being present (`ollama list | grep`), so dependents that wait on
 # `kubectl rollout status` / Ready will not dispatch before inference can serve.
@@ -28,8 +30,8 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      # ~6Gi: qwen2.5-coder:3b is ~1.9Gi on disk; headroom for the blob cache.
-      storage: 6Gi
+      # ~2Gi: qwen2.5-coder:0.5b is ~398Mi on disk; headroom for the blob cache.
+      storage: 2Gi
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -96,10 +98,10 @@ spec:
               until ollama list >/dev/null 2>&1; do
                 sleep 2
               done
-              echo "[ollama] server up; ensuring model qwen2.5-coder:3b is present..."
-              if ! ollama list | grep -q 'qwen2.5-coder:3b'; then
-                echo "[ollama] pulling qwen2.5-coder:3b (one-time; cached on the PVC)..."
-                ollama pull qwen2.5-coder:3b
+              echo "[ollama] server up; ensuring model qwen2.5-coder:0.5b is present..."
+              if ! ollama list | grep -q 'qwen2.5-coder:0.5b'; then
+                echo "[ollama] pulling qwen2.5-coder:0.5b (one-time; cached on the PVC)..."
+                ollama pull qwen2.5-coder:0.5b
               fi
               echo "[ollama] model ready; serving."
               wait $SERVE_PID
@@ -134,7 +136,7 @@ spec:
               command:
                 - /bin/sh
                 - -c
-                - "ollama list | grep -q 'qwen2.5-coder:3b'"
+                - "ollama list | grep -q 'qwen2.5-coder:0.5b'"
             initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 5


### PR DESCRIPTION
## Why

The `code-review-rank` package defaulted to `qwen2.5-coder:3b` (~1.9 GB), so a first deploy pulls a ~2 GB model — slow for **testing the pipeline**. Switch the reference model to **`qwen2.5-coder:0.5b` (~398 MB, ~5× smaller)** so the package can be exercised end-to-end without a big download.

## What changed

Swapped `qwen2.5-coder:3b` → `qwen2.5-coder:0.5b` consistently across the package:

| File | Change |
|---|---|
| `llm-adapter-config.yaml` | `model:` → `qwen2.5-coder:0.5b` (+ comment) |
| `ollama.yaml` | `ollama pull` tag + **both readiness greps** (startup + readinessProbe) → `:0.5b`; PVC `6Gi → 2Gi`; comments/sizes |
| `apply-job.yaml` | size mentions in the wait comment/log (the `qwen2.5-coder` grep is tag-less, so it still matches) |
| `README.md` | model + size references |

Same code-focused **Qwen2.5-Coder** family. The 0.5B writes shallower, less-precise reviews, but runs the full pipeline (`codereview` → data-flow → `summarize` → `WORKFLOW_STATUS_COMPLETED`) and is much faster on CPU. **Raise back to `:3b` for higher-quality reviews** — that path is noted inline in both `ollama.yaml` and `llm-adapter-config.yaml`.

## Test plan & acceptance

| Check | Result |
|---|---|
| `kubectl kustomize infra/packages/code-review-rank/` builds | ✅ 9 resources |
| No stray `:3b` in functional spots (model/pull/grep) | ✅ only the intentional "raise to :3b" notes remain |
| Model exists on the Ollama registry at the stated size | ✅ `qwen2.5-coder:0.5b` = 398 MB (instruct) |
| Manifests still pass `security` (Trivy) + `secret scan` | CI on this PR |

**Runtime:** this is a config-only model swap and the dispatch pipeline is model-agnostic, so I did **not** redeploy here (the running cluster is mid-use on the 3B). Verify end-to-end via the from-scratch runbook — it now pulls only ~398 MB.

## Risk & rollback
Low — config only, no platform/service change. Rollback: revert this PR (back to `:3b`), or set the model back in `llm-adapter-config.yaml` + `ollama.yaml`.
