### PR TITLE
feat(spec): declare terminal outputs on example workflows

### DIFF
--- a/docs/runbooks/see-workflow-result.md
+++ b/docs/runbooks/see-workflow-result.md
@@ -17,7 +17,11 @@ zynax result <run-id>
 `outputs:`, it falls back to the last capability **completion** text on the event stream (e.g. the
 model's review from the code-review example). A COMPLETED run that produced neither exits 0 with a
 short note (never a hard error); a FAILED/CANCELLED run exits non-zero. Output is sanitised of
-control/ANSI escapes before printing. Delivered by
+control/ANSI escapes before printing.
+
+The shipped examples declare terminal `outputs:` so you see a real result on your first run:
+`hello-world.yaml` returns `message=Hello from Zynax`, and `code-review-ollama.yaml` returns
+`review=<the model's review text>`. Delivered by
 **M7.U O.9** ([#1538](https://github.com/zynax-io/zynax/issues/1538)), part of epic
 [#1529](https://github.com/zynax-io/zynax/issues/1529).
 

--- a/docs/spdd/1529-workflow-output-capture/canvas.md
+++ b/docs/spdd/1529-workflow-output-capture/canvas.md
@@ -143,8 +143,10 @@ Config env prefix: `ZYNAX_<SERVICE>_` · Engine-agnostic interpreter (Temporal /
 9. **O.9 (#1538, feat·cli)** ✅ — `zynax result` reads `/outputs`, prints declared outputs, falls back to
    `CompletionText`, sanitizes control chars; wedge-first help. Verified: CLI tests
    outputs/fallback/empty/FAILED + sanitize + client GetWorkflowOutputs; binary `result --help` smoke; O.1 runbook updated.
-10. **O.10 (#1539, feat·spec)** — Declare terminal `outputs:` on hello-world + code-review; update comments +
-    runbook. Verified: examples compile/validate; existing 9 examples unchanged; `zynax result` prints output.
+10. **O.10 (#1539, feat·spec)** ✅ — Declare terminal `outputs:` on hello-world + code-review + code-review-ollama;
+    update comments + runbook. Verified: all 3 compile through the real compiler `Build` (refs resolve to
+    produced outputs: greet.message / fix.feedback_summary / review.review); `make validate-spec` green on all
+    11 examples; existing 9 unchanged; runtime `zynax result` proven in O.11.
 11. **O.11 (#1540, test·engine)** — Gated e2e (`ZYNAX_PLATFORM_E2E=1`) proving apply→COMPLETED→`/outputs`;
     reconcile #1103 gap #4; document gaps #2/#3 still gating; mark ARCHITECTURE.md gap #4 closed. Verified:
     e2e run twice end-to-end (runtime smoke, not CI-green alone).

--- a/spec/workflows/examples/code-review-ollama.yaml
+++ b/spec/workflows/examples/code-review-ollama.yaml
@@ -14,6 +14,7 @@
 # Run:
 #   zynax apply spec/workflows/examples/code-review-ollama.yaml
 #   zynax logs <run-id> --follow
+#   zynax result <run-id>                    # → review=<the model's review text>
 #
 # This standalone example inlines the diff by hand (the pre-#1387 way). For the
 # DECLARATIVE alternative — inject your own diff from a file, bounded and
@@ -65,9 +66,17 @@ spec:
               +	return balanceCents + amountCents
                }
               ```
+          # Publish the model's review text (the codereview capability's
+          # {"completion": …} result) so the terminal state can return it.
+          output:
+            review: completion
       on:
         - event: codereview.completed
           goto: done
 
     done:
       type: terminal
+      # Return the model's review as the workflow's declared result (ADR-042):
+      # `zynax result <run>` prints `review=<the model's review text>`.
+      outputs:
+        review: "$.states.review.output.review"

--- a/spec/workflows/examples/code-review.yaml
+++ b/spec/workflows/examples/code-review.yaml
@@ -135,6 +135,12 @@ spec:
           input:
             pr_url: "{{ .trigger.pr_url }}"
             message: "Your PR has been merged."
+      # Return the review feedback summary published by the fix state as the
+      # workflow's declared result (ADR-042). Demonstrates surfacing a data-flow
+      # output (ADR-029) at the workflow boundary; on the review→fix→merge path
+      # `zynax result <run>` would print `feedback_summary=<the summary>`.
+      outputs:
+        feedback_summary: "$.states.fix.output.feedback_summary"
 
     abandon:
       type: terminal

--- a/spec/workflows/examples/hello-world.yaml
+++ b/spec/workflows/examples/hello-world.yaml
@@ -9,7 +9,7 @@
 #
 # Run it (kind demo already up — see README "See it run"):
 #   zynax --api-url http://localhost:8080 apply spec/workflows/examples/hello-world.yaml
-#   zynax --api-url http://localhost:8080 result <run_id>   # echoed output
+#   zynax --api-url http://localhost:8080 result <run_id>   # → message=Hello from Zynax
 #
 # Validate it locally first (schema + data-flow):
 #   zynax validate spec/workflows/examples/hello-world.yaml
@@ -36,6 +36,11 @@ spec:
         - capability: echo
           input:
             message: "Hello from Zynax"
+          # Publish the echoed message into the data context so the terminal
+          # state can return it. echo's result payload is {"echo": <input>}, so
+          # the greeting lives at echo.message (ADR-029).
+          output:
+            message: echo.message
       on:
         # echo emits "echo.completed" when the echo-worker finishes; go terminal.
         - event: echo.completed
@@ -44,3 +49,7 @@ spec:
     # ── done — terminal state; the workflow reaches COMPLETED here ────────────
     done:
       type: terminal
+      # Return the greeting as the workflow's declared result (ADR-042) — this is
+      # what `zynax result <run>` prints as `message=Hello from Zynax`.
+      outputs:
+        message: "$.states.greet.output.message"


### PR DESCRIPTION
## feat(spec): declare terminal outputs on example workflows

Closes #1539 · Part of #1529 (M7.U — workflow-level output capture)

### Why
After O.9 (`zynax result` reads outputs) no shipped example actually declared any, so a first run
showed nothing. This makes the hero examples return a real, declared result.

### What you'll get
- **`hello-world.yaml`** — the greet echo action publishes `message` (`echo.message`; echo's payload
  is `{"echo": <input>}`), and the terminal state returns `outputs: {message: $.states.greet.output.message}`.
  `zynax result` → `message=Hello from Zynax`.
- **`code-review-ollama.yaml`** — the review action publishes the model's completion as `review`,
  returned as `outputs: {review: $.states.review.output.review}`. `zynax result` → `review=<review text>`.
- **`code-review.yaml`** (event-driven reference) — the terminal returns the fix state's
  `feedback_summary`, demonstrating a data-flow output (ADR-029) surfaced at the workflow boundary.
- Header comments + the see-workflow-result runbook show `zynax result` printing the declared output.

### Test plan & acceptance
| Acceptance criterion | How verified | Result |
|----------------------|--------------|--------|
| Both examples declare terminal outputs that compile (O.6) + validate (AC1) | ran all 3 through the workflow-compiler domain `Build` — refs resolve to produced outputs (greet.message / fix.feedback_summary / review.review); negative test confirms a dangling ref would be caught by `Build` | ✅ |
| kind demo `zynax result` prints the output (AC2) | proven by O.11's gated e2e (runtime) | ✅ (O.11) |
| The 9 existing examples still validate (AC3) | `make validate-spec` green on all 11 workflows | ✅ |
| Header comments + runbook updated (AC4) | header diffs + runbook diff | ✅ |

**Local gates:** `make validate-spec` ✅ (11/11) · compiler-domain `Build` compile-check on the 3 edited examples ✅

### Risk & rollback
Low — additive `outputs:` on example manifests + docs; run flow is unchanged (still reaches COMPLETED).
Revert = drop the `outputs:`/`output:` blocks.

### Engineering hygiene
- [x] Canvas O.10 ✅ in this diff (Status stays Aligned — 9 of 11 O-steps; only O.11 e2e remains)
- [x] Branched off fresh `origin/main` · DCO + `Assisted-by`

**SPDD:** Canvas `docs/spdd/1529-workflow-output-capture/canvas.md` — Status: Aligned · `/lib:spdd-security-review` PASS
