### PR TITLE
fix(cli): zynax result exits 0 on completed-empty runs

### DIFF
--- a/cmd/zynax/cmd/cmd_test.go
+++ b/cmd/zynax/cmd/cmd_test.go
@@ -601,14 +601,62 @@ func TestResultCmd_PrintsCompletion(t *testing.T) {
 	}
 }
 
-func TestResultCmd_NoResult_Errors(t *testing.T) {
+func TestResultCmd_Failed_Errors(t *testing.T) {
 	srv := sseServer(t, []map[string]any{
 		{"run_id": "r6", "event_type": "workflow.failed", "status": "WORKFLOW_STATUS_FAILED"},
 	})
 	apiURL = srv.URL
 
 	if _, err := runResult(t, []string{"r6"}); err == nil {
-		t.Error("expected error when run finishes with no result payload")
+		t.Error("expected error when a FAILED run produced no result payload")
+	}
+}
+
+// runResultStreams runs the result command and returns stdout, stderr, and err
+// separately so the COMPLETED-empty note (written to stderr) can be asserted.
+func runResultStreams(t *testing.T, args []string) (string, string, error) {
+	t.Helper()
+	cmd := &cobra.Command{}
+	var out, errOut bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errOut)
+	cmd.SetContext(context.Background())
+	err := resultCmd.RunE(cmd, args)
+	return out.String(), errOut.String(), err
+}
+
+// TestResultCmd_CompletedNoOutput_ExitsZeroWithNote asserts AC1: a COMPLETED run
+// that declared no output exits 0 (no error), prints nothing to stdout, and emits
+// the graceful runbook note on stderr — a successful run never looks like a failure.
+func TestResultCmd_CompletedNoOutput_ExitsZeroWithNote(t *testing.T) {
+	srv := sseServer(t, []map[string]any{
+		{"run_id": "r7", "event_type": "state.entered", "to_state": "done", "status": "WORKFLOW_STATUS_RUNNING"},
+		{"run_id": "r7", "event_type": "workflow.completed", "status": "WORKFLOW_STATUS_COMPLETED"},
+	})
+	apiURL = srv.URL
+
+	stdout, stderr, err := runResultStreams(t, []string{"r7"})
+	if err != nil {
+		t.Fatalf("COMPLETED-empty run must exit 0, got error: %v", err)
+	}
+	if strings.TrimSpace(stdout) != "" {
+		t.Errorf("stdout should be empty for a no-output run, got: %q", stdout)
+	}
+	if !strings.Contains(stderr, "docs/runbooks/see-workflow-result.md") {
+		t.Errorf("expected runbook note on stderr, got: %q", stderr)
+	}
+}
+
+// TestResultCmd_Cancelled_Errors asserts AC2: a CANCELLED run with no output
+// exits non-zero (a real failure must not read as success).
+func TestResultCmd_Cancelled_Errors(t *testing.T) {
+	srv := sseServer(t, []map[string]any{
+		{"run_id": "r8", "event_type": "workflow.cancelled", "status": "WORKFLOW_STATUS_CANCELLED"},
+	})
+	apiURL = srv.URL
+
+	if _, _, err := runResultStreams(t, []string{"r8"}); err == nil {
+		t.Error("expected non-zero exit for a CANCELLED run with no result")
 	}
 }
 

