### PR TITLE
fix(demo): return all step outputs; port-forward the gateway in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,31 +50,26 @@ When it finishes it prints a **Platform ready** banner with the gateway URL
 
 ### 2. Reach the gateway and run your first workflow
 
-The api-gateway is auth-enabled, so fetch the bearer key the cluster provisioned, then apply the
-zero-dependency [`hello-world`](spec/workflows/examples/hello-world.yaml) workflow (the built-in
-`echo` capability — no model, no external secret):
+The api-gateway is auth-enabled. Reach it over a **`kubectl port-forward`** — the reliable path. (The
+kind NodePort on `localhost:8080` also works, but resets under load on repeat runs, so prefer the
+forward.) Start it once, export the URL + the cluster's bearer key, then apply the zero-dependency
+[`hello-world`](spec/workflows/examples/hello-world.yaml) workflow (the built-in `echo` capability —
+no model, no external secret):
 
 ```bash
+kubectl -n zynax port-forward svc/zynax-api-gateway 18080:8080 &
+export ZYNAX_API_URL=http://localhost:18080
 export ZYNAX_API_KEY=$(kubectl -n zynax get secret zynax-gw-api-key -o jsonpath='{.data.api-key}' | base64 -d)
+
 zynax apply spec/workflows/examples/hello-world.yaml
 # run_id: wf-<hex>
-
 zynax status workflow wf-<hex>
 # WORKFLOW_STATUS_COMPLETED
 ```
 
 That `WORKFLOW_STATUS_COMPLETED` is your first success — the engine dispatched the in-cluster `echo`
-capability and ran to a terminal state with zero secrets. Inspect the run with
-`zynax logs wf-<hex>`.
-
-The CLI defaults to `--api-url http://localhost:8080` (mapped from the kind NodePort `30080`). The
-NodePort can be reset by kube-proxy on repeat runs; if `localhost:8080` is flaky, port-forward to a
-**different** local port (the NodePort already holds `8080`) and target it with `--api-url`:
-
-```bash
-kubectl -n zynax port-forward svc/zynax-api-gateway 18080:8080 &
-zynax --api-url http://localhost:18080 apply spec/workflows/examples/hello-world.yaml
-```
+capability and ran to a terminal state with zero secrets. Inspect the run with `zynax logs wf-<hex>`
+(exporting `ZYNAX_API_URL`/`ZYNAX_API_KEY` above means the `zynax` commands need no flags).
 
 ### 3. Switch engines — same workflow, one flag
 

--- a/docs/local-dev-kind.md
+++ b/docs/local-dev-kind.md
@@ -50,6 +50,16 @@ point that resolves the repo root itself. Flags map 1:1 to the script env
 at one with `--repo-root` or `$ZYNAX_REPO_ROOT`. After bring-up, run a workflow
 with `zynax apply` (see the README golden path).
 
+**Reaching the gateway:** use a `kubectl port-forward` — the reliable path — not
+the host NodePort on `localhost:8080`, which resets under load on repeat runs.
+Export the URL + key once and the `zynax` commands need no flags:
+
+```bash
+kubectl -n zynax port-forward svc/zynax-api-gateway 18080:8080 &
+export ZYNAX_API_URL=http://localhost:18080
+export ZYNAX_API_KEY=$(kubectl -n zynax get secret zynax-gw-api-key -o jsonpath='{.data.api-key}' | base64 -d)
+```
+
 ## Two profiles
 
 | | `PROFILE=full` (default) | `PROFILE=lite` |

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -48,18 +48,14 @@ Temporal and disables the event-bus / memory-service.
 
 The api-gateway is auth-enabled. Fetch the bearer key the cluster provisioned:
 
-```bash
-export ZYNAX_API_KEY=$(kubectl -n zynax get secret zynax-gw-api-key -o jsonpath='{.data.api-key}' | base64 -d)
-```
-
-The CLI defaults to `--api-url http://localhost:8080` (the kind NodePort `30080` mapped to host
-`8080`). The NodePort can be reset by kube-proxy on repeat runs; if `localhost:8080` is flaky,
-port-forward to a **different** local port (the NodePort already holds `8080`) and target it with
-`--api-url`:
+Reach the gateway over a **`kubectl port-forward`** — the reliable path. The kind NodePort on
+`localhost:8080` also works, but resets under load on repeat runs, so prefer the forward. Start it,
+then export the URL + the cluster's bearer key so the `zynax` commands below need no flags:
 
 ```bash
 kubectl -n zynax port-forward svc/zynax-api-gateway 18080:8080 &
-# then add --api-url http://localhost:18080 to the zynax commands below
+export ZYNAX_API_URL=http://localhost:18080
+export ZYNAX_API_KEY=$(kubectl -n zynax get secret zynax-gw-api-key -o jsonpath='{.data.api-key}' | base64 -d)
 ```
 
 ---

