### PR TITLE
feat(workflow-compiler): compile and validate terminal outputs

### DIFF
--- a/docs/spdd/1529-workflow-output-capture/canvas.md
+++ b/docs/spdd/1529-workflow-output-capture/canvas.md
@@ -125,9 +125,12 @@ Config env prefix: `ZYNAX_<SERVICE>_` · Engine-agnostic interpreter (Temporal /
    before impl. Verified: scenarios committed and red; `protos/tests` compiles.
 5. **O.5 (#1534, feat·protos)** ✅ — Add `StateIR.outputs=5`, `WorkflowRun.outputs=12`, document terminal
    event payload JSON; regenerate stubs. Verified: `buf breaking` green; stubs committed.
-6. **O.6 (#1535, feat·compiler)** — Schema + `manifest.go` parse/validate terminal `outputs:` →
-   `StateIR.outputs`; dangling/non-terminal ref → COMPILATION_ERROR + line. Verified: `make validate-spec`;
-   domain cov ≥ 90%; O.4 compiler scenario green.
+6. **O.6 (#1535, feat·compiler)** ✅ — Schema + `manifest.go` parse/validate terminal `outputs:` →
+   `StateIR.outputs`; dangling/non-terminal ref → COMPILATION_ERROR + line. Verified: `make validate-spec`
+   green; domain cov 96.7% (literal/valid-ref/dangling/unknown-state/non-terminal). The O.4 compiler
+   `@outputs` scenarios stay pending at the in-memory gRPC stub (it models neither action outputs nor
+   StateIR structure — same precedent as the EPIC-W data-flow binding scenarios); the contract is verified
+   by the domain unit tests. Turning the stub scenarios green is deferred with the stub IR-modeling work.
 7. **O.7 (#1536, feat·engine)** — Resolve `StateIR.outputs` at the terminal state before discard; return as
    Temporal result onto `WorkflowRun.outputs`; widen `EventPublisher.Publish` with one additive arg; enforce
    size bounds. Verified: O.4 engine scenario green; empty=success, unresolved=DataReferenceError; cov ≥ 90%; race.

--- a/services/workflow-compiler/internal/domain/graph.go
+++ b/services/workflow-compiler/internal/domain/graph.go
@@ -87,6 +87,10 @@ func Build(_ context.Context, m *Manifest) (*WorkflowGraph, ParseErrors) {
 	// Every input binding reference must resolve to a declared upstream output.
 	errs = append(errs, validateInputBindings(m.States)...)
 
+	// Terminal workflow outputs must be terminal-only and resolve to a declared
+	// upstream output (ADR-042, M7.U).
+	errs = append(errs, validateWorkflowOutputs(m.States)...)
+
 	if len(errs) > 0 {
 		return nil, errs
 	}
@@ -105,18 +109,7 @@ func Build(_ context.Context, m *Manifest) (*WorkflowGraph, ParseErrors) {
 // COMPILATION_ERROR (ErrorCodeInvalidFieldValue) carrying the manifest line of
 // the consuming state. Returns all errors found — not just the first.
 func validateInputBindings(states map[string]*State) ParseErrors {
-	// Index declared outputs: stateID → set of output keys.
-	declared := make(map[string]map[string]struct{}, len(states))
-	for id, st := range states {
-		for _, a := range st.Actions {
-			for key := range a.OutputBindings {
-				if declared[id] == nil {
-					declared[id] = make(map[string]struct{})
-				}
-				declared[id][key] = struct{}{}
-			}
-		}
-	}
+	declared := indexDeclaredOutputs(states)
 
 	var errs ParseErrors
 	for id, st := range states {
@@ -129,6 +122,99 @@ func validateInputBindings(states map[string]*State) ParseErrors {
 		}
 	}
 	return errs
+}
+
+// indexDeclaredOutputs builds stateID → set of output keys declared by that
+// state's action output_bindings. This is the set of "$.states.<id>.output.<key>"
+// references resolvable elsewhere in the manifest.
+func indexDeclaredOutputs(states map[string]*State) map[string]map[string]struct{} {
+	declared := make(map[string]map[string]struct{}, len(states))
+	for id, st := range states {
+		for _, a := range st.Actions {
+			for key := range a.OutputBindings {
+				if declared[id] == nil {
+					declared[id] = make(map[string]struct{})
+				}
+				declared[id][key] = struct{}{}
+			}
+		}
+	}
+	return declared
+}
+
+// validateWorkflowOutputs enforces the terminal-output contract (ADR-042, M7.U):
+//   - outputs: may be declared only on a TERMINAL state;
+//   - each value is a literal, or a well-formed "$.states.<state>.output.<key>"
+//     reference whose target state declares <key> in its output_bindings.
+//
+// Violations yield a COMPILATION_ERROR (ErrorCodeInvalidFieldValue) carrying the
+// offending state's manifest line. Returns all errors found — not just the first.
+func validateWorkflowOutputs(states map[string]*State) ParseErrors {
+	declared := indexDeclaredOutputs(states)
+
+	var errs ParseErrors
+	for id, st := range states {
+		if len(st.Outputs) == 0 {
+			continue
+		}
+		if st.Type != StateTypeTerminal {
+			errs = append(errs, ParseError{
+				Code:      ErrorCodeInvalidFieldValue,
+				Message:   fmt.Sprintf("state %q: outputs may be declared only on a terminal state", id),
+				Line:      st.Line,
+				StateName: id,
+			})
+			continue
+		}
+		for name, ref := range st.Outputs {
+			// Literals (anything not rooted at the data-reference prefix) pass
+			// through verbatim — there is no transform language in M7 (ADR-029).
+			if !strings.HasPrefix(ref, inputBindingPrefix) {
+				continue
+			}
+			if perr := resolveWorkflowOutput(id, name, ref, st.Line, declared); perr != nil {
+				errs = append(errs, *perr)
+			}
+		}
+	}
+	return errs
+}
+
+// resolveWorkflowOutput parses a terminal output's "$.states.<state>.output.<key>"
+// reference and verifies the target state and output key are declared upstream.
+// Returns nil when the reference resolves, or a ParseError describing why not.
+func resolveWorkflowOutput(
+	state, outputName, ref string,
+	line int,
+	declared map[string]map[string]struct{},
+) *ParseError {
+	srcState, srcKey, ok := parseBindingRef(ref)
+	if !ok {
+		return &ParseError{
+			Code:      ErrorCodeInvalidFieldValue,
+			Message:   fmt.Sprintf("state %q: outputs[%q] reference %q is malformed; expected \"$.states.<state>.output.<key>\"", state, outputName, ref),
+			Line:      line,
+			StateName: state,
+		}
+	}
+	outputs, stateOK := declared[srcState]
+	if !stateOK {
+		return &ParseError{
+			Code:      ErrorCodeInvalidFieldValue,
+			Message:   fmt.Sprintf("state %q: outputs[%q] references output of unknown or output-less state %q", state, outputName, srcState),
+			Line:      line,
+			StateName: state,
+		}
+	}
+	if _, keyOK := outputs[srcKey]; !keyOK {
+		return &ParseError{
+			Code:      ErrorCodeInvalidFieldValue,
+			Message:   fmt.Sprintf("state %q: outputs[%q] references undeclared output %q of state %q", state, outputName, srcKey, srcState),
+			Line:      line,
+			StateName: state,
+		}
+	}
+	return nil
 }
 
 // resolveBinding parses a single "$.states.<state>.output.<key>" reference and

--- a/services/workflow-compiler/internal/domain/graph_test.go
+++ b/services/workflow-compiler/internal/domain/graph_test.go
@@ -5,6 +5,9 @@ import (
 	"testing"
 )
 
+// stateDone is the terminal-state id reused across the terminal-output tests.
+const stateDone = "done"
+
 // buildMinimalManifest returns a valid two-state manifest for graph tests.
 func buildMinimalManifest() *Manifest {
 	return &Manifest{
@@ -349,5 +352,115 @@ func TestBuild_InputBindingValidationFailures(t *testing.T) {
 				t.Errorf("expected ErrorCodeInvalidFieldValue on 'summarize', got: %v", errs)
 			}
 		})
+	}
+}
+
+// terminalOutputsManifest builds a two-state workflow whose initial "greet"
+// state produces output "message" and whose terminal "done" state declares the
+// given outputs YAML block (indented under `outputs:`). When onGreet is true the
+// outputs block is placed on the non-terminal "greet" state instead.
+func terminalOutputsManifest(outputsBlock string, onGreet bool) []byte {
+	greetOutputs, doneOutputs := "", outputsBlock
+	if onGreet {
+		greetOutputs, doneOutputs = outputsBlock, ""
+	}
+	return []byte(`
+kind: Workflow
+apiVersion: zynax.io/v1
+metadata:
+  name: outputs-wf
+spec:
+  initial_state: greet
+  states:
+    greet:
+      actions:
+        - capability: echo
+          output:
+            message: message
+      on:
+        - event: greet.done
+          goto: done
+` + greetOutputs + `    done:
+      type: terminal
+` + doneOutputs)
+}
+
+func TestBuild_TerminalOutputs_LiteralAndValidRef(t *testing.T) {
+	block := "      outputs:\n        review: \"$.states.greet.output.message\"\n        note: \"shipped\"\n"
+	m, parseErrs := ParseManifest(context.Background(), terminalOutputsManifest(block, false))
+	if len(parseErrs) != 0 {
+		t.Fatalf("parse failed: %v", parseErrs)
+	}
+	// The terminal state carries both outputs after parsing.
+	if got := m.States[stateDone].Outputs; len(got) != 2 || got["review"] != "$.states.greet.output.message" || got["note"] != "shipped" {
+		t.Fatalf("parsed terminal outputs = %v, want review+note", got)
+	}
+	if _, errs := Build(context.Background(), m); len(errs) != 0 {
+		t.Fatalf("expected literal + resolvable ref to compile, got: %v", errs)
+	}
+}
+
+func TestBuild_TerminalOutputs_ValidationFailures(t *testing.T) {
+	tests := []struct {
+		name string
+		ref  string
+	}{
+		{"undeclared output key", "$.states.greet.output.missing"},
+		{"unknown source state", "$.states.nope.output.message"},
+		{"malformed reference", "$.states.greet.message"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			block := "      outputs:\n        review: \"" + tt.ref + "\"\n"
+			m, parseErrs := ParseManifest(context.Background(), terminalOutputsManifest(block, false))
+			if len(parseErrs) != 0 {
+				t.Fatalf("parse failed: %v", parseErrs)
+			}
+			_, errs := Build(context.Background(), m)
+			found := false
+			for _, e := range errs {
+				if e.Code == ErrorCodeInvalidFieldValue && e.StateName == stateDone {
+					found = true
+					if e.Line <= 0 {
+						t.Errorf("expected a line number on the error, got %d", e.Line)
+					}
+				}
+			}
+			if !found {
+				t.Errorf("expected ErrorCodeInvalidFieldValue on 'done' for %q, got: %v", tt.ref, errs)
+			}
+		})
+	}
+}
+
+func TestBuild_OutputsOnNonTerminalState(t *testing.T) {
+	block := "      outputs:\n        review: \"done\"\n"
+	m, parseErrs := ParseManifest(context.Background(), terminalOutputsManifest(block, true))
+	if len(parseErrs) != 0 {
+		t.Fatalf("parse failed: %v", parseErrs)
+	}
+	_, errs := Build(context.Background(), m)
+	found := false
+	for _, e := range errs {
+		if e.Code == ErrorCodeInvalidFieldValue && e.StateName == "greet" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected a COMPILATION_ERROR for outputs on a non-terminal state, got: %v", errs)
+	}
+}
+
+func TestConvertWorkflowOutputs_NonStringValue(t *testing.T) {
+	block := "      outputs:\n        review:\n          nested: true\n"
+	_, parseErrs := ParseManifest(context.Background(), terminalOutputsManifest(block, false))
+	found := false
+	for _, e := range parseErrs {
+		if e.Code == ErrorCodeInvalidFieldValue && e.StateName == stateDone {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected a parse error for a non-string output value, got: %v", parseErrs)
 	}
 }

--- a/services/workflow-compiler/internal/domain/ir/ir.go
+++ b/services/workflow-compiler/internal/domain/ir/ir.go
@@ -68,6 +68,7 @@ func convertStates(states map[string]*domain.State) ([]*zynaxv1.StateIR, error) 
 			Type:        convertStateType(s.Type),
 			Actions:     actions,
 			Transitions: convertTransitions(s.Transitions),
+			Outputs:     copyBindings(s.Outputs),
 		})
 	}
 	return out, nil

--- a/services/workflow-compiler/internal/domain/ir/ir_test.go
+++ b/services/workflow-compiler/internal/domain/ir/ir_test.go
@@ -383,3 +383,35 @@ func TestToIR_HITLGraph(t *testing.T) {
 		t.Errorf("review transitions: got %d, want 2", len(reviewState.Transitions))
 	}
 }
+
+// TestToIR_TerminalStateOutputs verifies the terminal state's declared outputs
+// (ADR-042, M7.U) are lowered onto StateIR.outputs, and that a state with no
+// declared outputs carries an empty map.
+func TestToIR_TerminalStateOutputs(t *testing.T) {
+	g := minimalGraph()
+	g.States[stateEnd].Outputs = map[string]string{"review": "$.states.start.output.text"}
+
+	wfIR, err := call(g)
+	if err != nil {
+		t.Fatalf("ToIR error: %v", err)
+	}
+
+	var end, start *zynaxv1.StateIR
+	for _, s := range wfIR.States {
+		switch s.Id {
+		case stateEnd:
+			end = s
+		case stateStart:
+			start = s
+		}
+	}
+	if end == nil || start == nil {
+		t.Fatalf("missing states in IR: start=%v end=%v", start, end)
+	}
+	if got := end.Outputs["review"]; got != "$.states.start.output.text" {
+		t.Errorf("terminal StateIR.outputs[review] = %q, want the declared reference", got)
+	}
+	if len(start.Outputs) != 0 {
+		t.Errorf("non-terminal StateIR.outputs = %v, want empty", start.Outputs)
+	}
+}

--- a/services/workflow-compiler/internal/domain/manifest.go
+++ b/services/workflow-compiler/internal/domain/manifest.go
@@ -58,7 +58,12 @@ type State struct {
 	Type        StateType
 	Actions     []Action
 	Transitions []Transition
-	Line        int // 1-based source line in the YAML manifest
+	// Outputs declares the workflow-level result of a TERMINAL state (ADR-042,
+	// M7.U): result name → a literal or an ADR-029 data reference
+	// "$.states.<state>.output.<key>". Nil when the state declares none. Valid
+	// only on terminal states; the graph builder rejects it elsewhere.
+	Outputs map[string]string
+	Line    int // 1-based source line in the YAML manifest
 }
 
 // Manifest is the domain-level representation of a parsed workflow YAML manifest.
@@ -98,9 +103,10 @@ type yamlSpec struct {
 }
 
 type yamlState struct {
-	Type    string           `yaml:"type"`
-	Actions []yamlAction     `yaml:"actions"`
-	On      []yamlTransition `yaml:"on"`
+	Type    string                 `yaml:"type"`
+	Actions []yamlAction           `yaml:"actions"`
+	On      []yamlTransition       `yaml:"on"`
+	Outputs map[string]interface{} `yaml:"outputs"`
 }
 
 type yamlAction struct {
@@ -299,10 +305,49 @@ func convertState( //nolint:funlen // validates type + actions + transitions in 
 		})
 	}
 
