### PR TITLE
ci: rebuild adapter images on dependency-lock changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,7 +197,11 @@ jobs:
             fi
             # docker: any path that ends up inside a container image (#1118 / ADR-027).
             # Locked matrix strategy: ALL images build when ANY of these change.
-            if echo "$f" | grep -qE '^(services/|infra/docker/Dockerfile\.|agents/adapters/[^/]+/Dockerfile$)'; then
+            # Runtime dependency locks/manifests count: a lock-only change (e.g. a
+            # protobuf runtime bump to match regenerated gencode) alters the image
+            # contents, so it must rebuild — otherwise the promoted :main image goes
+            # stale against the committed source (see #1550).
+            if echo "$f" | grep -qE '^(services/|infra/docker/Dockerfile\.|agents/adapters/[^/]+/Dockerfile$|agents/adapters/[^/]+/(uv\.lock|pyproject\.toml)$|agents/sdk/(uv\.lock|pyproject\.toml)$)'; then
               docker=true
             fi
             if echo "$f" | grep -qE '^(protos/|spec/|CLAUDE\.md|AGENTS\.md|.*/AGENTS\.md|docs/ai-assistant-setup\.md|\.ai/|\.claude/)'; then

--- a/agents/adapters/langgraph/Dockerfile
+++ b/agents/adapters/langgraph/Dockerfile
@@ -41,6 +41,12 @@ WORKDIR /app
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 
 # Install locked dependencies (without the project itself — source is copied separately)
+#
+# Runtime/gencode invariant: the protobuf runtime pinned in uv.lock must be >= the
+# gencode version of the stubs copied below from protos/generated/python. protobuf
+# rejects runtime < gencode at import, which would crash the adapter on startup
+# (regressed in #1550: gencode bumped to 7.35.1 while the lock lagged at 7.35.0).
+# CI's docker-change detection now rebuilds this image on uv.lock/pyproject changes.
 COPY agents/adapters/langgraph/pyproject.toml agents/adapters/langgraph/uv.lock ./
 RUN uv sync --no-dev --no-install-project --frozen --no-build
 


### PR DESCRIPTION
## ci: rebuild adapter images on dependency-lock changes

### Why
#1550 corrected `langgraph-adapter`'s protobuf **runtime** lock (7.35.0 → 7.35.1) so it matches the
regenerated gencode — but **`langgraph-adapter:main` was never rebuilt**. The `changes` job's
`docker=true` trigger only fired on `services/` or `Dockerfile` changes, so a `uv.lock`-only fix ran
the Python tests yet built **no staging image** (`Build + scan: skipping`), leaving `release.yml`
with nothing to promote. `langgraph-adapter:main` stayed at the old broken digest and still crashes
at import (`protobuf VersionError: runtime 7.35.0 < gencode 7.35.1`) — the e2e `echo-worker` blocker.

### What
- **`ci.yml`** — `docker`-change detection now also fires on a Python adapter's or the SDK's
  `uv.lock` / `pyproject.toml`. A runtime-dependency change alters the image, so it must rebuild;
  otherwise the promoted `:main` goes stale against the committed source.
- **`langgraph/Dockerfile`** — documents the runtime ≥ gencode invariant, and this touch **forces the
  pending `langgraph-adapter:main` rebuild** so `:main` picks up the 7.35.1 runtime from #1550 and the
  e2e `echo-worker` starts again.

### Verification
- Regex tested: matches `agents/adapters/*/uv.lock|pyproject.toml`, `agents/sdk/uv.lock|pyproject.toml`,
  `*/Dockerfile`, `services/` — and does **not** match `src/*.py`, `README.md`, or `docs/`.
- The Dockerfile change sets `docker=true` (pre-existing `*/Dockerfile` match), so this PR's
  `build-images` builds a fresh langgraph staging image; on merge `release.yml` promotes it to `:main`.
- Root-cause fix (protobuf runtime bump) landed in #1550 and was runtime-smoke-verified there.

### Impact
Unblocks the e2e platform regression that stalls every M7 service PR (keystone #1536 …). After merge,
`langgraph-adapter:main` is rebuilt with protobuf 7.35.1 → `echo-worker` reaches readiness → e2e recovers.

### Risk & rollback
Low — a `changes`-detection widening (conservative: rebuilds on dep changes, matching existing
Dockerfile behaviour) plus a Dockerfile comment. `.github/workflows/` is PR-size-excluded. Revert = restore the regex.
