### PR TITLE
feat(cli): zynax result prints declared workflow outputs

### DIFF
--- a/cmd/zynax/client/gateway.go
+++ b/cmd/zynax/client/gateway.go
@@ -231,6 +231,35 @@ func (g *Gateway) GetWorkflow(ctx context.Context, runID string) (*WorkflowStatu
 	}
 }
 
+// GetWorkflowOutputs returns the declared workflow-level outputs of a run
+// (ADR-042, M7.U). The gateway returns an empty object for a run that declared
+// none and 404 for an unknown id (surfaced as ErrNotFound).
+func (g *Gateway) GetWorkflowOutputs(ctx context.Context, runID string) (map[string]string, error) {
+	req, err := g.newRequest(ctx, http.MethodGet, g.base+"/api/v1/workflows/"+runID+"/outputs", nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := g.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("zynax: get workflow outputs: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	raw, _ := io.ReadAll(resp.Body)
+	switch resp.StatusCode {
+	case http.StatusOK:
+		var outputs map[string]string
+		if err := json.Unmarshal(raw, &outputs); err != nil {
+			return nil, fmt.Errorf("zynax: decode workflow outputs: %w", err)
+		}
+		return outputs, nil
+	case http.StatusNotFound:
+		return nil, ErrNotFound
+	default:
+		return nil, fmt.Errorf("zynax: get workflow outputs: HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(raw)))
+	}
+}
+
 // DeleteWorkflow cancels a running workflow run.
 func (g *Gateway) DeleteWorkflow(ctx context.Context, runID string) error {
 	req, err := g.newRequest(ctx, http.MethodDelete, g.base+"/api/v1/workflows/"+runID, nil)

--- a/cmd/zynax/client/gateway_test.go
+++ b/cmd/zynax/client/gateway_test.go
@@ -145,6 +145,33 @@ func TestGetWorkflow_NotFound(t *testing.T) {
 	}
 }
 
+func TestGetWorkflowOutputs_ReturnsMap(t *testing.T) {
+	gw := newGW(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/workflows/run-42/outputs" {
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]string{"review": "LGTM", "score": "9"})
+	})
+	out, err := gw.GetWorkflowOutputs(context.Background(), "run-42")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out["review"] != "LGTM" || out["score"] != "9" {
+		t.Errorf("outputs = %v, want review=LGTM score=9", out)
+	}
+}
+
+func TestGetWorkflowOutputs_NotFound(t *testing.T) {
+	gw := newGW(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+	_, err := gw.GetWorkflowOutputs(context.Background(), "missing")
+	if !errors.Is(err, client.ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}
+
 func TestDeleteWorkflow_Returns204(t *testing.T) {
 	gw := newGW(t, func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNoContent)

--- a/cmd/zynax/cmd/cmd_test.go
+++ b/cmd/zynax/cmd/cmd_test.go
@@ -660,6 +660,117 @@ func TestResultCmd_Cancelled_Errors(t *testing.T) {
 	}
 }
 
+// resultServer serves both the SSE /logs stream and the JSON /outputs read path
+// so `zynax result`'s structured-outputs-plus-fallback flow can be exercised.
+func resultServer(t *testing.T, events []map[string]any, outputs map[string]string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/outputs"):
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(outputs)
+		case strings.HasSuffix(r.URL.Path, "/logs"):
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(http.StatusOK)
+			for _, ev := range events {
+				b, _ := json.Marshal(ev)
+				_, _ = fmt.Fprintf(w, "data: %s\n\n", b)
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// TestResultCmd_PrintsDeclaredOutputs asserts AC1: declared outputs are read from
+// the gateway /outputs route and printed as sorted name=value lines.
+func TestResultCmd_PrintsDeclaredOutputs(t *testing.T) {
+	srv := resultServer(t,
+		[]map[string]any{{"run_id": "ro", "event_type": "workflow.completed", "status": "WORKFLOW_STATUS_COMPLETED"}},
+		map[string]string{"message": "hello world", "score": "9"},
+	)
+	apiURL = srv.URL
+
+	out, err := runResult(t, []string{"ro"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "message=hello world") || !strings.Contains(out, "score=9") {
+		t.Errorf("outputs render = %q, want message=hello world + score=9", out)
+	}
+}
+
+// TestResultCmd_OutputsPreferredOverCompletion asserts the structured outputs win
+// over the legacy completion-text fallback when both are present.
+func TestResultCmd_OutputsPreferredOverCompletion(t *testing.T) {
+	srv := resultServer(t,
+		[]map[string]any{
+			{"run_id": "rp", "event_type": "task.completed", "status": "capability_event",
+				"payload": `{"result_payload":"{\"completion\":\"fallback text\"}"}`},
+			{"run_id": "rp", "event_type": "workflow.completed", "status": "WORKFLOW_STATUS_COMPLETED"},
+		},
+		map[string]string{"review": "structured wins"},
+	)
+	apiURL = srv.URL
+
+	out, err := runResult(t, []string{"rp"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "review=structured wins") {
+		t.Errorf("expected structured outputs, got %q", out)
+	}
+	if strings.Contains(out, "fallback text") {
+		t.Errorf("structured outputs must win over the completion fallback, got %q", out)
+	}
+}
+
+// TestResultCmd_CompletionFallback_WhenOutputsEmpty asserts AC2: a run whose
+// /outputs is empty still prints via the completion-text fallback.
+func TestResultCmd_CompletionFallback_WhenOutputsEmpty(t *testing.T) {
+	srv := resultServer(t,
+		[]map[string]any{
+			{"run_id": "rf", "event_type": "task.completed", "status": "capability_event",
+				"payload": `{"result_payload":"{\"completion\":\"the model review text\"}"}`},
+			{"run_id": "rf", "event_type": "workflow.completed", "status": "WORKFLOW_STATUS_COMPLETED"},
+		},
+		map[string]string{},
+	)
+	apiURL = srv.URL
+
+	out, err := runResult(t, []string{"rf"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.TrimSpace(out) != "the model review text" {
+		t.Errorf("fallback output = %q, want completion text", strings.TrimSpace(out))
+	}
+}
+
+// TestResultCmd_SanitizesControlAndANSI asserts AC4: control chars and ANSI
+// escapes in an output value are stripped before printing.
+func TestResultCmd_SanitizesControlAndANSI(t *testing.T) {
+	srv := resultServer(t,
+		[]map[string]any{{"run_id": "rs", "event_type": "workflow.completed", "status": "WORKFLOW_STATUS_COMPLETED"}},
+		map[string]string{"x": "a\x1b[31mred\x00\x07b"},
+	)
+	apiURL = srv.URL
+
+	out, err := runResult(t, []string{"rs"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.ContainsAny(out, "\x1b\x00\x07") {
+		t.Errorf("control/ANSI bytes leaked to output: %q", out)
+	}
+	if !strings.Contains(out, "x=aredb") {
+		t.Errorf("sanitised output = %q, want line x=aredb", out)
+	}
+}
+
 // ── last-run state (#1491, canvas O21) ────────────────────────────────────────
 
 // TestRunApply_RecordsLastRunID asserts AC1: a successful apply that returns a

--- a/cmd/zynax/cmd/result.go
+++ b/cmd/zynax/cmd/result.go
@@ -5,6 +5,8 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"io"
+	"sort"
 
 	"github.com/spf13/cobra"
 	"github.com/zynax-io/zynax/cmd/zynax/client"
@@ -18,15 +20,20 @@ var errResultDone = errors.New("result: terminal state reached")
 var resultCmd = &cobra.Command{
 	Use:     "result [run-id]",
 	GroupID: beginnerGroupID,
-	Short:   "Print the capability output (result payload) of a workflow run",
-	Long: "Stream a run's events and print the capability result payload — e.g. the " +
-		"model's review text from the code-review example — straight from the CLI.\n\n" +
+	Short:   "Print a workflow run's declared result",
+	Long: "See your declared workflow result from one command — the same whether the " +
+		"run executed on Temporal or Argo.\n\n" +
+		"`zynax result <run>` reads the run's declared outputs from " +
+		"GET /api/v1/workflows/{id}/outputs and prints them as name=value lines. If " +
+		"the workflow declared no outputs, it falls back to the last capability " +
+		"completion text it saw on the event stream (e.g. the model's review text " +
+		"from the code-review example).\n\n" +
 		"With no run id the command targets your most recent run (recorded by the " +
 		"last `zynax apply`/`run`). An explicit run id always overrides.\n\n" +
-		"The command tails the run until it reaches a terminal state and prints the " +
-		"last completion text it saw. A run that COMPLETED but declared no output " +
-		"exits 0 with a note (see the see-workflow-result runbook); a FAILED or " +
-		"CANCELLED run exits non-zero.",
+		"The command tails the run until it reaches a terminal state. A run that " +
+		"COMPLETED but declared neither outputs nor completion text exits 0 with a " +
+		"note; a FAILED or CANCELLED run exits non-zero. Output is sanitised of " +
+		"control/ANSI escapes before printing.",
 	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		runID, err := resolveRunID(args)
@@ -34,10 +41,12 @@ var resultCmd = &cobra.Command{
 			return err
 		}
 		gw := newGateway()
-		var output, terminalStatus string
+		// Tail the run to a terminal state, capturing the legacy completion-text
+		// fallback and the terminal status for the empty-result decision.
+		var completion, terminalStatus string
 		err = gw.WatchWorkflowLogs(cmd.Context(), runID, func(ev client.LogEvent) error {
 			if text := client.CompletionText(ev.Payload); text != "" {
-				output = text
+				completion = text
 			}
 			if terminalStatuses[ev.Status] {
 				terminalStatus = ev.Status
@@ -48,15 +57,23 @@ var resultCmd = &cobra.Command{
 		if err != nil && !errors.Is(err, errResultDone) {
 			return err
 		}
-		if output != "" {
-			_, _ = fmt.Fprintln(cmd.OutOrStdout(), output)
+
+		// Prefer the structured declared outputs (ADR-042, O.8 gateway route). A
+		// read error (older gateway, transient) is non-fatal — fall back to the
+		// completion text so the command still works against a legacy gateway.
+		if outputs, oErr := gw.GetWorkflowOutputs(cmd.Context(), runID); oErr == nil && len(outputs) > 0 {
+			printOutputs(cmd.OutOrStdout(), outputs)
 			return nil
 		}
-		// No completion text was emitted. A COMPLETED run that simply declared no
-		// output is a success — echo/hello-world style runs produce none — so exit
-		// 0 with a note pointing at the runbook (the structured-output reader in
-		// O.9 supersedes this). FAILED/CANCELLED, or a stream that closed before
-		// any terminal state, remain errors so a real failure never reads as success.
+		// Fallback: the last capability completion text seen on the stream.
+		if completion != "" {
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), sanitizeForTTY(completion))
+			return nil
+		}
+		// Neither structured outputs nor completion text. A COMPLETED run that
+		// simply declared no output is a success — exit 0 with a note pointing at
+		// the runbook. FAILED/CANCELLED, or a stream that closed before any
+		// terminal state, remain errors so a real failure never reads as success.
 		switch terminalStatus {
 		case "WORKFLOW_STATUS_COMPLETED":
 			_, _ = fmt.Fprintln(cmd.ErrOrStderr(),
@@ -68,6 +85,19 @@ var resultCmd = &cobra.Command{
 			return fmt.Errorf("run %s did not produce a result: status %s", runID, terminalStatus)
 		}
 	},
+}
+
+// printOutputs writes the declared outputs as sanitised name=value lines, sorted
+// by name for stable output.
+func printOutputs(w io.Writer, outputs map[string]string) {
+	keys := make([]string, 0, len(outputs))
+	for k := range outputs {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		_, _ = fmt.Fprintf(w, "%s=%s\n", sanitizeForTTY(k), sanitizeForTTY(outputs[k]))
+	}
 }
 
 func init() {

--- a/cmd/zynax/cmd/sanitize.go
+++ b/cmd/zynax/cmd/sanitize.go
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"regexp"
+	"strings"
+)
+
+// ansiEscapeRe matches ANSI/VT escape sequences: CSI (ESC[…), OSC (ESC]…BEL/ST),
+// and simple ESC-prefixed forms. Stripping them stops attacker-influenced
+// workflow output from driving the user's terminal (ADR-042 §6).
+var ansiEscapeRe = regexp.MustCompile("\x1b(\\[[0-9;?]*[ -/]*[@-~]|\\][^\x07\x1b]*(\x07|\x1b\\\\)|[@-Z\\\\-_])")
+
+// sanitizeForTTY strips ANSI escape sequences and C0/C1 control characters —
+// keeping only the common whitespace \t, \n, \r — from untrusted output before
+// it is printed to a terminal. Workflow outputs and completion text are
+// attacker-influenced (ADR-042 §6).
+func sanitizeForTTY(s string) string {
+	s = ansiEscapeRe.ReplaceAllString(s, "")
+	return strings.Map(func(r rune) rune {
+		switch {
+		case r == '\t' || r == '\n' || r == '\r':
+			return r
+		case r < 0x20, r >= 0x7f && r <= 0x9f:
+			return -1
+		default:
+			return r
+		}
+	}, s)
+}

--- a/docs/runbooks/see-workflow-result.md
+++ b/docs/runbooks/see-workflow-result.md
@@ -3,23 +3,26 @@
 > **Watch your workflow run and see its result the same way whether it executed on Temporal or
 > Argo.** This page is the reliable, copy-pasteable way to read a completed run's output **today**.
 
-## When to use this
+## The quick answer: `zynax result`
 
-You ran a workflow, it reached `WORKFLOW_STATUS_COMPLETED`, and you want its result — but
-`zynax result <run-id>` printed:
+You ran a workflow, it reached `WORKFLOW_STATUS_COMPLETED`, and you want its result:
 
 ```
-no result payload for run wf-<hex>
+zynax result <run-id>
 ```
 
-That error is a **known interim limitation**, not a failed run. `zynax result` hard-errors on a
-COMPLETED run whose capabilities emit no `completion` field (for example a plain echo/hello-world
-step), even though the run succeeded — see
-[cmd/zynax/cmd/result.go](../../cmd/zynax/cmd/result.go). The permanent fix — declared
-workflow-level outputs surfaced by `zynax result`, and a graceful exit-0 on empty — lands in
+`zynax result` reads the run's **declared outputs** from
+`GET /api/v1/workflows/{id}/outputs` and prints them as `name=value` lines
+([cmd/zynax/cmd/result.go](../../cmd/zynax/cmd/result.go), ADR-042). If the workflow declared no
+`outputs:`, it falls back to the last capability **completion** text on the event stream (e.g. the
+model's review from the code-review example). A COMPLETED run that produced neither exits 0 with a
+short note (never a hard error); a FAILED/CANCELLED run exits non-zero. Output is sanitised of
+control/ANSI escapes before printing. Delivered by
 **M7.U O.9** ([#1538](https://github.com/zynax-io/zynax/issues/1538)), part of epic
-[#1529](https://github.com/zynax-io/zynax/issues/1529). Until then, use any of the four methods
-below. They all read the **same** lifecycle stream, so the result is identical no matter which
+[#1529](https://github.com/zynax-io/zynax/issues/1529).
+
+The methods below remain useful for **watching** a run live, replaying/scripting, or proving a run
+is terminal. They all read the **same** lifecycle stream, so the result is identical no matter which
 engine executed the run.
 
 > Every command takes an explicit `<run-id>` (the `run_id: wf-<hex>` line printed by `zynax apply`).
@@ -80,7 +83,8 @@ zynax logs <run-id> --format json \
 ```
 
 The last non-empty line is your result. Runs with no completion field (e.g. echo/hello-world) print
-nothing here — that is expected, and is exactly the case the interim `zynax result` mishandles.
+nothing here — that is expected; `zynax result` reads the run's declared `outputs:` instead, and for
+a run with neither exits 0 with a graceful note.
 
 ---
 

--- a/docs/spdd/1529-workflow-output-capture/canvas.md
+++ b/docs/spdd/1529-workflow-output-capture/canvas.md
@@ -140,8 +140,9 @@ Config env prefix: `ZYNAX_<SERVICE>_` · Engine-agnostic interpreter (Temporal /
 8. **O.8 (#1537, feat·gateway)** ✅ — `GET /api/v1/workflows/{id}/outputs` ({} / 404); outputs on SSE terminal
    event. Verified: `handler_test` populated/empty/404 + safe-JSON + terminal-SSE-carries-outputs;
    `platform_client.get_outputs()` already targets the route (now resolves instead of raising); domain cov 96.7%.
-9. **O.9 (#1538, feat·cli)** — `zynax result` reads `/outputs`, prints declared outputs, falls back to
-   `CompletionText`, sanitizes control chars; wedge-first help. Verified: CLI tests outputs/fallback/empty/FAILED.
+9. **O.9 (#1538, feat·cli)** ✅ — `zynax result` reads `/outputs`, prints declared outputs, falls back to
+   `CompletionText`, sanitizes control chars; wedge-first help. Verified: CLI tests
+   outputs/fallback/empty/FAILED + sanitize + client GetWorkflowOutputs; binary `result --help` smoke; O.1 runbook updated.
 10. **O.10 (#1539, feat·spec)** — Declare terminal `outputs:` on hello-world + code-review; update comments +
     runbook. Verified: examples compile/validate; existing 9 examples unchanged; `zynax result` prints output.
 11. **O.11 (#1540, test·engine)** — Gated e2e (`ZYNAX_PLATFORM_E2E=1`) proving apply→COMPLETED→`/outputs`;


### PR DESCRIPTION
## feat(cli): zynax result prints declared workflow outputs

Closes #1538 · Part of #1529 (M7.U — workflow-level output capture) — **the epic's payoff**

### Why
`zynax result` only scraped the last capability `completion` text and hard-errored on empty, so a
workflow's declared result was invisible at the CLI. This makes one command show the declared outputs.

### What you'll get
- **Structured outputs first:** reads `GET /api/v1/workflows/{id}/outputs` (O.8) and prints the
  declared outputs as sorted `name=value` lines.
- **Fallback:** if the workflow declared no `outputs:`, falls back to the last completion text on the
  event stream (legacy/echo runs).
- **Graceful empty:** a COMPLETED run with neither exits 0 with the O.3 runbook note; FAILED/CANCELLED
  exit non-zero.
- **Output safety (ADR-042 §6):** `sanitize.go` strips ANSI escapes + C0/C1 control chars (keeps
  `\t \n \r`) before TTY render — outputs are attacker-influenced.
- **Wedge-first help:** "See your declared workflow result from one command — the same whether the run
  executed on Temporal or Argo."
- **client:** `Gateway.GetWorkflowOutputs` (404 → `ErrNotFound`).
- **runbook:** the O.1 caveat is updated — `zynax result` now works.

### Test plan & acceptance
| Acceptance criterion | How verified | Result |
|----------------------|--------------|--------|
| Outputs present → prints name=value, exit 0 (AC1) | `TestResultCmd_PrintsDeclaredOutputs`, `_OutputsPreferredOverCompletion` | ✅ |
| Completion-only legacy run prints via fallback (AC2) | `_CompletionFallback_WhenOutputsEmpty` + existing `_PrintsCompletion` | ✅ |
| COMPLETED with neither → graceful message, exit 0 (AC3) | `_CompletedNoOutput_ExitsZeroWithNote` | ✅ |
| Control/ANSI stripped before TTY (AC4) | `_SanitizesControlAndANSI` | ✅ |
| CLI tests outputs/fallback/empty/FAILED; runbook updated (AC5) | 7 result tests + 2 client tests + `_Failed_Errors`/`_Cancelled_Errors`; runbook diff | ✅ |

**Local gates:** `GOWORK=off go test ./... -race` ✅ all `cmd/zynax` packages · `golangci-lint run` ✅ 0 issues · binary `result --help` smoke ✅

### Risk & rollback
Low — strictly improves `zynax result`; the outputs read is best-effort (falls back on any read error,
so it still works against an older gateway). Revert = restore the completion-only `result.go` + drop `sanitize.go`.

### Engineering hygiene
- [x] Canvas O.9 ✅ in this diff (Status stays Aligned — 8 of 11 O-steps; only O.10 spec + O.11 e2e remain)
- [x] Branched off fresh `origin/main` · DCO + `Assisted-by`

**SPDD:** Canvas `docs/spdd/1529-workflow-output-capture/canvas.md` — Status: Aligned · `/lib:spdd-security-review` PASS
