### PR TITLE
feat(cli): repo-root discovery + zynax down wrapping cluster-down.sh

### DIFF
--- a/cmd/zynax/cmd/down.go
+++ b/cmd/zynax/cmd/down.go
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+)
+
+// clusterRunner runs a kind bring-up / teardown script with its stdout and
+// stderr streamed live to the caller, plus an environment overlay. It is
+// injected so `up`/`down` unit tests can record the (script, env) they would
+// run without executing kind/helm/kubectl or touching a cluster.
+type clusterRunner func(ctx context.Context, stdout, stderr io.Writer, script string, env []string) error
+
+// streamRunner is the production clusterRunner: it execs the script and streams
+// its output. Bring-up runs for minutes and prints progressive status, so the
+// stdio is wired through directly (as in mcp.go's git-adapter launch) rather
+// than buffered with CombinedOutput.
+func streamRunner(ctx context.Context, stdout, stderr io.Writer, script string, env []string) error {
+	// #nosec G204 — script is the fixed repo-relative cluster-up/cluster-down
+	// path resolved under a verified checkout root (isRepoRoot), never derived
+	// from prompt/tool input; there are no arguments — all config flows via env.
+	cmd := exec.CommandContext(ctx, script)
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	cmd.Env = env
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("%s: %w", filepath.Base(script), err)
+	}
+	return nil
+}
+
+// clusterDeps bundles the injectable collaborators shared by `up` and `down`
+// so their unit tests are hermetic (no repo-root walk, no real script exec).
+type clusterDeps struct {
+	run      clusterRunner
+	findRoot func(override string) (string, error)
+}
+
+// defaultClusterDeps wires the production collaborators.
+func defaultClusterDeps() clusterDeps {
+	return clusterDeps{run: streamRunner, findRoot: findRepoRoot}
+}
+
+var (
+	downClusterName string
+	downRepoRoot    string
+)
+
+var downCmd = &cobra.Command{
+	Use:     "down",
+	GroupID: beginnerGroupID,
+	Short:   "Tear down the local kind cluster created by `zynax up`",
+	Long: `Delete the local kind cluster and everything on it — the teardown half of
+the write-once-run-on-Temporal-or-Argo local runtime.
+
+This wraps the same script as ` + "`make kind-down`" + ` (scripts/e2e/cluster-down.sh),
+but works ` + "`make`" + `-free from any directory inside a checkout. It is idempotent:
+it succeeds even when no cluster exists.
+
+Run this from inside a Zynax checkout, or point at one with --repo-root /
+$ZYNAX_REPO_ROOT.`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		return runDown(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), defaultClusterDeps())
+	},
+}
+
+// runDown resolves the repo root and streams scripts/e2e/cluster-down.sh,
+// forwarding the cluster name via CLUSTER_NAME when set (otherwise the script's
+// own default applies). Teardown takes no other configuration.
+func runDown(ctx context.Context, stdout, stderr io.Writer, deps clusterDeps) error {
+	root, err := deps.findRoot(downRepoRoot)
+	if err != nil {
+		return err
+	}
+	script := filepath.Join(root, clusterDownRel)
+
+	env := os.Environ()
+	if downClusterName != "" {
+		env = append(env, "CLUSTER_NAME="+downClusterName)
+	}
+	_, _ = fmt.Fprintln(stdout, "zynax down — tearing down the local kind cluster.")
+	return deps.run(ctx, stdout, stderr, script, env)
+}
+
+func init() {
+	downCmd.Flags().StringVar(&downClusterName, "cluster-name", "",
+		"kind cluster name to delete (default: the script's default, zynax-e2e)")
+	downCmd.Flags().StringVar(&downRepoRoot, "repo-root", "",
+		"path to the Zynax checkout ($ZYNAX_REPO_ROOT); default: walk up from the current directory")
+	rootCmd.AddCommand(downCmd)
+}

