### PR TITLE
feat(cli): zynax up brings the platform up on kind (Temporal or Argo)

### DIFF
--- a/cmd/zynax/cmd/up.go
+++ b/cmd/zynax/cmd/up.go
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	upProfile     string
+	upEngine      string
+	upNoLoad      bool
+	upClusterName string
+	upNamespace   string
+	upRepoRoot    string
+)
+
+var upCmd = &cobra.Command{
+	Use:     "up",
+	GroupID: beginnerGroupID,
+	Short:   "Bring up the full Zynax platform on a local kind cluster",
+	Long: `Create (or reuse) a local kind cluster and deploy the full Zynax umbrella —
+every core service plus the always-on echo capability — so a single command
+takes you from a fresh checkout to a live gateway on http://localhost:8080.
+
+Write your workflow ONCE — it runs on Temporal OR Argo on the same kind cluster
+that mirrors production. Pick the engine with a flag:
+
+  zynax up --engine temporal    # (default)
+  zynax up --engine argo        # same platform, same workflow, Argo engine
+
+This wraps the same proven, idempotent script as ` + "`make kind-up`" + `
+(scripts/e2e/cluster-up.sh), but works ` + "`make`" + `-free from any directory inside a
+checkout. Re-running against an existing cluster reuses it.
+
+Prerequisites: Docker, kind, kubectl, helm on PATH (~4 CPU / 8 GB RAM).
+Run this from inside a Zynax checkout, or point at one with --repo-root /
+$ZYNAX_REPO_ROOT. Tear down with: zynax down`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		return runUp(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), defaultClusterDeps())
+	},
+}
+
+// runUp resolves the repo root and streams scripts/e2e/cluster-up.sh, mapping
+// the command flags 1:1 onto the script's env-var contract. The child env is the
+// process environment plus our overrides appended last (last-wins, matching the
+// script's ${VAR:-default} semantics) so power-user vars (WAIT_TIMEOUT,
+// KIND_NODE_IMAGE, …) still pass through untouched. Profile/engine validation is
+// owned by the script (full|lite, temporal|argo) to avoid drift.
+func runUp(ctx context.Context, stdout, stderr io.Writer, deps clusterDeps) error {
+	root, err := deps.findRoot(upRepoRoot)
+	if err != nil {
+		return err
+	}
+	script := filepath.Join(root, clusterUpRel)
+
+	env := os.Environ()
+	env = append(env, "PROFILE="+upProfile, "E2E_ENGINE="+upEngine)
+	if upClusterName != "" {
+		env = append(env, "CLUSTER_NAME="+upClusterName)
+	}
+	if upNamespace != "" {
+		env = append(env, "NAMESPACE="+upNamespace)
+	}
+	// Default: side-load local images (mirrors `make kind-up`, which forces
+	// KIND_LOAD_IMAGES=1). --no-load-images omits it, so the script pulls from
+	// the registry instead.
+	if !upNoLoad {
+		env = append(env, "KIND_LOAD_IMAGES=1")
+	}
+
+	_, _ = fmt.Fprintf(stdout,
+		"zynax up — full platform on kind (profile: %s, engine: %s). Write once, run on Temporal or Argo.\n",
+		upProfile, upEngine)
+	return deps.run(ctx, stdout, stderr, script, env)
+}
+
+func init() {
+	upCmd.Flags().StringVar(&upProfile, "profile", "full",
+		"cluster profile: full (3-node, prod-mirroring) or lite (1-node, lean)")
+	upCmd.Flags().StringVar(&upEngine, "engine", "temporal",
+		"workflow engine to run on: temporal or argo")
+	upCmd.Flags().BoolVar(&upNoLoad, "no-load-images", false,
+		"do not side-load local images into the cluster (pull from the registry instead)")
+	upCmd.Flags().StringVar(&upClusterName, "cluster-name", "",
+		"kind cluster name (default: the script's default, zynax-e2e)")
+	upCmd.Flags().StringVar(&upNamespace, "namespace", "",
+		"Kubernetes namespace for the Zynax release (default: the script's default, zynax)")
+	upCmd.Flags().StringVar(&upRepoRoot, "repo-root", "",
+		"path to the Zynax checkout ($ZYNAX_REPO_ROOT); default: walk up from the current directory")
+	rootCmd.AddCommand(upCmd)
+}

