### PR TITLE
test(protos): BDD feature for declared workflow outputs

### DIFF
--- a/docs/spdd/1529-workflow-output-capture/canvas.md
+++ b/docs/spdd/1529-workflow-output-capture/canvas.md
@@ -121,7 +121,7 @@ Config env prefix: `ZYNAX_<SERVICE>_` · Engine-agnostic interpreter (Temporal /
    typing / empty-output contract / output-safety. Verified: ADR Accepted; gates all `feat:`.
 3. **O.3 (#1532, fix·cli)** ✅ — `zynax result` exits 0 with a graceful note on COMPLETED-empty; hard error
    kept for FAILED/CANCELLED. Verified: unit tests for COMPLETED-empty / FAILED / completion-present.
-4. **O.4 (#1533, test·protos)** — BDD `.feature` scenarios (engine_adapter + workflow_compiler), RED
+4. **O.4 (#1533, test·protos)** ✅ — BDD `.feature` scenarios (engine_adapter + workflow_compiler), RED
    before impl. Verified: scenarios committed and red; `protos/tests` compiles.
 5. **O.5 (#1534, feat·protos)** — Add `StateIR.outputs=5`, `WorkflowRun.outputs=12`, document terminal
    event payload JSON; regenerate stubs. Verified: `buf breaking` green; stubs committed.

--- a/protos/tests/features/engine_adapter_service.feature
+++ b/protos/tests/features/engine_adapter_service.feature
@@ -14,6 +14,10 @@
 # Tags:
 #   @lifecycle — workflow submission, status query, cancellation (TestLifecycle)
 #   @signals   — signal delivery and watch stream (TestSignals)
+#   @outputs   — workflow-level output capture & return (M7.U epic #1529). RED contract
+#                pinned by O.4 (#1533) before O.5/O.7; no runner registers @outputs yet,
+#                so these scenarios are committed-but-not-executed until O.7 (#1536) adds
+#                TestOutputs with Tags "@outputs". (ADR-016, ADR-042)
 
 Feature: EngineAdapterService contract — workflow execution lifecycle
   As a Zynax control plane submitting compiled workflows for execution
@@ -198,3 +202,23 @@ Feature: EngineAdapterService contract — workflow execution lifecycle
     When GetWorkflowStatus is called
     Then the gRPC status is INVALID_ARGUMENT
     And the error message mentions "run_id"
+
+  # ─── Workflow-level outputs (M7.U #1529) ────────────────────────────────────
+  # RED contract for O.5 (proto fields) and O.7 (engine resolve-at-terminal).
+  # The result is engine-agnostic: identical whether the run executed on
+  # Temporal or Argo (ADR-015, ADR-042).
+
+  @outputs
+  Scenario: A completed run returns its declared workflow outputs
+    Given a compiled WorkflowIR whose terminal state declares outputs {"review": "$.states.assess.output.text"}
+    And the "assess" state produces output "text" with value "LGTM"
+    When the workflow is submitted and watched to COMPLETED
+    Then GetWorkflowStatus returns outputs {"review": "LGTM"}
+    And the terminal WorkflowEvent payload carries the same outputs
+
+  @outputs
+  Scenario: A completed run with no declared outputs returns an empty map
+    Given a compiled WorkflowIR whose terminal state declares no outputs
+    When the workflow is submitted and watched to COMPLETED
+    Then GetWorkflowStatus returns an empty outputs map
+    And the gRPC status is OK

--- a/protos/tests/features/workflow_compiler_service.feature
+++ b/protos/tests/features/workflow_compiler_service.feature
@@ -174,6 +174,31 @@ Feature: WorkflowCompilerService contract — YAML manifest compilation
     And the response contains a WorkflowIR
     And every ActionIR has zero output_bindings and zero input_bindings
 
+  # ─── Terminal workflow outputs (M7.U epic #1529, ADR-042) ─────────────────
+  # RED contract for O.6 (#1535): the compiler validates a terminal state's
+  # "outputs:" map (result name → $.states.<state>.output.<key>, reusing the
+  # ADR-029 grammar) and lowers it to StateIR.outputs. Steps are intentionally
+  # undefined until O.6 registers them — committed red per ADR-016, mirroring the
+  # data-flow bindings precedent above (suite stays green; scenarios pending).
+
+  Scenario: Compiler accepts a terminal output that resolves to a produced state output
+    Given a Workflow YAML whose terminal state declares an output "review" referencing "$.states.assess.output.text"
+    And state "assess" produces output "text"
+    When CompileWorkflow is called
+    Then the gRPC status is OK
+    And the response contains a WorkflowIR
+    And the terminal StateIR declares output "review"
+
+  Scenario: Compiler rejects a dangling terminal output reference
+    Given a Workflow YAML whose terminal state declares an output referencing a state that produces no such output
+    When CompileWorkflow is called
+    Then the response reports a COMPILATION_ERROR naming the offending line
+
+  Scenario: Compiler rejects outputs declared on a non-terminal state
+    Given a Workflow YAML where a non-terminal state declares an "outputs:" map
+    When CompileWorkflow is called
+    Then the response reports a COMPILATION_ERROR naming the offending line
+
   # ─── GetCompiledWorkflow ───────────────────────────────────────────────────
 
   Scenario: GetCompiledWorkflow returns the IR for a previously compiled workflow


### PR DESCRIPTION
## test(protos): BDD feature for declared workflow outputs

Closes #1533
Part of #1529 (M7.U — workflow-level output capture)

### Why
ADR-016 requires the gRPC-boundary contract to be pinned as `.feature` scenarios **before**
implementation, so the proto (O.5), compiler (O.6), and engine (O.7) work is built to a committed,
engine-agnostic contract instead of drifting.

### What you'll get
- **`engine_adapter_service.feature`** — new `@outputs` scenarios: a COMPLETED run returns its
  declared workflow outputs via `GetWorkflowStatus` (and the same map on the terminal `WorkflowEvent`
  payload); a COMPLETED run with no declared outputs returns an **empty map**, not an error.
- **`workflow_compiler_service.feature`** — terminal-outputs validation scenarios: accept a valid
  terminal `outputs:` reference (→ `StateIR.outputs`), reject a **dangling** reference with a
  `COMPILATION_ERROR` + line, reject `outputs:` on a **non-terminal** state.

### How this stays RED yet keeps CI green
This follows the **existing data-flow bindings precedent** in the same compiler feature (scenarios
whose steps are intentionally undefined until their implementation step lands):
- engine `@outputs` scenarios carry a tag **no runner registers yet** → committed-but-not-executed
  until O.7 (#1536) adds `TestOutputs` with `Tags "@outputs"`.
- compiler scenarios report **undefined/pending** (godog `Strict=false`, the repo default) → the
  suite still returns 0. O.6 (#1535) registers the steps to turn them green.

### Test plan & acceptance
| Acceptance criterion | How verified | Result |
|----------------------|--------------|--------|
| Scenarios added to engine_adapter + workflow_compiler features (AC1) | both files edited | ✅ |
| Scenarios are RED before O.5–O.7 (AC2) | compiler suite: `28 scenarios (22 passed, 6 undefined)` — the 3 new + 3 precedent; engine `@outputs` not executed by any runner | ✅ |
| `GOWORK=off go test ./...` in `protos/tests/` compiles (AC3) | `go build ./...` + `go vet` exit 0; `TestFeatures`/`TestLifecycle`/`TestSignals` all `ok` | ✅ |

**Local gates:** `GOWORK=off go test` compiler `ok` · engine `ok` · `go build ./...` ✅ · `go vet` ✅

### Risk & rollback
Low — test specification only; no proto, service, or production code touched. New scenarios are
pending/unexecuted, so they cannot break existing suites. Revert = drop the scenario blocks.

### Engineering hygiene
- [x] Canvas O.4 ✅ in this diff (Status stays Aligned — 3 of 11 O-steps)
- [x] `.feature` committed before implementation (ADR-016) · DCO + `Assisted-by` on the commit
