### PR TITLE
fix(demo): return the ranked review as the code-review-rank result

### DIFF
--- a/infra/packages/code-review-rank/workflow.yaml
+++ b/infra/packages/code-review-rank/workflow.yaml
@@ -152,3 +152,8 @@ data:
 
         done:
           type: terminal
+          # Return the ranked review — the LAST step's output — as the workflow's
+          # declared result (ADR-042): `zynax result <run>` prints the ranked
+          # review instead of "no declared output".
+          outputs:
+            ranking: "$.states.rank.output.ranking"

--- a/spec/workflows/examples/code-review-rank-ollama.yaml
+++ b/spec/workflows/examples/code-review-rank-ollama.yaml
@@ -142,3 +142,8 @@ spec:
 
     done:
       type: terminal
+      # Return the ranked review — the LAST step's output — as the workflow's
+      # declared result (ADR-042): `zynax result <run>` prints
+      # `ranking=<the ranked review text>` instead of "no declared output".
+      outputs:
+        ranking: "$.states.rank.output.ranking"


### PR DESCRIPTION
## fix(demo): return the ranked review as the code-review-rank result

### Why
The `code-review-rank` workflow ran to `COMPLETED` but declared no workflow-level output, so `zynax result <run>` printed *"run completed with no declared output"* — the ranked review (the whole point of the demo) was unreachable via the CLI.

### What changed
Bind the workflow result to the **last step's output** on the terminal `done` state (ADR-042):

```yaml
done:
  type: terminal
  outputs:
    ranking: "$.states.rank.output.ranking"   # the summarize step's output
```

Applied to both:
- `spec/workflows/examples/code-review-rank-ollama.yaml` (canonical example)
- `infra/packages/code-review-rank/workflow.yaml` (the ConfigMap the kustomize package deploys)

### Test plan & acceptance
| Criterion | How verified | Result |
|---|---|---|
| Manifests still valid (schema + data-flow) | `zynax validate` on the example + the extracted package workflow | ✅ `ok` for both |
| `zynax result` returns the ranked review | redeployed the package on kind, fresh run `wf-6bec695c4cc2a30d` → `COMPLETED` | ✅ `ranking=The total number of distinct issues identified is 5…` |

### Evidence
Real end-to-end on a live kind cluster: `kubectl apply -k` the fixed package → apply-Job resubmitted → workflow reached `COMPLETED` → `zynax result <run>` printed the ranked review instead of the empty-output note.

### Risk & rollback
Minimal — adds a declarative output binding on the terminal state; no behavior change to the review/rank steps. Revert = revert the commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