--- a/cmd/zynax/cmd/up_test.go
+++ b/cmd/zynax/cmd/up_test.go
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"context"
+	"io"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// envHasKey reports whether any entry sets KEY (i.e. "KEY=..."). Used to assert
+// that --no-load-images omits KIND_LOAD_IMAGES entirely.
+func envHasKey(env []string, key string) bool {
+	for _, e := range env {
+		if strings.HasPrefix(e, key+"=") {
+			return true
+		}
+	}
+	return false
+}
+
+// setUpDefaults resets the package-level up flag vars to their command defaults.
+// runUp is called directly (no cobra flag parse), so tests must set them.
+func setUpDefaults() {
+	upProfile = "full"
+	upEngine = "temporal"
+	upNoLoad = false
+	upClusterName = ""
+	upNamespace = ""
+	upRepoRoot = ""
+}
+
+func runUpRecording(t *testing.T) *recordingRunner {
+	t.Helper()
+	rr := &recordingRunner{}
+	deps := clusterDeps{run: rr.run, findRoot: fixedRoot("/repo")}
+	if err := runUp(context.Background(), io.Discard, io.Discard, deps); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !rr.called {
+		t.Fatal("runner was not invoked")
+	}
+	if rr.script != filepath.Join("/repo", clusterUpRel) {
+		t.Errorf("script = %q, want %q", rr.script, filepath.Join("/repo", clusterUpRel))
+	}
+	return rr
+}
+
+func TestRunUp_Defaults(t *testing.T) {
+	setUpDefaults()
+	rr := runUpRecording(t)
+	for _, want := range []string{"PROFILE=full", "E2E_ENGINE=temporal", "KIND_LOAD_IMAGES=1"} {
+		if !envHas(rr.env, want) {
+			t.Errorf("default env missing %q", want)
+		}
+	}
+	// No overrides → cluster name / namespace fall through to the script defaults.
+	if envHasKey(rr.env, "CLUSTER_NAME") {
+		t.Error("CLUSTER_NAME should be absent when --cluster-name is empty")
+	}
+	if envHasKey(rr.env, "NAMESPACE") {
+		t.Error("NAMESPACE should be absent when --namespace is empty")
+	}
+}
+
+func TestRunUp_LiteArgo(t *testing.T) {
+	setUpDefaults()
+	upProfile = "lite"
+	upEngine = "argo"
+	rr := runUpRecording(t)
+	if !envHas(rr.env, "PROFILE=lite") || !envHas(rr.env, "E2E_ENGINE=argo") {
+		t.Errorf("lite/argo not mapped; env tail=%v", rr.env[len(rr.env)-4:])
+	}
+}
+
+func TestRunUp_NoLoadImages_OmitsVar(t *testing.T) {
+	setUpDefaults()
+	upNoLoad = true
+	rr := runUpRecording(t)
+	if envHasKey(rr.env, "KIND_LOAD_IMAGES") {
+		t.Error("--no-load-images must omit KIND_LOAD_IMAGES")
+	}
+}
+
+func TestRunUp_ClusterAndNamespaceOverrides(t *testing.T) {
+	setUpDefaults()
+	upClusterName = "my-kind"
+	upNamespace = "zynax-dev"
+	rr := runUpRecording(t)
+	if !envHas(rr.env, "CLUSTER_NAME=my-kind") || !envHas(rr.env, "NAMESPACE=zynax-dev") {
+		t.Errorf("cluster/namespace overrides not forwarded; env=%v", rr.env[len(rr.env)-4:])
+	}
+}
+
+func TestRunUp_RepoRootError_RunnerNotCalled(t *testing.T) {
+	setUpDefaults()
+	rr := &recordingRunner{}
+	deps := clusterDeps{run: rr.run, findRoot: func(string) (string, error) { return "", errNoRepoRoot }}
+	if err := runUp(context.Background(), io.Discard, io.Discard, deps); err == nil {
+		t.Fatal("expected error when repo root cannot be resolved")
+	}
+	if rr.called {
+		t.Error("runner must not run when repo-root resolution fails")
+	}
+}
+
+func TestUpCmd_Registered(t *testing.T) {
+	c, _, err := rootCmd.Find([]string{"up"})
+	if err != nil || c.Name() != "up" {
+		t.Fatalf("up command not registered: cmd=%v err=%v", c, err)
+	}
+	if c.GroupID != beginnerGroupID {
+		t.Errorf("up GroupID = %q, want %q", c.GroupID, beginnerGroupID)
+	}
+}