--- a/cmd/zynax/cmd/down_test.go
+++ b/cmd/zynax/cmd/down_test.go
@@ -1,0 +1,234 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// recordingRunner is a clusterRunner that records the script path and env it was
+// asked to run and returns a canned error — it never execs anything. Shared by
+// the down and up command tests (same package).
+type recordingRunner struct {
+	called bool
+	script string
+	env    []string
+	err    error
+}
+
+func (r *recordingRunner) run(_ context.Context, _, _ io.Writer, script string, env []string) error {
+	r.called = true
+	r.script = script
+	r.env = env
+	return r.err
+}
+
+// envHas reports whether env contains the exact "KEY=VALUE" entry.
+func envHas(env []string, kv string) bool {
+	for _, e := range env {
+		if e == kv {
+			return true
+		}
+	}
+	return false
+}
+
+// fixedRoot returns a findRoot that always resolves to root (no filesystem walk).
+func fixedRoot(root string) func(string) (string, error) {
+	return func(string) (string, error) { return root, nil }
+}
+
+// ── reporoot.go ───────────────────────────────────────────────────────────────
+
+func TestFindRepoRoot_FlagOverride(t *testing.T) {
+	root := repoRoot(t) // the real checkout — contains scripts/e2e/cluster-up.sh
+	got, err := findRepoRoot(root)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want, _ := filepath.Abs(root)
+	if got != want {
+		t.Errorf("findRepoRoot(%q) = %q, want %q", root, got, want)
+	}
+}
+
+func TestFindRepoRoot_FlagWithoutSentinel(t *testing.T) {
+	if _, err := findRepoRoot(t.TempDir()); err == nil {
+		t.Error("expected error for a --repo-root dir missing the sentinel script")
+	}
+}
+
+func TestFindRepoRoot_EnvVar(t *testing.T) {
+	root := repoRoot(t)
+	t.Setenv(repoRootEnv, root)
+	got, err := findRepoRoot("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want, _ := filepath.Abs(root)
+	if got != want {
+		t.Errorf("findRepoRoot via %s = %q, want %q", repoRootEnv, got, want)
+	}
+}
+
+func TestFindRepoRoot_EnvVarWithoutSentinel(t *testing.T) {
+	t.Setenv(repoRootEnv, t.TempDir())
+	if _, err := findRepoRoot(""); err == nil {
+		t.Errorf("expected error when %s points at a tree without the sentinel", repoRootEnv)
+	}
+}
+
+func TestFindRepoRoot_WalkUpFromSubdir(t *testing.T) {
+	// Build an isolated fake checkout: <tmp>/scripts/e2e/cluster-up.sh + a nested subdir.
+	tmp := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(tmp, "scripts", "e2e"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmp, clusterUpRel), []byte("#!/bin/sh\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	sub := filepath.Join(tmp, "a", "b")
+	if err := os.MkdirAll(sub, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(repoRootEnv, "") // ensure the env branch does not short-circuit the walk
+	t.Chdir(sub)
+
+	got, err := findRepoRoot("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want, _ := filepath.Abs(tmp)
+	gotAbs, _ := filepath.Abs(got)
+	if gotAbs != want {
+		t.Errorf("walk-up findRepoRoot = %q, want %q", gotAbs, want)
+	}
+}
+
+func TestFindRepoRoot_OutsideCheckout(t *testing.T) {
+	tmp := t.TempDir() // no sentinel anywhere above it
+	t.Setenv(repoRootEnv, "")
+	t.Chdir(tmp)
+	_, err := findRepoRoot("")
+	if !errors.Is(err, errNoRepoRoot) {
+		t.Errorf("outside a checkout want errNoRepoRoot, got %v", err)
+	}
+}
+
+// ── down.go ───────────────────────────────────────────────────────────────────
+
+func TestRunDown_ForwardsClusterNameAndScript(t *testing.T) {
+	downClusterName = "my-cluster"
+	downRepoRoot = ""
+	defer func() { downClusterName = "" }()
+
+	rr := &recordingRunner{}
+	deps := clusterDeps{run: rr.run, findRoot: fixedRoot("/repo")}
+	if err := runDown(context.Background(), io.Discard, io.Discard, deps); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !rr.called {
+		t.Fatal("runner was not invoked")
+	}
+	if rr.script != filepath.Join("/repo", clusterDownRel) {
+		t.Errorf("script = %q, want %q", rr.script, filepath.Join("/repo", clusterDownRel))
+	}
+	if !envHas(rr.env, "CLUSTER_NAME=my-cluster") {
+		t.Errorf("CLUSTER_NAME not forwarded; env tail=%v", rr.env[len(rr.env)-1:])
+	}
+}
+
+func TestRunDown_NoClusterName_AppendsNothing(t *testing.T) {
+	downClusterName = ""
+	downRepoRoot = ""
+
+	rr := &recordingRunner{}
+	deps := clusterDeps{run: rr.run, findRoot: fixedRoot("/repo")}
+	if err := runDown(context.Background(), io.Discard, io.Discard, deps); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Robust against an ambient CLUSTER_NAME in the test env: assert runDown
+	// appended zero entries rather than checking for absence of the key.
+	if len(rr.env) != len(os.Environ()) {
+		t.Errorf("runDown appended %d env entries with an empty --cluster-name, want 0",
+			len(rr.env)-len(os.Environ()))
+	}
+}
+
+func TestRunDown_RepoRootError_RunnerNotCalled(t *testing.T) {
+	downRepoRoot = ""
+	rr := &recordingRunner{}
+	deps := clusterDeps{
+		run:      rr.run,
+		findRoot: func(string) (string, error) { return "", errNoRepoRoot },
+	}
+	err := runDown(context.Background(), io.Discard, io.Discard, deps)
+	if !errors.Is(err, errNoRepoRoot) {
+		t.Errorf("want errNoRepoRoot, got %v", err)
+	}
+	if rr.called {
+		t.Error("runner must not run when repo-root resolution fails")
+	}
+}
+
+func TestRunDown_RunnerErrorPropagates(t *testing.T) {
+	downClusterName = ""
+	downRepoRoot = ""
+	rr := &recordingRunner{err: errors.New("boom")}
+	deps := clusterDeps{run: rr.run, findRoot: fixedRoot("/repo")}
+	if err := runDown(context.Background(), io.Discard, io.Discard, deps); err == nil {
+		t.Fatal("expected the runner error to propagate")
+	}
+}
+
+// ── streamRunner (production exec seam) ───────────────────────────────────────
+
+func TestStreamRunner_StreamsStdoutAndPassesEnv(t *testing.T) {
+	dir := t.TempDir()
+	script := filepath.Join(dir, "echo.sh")
+	// Echoes a marker plus the value of an env var supplied via the overlay.
+	body := "#!/bin/sh\necho \"marker:$ZYNAX_TEST_VAR\"\n"
+	if err := os.WriteFile(script, []byte(body), 0o700); err != nil { //nolint:gosec // G306: test-only executable script in a temp dir
+		t.Fatal(err)
+	}
+	var out, errOut bytes.Buffer
+	env := append(os.Environ(), "ZYNAX_TEST_VAR=hello")
+	if err := streamRunner(context.Background(), &out, &errOut, script, env); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out.String(), "marker:hello") {
+		t.Errorf("streamRunner did not stream stdout / pass env overlay; stdout=%q", out.String())
+	}
+}
+
+func TestStreamRunner_NonZeroExitErrorsNamesScript(t *testing.T) {
+	dir := t.TempDir()
+	script := filepath.Join(dir, "fail.sh")
+	if err := os.WriteFile(script, []byte("#!/bin/sh\nexit 3\n"), 0o700); err != nil { //nolint:gosec // G306: test-only executable script in a temp dir
+		t.Fatal(err)
+	}
+	err := streamRunner(context.Background(), io.Discard, io.Discard, script, os.Environ())
+	if err == nil {
+		t.Fatal("expected an error on non-zero script exit")
+	}
+	if !strings.Contains(err.Error(), "fail.sh") {
+		t.Errorf("error should name the script (base), got %v", err)
+	}
+}
+
+func TestDownCmd_Registered(t *testing.T) {
+	c, _, err := rootCmd.Find([]string{"down"})
+	if err != nil || c.Name() != "down" {
+		t.Fatalf("down command not registered: cmd=%v err=%v", c, err)
+	}
+	if c.GroupID != beginnerGroupID {
+		t.Errorf("down GroupID = %q, want %q", c.GroupID, beginnerGroupID)
+	}
+}

--- a/cmd/zynax/cmd/reporoot.go
+++ b/cmd/zynax/cmd/reporoot.go
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// repoRootEnv overrides repo-root discovery for the `up`/`down` cluster wrappers.
+const repoRootEnv = "ZYNAX_REPO_ROOT"
+
+// clusterUpRel and clusterDownRel are the kind bring-up / teardown scripts,
+// relative to the repo root. cluster-up.sh doubles as the discovery sentinel:
+// the one file `zynax up`/`down` must have is the script they exec, so probing
+// for it is both the checkout marker and a pre-flight existence check.
+const (
+	clusterUpRel   = "scripts/e2e/cluster-up.sh"
+	clusterDownRel = "scripts/e2e/cluster-down.sh"
+)
+
+// errNoRepoRoot is returned when no Zynax checkout can be located. `zynax up`/
+// `down` drive the in-repo kind scripts (ADR-041), so a checkout is required;
+// the message points at the three ways to supply one.
+var errNoRepoRoot = errors.New(
+	"zynax up/down needs a Zynax checkout — could not find " + clusterUpRel + " above the current directory.\n" +
+		"  • run this from inside a `git clone https://github.com/zynax-io/zynax` checkout, or\n" +
+		"  • set " + repoRootEnv + "=/path/to/zynax, or\n" +
+		"  • pass --repo-root /path/to/zynax")
+
+// findRepoRoot resolves the Zynax checkout root that holds the kind bring-up
+// scripts, trying in order: an explicit --repo-root value, $ZYNAX_REPO_ROOT,
+// then a walk up from the current directory for the sentinel cluster-up.sh.
+// It returns errNoRepoRoot (clone-pointing) when no checkout is found. The
+// returned path is always absolute so callers can join the script path safely.
+func findRepoRoot(override string) (string, error) {
+	if override != "" {
+		if isRepoRoot(override) {
+			return filepath.Abs(override)
+		}
+		return "", fmt.Errorf("--repo-root %q does not contain %s", override, clusterUpRel)
+	}
+	if env := os.Getenv(repoRootEnv); env != "" {
+		if isRepoRoot(env) {
+			return filepath.Abs(env)
+		}
+		return "", fmt.Errorf("%s=%q does not contain %s", repoRootEnv, env, clusterUpRel)
+	}
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	for {
+		if isRepoRoot(dir) {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir { // reached the filesystem root without a match
+			return "", errNoRepoRoot
+		}
+		dir = parent
+	}
+}
+
+// isRepoRoot reports whether dir looks like a Zynax checkout — the bring-up
+// script exists there. Using the script itself as the sentinel means discovery
+// fails loudly if pointed at a tree without the kind harness.
+func isRepoRoot(dir string) bool {
+	// #nosec G304 G703 — existence probe only (os.Stat reads no file content); the
+	// joined path is a fixed repo-relative sentinel, and the discovery root is
+	// operator-supplied (flag/env/cwd), never prompt/tool input.
+	_, err := os.Stat(filepath.Join(dir, clusterUpRel))
+	return err == nil
+}


### PR DESCRIPTION
## feat(cli): repo-root discovery + `zynax down` wrapping cluster-down.sh

Closes #1562 · Part of #1561 (M7.V) · Canvas O1 — `docs/spdd/1561-zynax-up-down/canvas.md`

### Why (problem & intent)
The `zynax` binary can talk to a running platform but can't manage its lifecycle. This lands O1 — the shared, `make`-free plumbing — and its first consumer, `zynax down`. `zynax up` (O2, #1563) reuses the same runner + repo-root finder.

### What you'll get
- **`zynax down`** — deletes the local kind cluster from the CLI, from any directory ← `cmd/zynax/cmd/down.go`
- **Repo-root discovery** — `--repo-root` → `ZYNAX_REPO_ROOT` → walk-up sentinel `scripts/e2e/cluster-up.sh`; friendly clone-pointing error outside a checkout ← `cmd/zynax/cmd/reporoot.go`
- **Injectable streaming runner** (`clusterRunner`/`streamRunner`/`clusterDeps`) — streams the wrapped script's live output; reused by `zynax up` in O2 ← `cmd/zynax/cmd/down.go`

### Scope & boundaries
- **In scope:** `zynax down` + the shared repo-root/runner plumbing + unit tests.
- **Out of scope (deferred):** `zynax up` → #1563 (O2); user-facing docs + ADR-041 doc pass → #1564 (O3); auto-adapter provisioning → M-dx #1359.

### Test plan & acceptance
| Acceptance criterion (issue/canvas) | How verified | Result |
|---|---|---|
| `zynax down` wraps cluster-down.sh; output streams live | `zynax down --repo-root <wt> --cluster-name zynax-smoketest` | ✅ streamed `[cluster-down] … nothing to tear down`, exit 0 |
| Idempotent | ran the same command twice | ✅ exit 0 both runs |
| Repo-root: flag/env/walk-up; clone-pointing error outside a checkout | run from `/tmp` with `ZYNAX_REPO_ROOT` unset | ✅ clone-pointing error, exit 1 · run from `cmd/zynax/` subdir → resolved via walk-up, exit 0 |
| `CLUSTER_NAME` forwarding + repo-root paths unit-tested (no cluster) | `GOWORK=off go test ./cmd/... -race` | ✅ all pass (recording runner) |

**Local gates:** `GOWORK=off go build/vet ./...` ✅ · `go test ./... -race` ✅ · `golangci-lint run` ✅ (0 issues) · gofmt ✅ · gitleaks ✅

### Evidence
- **Runtime smoke (real, not CI-green):** built the binary and ran `zynax down` end-to-end — error path (exit 1, clone message), happy path (streamed cluster-down.sh, exit 0), walk-up discovery from a subdir, and idempotent re-run. No cluster touched (`zynax-smoketest` doesn't exist).
- **Coverage:** `streamRunner` 100% · `runDown` 100% · `isRepoRoot` 100% · `findRepoRoot` 94.4% · command registration tested.
- **Artifacts / images:** none — no service source changed (CLI-only, standalone module).

### Risk & rollback
Low — additive new command + a new file; no change to any existing path. Revert = revert the commit.

### Review aids
Start with `cmd/zynax/cmd/reporoot.go` (discovery), then `down.go` (runner + command). The injectable `clusterDeps` seam is what makes it testable without kind.

### Engineering hygiene
- [x] Branched off fresh `origin/main` · PR ≤ 900 lines · DCO + `Assisted-by` on the commit
- [x] `feat:` canvas gated — `docs/spdd/1561-zynax-up-down/canvas.md` Status: Aligned (merged in #1565)
- [ ] Planning-doc row — N/A (M7.V is a late-added epic with no planning-doc rows; tracked via issues/labels)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
