### PR TITLE
docs(cli): document zynax up/down + mark M7.V canvas Implemented

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ the in-cluster **`echo`** capability — **no Ollama, no model, no API key neede
 When it finishes it prints a **Platform ready** banner with the gateway URL
 (`http://localhost:8080`). Lean laptop? `PROFILE=lite make demo`.
 
+> Prefer the CLI? `zynax up` (add `--profile lite`, or `--engine argo` for the wedge) brings the same
+> stack up `make`-free from any directory — it wraps the same script as `make kind-up` — and `zynax down`
+> tears it back down. See [local dev on kind](docs/local-dev-kind.md).
+
 ### 2. Reach the gateway and run your first workflow
 
 The api-gateway is auth-enabled, so fetch the bearer key the cluster provisioned, then apply the
@@ -80,7 +84,7 @@ ENGINE=argo make demo     # (or E2E_ENGINE=argo make demo)
 
 The *same* `hello-world.yaml` runs unchanged on Argo instead of Temporal — write once, run on
 either engine, no rewrite. That is the wedge ([ADR-041](docs/adr/ADR-041-kind-native-unified-runtime.md),
-[#1370](https://github.com/zynax-io/zynax/issues/1370)). Tear it all down with `make kind-down`.
+[#1370](https://github.com/zynax-io/zynax/issues/1370)). Tear it all down with `make kind-down` (or `zynax down`).
 
 > **Next:** a real model reviews a git diff (the code-review demo), scaling onto k3s / managed
 > Kubernetes, and observability are covered in the **[kind how-to](docs/quickstart.md)** — not

--- a/cmd/zynax/AGENTS.md
+++ b/cmd/zynax/AGENTS.md
@@ -30,6 +30,9 @@ cmd/zynax/
     validate.go      zynax validate <file> [--schema-dir] [--format]  (local: schema + data-flow)
     init.go          zynax init workflow|expert [name] [-o file]  (scaffold from spec/templates)
     doctor.go        zynax doctor   (read-only platform+model health checklist; shells out to kubectl/helm/ollama)
+    up.go            zynax up [--profile full|lite] [--engine temporal|argo] [--no-load-images] [--cluster-name] [--namespace]  (create/reuse kind cluster + deploy umbrella; shells out via scripts/e2e/cluster-up.sh, ADR-041)
+    down.go          zynax down [--cluster-name]   (delete the kind cluster; shells out via scripts/e2e/cluster-down.sh, ADR-041)
+    reporoot.go      repo-root discovery for up/down: --repo-root | $ZYNAX_REPO_ROOT | walk-up sentinel scripts/e2e/cluster-up.sh
   validate/
     manifest.go     JSON Schema validation (validate.Manifest) + combined pipeline (validate.File)
     dataflow.go     Workflow state-machine checks (initial_state + transition goto targets)

--- a/docs/local-dev-kind.md
+++ b/docs/local-dev-kind.md
@@ -29,6 +29,27 @@ make kind-up PROFILE=lite    # lean profile (single-node, trimmed)
 make kind-down               # delete the cluster
 ```
 
+## CLI-native lifecycle (`zynax up` / `zynax down`)
+
+The `zynax` CLI fronts the **same** lifecycle without `make`, and works from any
+directory inside a checkout:
+
+```bash
+zynax up                     # = make kind-up (full profile)
+zynax up --profile lite      # lean single-node profile
+zynax up --engine argo       # same platform on the Argo engine — the wedge, one flag
+zynax down                   # = make kind-down
+```
+
+Both wrap the **same** `scripts/e2e/cluster-up.sh` / `cluster-down.sh` as the
+`make` targets ([ADR-041](adr/ADR-041-kind-native-unified-runtime.md)), so the
+runtime is identical — `zynax up` is just a discoverable, `make`-free entry
+point that resolves the repo root itself. Flags map 1:1 to the script env
+(`--profile`→`PROFILE`, `--engine`→`E2E_ENGINE`, `--no-load-images` omits
+`KIND_LOAD_IMAGES`, `--cluster-name`, `--namespace`). Outside a checkout, point
+at one with `--repo-root` or `$ZYNAX_REPO_ROOT`. After bring-up, run a workflow
+with `zynax apply` (see the README golden path).
+
 ## Two profiles
 
 | | `PROFILE=full` (default) | `PROFILE=lite` |

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -151,6 +151,7 @@ without it.
 
 ```bash
 make kind-down       # delete the kind cluster (wraps scripts/e2e/cluster-down.sh)
+zynax down           # CLI-native equivalent — same script, make-free, from any directory
 ```
 
 ---
@@ -162,6 +163,8 @@ Every command this guide shows is a real `zynax` subcommand. Verify the surface 
 
 | Command | Purpose | Key flags |
 |---------|---------|-----------|
+| `zynax up` | Create/reuse a kind cluster + deploy the platform | `--profile full\|lite`, `--engine temporal\|argo`, `--no-load-images`, `--cluster-name`, `--namespace`, `--repo-root` |
+| `zynax down` | Delete the local kind cluster | `--cluster-name`, `--repo-root` |
 | `zynax validate <file>` | Local schema + data-flow checks (no gateway) | `--schema-dir`, `--format text\|json` |
 | `zynax init workflow\|expert [name]` | Scaffold a manifest from a template | `-o/--output`, `--template-dir` |
 | `zynax apply <file>` | Submit a manifest to the gateway | `--dry-run`, `--engine` |

--- a/docs/spdd/1561-zynax-up-down/canvas.md
+++ b/docs/spdd/1561-zynax-up-down/canvas.md
@@ -7,8 +7,9 @@
 **Issue:** #1561 (epic M7.V) — stories #1562 (O1), #1563 (O2), #1564 (O3)
 **Author:** Oscar Gómez Manresa
 **Date:** 2026-07-01
-**Status:** Aligned
+**Status:** Implemented
 **Aligned:** 2026-07-01 (maintainer-authorized; grounded in the ADR-041 kind runtime + the existing `scripts/e2e/cluster-up.sh` harness and the `cmd/zynax/cmd/doctor.go` shell-out precedent).
+**Implemented:** 2026-07-01 — all O-steps merged: O1 #1562 (PR #1566), O2 #1563 (PR #1567), O3 #1564. `zynax up`/`down` verified end-to-end on kind (up → idempotent up → down); ADR-041 amendment landed in PR #1565.
 
 ---
 


### PR DESCRIPTION
## docs(cli): document `zynax up`/`down` + mark M7.V canvas Implemented

Closes #1564 · Completes EPIC #1561 (M7.V) · Canvas O3 — `docs/spdd/1561-zynax-up-down/canvas.md`

### Why
O1 (#1562) and O2 (#1563) shipped `zynax up`/`down`; this makes them discoverable and reconciles the docs, wedge-first. The ADR-041 *amendment* already landed in PR #1565, so this covers the remaining user-facing surfaces and flips the canvas to Implemented.

### What changed
- **`cmd/zynax/AGENTS.md`** — `up.go`/`down.go`/`reporoot.go` added to the command Layout.
- **`docs/local-dev-kind.md`** — new *CLI-native lifecycle* section next to `make kind-up`/`kind-down`, noting they wrap the same script, `make`-free, from any directory.
- **`README.md`** — golden-path callout (`zynax up` / `zynax down`) + teardown mention.
- **`docs/quickstart.md`** — tear-down step + `zynax up`/`down` rows in the command reference.
- **Canvas** — Status `Aligned → Implemented` (all O-steps merged).

All new copy leads with the engine-portability wedge (`zynax up --engine temporal|argo`), never "control plane".

### Scope & boundaries
- **In scope:** documentation + canvas status. No code.
- **Out of scope:** ADR-041 amendment (already merged in #1565); `zynax up --run <workflow>` (follow-on).

### Test plan & acceptance
| Acceptance criterion | How verified | Result |
|---|---|---|
| Docs document `zynax up`/`down`, wedge-first, equivalence to `make` targets | reviewed rendered diff | ✅ 4 doc surfaces updated |
| ADR-041 records the CLI-native entry points | already merged in #1565 | ✅ on main |
| Code fences / links intact | fence-balance check on edited files | ✅ balanced |

### Evidence
- Docs-only; no runtime path changed. The commands themselves were runtime-verified end-to-end in O1/O2 (real `zynax up → up → down` on kind).

### Risk & rollback
Minimal — documentation + a canvas status line. Revert = revert the commit.

### Engineering hygiene
- [x] Branched off fresh `origin/main` · docs-only (PR-size excluded) · DCO + `Assisted-by`
- [x] `docs:` — SPDD-exempt; canvas flipped to Implemented as the epic's last O-step

🤖 Generated with [Claude Code](https://claude.com/claude-code)