+	outputs, outErrs := convertWorkflowOutputs(name, ys.Outputs, line)
+	errs = append(errs, outErrs...)
+	st.Outputs = outputs
+
 	if len(errs) > 0 {
 		return nil, errs
 	}
 	return st, nil
+}
+
+// convertWorkflowOutputs flattens a terminal state's outputs: mapping into a
+// string→string map of result name → source path (a literal or an ADR-029
+// "$.states.<state>.output.<key>" reference). Non-string values are a
+// compile-time error: M7 has no transform language, so each value must be a
+// literal string (ADR-042). Terminal-only placement and reference resolution are
+// enforced later by the graph builder, which has the full state set.
+func convertWorkflowOutputs(
+	state string,
+	raw map[string]interface{},
+	line int,
+) (map[string]string, ParseErrors) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	var errs ParseErrors
+	out := make(map[string]string, len(raw))
+	for key, val := range raw {
+		s, ok := val.(string)
+		if !ok {
+			errs = append(errs, ParseError{
+				Code:      ErrorCodeInvalidFieldValue,
+				Message:   fmt.Sprintf("state %q: outputs[%q] must be a string source path, got %T", state, key, val),
+				Line:      line,
+				StateName: state,
+			})
+			continue
+		}
+		out[key] = s
+	}
+	if len(out) == 0 {
+		return nil, errs
+	}
+	return out, errs
 }
 
 // inputBindingPrefix is the JSON-path root that marks a string input value as a

