### PR TITLE
fix(adk): harden adapter per review (done-frame, error sanitising, timeout)

### DIFF
--- a/agents/adapters/adk/internal/adapter/server.go
+++ b/agents/adapters/adk/internal/adapter/server.go
@@ -17,6 +17,7 @@ import (
 	"errors"
 	"fmt"
 	"iter"
+	"math"
 	"strings"
 	"time"
 
@@ -144,9 +145,9 @@ func (s *AgentServer) ExecuteCapability(req *zynaxv1.ExecuteCapabilityRequest, s
 	}
 
 	ctx := stream.Context()
-	if req.TimeoutSeconds > 0 {
+	if secs := resolveTimeout(req.TimeoutSeconds, rt.cfg.TimeoutSeconds); secs > 0 {
 		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, time.Duration(req.TimeoutSeconds)*time.Second)
+		ctx, cancel = context.WithTimeout(ctx, time.Duration(secs)*time.Second)
 		defer cancel()
 	}
 
@@ -392,4 +393,18 @@ func boundMessage(msg string) string {
 		r = r[:maxErrMsgLen]
 	}
 	return string(r)
+}
+
+// resolveTimeout picks the effective run budget: the request timeout when set,
+// else the capability's configured default, else 0 (no deadline). The AgentDef
+// declares a per-capability timeout_seconds; honouring it as a fallback makes
+// that config load-bearing even when a caller omits the request timeout.
+func resolveTimeout(reqSecs int32, cfgSecs int) int32 {
+	if reqSecs > 0 {
+		return reqSecs
+	}
+	if cfgSecs > 0 && cfgSecs <= math.MaxInt32 {
+		return int32(cfgSecs)
+	}
+	return 0
 }

--- a/agents/adapters/adk/internal/adapter/server_test.go
+++ b/agents/adapters/adk/internal/adapter/server_test.go
@@ -355,6 +355,19 @@ func TestBoundMessage(t *testing.T) {
 	}
 }
 
+func TestResolveTimeout(t *testing.T) {
+	cases := []struct{ req, cfg, want int32 }{
+		{30, 60, 30}, // request wins when set
+		{0, 60, 60},  // falls back to the capability default
+		{0, 0, 0},    // no deadline
+	}
+	for _, c := range cases {
+		if got := resolveTimeout(c.req, int(c.cfg)); got != c.want {
+			t.Errorf("resolveTimeout(%d,%d) = %d, want %d", c.req, c.cfg, got, c.want)
+		}
+	}
+}
+
 func TestOutputTargetKey(t *testing.T) {
 	cases := map[string]string{
 		triageOutputSchema:  "response",

--- a/agents/adapters/adk/internal/model/ollama.go
+++ b/agents/adapters/adk/internal/model/ollama.go
@@ -125,8 +125,11 @@ func (o *Ollama) GenerateContent(ctx context.Context, req *adkmodel.LLMRequest, 
 		defer func() { _ = resp.Body.Close() }()
 
 		if resp.StatusCode != http.StatusOK {
-			b, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrBody))
-			yield(nil, fmt.Errorf("ollama: chat status %d: %s", resp.StatusCode, strings.TrimSpace(string(b))))
+			// Do not surface the raw upstream body: it is untrusted external bytes
+			// that must not flow into a CapabilityError.message (adapter rule).
+			// The status code is enough to classify; the body stays in Ollama's logs.
+			_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, maxErrBody))
+			yield(nil, fmt.Errorf("ollama: chat status %d", resp.StatusCode))
 			return
 		}
 
@@ -168,6 +171,16 @@ func streamChat(body io.Reader, yield func(*adkmodel.LLMResponse, error) bool) {
 			return
 		}
 		if cr.Done {
+			// The done frame may itself carry the tail of the generation (some
+			// servers flush it alongside the done marker); include it so the
+			// aggregated final text is never truncated. Empty content (the
+			// canonical case) is a no-op.
+			if tail := cr.Message.Content; tail != "" {
+				full.WriteString(tail)
+				if !yield(partialResponse(tail), nil) {
+					return
+				}
+			}
 			yield(finalResponse(full.String()), nil)
 			return
 		}

--- a/agents/adapters/adk/internal/model/ollama_test.go
+++ b/agents/adapters/adk/internal/model/ollama_test.go
@@ -119,6 +119,28 @@ func TestGenerateContent_Stream(t *testing.T) {
 	}
 }
 
+// TestGenerateContent_StreamContentOnDone covers a server that flushes the tail
+// of the generation alongside the done marker — the tail must land in the final
+// aggregated text, not be dropped.
+func TestGenerateContent_StreamContentOnDone(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		enc := json.NewEncoder(w)
+		_ = enc.Encode(chatResponse{Message: chatMessage{Content: "Hel"}})
+		_ = enc.Encode(chatResponse{Message: chatMessage{Content: "lo"}, Done: true}) // content ON the done frame
+	}))
+	defer srv.Close()
+
+	o := NewOllama(srv.URL, "m")
+	got, err := collect(o.GenerateContent(context.Background(), userReq("hi"), true))
+	if err != nil {
+		t.Fatalf("GenerateContent: %v", err)
+	}
+	final := got[len(got)-1]
+	if final.Partial || !final.TurnComplete || contentText(final.Content) != "Hello" {
+		t.Errorf("final aggregated text = %q, want %q (done-frame tail must not be dropped)", contentText(final.Content), "Hello")
+	}
+}
+
 func TestGenerateContent_HTTPError(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.Error(w, "model not found", http.StatusNotFound)


### PR DESCRIPTION
## What

Closes out the three lower-severity findings from the adk-adapter adversarial
review (the two contract-critical ones landed in #1557 / #1479). All internal to
the adapter — no interface change.

1. **Done-frame content** (`model/ollama.go`): `streamChat` now includes any
   text carried on the Ollama `done:true` frame in the aggregated final response
   (and forwards it as a partial). A server that flushes the generation tail
   alongside the done marker previously had that text silently dropped from the
   `COMPLETED` payload. Matches the `llm-adapter`'s own done-frame handling.
2. **Error sanitising** (`model/ollama.go`): the HTTP-status error no longer
   embeds the raw upstream response body — untrusted external bytes must not flow
   into a `CapabilityError.message`. The status code classifies; the body stays
   in Ollama's logs.
3. **Per-capability timeout** (`adapter/server.go`): `ExecuteCapability` applies
   the declared `timeout_seconds` as a fallback when the request omits one
   (`resolveTimeout`, bounds-checked int→int32), making the AgentDef's budget
   load-bearing.

## Verification

New tests: content-on-done stream frame, `resolveTimeout` precedence. `GOWORK=off
go test ./... -race` green; `golangci-lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