### PR DESCRIPTION
## feat(cli): `zynax up` brings the platform up on kind (Temporal or Argo)

Closes #1563 · Part of #1561 (M7.V) · Canvas O2 — `docs/spdd/1561-zynax-up-down/canvas.md`

### Why (problem & intent)
The `zynax` binary could tear a cluster down (O1) but not bring one up. This adds `zynax up` — create/reuse a local kind cluster and deploy the full umbrella — so the whole journey is one CLI, `make`-free, from any directory. It also makes the **engine-portability wedge a single flag**: `zynax up --engine temporal|argo` brings the *same* platform up on either engine.

### What you'll get
- **`zynax up`** — wraps the same proven `scripts/e2e/cluster-up.sh` as `make kind-up`, streamed live ← `cmd/zynax/cmd/up.go`
- **Flags → script env (1:1):** `--profile`→`PROFILE` (full\|lite) · `--engine`→`E2E_ENGINE` (temporal\|argo) · `--no-load-images` omits `KIND_LOAD_IMAGES` (default on, mirrors `make kind-up`) · `--cluster-name`→`CLUSTER_NAME` · `--namespace`→`NAMESPACE`. Power-user vars (`WAIT_TIMEOUT`, `KIND_NODE_IMAGE`, …) pass through untouched.
- Reuses the repo-root finder + injectable streaming runner from O1 (#1562).

### Scope & boundaries
- **In scope:** `zynax up` + flag→env mapping + unit tests. Reuses O1 plumbing.
- **Out of scope (deferred):** user-facing docs + ADR-041 doc pass → #1564 (O3); `zynax up --run <workflow>` and auto-adapter provisioning → follow-ons / M-dx #1359.

### Test plan & acceptance
| Acceptance criterion (issue/canvas) | How verified | Result |
|---|---|---|
| Reaches the same healthy state as `make kind-up` | real `zynax up --profile lite` on a live host | ✅ 8/8 pods Running; `curl localhost:8080/healthz` → **200**; exit 0 |
| Idempotent — re-run reuses the cluster | ran `zynax up` a **2nd** time on the same cluster | ✅ exit 0, healthz 200, single `zynax-e2e` cluster (pods not recreated) |
| Full lifecycle from the CLI | `zynax up` → `zynax up` → `zynax down` | ✅ `down` deleted the cluster; `kind get clusters` empty; healthz refused |
| Every flag→env mapping (defaults, lite+argo, `--no-load-images`, overrides) | stub `cluster-up.sh` echoing its env (real exec) + `go test -race` | ✅ `PROFILE`/`E2E_ENGINE`/`KIND_LOAD_IMAGES`/`CLUSTER_NAME`/`NAMESPACE` all correct |

**Local gates:** `GOWORK=off go build/vet ./...` ✅ · `go test ./... -race` ✅ · `golangci-lint run` ✅ (0 issues) · gofmt ✅

### Evidence
- **Runtime smoke (real, not CI-green):** brought the full lite stack up on kind end-to-end (all pods Running, healthz 200), proved idempotency by re-running, and tore it down with `zynax down` — the complete `up → up → down` lifecycle from the CLI. Deterministic flag→env proof via a stub `cluster-up.sh` that echoed the exact env for every flag combination.
- **Coverage:** `runUp` 100% · command registration tested.
- **Artifacts / images:** none — CLI-only, standalone module (no service source changed).

### Risk & rollback
Low — additive new command reusing O1's tested plumbing; no change to any existing path. Revert = revert the commit.

### Review aids
`cmd/zynax/cmd/up.go` is the whole feature; the flag→env mapping in `runUp` is the crux. Shared runner/repo-root live in `down.go`/`reporoot.go` from O1.

### Engineering hygiene
- [x] Branched off fresh `origin/main` (incl. O1) · PR ≤ 900 lines · DCO + `Assisted-by` on the commit
- [x] `feat:` canvas gated — `docs/spdd/1561-zynax-up-down/canvas.md` Status: Aligned
- [ ] Planning-doc row — N/A (M7.V is a late-added epic with no planning-doc rows; tracked via issues/labels)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
