### PR TITLE
feat(adk): AgentDef config, demo workflow + image/compose wiring (S4 of #1476)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -70,6 +70,7 @@ infra/k8s/
 # ── Adapter build allowlist (negations for agents/adapters/*/Dockerfile) ──────
 # Adapter Dockerfiles are built from repo root and need their module source
 # plus the generated proto stubs to resolve the workspace replace directive.
+!agents/adapters/adk/
 !agents/adapters/http/
 !agents/adapters/git/
 !agents/adapters/ci/

--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ Replace `api-gateway` with any image name from the table above.
               ↓
         Task Broker (Go)       ← Capability routing
               ↓
-    Execution Adapters Layer   ← LLM / HTTP / Git / CI / LangGraph
+    Execution Adapters Layer   ← LLM / HTTP / Git / CI / LangGraph / ADK
               ↓
      Event Bus — NATS (Go)     ← All events
               ↓
@@ -486,6 +486,7 @@ Current implementation status per service and adapter (as of M7 active developme
 | ci-adapter | Go | ✅ Complete | `trigger_workflow`, `get_run_status` via GitHub Actions REST API |
 | llm-adapter | Go | ✅ Complete | `chat_completion` — OpenAI, AWS Bedrock, Ollama (ported from Python, ADR-035) |
 | langgraph-adapter | Python | ✅ Complete | LangGraph `StateGraph` as Zynax capabilities; wired in e2e-demo |
+| adk-adapter | Go | ✅ Complete | Google ADK (Go) `llmagent` per capability over a zero-secret local Ollama model (ADR-038) |
 
 **Legend:** ✅ Complete · 🟡 MVP (in-memory, ephemeral) · 🔄 In Progress · 📋 Planned
 

--- a/agents/adapters/adk/AGENTS.md
+++ b/agents/adapters/adk/AGENTS.md
@@ -50,11 +50,16 @@ YAML at the path in `ADAPTER_CONFIG`. Key fields:
 | Field | Description |
 |-------|-------------|
 | `agent_id` | Unique id registered with agent-registry. |
-| `endpoint` | gRPC bind address (default `:50080`). |
+| `endpoint` | gRPC **bind** address (default `:50080`). A hostless value binds all interfaces but is not routable. |
+| `advertise_endpoint` | **Routable** address the task-broker dials (e.g. `adk-adapter:50080`). Required when `endpoint` is hostless (issue #1371); else falls back to `endpoint`. |
 | `registry_endpoint` | agent-registry address (e.g. `agent-registry:50052`). |
-| `model.provider` | `ollama` (default) or `gemini`. |
-| `model.name` | Model id (e.g. `qwen2.5-coder:3b`). |
+| `model.provider` | `ollama` (default; only value wired). |
+| `model.name` | Model id (e.g. `qwen2.5-coder:0.5b`). |
 | `capabilities[]` | `name`, `instruction`, `input_schema_json`, `output_schema_json`, `timeout_seconds`. |
+
+Runnable demo (secret-free, local Ollama): `spec/workflows/examples/adk-code-review-ollama.yaml`
+dispatches the `review` capability declared in `agent-def.yaml.example`. Bring up the
+Ollama overlay (`docker-compose.ollama.yml`), then `zynax apply … && zynax result <run>`.
 
 ## The bridge (`internal/adapter`)
 

--- a/agents/adapters/adk/Dockerfile
+++ b/agents/adapters/adk/Dockerfile
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: Apache-2.0
+# Build context: repo root  (docker build -f agents/adapters/adk/Dockerfile .)
+# BEGIN zynax-ci:images:golang-alpine
+ARG GO_ALPINE_DIGEST=sha256:f23e8b227fb4493eabe03bede4d5a32d04092da71962f1fb79b5f7d1e6c2a17f
+# END zynax-ci:images:golang-alpine
+# BEGIN zynax-ci:images:distroless-static
+ARG DISTROLESS_DIGEST=sha256:dfadf31470f770fcabd48903762dce126958e98d1ce320acf1216bbfaa42d79c
+# END zynax-ci:images:distroless-static
+FROM golang:1.26.4-alpine@${GO_ALPINE_DIGEST} AS builder
+
+WORKDIR /workspace
+
+COPY protos/generated/go/go.mod protos/generated/go/go.sum ./protos/generated/go/
+COPY agents/adapters/adk/go.mod agents/adapters/adk/go.sum ./agents/adapters/adk/
+RUN cd agents/adapters/adk && GOWORK=off go mod download
+
+COPY protos/generated/go/ ./protos/generated/go/
+COPY agents/adapters/adk/ ./agents/adapters/adk/
+COPY tools/healthcheck/ ./tools/healthcheck/
+RUN cd agents/adapters/adk && CGO_ENABLED=0 GOWORK=off \
+    go build -trimpath -ldflags "-s -w" -o /adk-adapter ./cmd/adk-adapter/
+RUN cd tools/healthcheck && CGO_ENABLED=0 GOWORK=off \
+    go build -trimpath -ldflags "-s -w" -o /healthcheck .
+
+# renovate: datasource=docker depName=gcr.io/distroless/static
+FROM gcr.io/distroless/static:nonroot@${DISTROLESS_DIGEST}
+COPY --from=builder /adk-adapter /adk-adapter
+COPY --from=builder /healthcheck /healthcheck
+COPY --from=builder /workspace/agents/adapters/adk/agent-def.yaml.example /etc/adk-adapter/config.yaml
+LABEL org.opencontainers.image.title="Zynax ADK Adapter" \
+      org.opencontainers.image.description="Zynax capability adapter embedding Google ADK (Go) agents. Runs an llmagent per capability over a zero-secret local Ollama model and bridges the ADK Runner onto the AgentService TaskEvent stream." \
+      org.opencontainers.image.url="https://github.com/zynax-io/zynax" \
+      org.opencontainers.image.source="https://github.com/zynax-io/zynax" \
+      org.opencontainers.image.documentation="https://github.com/zynax-io/zynax/blob/main/agents/adapters/adk/Dockerfile" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.vendor="Zynax"
+ENTRYPOINT ["/adk-adapter"]

--- a/agents/adapters/adk/agent-def.yaml.example
+++ b/agents/adapters/adk/agent-def.yaml.example
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: Apache-2.0
+# adk-adapter config — Google ADK (Go) agents as Zynax capabilities (ADR-038).
+#
+# Baked into the image at /etc/adk-adapter/config.yaml (ADAPTER_CONFIG). The
+# default is the ZERO-SECRET local Ollama path: no API key, no cloud call. Pull
+# the model first on the host (`ollama pull qwen2.5-coder:0.5b`) and bring up the
+# stack with the Ollama overlay:
+#
+#   docker compose -f infra/docker-compose/docker-compose.yml \
+#     -f infra/docker-compose/docker-compose.ollama.yml up -d ollama adk-adapter
+#
+# Then dispatch the capability from a workflow:
+#   zynax apply spec/workflows/examples/adk-code-review-ollama.yaml
+#   zynax logs <run-id> --follow
+#   zynax result <run-id>                    # → review=<the ADK agent's review>
+
+agent_id: adk-adapter
+name: ADK Adapter (Ollama / local)
+description: Google ADK (Go) agents exposed as Zynax capabilities, zero-secret on local Ollama.
+
+# `endpoint` is the gRPC BIND address; ":50080" binds all interfaces so the
+# in-container healthcheck (which dials localhost:50080) passes. `advertise_endpoint`
+# is the ROUTABLE address the task-broker dials — the compose service name. A
+# hostless bind endpoint must never be advertised verbatim (issue #1371).
+endpoint: ":50080"
+advertise_endpoint: adk-adapter:50080
+registry_endpoint: agent-registry:50052
+
+model:
+  provider: ollama
+  # A small, fast, code-focused local model — makes the first run zero-cost and
+  # quick. Switch model/host here; host also falls back to $OLLAMA_HOST.
+  name: qwen2.5-coder:0.5b
+  host: http://ollama:11434
+
+capabilities:
+  # Capability name has NO underscore on purpose — the engine derives the
+  # completion event as "<capability>.completed", and the workflow compiler
+  # rejects event types containing underscores (must be dot-separated lowercase).
+  - name: review
+    timeout_seconds: 300
+    description: Review a code diff with an ADK agent and return concrete findings.
+    instruction: |
+      You are a senior Go code reviewer. Review the diff the user provides and
+      reply with a short, numbered list of concrete issues (correctness, security,
+      edge cases), each citing the function name. End with an APPROVE or
+      REQUEST-CHANGES verdict. Be concise.
+    input_schema_json: |
+      {
+        "type": "object",
+        "required": ["prompt"],
+        "properties": { "prompt": { "type": "string", "minLength": 1 } },
+        "additionalProperties": false
+      }
+    output_schema_json: |
+      {
+        "type": "object",
+        "required": ["response"],
+        "properties": { "response": { "type": "string" } }
+      }

--- a/agents/adapters/adk/internal/config/config.go
+++ b/agents/adapters/adk/internal/config/config.go
@@ -10,6 +10,7 @@ package config
 
 import (
 	"fmt"
+	"net"
 	"os"
 
 	"gopkg.in/yaml.v3"
@@ -24,13 +25,20 @@ const ProviderOllama = "ollama"
 
 // AdapterConfig is the top-level YAML struct parsed from the file at startup.
 type AdapterConfig struct {
-	AgentID          string             `yaml:"agent_id"`
-	Name             string             `yaml:"name"`
-	Description      string             `yaml:"description"`
-	Endpoint         string             `yaml:"endpoint"`
-	RegistryEndpoint string             `yaml:"registry_endpoint"`
-	Model            ModelConfig        `yaml:"model"`
-	Capabilities     []CapabilityConfig `yaml:"capabilities"`
+	AgentID     string `yaml:"agent_id"`
+	Name        string `yaml:"name"`
+	Description string `yaml:"description"`
+	// Endpoint is the address the gRPC server binds to (net.Listen). A hostless
+	// value such as ":50080" binds all interfaces but is NOT routable, so it must
+	// never be advertised to the registry verbatim (issue #1371).
+	Endpoint string `yaml:"endpoint"`
+	// AdvertiseEndpoint is the routable address the task-broker dials for this
+	// adapter, e.g. "adk-adapter:50080". When empty it falls back to Endpoint —
+	// but only if Endpoint carries an explicit host (see AdvertisedEndpoint).
+	AdvertiseEndpoint string             `yaml:"advertise_endpoint"`
+	RegistryEndpoint  string             `yaml:"registry_endpoint"`
+	Model             ModelConfig        `yaml:"model"`
+	Capabilities      []CapabilityConfig `yaml:"capabilities"`
 }
 
 // ModelConfig selects the LLM backend shared by every ADK agent in this adapter.
@@ -87,6 +95,14 @@ func (c *AdapterConfig) validate() error {
 	if c.RegistryEndpoint == "" {
 		return fmt.Errorf("config: registry_endpoint is required")
 	}
+	// The address advertised to the registry must be routable. A hostless bind
+	// endpoint (":50080") advertised verbatim makes the broker dial localhost
+	// (issue #1371), so require an explicit advertise_endpoint in that case.
+	if c.AdvertiseEndpoint == "" && !hasExplicitHost(c.Endpoint) {
+		return fmt.Errorf(
+			"config: advertise_endpoint is required when endpoint %q is hostless "+
+				"(a hostless bind address is not routable by the task-broker)", c.Endpoint)
+	}
 	if c.Model.Provider != ProviderOllama {
 		return fmt.Errorf("config: model.provider %q unsupported (only %q is wired)", c.Model.Provider, ProviderOllama)
 	}
@@ -99,4 +115,25 @@ func (c *AdapterConfig) validate() error {
 		}
 	}
 	return nil
+}
+
+// AdvertisedEndpoint returns the routable address registered with the registry
+// and dialled by the task-broker. It prefers an explicit advertise_endpoint and
+// otherwise falls back to the bind Endpoint — which validate() guarantees has an
+// explicit host when no advertise_endpoint is set.
+func (c *AdapterConfig) AdvertisedEndpoint() string {
+	if c.AdvertiseEndpoint != "" {
+		return c.AdvertiseEndpoint
+	}
+	return c.Endpoint
+}
+
+// hasExplicitHost reports whether addr carries a non-empty host component.
+// Hostless forms such as ":50080" return false; "host:port" returns true.
+func hasExplicitHost(addr string) bool {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return false
+	}
+	return host != ""
 }

--- a/agents/adapters/adk/internal/config/config_test.go
+++ b/agents/adapters/adk/internal/config/config_test.go
@@ -32,12 +32,15 @@ capabilities:
     output_schema_json: '{"type":"object"}'
 `
 
+// advAddr is the routable advertise endpoint reused across the config tests.
+const advAddr = "adk-adapter:50080"
+
 func TestLoad_Valid(t *testing.T) {
 	cfg, err := Load(writeConfig(t, validConfig))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if cfg.AgentID != "adk-adapter-1" || cfg.Endpoint != "adk-adapter:50080" {
+	if cfg.AgentID != "adk-adapter-1" || cfg.Endpoint != advAddr {
 		t.Errorf("cfg = %+v", cfg)
 	}
 	if len(cfg.Capabilities) != 1 || cfg.Capabilities[0].Name != "triage" {
@@ -46,12 +49,29 @@ func TestLoad_Valid(t *testing.T) {
 }
 
 func TestLoad_DefaultsEndpoint(t *testing.T) {
-	cfg, err := Load(writeConfig(t, "agent_id: a\nregistry_endpoint: r:1\ncapabilities:\n  - {name: c}\n"))
+	// A hostless bind endpoint needs an explicit advertise_endpoint (issue #1371).
+	cfg, err := Load(writeConfig(t, "agent_id: a\nregistry_endpoint: r:1\nadvertise_endpoint: adk-adapter:50080\ncapabilities:\n  - {name: c}\n"))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if cfg.Endpoint != DefaultEndpoint {
 		t.Errorf("endpoint default = %q, want %q", cfg.Endpoint, DefaultEndpoint)
+	}
+	if cfg.AdvertisedEndpoint() != advAddr {
+		t.Errorf("advertised = %q, want the explicit advertise_endpoint", cfg.AdvertisedEndpoint())
+	}
+}
+
+func TestAdvertisedEndpoint(t *testing.T) {
+	// Explicit advertise_endpoint wins; otherwise an explicit-host bind endpoint
+	// is routable and falls through.
+	adv := &AdapterConfig{Endpoint: ":50080", AdvertiseEndpoint: advAddr}
+	if got := adv.AdvertisedEndpoint(); got != advAddr {
+		t.Errorf("advertise precedence: got %q", got)
+	}
+	host := &AdapterConfig{Endpoint: advAddr}
+	if got := host.AdvertisedEndpoint(); got != advAddr {
+		t.Errorf("host fallback: got %q", got)
 	}
 }
 
@@ -61,11 +81,12 @@ func TestLoad_ValidationErrors(t *testing.T) {
 		body string
 		want string
 	}{
-		{"missing agent_id", "registry_endpoint: r:1\ncapabilities:\n  - {name: c}\n", "agent_id is required"},
-		{"missing registry_endpoint", "agent_id: a\ncapabilities:\n  - {name: c}\n", "registry_endpoint is required"},
-		{"no capabilities", "agent_id: a\nregistry_endpoint: r:1\n", "at least one capability"},
-		{"capability missing name", "agent_id: a\nregistry_endpoint: r:1\ncapabilities:\n  - {description: d}\n", "name is required"},
-		{"unsupported provider", "agent_id: a\nregistry_endpoint: r:1\nmodel:\n  provider: openai\ncapabilities:\n  - {name: c}\n", "unsupported"},
+		{"missing agent_id", "registry_endpoint: r:1\nendpoint: h:1\ncapabilities:\n  - {name: c}\n", "agent_id is required"},
+		{"missing registry_endpoint", "agent_id: a\nendpoint: h:1\ncapabilities:\n  - {name: c}\n", "registry_endpoint is required"},
+		{"hostless endpoint without advertise", "agent_id: a\nregistry_endpoint: r:1\ncapabilities:\n  - {name: c}\n", "advertise_endpoint is required"},
+		{"no capabilities", "agent_id: a\nregistry_endpoint: r:1\nendpoint: h:1\n", "at least one capability"},
+		{"capability missing name", "agent_id: a\nregistry_endpoint: r:1\nendpoint: h:1\ncapabilities:\n  - {description: d}\n", "name is required"},
+		{"unsupported provider", "agent_id: a\nregistry_endpoint: r:1\nendpoint: h:1\nmodel:\n  provider: openai\ncapabilities:\n  - {name: c}\n", "unsupported"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -77,7 +98,7 @@ func TestLoad_ValidationErrors(t *testing.T) {
 }
 
 func TestLoad_ModelBlock(t *testing.T) {
-	body := "agent_id: a\nregistry_endpoint: r:1\n" +
+	body := "agent_id: a\nregistry_endpoint: r:1\nadvertise_endpoint: adk-adapter:50080\n" +
 		"model:\n  provider: ollama\n  name: qwen2.5-coder:0.5b\n  host: http://ollama:11434\n" +
 		"capabilities:\n  - name: triage\n    instruction: classify tickets\n"
 	cfg, err := Load(writeConfig(t, body))

--- a/agents/adapters/adk/internal/registry/client.go
+++ b/agents/adapters/adk/internal/registry/client.go
@@ -76,10 +76,12 @@ func BuildAgentDef(cfg *config.AdapterConfig) *zynaxv1.AgentDef {
 		})
 	}
 	return &zynaxv1.AgentDef{
-		AgentId:      cfg.AgentID,
-		Name:         cfg.Name,
-		Description:  cfg.Description,
-		Endpoint:     cfg.Endpoint,
+		AgentId:     cfg.AgentID,
+		Name:        cfg.Name,
+		Description: cfg.Description,
+		// Register the routable advertised endpoint, not the bind address —
+		// otherwise the broker dials localhost (issue #1371).
+		Endpoint:     cfg.AdvertisedEndpoint(),
 		Capabilities: caps,
 	}
 }

--- a/docs/spdd/1476-adk-go-adapter/canvas.md
+++ b/docs/spdd/1476-adk-go-adapter/canvas.md
@@ -7,7 +7,7 @@
 **Issue:** #1476
 **Author:** Oscar Gómez Manresa
 **Date:** 2026-06-21
-**Status:** Aligned
+**Status:** Implemented
 
 ---
 
@@ -82,7 +82,7 @@ Config env prefix: `ADAPTER_CONFIG` (path) · `OLLAMA_HOST` (model endpoint) · 
 1. ✅ **S1 (#1477, docs):** ADR-038 + this Canvas + adapter `AGENTS.md`. *Verify:* Canvas passes security review and is set **Aligned**; `docs:` PR (size-excluded). *(Merged via PR #1481.)*
 2. ✅ **S2 (#1478, feat):** adapter skeleton — `config`, `registry` client, `main.go` wiring, health; `ExecuteCapability` returns "not wired" until S3. *Verify:* `.feature` committed spec-first; unit tests green (`-race`, 87.9% total coverage); golangci-lint + govulncheck clean; binary boots, loads config, attempts registration with backoff; `serve()` integration test exercises register → health `SERVING` → deregister. Module added to `go.work` (Makefile auto-discovers it for lint/test/coverage).
 3. ✅ **S3 (#1479, feat):** custom Ollama `model.LLM` + ADK `Runner`→`TaskEvent` bridge (`model/ollama.go`, `adk/agent.go`, `adapter/server.go`). *Verify:* `.feature` covers dispatch, schema-validate, `timeout→TIMEOUT`, terminal `COMPLETED`/`FAILED`; unit tests green (`-race`; the real ADK Runner is driven by a stub `model.LLM` and the Ollama translation by an httptest server — no live Ollama needed); golangci-lint clean; `make security` (govulncheck on `google.golang.org/adk` v1.4.0 + `genai` v1.62.0) green — 0 vulnerabilities called. Live secret-free Ollama dispatch is S4 (#1480).
-4. **S4 (#1480, feat):** `agent-def.yaml.example` + demo workflow + `Dockerfile` + `images.yaml` + compose wiring. *Verify:* secret-free Ollama run returns `COMPLETED` (twice); `make check-images` green.
+4. ✅ **S4 (#1480, feat):** `agent-def.yaml.example` + demo workflow (`spec/workflows/examples/adk-code-review-ollama.yaml`) + `Dockerfile` + `images.yaml` entry + compose/Ollama wiring; adds `advertise_endpoint` (issue #1371) so the capability routes. *Verify:* PROVEN end-to-end — the adk-adapter image builds (distroless), boots, registers; `zynax apply` → the `review` capability dispatches to the ADK Runner → local Ollama (`qwen2.5-coder:0.5b`, `POST /api/chat` 200) → terminal `COMPLETED` with the declared `review` output; ran the stateful path **twice** (two fresh runs, both `COMPLETED` with the agent's review), secret-free (no API key); `make check-images` green. `.dockerignore` build-allowlist gap for the new module fixed.
 
 ---
 

--- a/images/images.yaml
+++ b/images/images.yaml
@@ -29,6 +29,7 @@ images:
     tag: "1.26.4-alpine"
     digest: sha256:f23e8b227fb4493eabe03bede4d5a32d04092da71962f1fb79b5f7d1e6c2a17f
     consumers:
+      - agents/adapters/adk/Dockerfile
       - agents/adapters/ci/Dockerfile
       - agents/adapters/git/Dockerfile
       - agents/adapters/http/Dockerfile
@@ -55,6 +56,7 @@ images:
     tag: nonroot
     digest: sha256:dfadf31470f770fcabd48903762dce126958e98d1ce320acf1216bbfaa42d79c
     consumers:
+      - agents/adapters/adk/Dockerfile
       - agents/adapters/ci/Dockerfile
       - agents/adapters/git/Dockerfile
       - agents/adapters/http/Dockerfile
@@ -158,4 +160,11 @@ images:
   - name: llm-adapter
     ref: ghcr.io/zynax-io/zynax/llm-adapter
     digest: sha256:0539b6055a53c8c43839be4f5533efc28342f9d7809c0d441802b95f864c1e35
+    consumers: []
+
+  - name: adk-adapter
+    ref: ghcr.io/zynax-io/zynax/adk-adapter
+    # Placeholder — the image-sync bot stamps the real digest on first publish;
+    # no consumer pins it by digest yet (compose uses the :main tag).
+    digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
     consumers: []

--- a/infra/docker-compose/docker-compose.ollama.yml
+++ b/infra/docker-compose/docker-compose.ollama.yml
@@ -38,3 +38,12 @@ services:
         condition: service_healthy
       agent-registry:
         condition: service_healthy
+
+  # The adk-adapter's baked config already targets local Ollama (zero-secret),
+  # so no config overlay is needed — it only has to wait for the ollama service.
+  adk-adapter:
+    depends_on:
+      ollama:
+        condition: service_healthy
+      agent-registry:
+        condition: service_healthy

--- a/infra/docker-compose/docker-compose.yml
+++ b/infra/docker-compose/docker-compose.yml
@@ -354,6 +354,27 @@ services:
       retries: 10
       start_period: 15s
 
+  adk-adapter:
+    image: ghcr.io/zynax-io/zynax/adk-adapter:main
+    build:
+      context: ../..
+      dockerfile: agents/adapters/adk/Dockerfile
+    environment:
+      # Google ADK (Go) agents as capabilities (ADR-038). Zero-secret by default:
+      # the baked config selects a local Ollama model; OLLAMA_HOST is an override.
+      # Ollama itself is provided by the docker-compose.ollama.yml overlay.
+      ADAPTER_CONFIG: /etc/adk-adapter/config.yaml
+      OLLAMA_HOST: ${OLLAMA_HOST:-http://ollama:11434}
+    depends_on:
+      agent-registry:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "/healthcheck", "tcp://localhost:50080"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 15s
+
   langgraph-adapter:
     image: ghcr.io/zynax-io/zynax/langgraph-adapter:main
     build:

--- a/spec/workflows/examples/adk-code-review-ollama.yaml
+++ b/spec/workflows/examples/adk-code-review-ollama.yaml
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: Apache-2.0
+# Runnable code-review workflow — backed by a Google ADK (Go) agent on local Ollama.
+#
+# The ADK sibling of code-review-ollama.yaml: instead of the single-shot
+# llm-adapter, the `review` capability here is served by the adk-adapter, which
+# runs an ADK `llmagent` (instruction-driven reasoning loop) over the same
+# zero-secret local Ollama model. It proves an ADK agent answers from a Zynax
+# workflow with no API key (ADR-038).
+#
+# Prereqs (pull the model on the host first: `ollama pull qwen2.5-coder:0.5b`):
+#   docker compose -f infra/docker-compose/docker-compose.yml \
+#     -f infra/docker-compose/docker-compose.ollama.yml up -d ollama adk-adapter
+#
+# Run:
+#   zynax apply spec/workflows/examples/adk-code-review-ollama.yaml
+#   zynax logs <run-id> --follow
+#   zynax result <run-id>                    # → review=<the ADK agent's review text>
+
+kind: Workflow
+apiVersion: zynax.io/v1
+
+metadata:
+  name: adk-code-review-ollama
+  namespace: demo
+  version: "1.0.0"
+  annotations:
+    description: "ADK-agent code review of a git diff via local Ollama (secret-free)."
+
+spec:
+  initial_state: review
+
+  states:
+    review:
+      actions:
+        - capability: review
+          input:
+            prompt: |
+              Review the following git diff:
+
+              ```diff
+              diff --git a/payments.go b/payments.go
+              --- a/payments.go
+              +++ b/payments.go
+              @@ -7,5 +7,12 @@ func Charge(balanceCents, amountCents int) (int, error) {
+               	if amountCents < 0 {
+               		return balanceCents, errors.New("amount must be non-negative")
+               	}
+              -	return balanceCents - amountCents, nil
+              +	// Apply a 2% loyalty discount before charging.
+              +	discounted := amountCents - (amountCents / 50)
+              +	return balanceCents - discounted, nil
+              +}
+              +
+              +// Refund credits amountCents back to the account.
+              +func Refund(balanceCents, amountCents int) int {
+              +	return balanceCents + amountCents
+               }
+              ```
+          # Publish the ADK agent's review text (the review capability's
+          # {"response": …} result) so the terminal state can return it.
+          output:
+            review: response
+      on:
+        - event: review.completed
+          goto: done
+
+    done:
+      type: terminal
+      # Return the agent's review as the workflow's declared result (ADR-042):
+      # `zynax result <run>` prints `review=<the ADK agent's review text>`.
+      outputs:
+        review: "$.states.review.output.review"


### PR DESCRIPTION
## What

**Closes #1480 · completes EPIC #1476** (the ADK Go adapter, stories S1–S4). Makes
the adapter runnable end-to-end and ships the image — the demo that proves a
Google ADK (Go) agent answers from a Zynax workflow, **secret-free**.

- **`agent-def.yaml.example`** — the baked adapter config, Ollama-ready by default
  (`qwen2.5-coder:0.5b`, no API key), declaring a `review` capability.
- **`spec/workflows/examples/adk-code-review-ollama.yaml`** — the ADK sibling of
  `code-review-ollama.yaml`: dispatches `review` (served by the adk-adapter) over a
  git diff and returns the agent's review as the run's declared output.
- **`Dockerfile`** — distroless multi-stage build mirroring git-adapter.
- **`images/images.yaml`** — adk-adapter image entry + the adk Dockerfile added to
  the `golang-alpine` / `distroless-static` consumer lists.
- **`infra/docker-compose`** — adk-adapter service + Ollama-overlay wiring.
- **`advertise_endpoint`** (config + registry) so the capability is routable — a
  hostless bind endpoint registered verbatim makes the broker dial localhost
  (issue #1371); same fix llm/langgraph carry.
- **`.dockerignore`** build-allowlist fix — the new adk module was excluded from
  every image build context (only a real build exposed this).

## Runtime evidence (not config-only)

Booted the stack under the Ollama overlay and ran the documented path:

- The adk-adapter image **builds** (distroless), **boots**, and **registers**.
- `zynax apply` → the `review` capability **dispatches** to the ADK Runner → local
  Ollama (`POST /api/chat` 200) → terminal **`COMPLETED`** carrying the declared
  `review` output. `zynax result` prints `review=<the agent's review>`.
- Ran the stateful path **twice** (two fresh runs, both COMPLETED with the agent's
  review), **secret-free** (no API key).

The live stack needed `api-gateway` / `engine-adapter` / `workflow-compiler`
rebuilt from current source: the published `:main` images (2026-06-20) predate the
M7.U output-capture (ADR-042), so the `/outputs` read-back was empty on the stale
images. That's image staleness, **not** a change here — `main` already carries the
capture, and the control (`code-review-ollama.yaml`) failed identically on the
stale images and succeeded on the rebuilt ones.

## Checks

`GOWORK=off go test ./... -race` green; `golangci-lint` clean; `make check-images`
green; canvas → **Implemented**.

Closes #1480

🤖 Generated with [Claude Code](https://claude.com/claude-code)