--- a/infra/packages/code-review-rank/workflow.yaml
+++ b/infra/packages/code-review-rank/workflow.yaml
@@ -152,8 +152,9 @@ data:
 
         done:
           type: terminal
-          # Return the ranked review — the LAST step's output — as the workflow's
-          # declared result (ADR-042): `zynax result <run>` prints the ranked
-          # review instead of "no declared output".
+          # Expose BOTH steps' outputs as the workflow result (ADR-042) so
+          # `zynax result <run>` prints `review=<the code review>` AND
+          # `ranking=<the ranked summary>` — every step's output in one place.
           outputs:
+            review: "$.states.review.output.review"
             ranking: "$.states.rank.output.ranking"

--- a/spec/workflows/examples/code-review-rank-ollama.yaml
+++ b/spec/workflows/examples/code-review-rank-ollama.yaml
@@ -142,8 +142,9 @@ spec:
 
     done:
       type: terminal
-      # Return the ranked review — the LAST step's output — as the workflow's
-      # declared result (ADR-042): `zynax result <run>` prints
-      # `ranking=<the ranked review text>` instead of "no declared output".
+      # Expose BOTH steps' outputs as the workflow result (ADR-042) so
+      # `zynax result <run>` prints `review=<the code review>` AND
+      # `ranking=<the ranked summary>` — every step's output in one place.
       outputs:
+        review: "$.states.review.output.review"
         ranking: "$.states.rank.output.ranking"


### PR DESCRIPTION
## fix(demo): all step outputs in result + port-forward the gateway docs

Two related improvements to the local kind + code-review-rank experience (one PR, two commits).

### 1) `fix(demo)` — return **all** step outputs
The code-review-rank terminal state declared only the last step's output (`ranking`), so `zynax result` showed just the ranked summary. Now it declares **both** steps (ADR-042):

```yaml
done:
  type: terminal
  outputs:
    review:  "$.states.review.output.review"    # step 1 — codereview
    ranking: "$.states.rank.output.ranking"     # step 2 — summarize
```

Applied to the example (`spec/workflows/examples/code-review-rank-ollama.yaml`) and the package ConfigMap (`infra/packages/code-review-rank/workflow.yaml`).

**Verified live on kind:** fresh run `wf-5c1cd647c0948c16` → `zynax result` printed **both** `review=…` (full code review + suggested fix) and `ranking=…` (ranked summary).

### 2) `docs(kind)` — reach the gateway via **port-forward**, not the NodePort
The kind host NodePort on `localhost:8080` resets under load on repeat runs and intermittently returns connection-reset while the platform is healthy (observed this session: healthz flipped 200→000 with pods Running and ~9 GiB free). Made `kubectl port-forward` the documented, reliable access path — exporting `ZYNAX_API_URL`/`ZYNAX_API_KEY` so commands need no flags — across:
- `README.md` (golden path step 2)
- `docs/quickstart.md`
- `docs/local-dev-kind.md` (a "Reaching the gateway" note)

The NodePort stays as a best-effort note; **`zynax up`'s first-run `localhost:8080/healthz` assertion (#1488) is unchanged** — I did not remove the NodePort mapping (that would break the first-run contract).

### Test plan
| Criterion | How | Result |
|---|---|---|
| Manifests valid | `zynax validate` example + extracted package workflow | ✅ `ok` both |
| `zynax result` shows all step outputs | live redeploy + fresh run on kind | ✅ `review=…` + `ranking=…` |
| Docs render | code-fence balance on all edited files | ✅ balanced |

### Risk & rollback
Low — additive output binding (same mechanism as the merged `ranking` fix) + docs. No infra/NodePort change. Revert = revert the two commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