--- a/cmd/zynax/cmd/result.go
+++ b/cmd/zynax/cmd/result.go
@@ -24,8 +24,9 @@ var resultCmd = &cobra.Command{
 		"With no run id the command targets your most recent run (recorded by the " +
 		"last `zynax apply`/`run`). An explicit run id always overrides.\n\n" +
 		"The command tails the run until it reaches a terminal state and prints the " +
-		"last completion text it saw. Exits with an error if the run finishes with no " +
-		"result (e.g. a failed run).",
+		"last completion text it saw. A run that COMPLETED but declared no output " +
+		"exits 0 with a note (see the see-workflow-result runbook); a FAILED or " +
+		"CANCELLED run exits non-zero.",
 	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		runID, err := resolveRunID(args)
@@ -33,12 +34,13 @@ var resultCmd = &cobra.Command{
 			return err
 		}
 		gw := newGateway()
-		var output string
+		var output, terminalStatus string
 		err = gw.WatchWorkflowLogs(cmd.Context(), runID, func(ev client.LogEvent) error {
 			if text := client.CompletionText(ev.Payload); text != "" {
 				output = text
 			}
 			if terminalStatuses[ev.Status] {
+				terminalStatus = ev.Status
 				return errResultDone
 			}
 			return nil
@@ -46,11 +48,25 @@ var resultCmd = &cobra.Command{
 		if err != nil && !errors.Is(err, errResultDone) {
 			return err
 		}
-		if output == "" {
-			return fmt.Errorf("no result payload for run %s", runID)
+		if output != "" {
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), output)
+			return nil
 		}
-		_, _ = fmt.Fprintln(cmd.OutOrStdout(), output)
-		return nil
+		// No completion text was emitted. A COMPLETED run that simply declared no
+		// output is a success — echo/hello-world style runs produce none — so exit
+		// 0 with a note pointing at the runbook (the structured-output reader in
+		// O.9 supersedes this). FAILED/CANCELLED, or a stream that closed before
+		// any terminal state, remain errors so a real failure never reads as success.
+		switch terminalStatus {
+		case "WORKFLOW_STATUS_COMPLETED":
+			_, _ = fmt.Fprintln(cmd.ErrOrStderr(),
+				"run completed with no declared output — see docs/runbooks/see-workflow-result.md")
+			return nil
+		case "":
+			return fmt.Errorf("no result payload for run %s", runID)
+		default:
+			return fmt.Errorf("run %s did not produce a result: status %s", runID, terminalStatus)
+		}
 	},
 }
 

--- a/docs/spdd/1529-workflow-output-capture/canvas.md
+++ b/docs/spdd/1529-workflow-output-capture/canvas.md
@@ -119,7 +119,7 @@ Config env prefix: `ZYNAX_<SERVICE>_` · Engine-agnostic interpreter (Temporal /
    re-submit-and-stream, json replay, and `zynax status`. Verified: runbook commands work against the CLI.
 2. **O.2 (#1531, ADR)** — Author ADR-042 + register in `docs/adr/INDEX.md`; decide placement / carrier /
    typing / empty-output contract / output-safety. Verified: ADR Accepted; gates all `feat:`.
-3. **O.3 (#1532, fix·cli)** — `zynax result` exits 0 with a graceful note on COMPLETED-empty; hard error
+3. **O.3 (#1532, fix·cli)** ✅ — `zynax result` exits 0 with a graceful note on COMPLETED-empty; hard error
    kept for FAILED/CANCELLED. Verified: unit tests for COMPLETED-empty / FAILED / completion-present.
 4. **O.4 (#1533, test·protos)** — BDD `.feature` scenarios (engine_adapter + workflow_compiler), RED
    before impl. Verified: scenarios committed and red; `protos/tests` compiles.


### PR DESCRIPTION
## fix(cli): zynax result exits 0 on completed-empty runs

Closes #1532
Part of #1529 (M7.U — workflow-level output capture)

### Why
`zynax result <run-id>` hard-errored `no result payload for run X` on a run that genuinely
**succeeded** — echo/hello-world capabilities emit no `completion` field, so the golden-path demo
exited non-zero on the very first run. A COMPLETED run must read as success, not failure.

### What you'll get
- `zynax result` now branches on the **terminal status**:
  - **COMPLETED + no output** → exit **0**, prints a graceful note on **stderr** pointing to the
    O.1 runbook (`run completed with no declared output — see docs/runbooks/see-workflow-result.md`);
    stdout stays empty so scripts capturing stdout get a clean empty result.
  - **FAILED / CANCELLED** → exit **non-zero** with the failure status (a real failure never reads as success).
  - **completion present** → unchanged (prints the text, exit 0).
- Updated command help to describe the new contract.

### Scope & boundaries
- **In scope:** `cmd/zynax/cmd/result.go` exit-code/message logic + unit tests; canvas O.3 tick.
- **Out of scope (deferred):** the structured-output reader that supersedes the empty case → O.9 (#1538).

### Test plan & acceptance
| Acceptance criterion | How verified | Result |
|----------------------|--------------|--------|
| COMPLETED-empty exits 0 with runbook note | `TestResultCmd_CompletedNoOutput_ExitsZeroWithNote` (err nil, stdout empty, note on stderr) | ✅ |
| FAILED exits non-zero | `TestResultCmd_Failed_Errors` | ✅ |
| CANCELLED exits non-zero | `TestResultCmd_Cancelled_Errors` | ✅ |
| completion-present prints output | `TestResultCmd_PrintsCompletion` (unchanged) | ✅ |
| Unit tests cover the three cases (AC3) | all above | ✅ |
| PR < 200 lines (AC4) | 73 insertions / 9 deletions | ✅ |

**Local gates:** `GOWORK=off go test ./... -race` ✅ · `go vet` ✅ · `golangci-lint run` ✅ 0 issues · binary `result --help` smoke ✅

### Evidence
- **Local output:** all `cmd/zynax` packages `ok`; result-command tests 5/5 pass; built `zynax` binary, `result --help` reflects new contract.
- **Artifacts / images:** none — `cmd/zynax` is the standalone CLI, no service image rebuild.

### Risk & rollback
Low — only changes the exit code/message for the empty-COMPLETED case; FAILED/CANCELLED and
output-present paths are behaviourally unchanged. Revert = restore the single `if output == ""` block.

### Engineering hygiene
- [x] Canvas O.3 ✅ in this diff (Status stays Aligned — 2 of 11 O-steps)
- [x] Branched off fresh `origin/main` · PR < 200 lines · DCO + `Assisted-by` on the commit