--- a/spec/schemas/workflow.schema.json
+++ b/spec/schemas/workflow.schema.json
@@ -137,6 +137,13 @@
           "items": {
             "$ref": "#/$defs/transition"
           }
+        },
+        "outputs": {
+          "type": "object",
+          "description": "Workflow-level outputs declared on a terminal state (ADR-042). Maps a result name to a literal or an ADR-029 data reference '$.states.<state>.output.<key>'. Resolved at the terminal state and returned as the workflow result. Valid only on terminal states; the compiler rejects it elsewhere.",
+          "additionalProperties": {
+            "type": "string"
+          }
         }
       }
     },


### PR DESCRIPTION
## feat(workflow-compiler): compile and validate terminal outputs

Closes #1535
Part of #1529 (M7.U — workflow-level output capture)

### Why
The IR had no carrier for a workflow result and the schema rejected `outputs:` on states, so an
author could not declare what a workflow returns. This adds the declarative, **compile-time-validated**
`outputs:` surface that the engine (O.7) resolves at the terminal state.

### What you'll get
- **Schema:** `outputs` added to the terminal-state definition (`#/$defs/state`), `string`→`string`.
- **Parse:** `manifest.go` reads `outputs:` into `State.Outputs` (non-string value → COMPILATION_ERROR).
- **Validate (`graph.go` `validateWorkflowOutputs`):** `outputs:` only on a **terminal** state; each
  value is a literal or a well-formed `$.states.<state>.output.<key>` reference resolving to a
  produced upstream output (shares the declared-output index with input-binding validation). A
  non-terminal placement, dangling reference, or malformed reference is a **COMPILATION_ERROR with the
  offending manifest line**.
