### PR TITLE
feat(engine-adapter): capture terminal outputs as workflow result

### DIFF
--- a/docs/spdd/1529-workflow-output-capture/canvas.md
+++ b/docs/spdd/1529-workflow-output-capture/canvas.md
@@ -131,9 +131,12 @@ Config env prefix: `ZYNAX_<SERVICE>_` · Engine-agnostic interpreter (Temporal /
    `@outputs` scenarios stay pending at the in-memory gRPC stub (it models neither action outputs nor
    StateIR structure — same precedent as the EPIC-W data-flow binding scenarios); the contract is verified
    by the domain unit tests. Turning the stub scenarios green is deferred with the stub IR-modeling work.
-7. **O.7 (#1536, feat·engine)** — Resolve `StateIR.outputs` at the terminal state before discard; return as
+7. **O.7 (#1536, feat·engine)** ✅ — Resolve `StateIR.outputs` at the terminal state before discard; return as
    Temporal result onto `WorkflowRun.outputs`; widen `EventPublisher.Publish` with one additive arg; enforce
-   size bounds. Verified: O.4 engine scenario green; empty=success, unresolved=DataReferenceError; cov ≥ 90%; race.
+   size bounds. Verified: empty=success, unresolved=DataReferenceError, oversized=OutputSizeError, GetStatus
+   reads the result; domain cov 91.8% + race green. The O.4 engine `@outputs` scenarios stay committed-but-
+   unrun at the in-memory testserver stub (no `@outputs` runner; same precedent as O.6) — verified by the
+   domain/infra unit tests; wiring a `TestOutputs` runner is deferred with the stub work.
 8. **O.8 (#1537, feat·gateway)** — `GET /api/v1/workflows/{id}/outputs` ({} / 404); outputs on SSE terminal
    event. Verified: `handler_test` populated/empty/404; `platform_client.get_outputs()` resolves.
 9. **O.9 (#1538, feat·cli)** — `zynax result` reads `/outputs`, prints declared outputs, falls back to

--- a/services/engine-adapter/internal/api/handler.go
+++ b/services/engine-adapter/internal/api/handler.go
@@ -105,6 +105,7 @@ func runToProto(r *domain.WorkflowRun) *zynaxv1.WorkflowRun {
 		StartedAt:          tsOrNil(r.StartedAt),
 		FinishedAt:         tsOrNil(r.FinishedAt),
 		CancellationReason: r.CancellationReason,
+		Outputs:            r.Outputs,
 	}
 }
 

--- a/services/engine-adapter/internal/domain/datacontext_test.go
+++ b/services/engine-adapter/internal/domain/datacontext_test.go
@@ -223,7 +223,7 @@ func TestIRInterpreter_DataFlowHappyPath(t *testing.T) {
 		),
 		terminal("done"),
 	)
-	if err := (&IRInterpreter{}).Run(context.Background(), ir, capExec, &stubPublisher{}); err != nil {
+	if _, err := (&IRInterpreter{}).Run(context.Background(), ir, capExec, &stubPublisher{}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if string(captured.InputPayload) != `{"in":"the-answer"}` {
@@ -246,7 +246,7 @@ func TestIRInterpreter_DataFlowMissingReferenceFailsRun(t *testing.T) {
 		terminal("done"),
 	)
 	pub := &stubPublisher{}
-	err := (&IRInterpreter{}).Run(context.Background(), ir, &stubExecutor{}, pub)
+	_, err := (&IRInterpreter{}).Run(context.Background(), ir, &stubExecutor{}, pub)
 	if err == nil {
 		t.Fatal("expected run to fail on unresolved reference")
 	}
@@ -286,7 +286,7 @@ func TestIRInterpreter_DataFlowTypeMismatchFailsRun(t *testing.T) {
 		),
 		terminal("done"),
 	)
-	err := (&IRInterpreter{}).Run(context.Background(), ir, exec, &stubPublisher{})
+	_, err := (&IRInterpreter{}).Run(context.Background(), ir, exec, &stubPublisher{})
 	if err == nil {
 		t.Fatal("expected run to fail on typed-mismatch output")
 	}

--- a/services/engine-adapter/internal/domain/interpreter.go
+++ b/services/engine-adapter/internal/domain/interpreter.go
@@ -27,8 +27,13 @@ type ActivityExecutor interface {
 
 // EventPublisher abstracts CloudEvent publication via Temporal activities.
 // Domain code depends only on this interface (ADR-015).
+//
+// payload is an optional JSON-encoded event payload. It is nil for transition
+// events; on the terminal "completed" event it carries the typed
+// {"outputs": {...}} shape (ADR-042) so a consumer can read the workflow result
+// off the event stream without a separate query.
 type EventPublisher interface {
-	Publish(ctx context.Context, eventType, workflowID, stateID string) error
+	Publish(ctx context.Context, eventType, workflowID, stateID string, payload []byte) error
 }
 
 // ExecutionContext tracks the state machine's mutable state across activity executions.
@@ -46,12 +51,17 @@ type ExecutionContext struct {
 type IRInterpreter struct{}
 
 // Run drives the IR state machine until a terminal state or ctx cancellation.
+// On reaching a terminal state it resolves that state's declared outputs against
+// the still-live run-scoped data context (ADR-042) and returns them as the run
+// result. A run that declares no outputs returns an empty (non-nil) map; an
+// unresolved output reference fails the run loudly with a DataReferenceError, and
+// outputs that exceed the size bounds fail with an OutputSizeError.
 func (i *IRInterpreter) Run(
 	ctx context.Context,
 	ir *zynaxv1.WorkflowIR,
 	exec ActivityExecutor,
 	pub EventPublisher,
-) error {
+) (map[string]string, error) {
 	ec := &ExecutionContext{
 		WorkflowID:   ir.GetWorkflowId(),
 		CurrentState: ir.GetInitialState(),
@@ -67,37 +77,89 @@ func (i *IRInterpreter) Run(
 	for {
 		state := findState(ir, ec.CurrentState)
 		if state == nil {
-			return fmt.Errorf("engine-adapter: state %q not found in IR", ec.CurrentState)
+			return nil, fmt.Errorf("engine-adapter: state %q not found in IR", ec.CurrentState)
 		}
 		if state.GetType() == zynaxv1.StateType_STATE_TYPE_TERMINAL {
-			if err := pub.Publish(ctx, "zynax.workflow.completed", ec.WorkflowID, ec.CurrentState); err != nil {
-				slog.Warn("lifecycle event publish failed", "event", "zynax.workflow.completed", "workflow_id", ec.WorkflowID, "err", err)
-			}
-			return nil
+			return i.captureTerminalOutputs(ctx, state, ec, data, scope, pub)
 		}
-		if err := pub.Publish(ctx, "zynax.workflow.state.entered", ec.WorkflowID, ec.CurrentState); err != nil {
-			return fmt.Errorf("engine-adapter: publish state.entered: %w", err)
+		if err := pub.Publish(ctx, "zynax.workflow.state.entered", ec.WorkflowID, ec.CurrentState, nil); err != nil {
+			return nil, fmt.Errorf("engine-adapter: publish state.entered: %w", err)
 		}
 		result, err := executeActions(ctx, state, ec, exec, data, scope)
 		if err != nil {
-			if perr := pub.Publish(ctx, "zynax.workflow.failed", ec.WorkflowID, ec.CurrentState); perr != nil {
-				slog.Warn("lifecycle event publish failed", "event", "zynax.workflow.failed", "workflow_id", ec.WorkflowID, "err", perr)
-			}
-			return err
+			i.publishFailed(ctx, pub, ec)
+			return nil, err
 		}
 		transition, err := resolveTransition(state.GetTransitions(), result, ec.Ctx)
 		if err != nil {
-			if perr := pub.Publish(ctx, "zynax.workflow.failed", ec.WorkflowID, ec.CurrentState); perr != nil {
-				slog.Warn("lifecycle event publish failed", "event", "zynax.workflow.failed", "workflow_id", ec.WorkflowID, "err", perr)
-			}
-			return err
+			i.publishFailed(ctx, pub, ec)
+			return nil, err
 		}
-		if perr := pub.Publish(ctx, "zynax.workflow.state.exited", ec.WorkflowID, ec.CurrentState); perr != nil {
+		if perr := pub.Publish(ctx, "zynax.workflow.state.exited", ec.WorkflowID, ec.CurrentState, nil); perr != nil {
 			slog.Warn("lifecycle event publish failed", "event", "zynax.workflow.state.exited", "workflow_id", ec.WorkflowID, "err", perr)
 		}
 		mergePayload(ec.Ctx, result.Payload)
 		ec.CurrentState = transition.GetTargetState()
 	}
+}
+
+// captureTerminalOutputs resolves the terminal state's declared outputs against
+// the still-live data context, enforces the size bounds, publishes the typed
+// terminal "completed" event carrying the outputs, and returns the resolved map.
+// Resolution reuses ResolveInputs, so a dangling reference yields a
+// DataReferenceError and cross-run scope is still denied (canvas C.3). It runs
+// inside the Temporal workflow function and performs no I/O, so it stays
+// replay-deterministic.
+func (i *IRInterpreter) captureTerminalOutputs(
+	ctx context.Context,
+	state *zynaxv1.StateIR,
+	ec *ExecutionContext,
+	data *WorkflowDataContext,
+	scope DataContextScope,
+	pub EventPublisher,
+) (map[string]string, error) {
+	outputs, err := data.ResolveInputs(scope, state.GetOutputs())
+	if err != nil {
+		i.publishFailed(ctx, pub, ec)
+		return nil, err
+	}
+	if outputs == nil {
+		// Empty is success: a COMPLETED run with no declared outputs returns {}.
+		outputs = map[string]string{}
+	}
+	if err := enforceOutputBounds(outputs); err != nil {
+		i.publishFailed(ctx, pub, ec)
+		return nil, err
+	}
+	payload, err := marshalTerminalPayload(outputs)
+	if err != nil {
+		i.publishFailed(ctx, pub, ec)
+		return nil, err
+	}
+	if perr := pub.Publish(ctx, "zynax.workflow.completed", ec.WorkflowID, ec.CurrentState, payload); perr != nil {
+		slog.Warn("lifecycle event publish failed", "event", "zynax.workflow.completed", "workflow_id", ec.WorkflowID, "err", perr)
+	}
+	return outputs, nil
+}
+
+// publishFailed emits the best-effort terminal "failed" lifecycle event.
+func (i *IRInterpreter) publishFailed(ctx context.Context, pub EventPublisher, ec *ExecutionContext) {
+	if perr := pub.Publish(ctx, "zynax.workflow.failed", ec.WorkflowID, ec.CurrentState, nil); perr != nil {
+		slog.Warn("lifecycle event publish failed", "event", "zynax.workflow.failed", "workflow_id", ec.WorkflowID, "err", perr)
+	}
+}
+
+// marshalTerminalPayload encodes the resolved outputs as the typed terminal
+// event payload {"outputs": {...}} (ADR-042). "outputs" is namespaced separately
+// from the task-broker "completion" field so the two readers never cross-parse.
+func marshalTerminalPayload(outputs map[string]string) ([]byte, error) {
+	b, err := json.Marshal(struct {
+		Outputs map[string]string `json:"outputs"`
+	}{Outputs: outputs})
+	if err != nil {
+		return nil, fmt.Errorf("engine-adapter: marshal terminal outputs: %w", err)
+	}
+	return b, nil
 }
 
 // executeActions runs each synchronous action in the state and returns the result

--- a/services/engine-adapter/internal/domain/interpreter_bench_test.go
+++ b/services/engine-adapter/internal/domain/interpreter_bench_test.go
@@ -55,7 +55,7 @@ func BenchmarkIRInterpreter(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		// A fresh publisher per iteration keeps its event slice from growing
 		// unboundedly across iterations and skewing allocation accounting.
-		if err := interp.Run(ctx, ir, exec, &stubPublisher{}); err != nil {
+		if _, err := interp.Run(ctx, ir, exec, &stubPublisher{}); err != nil {
 			b.Fatalf("Run: %v", err)
 		}
 	}

--- a/services/engine-adapter/internal/domain/interpreter_test.go
+++ b/services/engine-adapter/internal/domain/interpreter_test.go
@@ -38,7 +38,7 @@ type stubPublisher struct {
 	err    error
 }
 
-func (p *stubPublisher) Publish(_ context.Context, eventType, _, _ string) error {
+func (p *stubPublisher) Publish(_ context.Context, eventType, _, _ string, _ []byte) error {
 	p.events = append(p.events, eventType)
 	return p.err
 }
@@ -80,7 +80,7 @@ func transition(eventType, target string, conditions map[string]string) *zynaxv1
 func TestIRInterpreter_TerminalInitialState(t *testing.T) {
 	ir := buildIR("wf-1", "done", terminal("done"))
 	pub := &stubPublisher{}
-	err := (&IRInterpreter{}).Run(context.Background(), ir, &stubExecutor{}, pub)
+	_, err := (&IRInterpreter{}).Run(context.Background(), ir, &stubExecutor{}, pub)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -98,7 +98,7 @@ func TestIRInterpreter_TwoStateWorkflow(t *testing.T) {
 		terminal("done"),
 	)
 	pub := &stubPublisher{}
-	err := (&IRInterpreter{}).Run(context.Background(), ir, &stubExecutor{}, pub)
+	_, err := (&IRInterpreter{}).Run(context.Background(), ir, &stubExecutor{}, pub)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -133,7 +133,7 @@ func TestIRInterpreter_GuardBranching(t *testing.T) {
 		terminal("rejected"),
 	)
 	pub := &stubPublisher{}
-	err := (&IRInterpreter{}).Run(context.Background(), ir, exec, pub)
+	_, err := (&IRInterpreter{}).Run(context.Background(), ir, exec, pub)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -147,7 +147,7 @@ func TestIRInterpreter_GuardBranching(t *testing.T) {
 
 func TestIRInterpreter_StateNotFound(t *testing.T) {
 	ir := buildIR("wf-4", "missing")
-	err := (&IRInterpreter{}).Run(context.Background(), ir, &stubExecutor{}, &stubPublisher{})
+	_, err := (&IRInterpreter{}).Run(context.Background(), ir, &stubExecutor{}, &stubPublisher{})
 	if err == nil || !containsMsg(err, "state \"missing\" not found") {
 		t.Errorf("expected state-not-found error, got: %v", err)
 	}
@@ -161,7 +161,7 @@ func TestIRInterpreter_NoMatchingTransition(t *testing.T) {
 		),
 		terminal("done"),
 	)
-	err := (&IRInterpreter{}).Run(context.Background(), ir, &stubExecutor{}, &stubPublisher{})
+	_, err := (&IRInterpreter{}).Run(context.Background(), ir, &stubExecutor{}, &stubPublisher{})
 	if err == nil {
 		t.Fatal("expected error for no matching transition")
 	}
@@ -173,7 +173,7 @@ func TestIRInterpreter_ActivityError(t *testing.T) {
 	)
 	exec := &stubExecutor{err: errors.New("broker down")}
 	pub := &stubPublisher{}
-	err := (&IRInterpreter{}).Run(context.Background(), ir, exec, pub)
+	_, err := (&IRInterpreter{}).Run(context.Background(), ir, exec, pub)
 	if err == nil {
 		t.Fatal("expected error from activity")
 	}
@@ -211,7 +211,7 @@ func TestIRInterpreter_CtxMergedIntoNextAction(t *testing.T) {
 		),
 		terminal("done"),
 	)
-	err := (&IRInterpreter{}).Run(context.Background(), ir, captureExec, &stubPublisher{})
+	_, err := (&IRInterpreter{}).Run(context.Background(), ir, captureExec, &stubPublisher{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -273,7 +273,7 @@ func TestIRInterpreter_AsyncActionsSkipped(t *testing.T) {
 		terminal("done"),
 	)
 	pub := &stubPublisher{}
-	if err := (&IRInterpreter{}).Run(context.Background(), ir, exec, pub); err != nil {
+	if _, err := (&IRInterpreter{}).Run(context.Background(), ir, exec, pub); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
@@ -362,7 +362,7 @@ func TestMergePayload_InvalidJSON(t *testing.T) {
 // errorPublisher fails with an error for a specific event type; all others succeed.
 type errorPublisher struct{ failOn string }
 
-func (p *errorPublisher) Publish(_ context.Context, eventType, _, _ string) error {
+func (p *errorPublisher) Publish(_ context.Context, eventType, _, _ string, _ []byte) error {
 	if eventType == p.failOn {
 		return errors.New("publish failed")
 	}
@@ -376,7 +376,7 @@ func TestIRInterpreter_StateEnteredPublishError(t *testing.T) {
 		terminal("done"),
 	)
 	pub := &errorPublisher{failOn: "zynax.workflow.state.entered"}
-	err := (&IRInterpreter{}).Run(context.Background(), ir, &stubExecutor{}, pub)
+	_, err := (&IRInterpreter{}).Run(context.Background(), ir, &stubExecutor{}, pub)
 	if err == nil || !containsMsg(err, "publish state.entered") {
 		t.Errorf("expected state.entered error, got: %v", err)
 	}
@@ -535,7 +535,7 @@ func TestIRInterpreter_PublishErrorLogged(t *testing.T) {
 	pub := &stubPublisher{err: errors.New("event bus down")}
 
 	// Run should succeed — publish failure is logged, not propagated.
-	if err := (&IRInterpreter{}).Run(context.Background(), ir, &stubExecutor{}, pub); err != nil {
+	if _, err := (&IRInterpreter{}).Run(context.Background(), ir, &stubExecutor{}, pub); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if !strings.Contains(buf.String(), "lifecycle event publish failed") {

--- a/services/engine-adapter/internal/domain/model.go
+++ b/services/engine-adapter/internal/domain/model.go
@@ -42,6 +42,11 @@ type WorkflowRun struct {
 	StartedAt          time.Time
 	FinishedAt         time.Time
 	CancellationReason string
+	// Outputs are the resolved workflow-level outputs captured at the terminal
+	// state and returned as the run result (ADR-042, M7.U). Populated by
+	// GetStatus for a COMPLETED run; empty for runs that declared none and for
+	// non-terminal runs.
+	Outputs map[string]string
 }
 
 // WorkflowEvent is emitted when the workflow transitions state or reaches

--- a/services/engine-adapter/internal/domain/outputs.go
+++ b/services/engine-adapter/internal/domain/outputs.go
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package domain
+
+import "fmt"
+
+// Output-safety size bounds (ADR-042 §6). Workflow outputs are attacker-influenced
+// and are rendered to terminal, SSE, logs, and gateway JSON, so they are bounded at
+// capture. Oversized outputs are REJECTED with a typed error — never silently
+// truncated — so a workflow that emits very large values fails loudly and must be
+// redesigned to emit a reference/handle instead.
+const (
+	// MaxOutputValueBytes bounds a single resolved output value.
+	MaxOutputValueBytes = 64 * 1024
+	// MaxOutputsTotalBytes bounds the sum of all output names and values.
+	MaxOutputsTotalBytes = 256 * 1024
+)
+
+// OutputSizeError is returned when a captured output exceeds a per-value or total
+// size bound (ADR-042 §6). It carries the offending key (empty for a total
+// overflow) so the failure is actionable.
+type OutputSizeError struct {
+	// Key is the output name that overflowed, or "" for a total-size overflow.
+	Key string
+	// Size is the measured byte size that exceeded the bound.
+	Size int
+	// Limit is the bound that was exceeded.
+	Limit int
+}
+
+func (e *OutputSizeError) Error() string {
+	if e.Key == "" {
+		return fmt.Sprintf(
+			"engine-adapter: workflow outputs total %d bytes exceed the %d-byte limit; emit a reference/handle instead",
+			e.Size, e.Limit,
+		)
+	}
+	return fmt.Sprintf(
+		"engine-adapter: output %q is %d bytes, exceeding the %d-byte per-value limit; emit a reference/handle instead",
+		e.Key, e.Size, e.Limit,
+	)
+}
+
+// enforceOutputBounds rejects oversized captured outputs with a typed
+// OutputSizeError (ADR-042 §6). A nil/empty map passes. The per-value bound is
+// checked first so the error names the offending key; otherwise the total
+// (names + values) is checked.
+func enforceOutputBounds(outputs map[string]string) error {
+	total := 0
+	for k, v := range outputs {
+		if len(v) > MaxOutputValueBytes {
+			return &OutputSizeError{Key: k, Size: len(v), Limit: MaxOutputValueBytes}
+		}
+		total += len(k) + len(v)
+	}
+	if total > MaxOutputsTotalBytes {
+		return &OutputSizeError{Key: "", Size: total, Limit: MaxOutputsTotalBytes}
+	}
+	return nil
+}

--- a/services/engine-adapter/internal/domain/outputs_test.go
+++ b/services/engine-adapter/internal/domain/outputs_test.go
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package domain
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	zynaxv1 "github.com/zynax-io/zynax/protos/generated/go/zynax/v1"
+)
+
+// capturingPublisher records each published event with its payload so tests can
+// assert the terminal "completed" event carries the typed outputs payload.
+type capturingPublisher struct {
+	events   []string
+	payloads map[string][]byte
+}
+
+func (p *capturingPublisher) Publish(_ context.Context, eventType, _, _ string, payload []byte) error {
+	p.events = append(p.events, eventType)
+	if p.payloads == nil {
+		p.payloads = make(map[string][]byte)
+	}
+	p.payloads[eventType] = payload
+	return nil
+}
+
+// searchToTerminal builds a run where "search" produces output "results" and a
+// terminal "done" state declares the given outputs map.
+func searchToTerminal(workflowID string, outputs map[string]string) *zynaxv1.WorkflowIR {
+	done := &zynaxv1.StateIR{
+		Id:      "done",
+		Type:    zynaxv1.StateType_STATE_TYPE_TERMINAL,
+		Outputs: outputs,
+	}
+	return buildIR(workflowID, "search",
+		normal("search",
+			[]*zynaxv1.ActionIR{{
+				Capability:     "search",
+				OutputBindings: map[string]string{"results": "results"},
+			}},
+			[]*zynaxv1.TransitionIR{transition("search.done", "done", nil)},
+		),
+		done,
+	)
+}
+
+func searchExec() *stubExecutor {
+	return &stubExecutor{results: map[string]*ActivityResult{
+		"search": {EventType: "search.done", Payload: []byte(`{"_event":"search.done","results":"the-answer"}`)},
+	}}
+}
+
+// TestIRInterpreter_TerminalOutputsResolved proves AC1: declared outputs (a ref
+// and a literal) are resolved at the terminal state, returned as the run result,
+// and carried on the terminal completed event payload.
+func TestIRInterpreter_TerminalOutputsResolved(t *testing.T) {
+	ir := searchToTerminal("wf-out", map[string]string{
+		"answer": "$.states.search.output.results",
+		"label":  "static-literal",
+	})
+	pub := &capturingPublisher{}
+	out, err := (&IRInterpreter{}).Run(context.Background(), ir, searchExec(), pub)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out["answer"] != "the-answer" || out["label"] != "static-literal" {
+		t.Errorf("resolved outputs = %v, want answer=the-answer label=static-literal", out)
+	}
+	// The completed event payload carries {"outputs": {...}}.
+	raw, ok := pub.payloads["zynax.workflow.completed"]
+	if !ok || len(raw) == 0 {
+		t.Fatalf("expected a payload on the completed event, got: %v", pub.payloads)
+	}
+	var decoded struct {
+		Outputs map[string]string `json:"outputs"`
+	}
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("completed payload is not valid JSON: %v", err)
+	}
+	if decoded.Outputs["answer"] != "the-answer" {
+		t.Errorf("payload outputs = %v, want answer=the-answer", decoded.Outputs)
+	}
+}
+
+// TestIRInterpreter_NoDeclaredOutputsEmptyMap proves AC2: a COMPLETED run that
+// declares no outputs returns a non-nil empty map (no regression, no error).
+func TestIRInterpreter_NoDeclaredOutputsEmptyMap(t *testing.T) {
+	ir := searchToTerminal("wf-empty", nil)
+	out, err := (&IRInterpreter{}).Run(context.Background(), ir, searchExec(), &capturingPublisher{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out == nil {
+		t.Fatal("expected a non-nil empty map for a run with no declared outputs")
+	}
+	if len(out) != 0 {
+		t.Errorf("expected empty outputs, got %v", out)
+	}
+}
+
+// TestIRInterpreter_TerminalOutputDanglingRefFails proves AC3: an output that
+// references an output no upstream state produced fails the run with a
+// DataReferenceError and emits the failed event.
+func TestIRInterpreter_TerminalOutputDanglingRefFails(t *testing.T) {
+	ir := searchToTerminal("wf-dangling", map[string]string{
+		"answer": "$.states.search.output.missing",
+	})
+	pub := &capturingPublisher{}
+	_, err := (&IRInterpreter{}).Run(context.Background(), ir, searchExec(), pub)
+	if err == nil {
+		t.Fatal("expected run to fail on an unresolved output reference")
+	}
+	var dre *DataReferenceError
+	if !errors.As(err, &dre) {
+		t.Fatalf("expected *DataReferenceError, got %T: %v", err, err)
+	}
+	if !contains(pub.events, "zynax.workflow.failed") {
+		t.Errorf("expected a failed event, got: %v", pub.events)
+	}
+}
+
+// TestIRInterpreter_TerminalOutputSizeBound proves AC4: a captured output that
+// exceeds the per-value size bound fails the run with a typed OutputSizeError —
+// never silently truncated.
+func TestIRInterpreter_TerminalOutputSizeBound(t *testing.T) {
+	big := strings.Repeat("x", MaxOutputValueBytes+1)
+	ir := searchToTerminal("wf-big", map[string]string{"blob": big})
+	pub := &capturingPublisher{}
+	_, err := (&IRInterpreter{}).Run(context.Background(), ir, searchExec(), pub)
+	if err == nil {
+		t.Fatal("expected run to fail on oversized output")
+	}
+	var se *OutputSizeError
+	if !errors.As(err, &se) {
+		t.Fatalf("expected *OutputSizeError, got %T: %v", err, err)
+	}
+	if se.Key != "blob" {
+		t.Errorf("OutputSizeError.Key = %q, want blob", se.Key)
+	}
+	if contains(pub.events, "zynax.workflow.completed") {
+		t.Error("a run that overflows the output bound must not emit completed")
+	}
+}
+
+func TestEnforceOutputBounds(t *testing.T) {
+	if err := enforceOutputBounds(nil); err != nil {
+		t.Errorf("nil outputs should pass, got %v", err)
+	}
+	if err := enforceOutputBounds(map[string]string{"a": "ok"}); err != nil {
+		t.Errorf("small outputs should pass, got %v", err)
+	}
+	// Per-value overflow.
+	err := enforceOutputBounds(map[string]string{"k": strings.Repeat("x", MaxOutputValueBytes+1)})
+	var se *OutputSizeError
+	if !errors.As(err, &se) || se.Key != "k" {
+		t.Errorf("expected per-value OutputSizeError for k, got %v", err)
+	}
+	// Total overflow across several in-bound values.
+	many := make(map[string]string, 8)
+	chunk := strings.Repeat("y", MaxOutputValueBytes-1)
+	for i := 0; i < 6; i++ {
+		many[string(rune('a'+i))] = chunk
+	}
+	err = enforceOutputBounds(many)
+	if !errors.As(err, &se) || se.Key != "" {
+		t.Errorf("expected total-size OutputSizeError, got %v", err)
+	}
+}
+
+func TestOutputSizeError_Error(t *testing.T) {
+	perKey := (&OutputSizeError{Key: "blob", Size: 100, Limit: 64}).Error()
+	if !strings.Contains(perKey, "blob") || !strings.Contains(perKey, "per-value") {
+		t.Errorf("per-value message unexpected: %q", perKey)
+	}
+	total := (&OutputSizeError{Key: "", Size: 1000, Limit: 256}).Error()
+	if !strings.Contains(total, "total") {
+		t.Errorf("total message unexpected: %q", total)
+	}
+}
+
+func contains(s []string, want string) bool {
+	for _, v := range s {
+		if v == want {
+			return true
+		}
+	}
+	return false
+}

--- a/services/engine-adapter/internal/infrastructure/activities.go
+++ b/services/engine-adapter/internal/infrastructure/activities.go
@@ -58,7 +58,7 @@ func lifecycleTopic(eventType string) string {
 // unavailability never interrupts the workflow state machine.
 //
 // Topic format: zynax.v1.engine-adapter.workflow.<event_type> (see lifecycleTopic).
-func (a *ActivityWorker) PublishLifecycleEventActivity(ctx context.Context, eventType, workflowID, stateID string) error {
+func (a *ActivityWorker) PublishLifecycleEventActivity(ctx context.Context, eventType, workflowID, stateID string, payload []byte) error {
 	topic := lifecycleTopic(eventType)
 
 	req := &zynaxv1.PublishRequest{
@@ -71,6 +71,9 @@ func (a *ActivityWorker) PublishLifecycleEventActivity(ctx context.Context, even
 			Subject:         stateID,
 			Time:            timestamppb.New(time.Now()),
 			WorkflowId:      workflowID,
+			// Typed terminal payload {"outputs": {...}} on the completed event
+			// (nil for transition events) (ADR-042, M7.U).
+			Data: payload,
 		},
 	}
 

--- a/services/engine-adapter/internal/infrastructure/activities_test.go
+++ b/services/engine-adapter/internal/infrastructure/activities_test.go
@@ -39,7 +39,7 @@ func TestPublishLifecycleEventActivity_TopicFormat(t *testing.T) {
 	stub := &stubEventBusPublisher{}
 	w := newTestActivityWorker(stub)
 
-	err := w.PublishLifecycleEventActivity(context.Background(), "submitted", "wf-42", "state-1")
+	err := w.PublishLifecycleEventActivity(context.Background(), "submitted", "wf-42", "state-1", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -57,7 +57,7 @@ func TestPublishLifecycleEventActivity_WorkflowIDInEvent(t *testing.T) {
 	stub := &stubEventBusPublisher{}
 	w := newTestActivityWorker(stub)
 
-	err := w.PublishLifecycleEventActivity(context.Background(), "running", "wf-99", "state-2")
+	err := w.PublishLifecycleEventActivity(context.Background(), "running", "wf-99", "state-2", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -85,7 +85,7 @@ func TestPublishLifecycleEventActivity_AllEventTypes(t *testing.T) {
 		t.Run(eventType, func(t *testing.T) {
 			stub := &stubEventBusPublisher{}
 			w := newTestActivityWorker(stub)
-			err := w.PublishLifecycleEventActivity(context.Background(), eventType, "wf-1", "")
+			err := w.PublishLifecycleEventActivity(context.Background(), eventType, "wf-1", "", nil)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -117,7 +117,7 @@ func TestPublishLifecycleEventActivity_InterpreterEventTypes_NoDoublePrefix(t *t
 		t.Run(eventType, func(t *testing.T) {
 			stub := &stubEventBusPublisher{}
 			w := newTestActivityWorker(stub)
-			if err := w.PublishLifecycleEventActivity(context.Background(), eventType, "wf-1149", "s1"); err != nil {
+			if err := w.PublishLifecycleEventActivity(context.Background(), eventType, "wf-1149", "s1", nil); err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
 			if len(stub.reqs) != 1 {
@@ -139,7 +139,7 @@ func TestPublishLifecycleEventActivity_EventBusError_BestEffort(t *testing.T) {
 	stub := &stubEventBusPublisher{publishErr: errors.New("connection refused")}
 	w := newTestActivityWorker(stub)
 
-	err := w.PublishLifecycleEventActivity(context.Background(), "failed", "wf-3", "state-3")
+	err := w.PublishLifecycleEventActivity(context.Background(), "failed", "wf-3", "state-3", nil)
 	if err != nil {
 		t.Errorf("expected nil error on publish failure (best-effort), got: %v", err)
 	}
@@ -149,7 +149,7 @@ func TestPublishLifecycleEventActivity_CloudEventFields(t *testing.T) {
 	stub := &stubEventBusPublisher{}
 	w := newTestActivityWorker(stub)
 
-	err := w.PublishLifecycleEventActivity(context.Background(), "completed", "wf-5", "end-state")
+	err := w.PublishLifecycleEventActivity(context.Background(), "completed", "wf-5", "end-state", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/services/engine-adapter/internal/infrastructure/temporal.go
+++ b/services/engine-adapter/internal/infrastructure/temporal.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"time"
 
 	enumspb "go.temporal.io/api/enums/v1"
@@ -34,6 +35,7 @@ type temporalClient interface {
 	CancelWorkflow(ctx context.Context, workflowID, runID string) error
 	DescribeWorkflowExecution(ctx context.Context, workflowID, runID string) (*workflowservice.DescribeWorkflowExecutionResponse, error)
 	GetWorkflowHistory(ctx context.Context, workflowID, runID string, isLongPoll bool, filterType enumspb.HistoryEventFilterType) client.HistoryEventIterator
+	GetWorkflow(ctx context.Context, workflowID, runID string) client.WorkflowRun
 }
 
 // TemporalEngine implements domain.WorkflowEngine backed by the Temporal Go SDK.
@@ -114,7 +116,22 @@ func (e *TemporalEngine) GetStatus(ctx context.Context, runID string) (*domain.W
 		}
 		return nil, fmt.Errorf("engine-adapter: describe workflow %q: %w", runID, err)
 	}
-	return describeToWorkflowRun(resp, runID, e.namespace), nil
+	run := describeToWorkflowRun(resp, runID, e.namespace)
+	// For a COMPLETED run, read the workflow result (the resolved outputs) and
+	// surface it on WorkflowRun.outputs (ADR-042, M7.U). Get() returns the stored
+	// result immediately for a finished workflow; gating on the terminal-completed
+	// status ensures it never blocks on a still-running execution. A read failure
+	// (e.g. history expired past Temporal retention) is non-fatal — status is
+	// still returned, just without outputs.
+	if run.Status == domain.WorkflowStatusCompleted {
+		var outputs map[string]string
+		if gerr := e.client.GetWorkflow(ctx, runID, "").Get(ctx, &outputs); gerr != nil {
+			slog.Warn("read workflow result failed", "run_id", runID, "err", gerr)
+		} else {
+			run.Outputs = outputs
+		}
+	}
+	return run, nil
 }
 
 // Watch long-polls the Temporal execution history and calls send for each

--- a/services/engine-adapter/internal/infrastructure/temporal_test.go
+++ b/services/engine-adapter/internal/infrastructure/temporal_test.go
@@ -23,15 +23,16 @@ import (
 
 // stubTemporalClient implements temporalClient for tests.
 type stubTemporalClient struct {
-	executeRun  client.WorkflowRun
-	executeErr  error
-	signalErr   error
-	cancelErr   error
-	descResps   []*workflowservice.DescribeWorkflowExecutionResponse
-	descErr     error
-	descCallIdx int
-	historyEvts []*historypb.HistoryEvent
-	historyErr  error
+	executeRun     client.WorkflowRun
+	executeErr     error
+	signalErr      error
+	cancelErr      error
+	descResps      []*workflowservice.DescribeWorkflowExecutionResponse
+	descErr        error
+	descCallIdx    int
+	historyEvts    []*historypb.HistoryEvent
+	historyErr     error
+	getWorkflowRun client.WorkflowRun
 }
 
 // stubHistoryIterator implements client.HistoryEventIterator over a fixed slice,
@@ -100,14 +101,35 @@ func (s *stubTemporalClient) DescribeWorkflowExecution(
 	return s.descResps[idx], nil
 }
 
-// stubWorkflowRun implements client.WorkflowRun for tests.
-type stubWorkflowRun struct{ id string }
+// stubWorkflowRun implements client.WorkflowRun for tests. When outputs/getErr
+// are set, Get copies outputs into the value pointer (mimicking Temporal
+// deserialising the workflow result) or returns getErr.
+type stubWorkflowRun struct {
+	id      string
+	outputs map[string]string
+	getErr  error
+}
 
-func (r *stubWorkflowRun) GetID() string                              { return r.id }
-func (r *stubWorkflowRun) GetRunID() string                           { return r.id + "-run" }
-func (r *stubWorkflowRun) Get(_ context.Context, _ interface{}) error { return nil }
+func (r *stubWorkflowRun) GetID() string    { return r.id }
+func (r *stubWorkflowRun) GetRunID() string { return r.id + "-run" }
+func (r *stubWorkflowRun) Get(_ context.Context, valuePtr interface{}) error {
+	if r.getErr != nil {
+		return r.getErr
+	}
+	if out, ok := valuePtr.(*map[string]string); ok {
+		*out = r.outputs
+	}
+	return nil
+}
 func (r *stubWorkflowRun) GetWithOptions(_ context.Context, _ interface{}, _ client.WorkflowRunGetOptions) error {
 	return nil
+}
+
+func (s *stubTemporalClient) GetWorkflow(_ context.Context, _, _ string) client.WorkflowRun {
+	if s.getWorkflowRun != nil {
+		return s.getWorkflowRun
+	}
+	return &stubWorkflowRun{}
 }
 
 func descResp(status enumspb.WorkflowExecutionStatus) *workflowservice.DescribeWorkflowExecutionResponse {
@@ -195,6 +217,43 @@ func TestTemporalEngine_GetStatus_Running(t *testing.T) {
 	}
 	if run.Status != domain.WorkflowStatusRunning {
 		t.Errorf("Status = %v; want Running", run.Status)
+	}
+}
+
+// TestTemporalEngine_GetStatus_CompletedReadsOutputs proves AC1 (infra): for a
+// COMPLETED run, GetStatus reads the Temporal workflow result and surfaces it on
+// WorkflowRun.Outputs.
+func TestTemporalEngine_GetStatus_CompletedReadsOutputs(t *testing.T) {
+	stub := &stubTemporalClient{
+		descResps: []*workflowservice.DescribeWorkflowExecutionResponse{
+			descResp(enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED),
+		},
+		getWorkflowRun: &stubWorkflowRun{outputs: map[string]string{"review": "LGTM"}},
+	}
+	run, err := newTestEngine(stub).GetStatus(context.Background(), "wf-done")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if run.Outputs["review"] != "LGTM" {
+		t.Errorf("Outputs = %v, want review=LGTM", run.Outputs)
+	}
+}
+
+// TestTemporalEngine_GetStatus_RunningSkipsResult proves the result-read is gated
+// on COMPLETED so it never blocks on a running execution.
+func TestTemporalEngine_GetStatus_RunningSkipsResult(t *testing.T) {
+	stub := &stubTemporalClient{
+		descResps: []*workflowservice.DescribeWorkflowExecutionResponse{
+			descResp(enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING),
+		},
+		getWorkflowRun: &stubWorkflowRun{getErr: errors.New("must not be called for a running run")},
+	}
+	run, err := newTestEngine(stub).GetStatus(context.Background(), "wf-run")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(run.Outputs) != 0 {
+		t.Errorf("running run should carry no outputs, got %v", run.Outputs)
 	}
 }
 

--- a/services/engine-adapter/internal/infrastructure/temporal_workflow.go
+++ b/services/engine-adapter/internal/infrastructure/temporal_workflow.go
@@ -49,17 +49,20 @@ var nonRetryableActivityErrors = []string{
 // IRInterpreterWorkflow is the Temporal workflow function registered by the worker
 // in cmd/engine-adapter/main.go. It bridges Temporal's workflow.Context to
 // domain.IRInterpreter.Run via the ActivityExecutor and EventPublisher port interfaces.
-func IRInterpreterWorkflow(ctx workflow.Context, ir *zynaxv1.WorkflowIR) error {
+func IRInterpreterWorkflow(ctx workflow.Context, ir *zynaxv1.WorkflowIR) (map[string]string, error) {
 	exec := &temporalActivityExecutor{ctx: ctx}
 	pub := &temporalEventPublisher{ctx: ctx}
 	// context.Background() is intentional: workflow.Context cannot be converted to
 	// context.Context without breaking Temporal's replay determinism (ADR-015).
 	// IRInterpreter.Run performs no I/O itself; all I/O is delegated to exec/pub,
 	// which receive workflow.Context via their struct fields.
-	if err := (&domain.IRInterpreter{}).Run(context.Background(), ir, exec, pub); err != nil {
-		return fmt.Errorf("engine-adapter: %w", err)
+	outputs, err := (&domain.IRInterpreter{}).Run(context.Background(), ir, exec, pub)
+	if err != nil {
+		return nil, fmt.Errorf("engine-adapter: %w", err)
 	}
-	return nil
+	// The resolved workflow outputs are the Temporal workflow result, surfaced on
+	// WorkflowRun.outputs by GetStatus (ADR-042, M7.U).
+	return outputs, nil
 }
 
 // temporalActivityExecutor implements domain.ActivityExecutor by scheduling
@@ -101,11 +104,13 @@ type temporalEventPublisher struct {
 }
 
 // Publish schedules the lifecycle event activity; errors are suppressed (best-effort).
-func (p *temporalEventPublisher) Publish(_ context.Context, eventType, workflowID, stateID string) error {
+// payload carries the typed terminal {"outputs": {...}} JSON on the completed
+// event (nil otherwise) and is forwarded to the activity as the CloudEvent data.
+func (p *temporalEventPublisher) Publish(_ context.Context, eventType, workflowID, stateID string, payload []byte) error {
 	actCtx := workflow.WithActivityOptions(p.ctx, workflow.ActivityOptions{
 		TaskQueue:           workflow.GetInfo(p.ctx).TaskQueueName,
 		StartToCloseTimeout: 5 * time.Second,
 	})
-	_ = workflow.ExecuteActivity(actCtx, publishEventActivityName, eventType, workflowID, stateID).Get(p.ctx, nil)
+	_ = workflow.ExecuteActivity(actCtx, publishEventActivityName, eventType, workflowID, stateID, payload).Get(p.ctx, nil)
 	return nil
 }


### PR DESCRIPTION
## feat(engine-adapter): capture terminal outputs as workflow result

Closes #1536
Part of #1529 (M7.U — workflow-level output capture) — **the keystone O-step**

### Why
At the terminal branch the interpreter returned `nil` and discarded the run-scoped data context, so a
COMPLETED run had no result to return. This captures the declared outputs at the terminal state — the
engine-agnostic interpreter resolves them, so the result is identical on Temporal or Argo.

### What you'll get
- **Capture at terminal:** `IRInterpreter.Run` resolves `StateIR.outputs` against the still-live
  data context (reusing `ResolveInputs` → scope isolation + `DataReferenceError` preserved) and returns
  the resolved map instead of discarding it.
- **Returned as the run result:** `IRInterpreterWorkflow` returns the map as the Temporal workflow
  result; `GetStatus` reads it for a COMPLETED run → `WorkflowRun.outputs`; the terminal completed
  event carries the typed `{"outputs": {...}}` payload.
- **EventPublisher.Publish** widened with one additive `payload []byte` arg (all impls + test stubs
  updated): `nil` for transitions, the outputs JSON on completed.
- **Output safety (ADR-042 §6):** per-value (64 KiB) + total (256 KiB) bounds enforced at capture with
  a typed `OutputSizeError` — **rejected, never truncated**.

### Scope & boundaries
- **In scope:** engine-adapter domain + infrastructure; no new service.
- **Out of scope:** the gateway `GET /outputs` read path → O.8 (#1537); CLI display → O.9 (#1538).
- **Argo:** unaffected — it does not use the IR interpreter's publisher path.

### Test plan & acceptance
| Acceptance criterion | How verified | Result |
|----------------------|--------------|--------|
| Declared outputs returned via GetStatus + terminal payload (AC1) | `TestIRInterpreter_TerminalOutputsResolved`, `TestTemporalEngine_GetStatus_CompletedReadsOutputs` | ✅ |
| No declared outputs → empty map, no regression (AC2) | `TestIRInterpreter_NoDeclaredOutputsEmptyMap` | ✅ |
| Unresolved ref → DataReferenceError; cross-run scope denied (AC3) | `TestIRInterpreter_TerminalOutputDanglingRefFails` (reuses scoped ResolveInputs) | ✅ |
| Per-value/total size bounds, typed error (AC4) | `TestIRInterpreter_TerminalOutputSizeBound`, `TestEnforceOutputBounds` | ✅ |
| Signature change compiles all impls; ≥90% domain cov; race (AC5) | build + `go test -race`; domain **91.8%** | ✅ |

**Local gates:** `GOWORK=off go test ./... -race` ✅ all packages · `golangci-lint run` ✅ 0 issues · `go vet` ✅

### Determinism
Resolution runs inside the Temporal workflow function and performs **no I/O** (pure map/JSON ops) — replay-safe.

### PR size
~470 lines, **justified**: keystone O-step with a one-arg port change rippling through all impls + stubs,
plus comprehensive tests (outputs_test.go +192, temporal_test.go +87 are the bulk). Production logic is small.

### BDD note
The O.4 engine `@outputs` scenarios stay committed-but-unrun at the in-memory testserver stub (no
`@outputs` runner; same precedent as O.6) — the contract is verified by the domain/infra unit tests.

### Risk & rollback
Low–moderate — runs without declared outputs are behaviourally unchanged (empty map). The port signature
change is additive (one arg). Revert = restore the `error`-only `Run`/`Publish` and drop `outputs.go`.

### Engineering hygiene
- [x] Canvas O.7 ✅ in this diff (Status stays Aligned — 6 of 11 O-steps)
- [x] Branched off fresh `origin/main` · DCO + `Assisted-by` · domain cov 91.8% · race green

**SPDD:** Canvas `docs/spdd/1529-workflow-output-capture/canvas.md` — Status: Aligned · `/lib:spdd-security-review` PASS
