### PR TITLE
feat(api-gateway): add GET workflows/{id}/outputs read path

### DIFF
--- a/docs/spdd/1529-workflow-output-capture/canvas.md
+++ b/docs/spdd/1529-workflow-output-capture/canvas.md
@@ -137,8 +137,9 @@ Config env prefix: `ZYNAX_<SERVICE>_` · Engine-agnostic interpreter (Temporal /
    reads the result; domain cov 91.8% + race green. The O.4 engine `@outputs` scenarios stay committed-but-
    unrun at the in-memory testserver stub (no `@outputs` runner; same precedent as O.6) — verified by the
    domain/infra unit tests; wiring a `TestOutputs` runner is deferred with the stub work.
-8. **O.8 (#1537, feat·gateway)** — `GET /api/v1/workflows/{id}/outputs` ({} / 404); outputs on SSE terminal
-   event. Verified: `handler_test` populated/empty/404; `platform_client.get_outputs()` resolves.
+8. **O.8 (#1537, feat·gateway)** ✅ — `GET /api/v1/workflows/{id}/outputs` ({} / 404); outputs on SSE terminal
+   event. Verified: `handler_test` populated/empty/404 + safe-JSON + terminal-SSE-carries-outputs;
+   `platform_client.get_outputs()` already targets the route (now resolves instead of raising); domain cov 96.7%.
 9. **O.9 (#1538, feat·cli)** — `zynax result` reads `/outputs`, prints declared outputs, falls back to
    `CompletionText`, sanitizes control chars; wedge-first help. Verified: CLI tests outputs/fallback/empty/FAILED.
 10. **O.10 (#1539, feat·spec)** — Declare terminal `outputs:` on hello-world + code-review; update comments +

--- a/services/api-gateway/internal/api/handler.go
+++ b/services/api-gateway/internal/api/handler.go
@@ -43,6 +43,7 @@ func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
 	applyHandler := rl.Middleware(http.HandlerFunc(requireBearer(h.apiKey, h.handleApply)))
 	mux.Handle("POST /api/v1/apply", applyHandler)
 	mux.HandleFunc("GET /api/v1/workflows/{id}/logs", h.handleWorkflowLogs)
+	mux.HandleFunc("GET /api/v1/workflows/{id}/outputs", h.handleWorkflowOutputs)
 	eventsHandler := rl.Middleware(http.HandlerFunc(requireBearer(h.apiKey, h.handlePublishEvent)))
 	mux.Handle("POST /api/v1/workflows/{id}/events", eventsHandler)
 	mux.HandleFunc("GET /api/v1/workflows/{id}", h.handleGetWorkflow)
@@ -141,6 +142,36 @@ func (h *Handler) handleGetWorkflow(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// statusCompleted is the terminal status string for a successfully completed run
+// (WorkflowStatus enum rendered via .String()).
+const statusCompleted = "WORKFLOW_STATUS_COMPLETED"
+
+// handleWorkflowOutputs serves the resolved workflow-level outputs of a run
+// (ADR-042, M7.U). It returns the outputs JSON object for a COMPLETED run, an
+// empty object {} for a run that declared none, and 404 for an unknown id.
+// GET stays open (read-only). json.Encoder escapes control characters, so
+// attacker-influenced output values render safely.
+func (h *Handler) handleWorkflowOutputs(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if id == "" {
+		writeError(w, http.StatusBadRequest, "run_id is required", "INVALID_ARGUMENT")
+		return
+	}
+	run, err := h.svc.GetWorkflowStatus(r.Context(), id)
+	switch {
+	case errors.Is(err, domain.ErrNotFound):
+		writeError(w, http.StatusNotFound, "workflow run not found", "NOT_FOUND")
+	case err != nil:
+		writeError(w, http.StatusInternalServerError, "internal error", "INTERNAL")
+	default:
+		outputs := run.Outputs
+		if outputs == nil {
+			outputs = map[string]string{}
+		}
+		writeJSON(w, http.StatusOK, outputs)
+	}
+}
+
 func (h *Handler) handleWorkflowLogs(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	if id == "" {
@@ -157,14 +188,27 @@ func (h *Handler) handleWorkflowLogs(w http.ResponseWriter, r *http.Request) {
 	// the server-wide deadline because they never call this code path.
 	rc := http.NewResponseController(w)
 	_ = rc.SetWriteDeadline(time.Time{})
+	ctx := r.Context()
 	started := false
-	err := h.svc.WatchWorkflowLogs(r.Context(), id, func(ev domain.WatchEvent) error {
+	err := h.svc.WatchWorkflowLogs(ctx, id, func(ev domain.WatchEvent) error {
 		if !started {
 			w.Header().Set("Content-Type", "text/event-stream")
 			w.Header().Set("Cache-Control", "no-cache")
 			w.Header().Set("Connection", "keep-alive")
 			w.WriteHeader(http.StatusOK)
 			started = true
+		}
+		// On the terminal completed event, enrich the payload with the run's
+		// declared outputs so streaming consumers get the result without a
+		// separate /outputs read-back (ADR-042, M7.U O.8). The engine's history
+		// stream does not carry the workflow result, so it is fetched here using
+		// the same request-scoped context.
+		if ev.Status == statusCompleted && ev.Payload == "" {
+			if run, gerr := h.svc.GetWorkflowStatus(ctx, id); gerr == nil && len(run.Outputs) > 0 { //nolint:contextcheck // same request ctx captured above; the WatchWorkflowLogs callback carries no ctx param
+				if b, merr := json.Marshal(map[string]map[string]string{"outputs": run.Outputs}); merr == nil {
+					ev.Payload = string(b)
+				}
+			}
 		}
 		data, merr := json.Marshal(sseWatchEvent(ev))
 		if merr != nil {

--- a/services/api-gateway/internal/api/handler_test.go
+++ b/services/api-gateway/internal/api/handler_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -288,9 +289,153 @@ func TestHandler_GetWorkflow_NotFound_Returns404(t *testing.T) {
 	}
 }
 
+// ── GET /api/v1/workflows/{id}/outputs (M7.U O.8) ────────────────────────
+
+func TestHandler_WorkflowOutputs_Returns200WithOutputs(t *testing.T) {
+	srv := newServer(&stubCompiler{}, &stubEngine{
+		statusRun: domain.WorkflowRunSummary{
+			RunID: "r1", Status: statusCompletedTest,
+			Outputs: map[string]string{"review": "LGTM", "score": "9"},
+		},
+	})
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/v1/workflows/r1/outputs")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status: got %d, want 200", resp.StatusCode)
+	}
+	body := decodeBody(t, resp)
+	if body["review"] != "LGTM" || body["score"] != "9" {
+		t.Errorf("outputs body = %v, want review=LGTM score=9", body)
+	}
+}
+
+func TestHandler_WorkflowOutputs_Empty_ReturnsEmptyObject(t *testing.T) {
+	srv := newServer(&stubCompiler{}, &stubEngine{
+		statusRun: domain.WorkflowRunSummary{RunID: "r1", Status: statusCompletedTest},
+	})
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/v1/workflows/r1/outputs")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status: got %d, want 200", resp.StatusCode)
+	}
+	body := decodeBody(t, resp)
+	if len(body) != 0 {
+		t.Errorf("expected empty object {}, got %v", body)
+	}
+}
+
+func TestHandler_WorkflowOutputs_NotFound_Returns404(t *testing.T) {
+	srv := newServer(&stubCompiler{}, &stubEngine{statusErr: domain.ErrNotFound})
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/v1/workflows/ghost/outputs")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("status: got %d, want 404", resp.StatusCode)
+	}
+}
+
+func TestHandler_WorkflowOutputs_SafeJSONEncoding(t *testing.T) {
+	// An attacker-influenced value with control/ANSI bytes must be JSON-escaped,
+	// never emitted raw, yet round-trip back to the original string.
+	val := "a\x1b[31mred\x00b"
+	srv := newServer(&stubCompiler{}, &stubEngine{
+		statusRun: domain.WorkflowRunSummary{
+			RunID: "r1", Status: statusCompletedTest,
+			Outputs: map[string]string{"x": val},
+		},
+	})
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/v1/workflows/r1/outputs")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	raw, _ := io.ReadAll(resp.Body)
+	if bytes.ContainsAny(raw, "\x00\x1b") {
+		t.Errorf("raw control bytes leaked into JSON output: %q", raw)
+	}
+	var m map[string]string
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatalf("body is not valid JSON: %v (%q)", err, raw)
+	}
+	if m["x"] != val {
+		t.Errorf("round-trip mismatch: got %q, want %q", m["x"], val)
+	}
+}
+
+func TestHandler_WorkflowLogs_TerminalEventCarriesOutputs(t *testing.T) {
+	events := []domain.WatchEvent{
+		{RunID: "r1", EventType: "state.entered", ToState: "done", Status: "WORKFLOW_STATUS_RUNNING"},
+		{RunID: "r1", EventType: "workflow.completed", Status: statusCompletedTest},
+	}
+	srv := newServer(&stubCompiler{}, &stubEngine{
+		watchEvents: events,
+		statusRun:   domain.WorkflowRunSummary{RunID: "r1", Status: statusCompletedTest, Outputs: map[string]string{"review": "LGTM"}},
+	})
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/v1/workflows/r1/logs")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var dataLines []string
+	scanner := bufio.NewScanner(resp.Body)
+	for scanner.Scan() {
+		if line := scanner.Text(); strings.HasPrefix(line, "data: ") {
+			dataLines = append(dataLines, strings.TrimPrefix(line, "data: "))
+		}
+	}
+	if len(dataLines) == 0 {
+		t.Fatal("no SSE data lines")
+	}
+	var ev struct {
+		Status  string `json:"status"`
+		Payload string `json:"payload"`
+	}
+	if err := json.Unmarshal([]byte(dataLines[len(dataLines)-1]), &ev); err != nil {
+		t.Fatalf("terminal event not JSON: %v", err)
+	}
+	if ev.Status != statusCompletedTest {
+		t.Errorf("last event status = %q, want COMPLETED", ev.Status)
+	}
+	var pl struct {
+		Outputs map[string]string `json:"outputs"`
+	}
+	if err := json.Unmarshal([]byte(ev.Payload), &pl); err != nil {
+		t.Fatalf("terminal payload not JSON: %v (%q)", err, ev.Payload)
+	}
+	if pl.Outputs["review"] != "LGTM" {
+		t.Errorf("terminal payload outputs = %v, want review=LGTM", pl.Outputs)
+	}
+}
+
 // ── POST /api/v1/apply (kind: AgentDef) ──────────────────────────────────
 
-const agentDefYAML = "kind: AgentDef\napiVersion: zynax.io/v1alpha1\nmetadata:\n  name: test-agent\n"
+const (
+	agentDefYAML        = "kind: AgentDef\napiVersion: zynax.io/v1alpha1\nmetadata:\n  name: test-agent\n"
+	statusCompletedTest = "WORKFLOW_STATUS_COMPLETED"
+)
 
 func TestHandler_Apply_ValidAgentDef_Returns201(t *testing.T) {
 	srv := newServerWithRegistry(

--- a/services/api-gateway/internal/domain/apply_test.go
+++ b/services/api-gateway/internal/domain/apply_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"strings"
 	"sync"
 	"testing"
@@ -210,7 +211,7 @@ func TestApplyService_GetWorkflowStatus_Success(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if got != want {
+	if !reflect.DeepEqual(got, want) {
 		t.Errorf("got %+v, want %+v", got, want)
 	}
 }

--- a/services/api-gateway/internal/domain/ports.go
+++ b/services/api-gateway/internal/domain/ports.go
@@ -32,6 +32,10 @@ type WorkflowRunSummary struct {
 	WorkflowID   string
 	Status       string
 	CurrentState string
+	// Outputs are the resolved workflow-level outputs of a COMPLETED run
+	// (ADR-042, M7.U). Empty for runs that declared none and for non-terminal
+	// runs. Surfaced over HTTP by GET /api/v1/workflows/{id}/outputs.
+	Outputs map[string]string
 }
 
 // WatchEvent is a single lifecycle event emitted by a streaming WatchWorkflow call.

--- a/services/api-gateway/internal/infrastructure/clients.go
+++ b/services/api-gateway/internal/infrastructure/clients.go
@@ -162,6 +162,7 @@ func (c *GatewayClients) GetWorkflowStatus(ctx context.Context, runID string) (d
 		WorkflowID:   run.GetWorkflowId(),
 		Status:       run.GetStatus().String(),
 		CurrentState: run.GetCurrentState(),
+		Outputs:      run.GetOutputs(),
 	}, nil
 }
 


### PR DESCRIPTION
## feat(api-gateway): add GET workflows/{id}/outputs read path

Closes #1537 · Part of #1529 (M7.U — workflow-level output capture) · closes #1103 gateway gap #4

### Why
No REST path existed to read a completed run's outputs; `zynax result` (O.9) has nothing to read.
This adds the dedicated `/outputs` sub-resource that the engine (O.7) now backs via `WorkflowRun.outputs`.

### What you'll get
- **`GET /api/v1/workflows/{id}/outputs`** → forwards to the engine's `GetWorkflowStatus` and returns
  the outputs JSON: the declared outputs for a COMPLETED run, **`{}`** for a run that declared none,
  **404** for an unknown id. GET stays open (read-only); `json.Encoder` escapes control chars so
  attacker-influenced values render safely.
- **SSE `/logs` terminal event** now carries the run's outputs as `{"outputs": {...}}` so streaming
  consumers need no read-back (the engine history stream doesn't carry the Temporal result, so the
  gateway fetches it on the terminal COMPLETED event, using the same request context).
- `WorkflowRunSummary` gains an `Outputs` field, mapped from the engine `WorkflowRun`.

### Test plan & acceptance
| Acceptance criterion | How verified | Result |
|----------------------|--------------|--------|
| `/outputs` returns outputs JSON / `{}` / 404 (AC1) | `TestHandler_WorkflowOutputs_Returns200WithOutputs`, `_Empty_ReturnsEmptyObject`, `_NotFound_Returns404` | ✅ |
| `/logs` SSE terminal event includes outputs (AC2) | `TestHandler_WorkflowLogs_TerminalEventCarriesOutputs` | ✅ |
| handler_test populated/empty/404 + safe JSON (AC3) | above + `_SafeJSONEncoding` (control/ANSI bytes escaped, round-trips) | ✅ |
| `platform_client.get_outputs()` resolves (AC4) | it already targets `GET /outputs` and only raised on HTTPError — now returns 200 → resolves; no client change needed | ✅ |

**Local gates:** `GOWORK=off go test ./... -race` ✅ all packages · `golangci-lint run` ✅ 0 issues · domain cov 96.7%

### Risk & rollback
Low — additive route + a field on the summary; existing endpoints unchanged. The SSE enrichment only
fires on the terminal COMPLETED event and degrades gracefully if the status read fails. Revert = drop the route + field.

### Engineering hygiene
- [x] Canvas O.8 ✅ in this diff (Status stays Aligned — 7 of 11 O-steps)
- [x] Branched off fresh `origin/main` · DCO + `Assisted-by` · domain cov 96.7%

**SPDD:** Canvas `docs/spdd/1529-workflow-output-capture/canvas.md` — Status: Aligned · `/lib:spdd-security-review` PASS