- **Lower:** `ir.go` maps `State.Outputs` → `StateIR.outputs`; states with none carry an empty map.

### Test plan & acceptance
| Acceptance criterion | How verified | Result |
|----------------------|--------------|--------|
| Terminal `outputs:` compiles into `StateIR.outputs` (AC1) | `TestBuild_TerminalOutputs_LiteralAndValidRef`, `TestToIR_TerminalStateOutputs` | ✅ |
| Dangling / non-terminal ref → COMPILATION_ERROR + line (AC2) | `TestBuild_TerminalOutputs_ValidationFailures` (undeclared key / unknown state / malformed), `TestBuild_OutputsOnNonTerminalState` | ✅ |
| `make validate-spec` passes with new schema field (AC3) | ran `make validate-spec` | ✅ |
| Unit tests ≥90% domain cover literal/valid-ref/dangling (AC4) | domain coverage **96.7%** | ✅ |

**Local gates:** `GOWORK=off go test ./... -race` ✅ · `golangci-lint run` ✅ 0 issues · `make validate-spec` ✅

### BDD note (transparency)
The O.4 compiler `@outputs` scenarios remain **pending at the in-memory gRPC stub** — it models neither
action outputs nor `StateIR` structure (and has no per-state line numbers), so it cannot express
ref-resolution or IR-shape assertions. This is the **same precedent** as the EPIC-W data-flow binding
scenarios (also pending). The contract is verified here by the domain unit tests; turning the stub
scenarios green is deferred with the stub IR-modeling work.

### Risk & rollback
Low — additive and backward-compatible: manifests without `outputs:` compile unchanged (`buf`-additive
field from O.5; empty map otherwise). Revert = drop the schema field + the two validators.

### Engineering hygiene
- [x] Canvas O.6 ✅ in this diff (Status stays Aligned — 5 of 11 O-steps)
- [x] Branched off fresh `origin/main` · DCO + `Assisted-by` · domain cov 96.7%

**SPDD:** Canvas `docs/spdd/1529-workflow-output-capture/canvas.md` — Status: Aligned · `/lib:spdd-security-review` PASS
