### PR TITLE
feat(agent-registry): scoring pipeline + SelectAgent RPC with degradation

### DIFF
--- a/services/agent-registry/internal/domain/scheduler/scorer.go
+++ b/services/agent-registry/internal/domain/scheduler/scorer.go
@@ -1,0 +1,282 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package scheduler
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync/atomic"
+)
+
+// ErrNoCapability is returned when no agent declares the capability at all
+// (pipeline stage 1). Maps to gRPC NOT_FOUND (contract invariant 3).
+var ErrNoCapability = errors.New("no agent declares capability")
+
+// FilteredError reports that candidates existed but a pipeline stage
+// eliminated all of them. Stage names the first eliminating filter (contract
+// invariant 4). Maps to gRPC FAILED_PRECONDITION.
+type FilteredError struct {
+	Capability string
+	Stage      string // "tags" | "language" | "model" | "gpu" | "protocols" | "ready" | "expert:<target>"
+}
+
+func (e *FilteredError) Error() string {
+	return fmt.Sprintf("no candidate for %q survives filter: %s", e.Capability, e.Stage)
+}
+
+// ErrMetricsUnavailable signals the metrics backend is down or slow; selection
+// must degrade to readiness-filtered round-robin, never fail (ADR-039 §3).
+var ErrMetricsUnavailable = errors.New("metrics source unavailable")
+
+// Metrics is the live, dynamic snapshot for one agent — pulled from the
+// metrics backend at selection time, NEVER stored in CRD status (ADR-039 §3).
+type Metrics struct {
+	Load         float64 // 0..1 utilization
+	LatencyP50Ms float64
+	QueueDepth   float64
+}
+
+// MetricsSource returns a live snapshot for the given agent keys. An error
+// means the telemetry backend is unavailable; the scorer degrades gracefully.
+type MetricsSource interface {
+	Snapshot(ctx context.Context, keys []string) (map[string]Metrics, error)
+}
+
+// Constraints are hard filters; a candidate failing any is dropped before
+// scoring (ADR-039 §4 stage 2). Empty fields are unconstrained.
+type Constraints struct {
+	RequiredTags      []string
+	RequiredLanguage  string
+	RequiredModel     string
+	RequireGPU        bool
+	RequiredProtocols []string
+}
+
+// Mode reports which scoring path produced the decision (proto SelectionMode).
+type Mode int
+
+// Scoring modes, mirroring zynax.v1.SelectionMode.
+const (
+	ModeMetricsWeighted Mode = iota + 1
+	ModeRoundRobin
+	ModeDegradedRoundRobin
+)
+
+// Request is one SelectAgent call in domain terms.
+type Request struct {
+	Capability   string
+	Constraints  Constraints
+	RoundRobin   bool   // caller explicitly requested rotation over scoring
+	ExpertTarget string // ADR-028: strict scope filter, no fallback
+}
+
+// Rationale explains the pick, structurally (maps 1:1 to proto
+// SelectionRationale): per-stage counts trace where candidates were
+// eliminated without reading scheduler logs.
+type Rationale struct {
+	CandidatesMatched           int
+	CandidatesAfterConstraints  int
+	CandidatesReady             int
+	CandidatesAfterExpertFilter int
+	Mode                        Mode
+	WinningFactors              []string
+	Summary                     string
+}
+
+// Result is the chosen agent plus the matching capability (the broker reads
+// its InputSchema for the ADR-028 context-slice binding) and the rationale.
+type Result struct {
+	Chosen     Candidate
+	Capability Capability
+	Rationale  Rationale
+}
+
+// Scorer runs the ordered, short-circuiting ADR-039 §4 pipeline. Promoted
+// from the KIND-verified spike (internal/scorer/scorer.go), with the rotation
+// counter added so round-robin modes genuinely rotate across calls.
+type Scorer struct {
+	Metrics MetricsSource
+	// weights of the balanced default policy (lower total score wins).
+	rr atomic.Uint64
+}
+
+// factorRotation is the stable winning-factor token for rotation modes.
+const factorRotation = "rotation"
+
+// Balanced default weights: load and latency dominate, cost tie-breaks.
+const (
+	weightLoad    = 0.4
+	weightLatency = 0.4
+	weightCost    = 0.2
+)
+
+// Select implements: capability match → hard constraints → readiness →
+// expert target → metrics-weighted score (or rotation) → cost tie-break.
+// Degrades (never fails) when the metrics source is unavailable.
+func (s *Scorer) Select(ctx context.Context, idx *Index, req Request) (Result, error) {
+	// Stage 1 — capability match (O(1) index lookup, key-sorted).
+	matched := idx.Candidates(req.Capability)
+	if len(matched) == 0 {
+		return Result{}, fmt.Errorf("%w: %q", ErrNoCapability, req.Capability)
+	}
+	r := Rationale{CandidatesMatched: len(matched)}
+
+	// Stage 2 — hard constraints, evaluated against the matching capability.
+	afterConstraints, stage := filterConstraints(matched, req.Capability, req.Constraints)
+	r.CandidatesAfterConstraints = len(afterConstraints)
+	if len(afterConstraints) == 0 {
+		return Result{}, &FilteredError{Capability: req.Capability, Stage: stage}
+	}
+
+	// Stage 3 — readiness: the stale-liveness fix (crashed agent => ready=false).
+	ready := filter(afterConstraints, func(c Candidate) bool { return c.Ready })
+	r.CandidatesReady = len(ready)
+	if len(ready) == 0 {
+		return Result{}, &FilteredError{Capability: req.Capability, Stage: "ready"}
+	}
+
+	// Stage 4 — expert target: strict isolation, no fallback (ADR-028).
+	afterExpert := ready
+	if req.ExpertTarget != "" {
+		afterExpert = filter(ready, func(c Candidate) bool { return c.ExpertScope == req.ExpertTarget })
+		if len(afterExpert) == 0 {
+			return Result{}, &FilteredError{Capability: req.Capability, Stage: "expert:" + req.ExpertTarget}
+		}
+	}
+	r.CandidatesAfterExpertFilter = len(afterExpert)
+
+	// Stage 5 — explicit rotation bypasses the metrics stage on request.
+	if req.RoundRobin {
+		return s.rotate(afterExpert, req.Capability, r, ModeRoundRobin, []string{factorRotation}), nil
+	}
+
+	// Stage 5b — metrics snapshot; on error degrade, never fail (ADR-039 §3).
+	keys := make([]string, len(afterExpert))
+	for i, c := range afterExpert {
+		keys[i] = c.Key
+	}
+	snap, err := s.Metrics.Snapshot(ctx, keys)
+	if err != nil {
+		return s.rotate(afterExpert, req.Capability, r, ModeDegradedRoundRobin, []string{"readiness", factorRotation}), nil
+	}
+
+	// Stage 6 — weighted score (lower is better) + cost/gpu/model tie-break
+	// (cost rides the weighted sum; key order makes ties deterministic).
+	best := afterExpert[0]
+	bestCap, _ := best.CapabilityByID(req.Capability)
+	bestScore := score(bestCap, snap[best.Key])
+	for _, c := range afterExpert[1:] {
+		capability, _ := c.CapabilityByID(req.Capability)
+		if sc := score(capability, snap[c.Key]); sc < bestScore {
+			best, bestCap, bestScore = c, capability, sc
+		}
+	}
+
+	m := snap[best.Key]
+	r.Mode = ModeMetricsWeighted
+	r.WinningFactors = []string{"load", "latency", "cost"}
+	r.Summary = fmt.Sprintf("selected %s for %s (load=%.2f latency_p50=%.0fms cost=%s)",
+		best.Key, req.Capability, m.Load, m.LatencyP50Ms, bestCap.Cost.LatencyClass)
+	return Result{Chosen: best, Capability: bestCap, Rationale: r}, nil
+}
+
+// rotate picks the next candidate in rotation order (candidates arrive
+// key-sorted from the index, so rotation is stable across replicas).
+func (s *Scorer) rotate(cands []Candidate, capID string, r Rationale, mode Mode, factors []string) Result {
+	n := s.rr.Add(1) - 1
+	chosen := cands[int(n%uint64(len(cands)))] //nolint:gosec // len > 0 guaranteed by caller
+	capability, _ := chosen.CapabilityByID(capID)
+	r.Mode = mode
+	r.WinningFactors = factors
+	verb := factorRotation
+	if mode == ModeDegradedRoundRobin {
+		verb = "degraded: metrics unavailable; readiness-filtered rotation"
+	}
+	r.Summary = fmt.Sprintf("selected %s for %s (%s)", chosen.Key, capID, verb)
+	return Result{Chosen: chosen, Capability: capability, Rationale: r}
+}
+
+// filterConstraints drops candidates failing any populated constraint and
+// reports the first eliminating filter name (contract invariant 4).
+func filterConstraints(in []Candidate, capID string, k Constraints) ([]Candidate, string) {
+	out := in[:0:0]
+	stage := ""
+	for _, c := range in {
+		capability, ok := c.CapabilityByID(capID)
+		if !ok {
+			continue
+		}
+		if f := failedConstraint(capability, k); f != "" {
+			stage = f
+			continue
+		}
+		out = append(out, c)
+	}
+	return out, stage
+}
+
+// failedConstraint names the first unmet constraint, or "" when satisfied.
+func failedConstraint(capability Capability, k Constraints) string {
+	for _, t := range k.RequiredTags {
+		if !containsFold(capability.Selectors.Tags, t) {
+			return "tags"
+		}
+	}
+	if k.RequiredLanguage != "" && !containsFold(capability.Selectors.Language, k.RequiredLanguage) {
+		return "language"
+	}
+	if k.RequiredModel != "" && !containsFold(capability.Models, k.RequiredModel) {
+		return "model"
+	}
+	if k.RequireGPU && capability.Resources.GPU <= 0 {
+		return "gpu"
+	}
+	for _, p := range k.RequiredProtocols {
+		if !containsFold(capability.Protocols, p) {
+			return "protocols"
+		}
+	}
+	return ""
+}
+
+// score: weighted sum, lower is better. Latency normalized to seconds; the
+// static cost hint rides as the tie-break weight (ADR-039 §4 stage 6).
+func score(capability Capability, m Metrics) float64 {
+	return weightLoad*m.Load +
+		weightLatency*(m.LatencyP50Ms/1000.0) +
+		weightCost*costScore(capability.Cost)
+}
+
+func costScore(c Cost) float64 {
+	switch c.LatencyClass {
+	case "low":
+		return 0.1
+	case "medium":
+		return 0.5
+	case "high":
+		return 1.0
+	default:
+		return c.TokenPrice // fall back to relative token price when class absent
+	}
+}
+
+func containsFold(haystack []string, needle string) bool {
+	for _, h := range haystack {
+		if strings.EqualFold(h, needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func filter(in []Candidate, keep func(Candidate) bool) []Candidate {
+	out := in[:0:0]
+	for _, c := range in {
+		if keep(c) {
+			out = append(out, c)
+		}
+	}
+	return out
+}

--- a/services/agent-registry/internal/domain/scheduler/scorer_test.go
+++ b/services/agent-registry/internal/domain/scheduler/scorer_test.go
@@ -1,0 +1,257 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package scheduler
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// fakeMetrics is the in-process metrics stub; Fail simulates an outage.
+type fakeMetrics struct {
+	data map[string]Metrics
+	fail bool
+}
+
+func (f *fakeMetrics) Snapshot(_ context.Context, keys []string) (map[string]Metrics, error) {
+	if f.fail {
+		return nil, ErrMetricsUnavailable
+	}
+	out := make(map[string]Metrics, len(keys))
+	for _, k := range keys {
+		out[k] = f.data[k]
+	}
+	return out, nil
+}
+
+func scoredCand(key string, ready bool, capability Capability) Candidate {
+	return Candidate{Key: key, Name: key, Endpoint: key + ".default.svc:50061", Ready: ready,
+		Capabilities: []Capability{capability}}
+}
+
+func reviewCap() Capability {
+	return Capability{
+		ID:        "review",
+		Selectors: Selectors{Language: []string{"go"}, Tags: []string{"fast"}},
+		Cost:      Cost{LatencyClass: "low"},
+		Resources: Resources{GPU: 0},
+		Models:    []string{"qwen2.5-coder:3b"},
+		Protocols: []string{"A2A", "HTTP"},
+	}
+}
+
+func newIdx(cands ...Candidate) *Index {
+	idx := NewIndex()
+	for _, c := range cands {
+		idx.Upsert(c)
+	}
+	return idx
+}
+
+const lessLoaded = "default/b"
+
+func TestSelect_LeastLoadedWins(t *testing.T) {
+	idx := newIdx(
+		scoredCand("default/a", true, reviewCap()),
+		scoredCand(lessLoaded, true, reviewCap()),
+	)
+	s := &Scorer{Metrics: &fakeMetrics{data: map[string]Metrics{
+		"default/a": {Load: 0.9, LatencyP50Ms: 200},
+		lessLoaded:  {Load: 0.1, LatencyP50Ms: 80},
+	}}}
+
+	res, err := s.Select(context.Background(), idx, Request{Capability: "review"})
+	if err != nil {
+		t.Fatalf("Select: %v", err)
+	}
+	if res.Chosen.Key != lessLoaded {
+		t.Errorf("chosen = %s, want the less-loaded default/b", res.Chosen.Key)
+	}
+	r := res.Rationale
+	if r.CandidatesMatched != 2 || r.CandidatesReady != 2 || r.CandidatesAfterExpertFilter != 2 {
+		t.Errorf("counts = %+v", r)
+	}
+	if r.Mode != ModeMetricsWeighted || len(r.WinningFactors) == 0 || r.Summary == "" {
+		t.Errorf("rationale = %+v", r)
+	}
+	if res.Capability.ID != "review" {
+		t.Errorf("capability = %q (ADR-028 binding needs the matching capability)", res.Capability.ID)
+	}
+}
+
+func TestSelect_NoCapability(t *testing.T) {
+	s := &Scorer{Metrics: &fakeMetrics{}}
+	_, err := s.Select(context.Background(), newIdx(), Request{Capability: "ghost"})
+	if !errors.Is(err, ErrNoCapability) {
+		t.Fatalf("err = %v, want ErrNoCapability", err)
+	}
+}
+
+func TestSelect_ConstraintsEliminateAll(t *testing.T) {
+	idx := newIdx(scoredCand("default/a", true, reviewCap()))
+	s := &Scorer{Metrics: &fakeMetrics{}}
+
+	cases := []struct {
+		name  string
+		k     Constraints
+		stage string
+	}{
+		{"gpu", Constraints{RequireGPU: true}, "gpu"},
+		{"tags", Constraints{RequiredTags: []string{"thorough"}}, "tags"},
+		{"language", Constraints{RequiredLanguage: "rust"}, "language"},
+		{"model", Constraints{RequiredModel: "gpt-x"}, "model"},
+		{"protocols", Constraints{RequiredProtocols: []string{"MCP"}}, "protocols"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := s.Select(context.Background(), idx, Request{Capability: "review", Constraints: tc.k})
+			var fe *FilteredError
+			if !errors.As(err, &fe) {
+				t.Fatalf("err = %v, want FilteredError", err)
+			}
+			if fe.Stage != tc.stage {
+				t.Errorf("stage = %q, want %q", fe.Stage, tc.stage)
+			}
+		})
+	}
+}
+
+func TestSelect_ConstraintsMatchFold(t *testing.T) {
+	idx := newIdx(scoredCand("default/a", true, reviewCap()))
+	s := &Scorer{Metrics: &fakeMetrics{}}
+	// Case-insensitive protocol + language + tag + model match must pass.
+	res, err := s.Select(context.Background(), idx, Request{Capability: "review", Constraints: Constraints{
+		RequiredTags:      []string{"FAST"},
+		RequiredLanguage:  "GO",
+		RequiredModel:     "QWEN2.5-CODER:3B",
+		RequiredProtocols: []string{"http"},
+	}})
+	if err != nil {
+		t.Fatalf("Select: %v", err)
+	}
+	if res.Rationale.CandidatesAfterConstraints != 1 {
+		t.Errorf("after constraints = %d", res.Rationale.CandidatesAfterConstraints)
+	}
+}
+
+func TestSelect_ReadinessFiltersDeadAgents(t *testing.T) {
+	idx := newIdx(
+		scoredCand("default/alive", true, reviewCap()),
+		scoredCand("default/dead", false, reviewCap()),
+	)
+	s := &Scorer{Metrics: &fakeMetrics{}}
+	res, err := s.Select(context.Background(), idx, Request{Capability: "review"})
+	if err != nil {
+		t.Fatalf("Select: %v", err)
+	}
+	if res.Chosen.Key != "default/alive" {
+		t.Errorf("chosen = %s", res.Chosen.Key)
+	}
+	if res.Rationale.CandidatesMatched != 2 || res.Rationale.CandidatesReady != 1 {
+		t.Errorf("counts = %+v", res.Rationale)
+	}
+}
+
+func TestSelect_AllNotReadyFails(t *testing.T) {
+	idx := newIdx(scoredCand("default/dead", false, reviewCap()))
+	s := &Scorer{Metrics: &fakeMetrics{}}
+	_, err := s.Select(context.Background(), idx, Request{Capability: "review"})
+	var fe *FilteredError
+	if !errors.As(err, &fe) || fe.Stage != "ready" {
+		t.Fatalf("err = %v, want FilteredError(ready)", err)
+	}
+}
+
+func TestSelect_ExpertStrictNoFallback(t *testing.T) {
+	sec := scoredCand("default/sec", true, reviewCap())
+	sec.ExpertScope = "security-reviewer"
+	idx := newIdx(sec, scoredCand("default/generalist", true, reviewCap()))
+	s := &Scorer{Metrics: &fakeMetrics{}}
+
+	res, err := s.Select(context.Background(), idx, Request{Capability: "review", ExpertTarget: "security-reviewer"})
+	if err != nil {
+		t.Fatalf("Select: %v", err)
+	}
+	if res.Chosen.Key != "default/sec" || res.Rationale.CandidatesAfterExpertFilter != 1 {
+		t.Errorf("chosen=%s counts=%+v", res.Chosen.Key, res.Rationale)
+	}
+
+	// No declared expert => FAILED_PRECONDITION-class error, never a fallback.
+	_, err = s.Select(context.Background(), idx, Request{Capability: "review", ExpertTarget: "compliance-reviewer"})
+	var fe *FilteredError
+	if !errors.As(err, &fe) || fe.Stage != "expert:compliance-reviewer" {
+		t.Fatalf("err = %v, want FilteredError(expert:compliance-reviewer)", err)
+	}
+}
+
+func TestSelect_MetricsDownDegradesNeverFails(t *testing.T) {
+	idx := newIdx(
+		scoredCand("default/a", true, reviewCap()),
+		scoredCand("default/b", true, reviewCap()),
+	)
+	s := &Scorer{Metrics: &fakeMetrics{fail: true}}
+
+	seen := map[string]bool{}
+	for range 4 {
+		res, err := s.Select(context.Background(), idx, Request{Capability: "review"})
+		if err != nil {
+			t.Fatalf("degraded selection must not fail: %v", err)
+		}
+		if res.Rationale.Mode != ModeDegradedRoundRobin {
+			t.Fatalf("mode = %v, want degraded", res.Rationale.Mode)
+		}
+		seen[res.Chosen.Key] = true
+	}
+	// Genuine rotation: both ready candidates receive work across calls.
+	if !seen["default/a"] || !seen[lessLoaded] {
+		t.Errorf("rotation did not spread: %v", seen)
+	}
+}
+
+func TestSelect_ExplicitRoundRobinMode(t *testing.T) {
+	idx := newIdx(scoredCand("default/a", true, reviewCap()))
+	s := &Scorer{Metrics: &fakeMetrics{}}
+	res, err := s.Select(context.Background(), idx, Request{Capability: "review", RoundRobin: true})
+	if err != nil {
+		t.Fatalf("Select: %v", err)
+	}
+	if res.Rationale.Mode != ModeRoundRobin {
+		t.Errorf("mode = %v, want ModeRoundRobin", res.Rationale.Mode)
+	}
+	if res.Rationale.WinningFactors[0] != "rotation" {
+		t.Errorf("factors = %v", res.Rationale.WinningFactors)
+	}
+}
+
+func TestSelect_CostTieBreak(t *testing.T) {
+	cheap := reviewCap()
+	cheap.Cost = Cost{LatencyClass: "low"}
+	pricey := reviewCap()
+	pricey.Cost = Cost{LatencyClass: "high"}
+	idx := newIdx(
+		scoredCand("default/pricey", true, pricey),
+		scoredCand("default/cheap", true, cheap),
+	)
+	// Identical live metrics => the static cost hint decides.
+	s := &Scorer{Metrics: &fakeMetrics{data: map[string]Metrics{
+		"default/pricey": {Load: 0.5, LatencyP50Ms: 100},
+		"default/cheap":  {Load: 0.5, LatencyP50Ms: 100},
+	}}}
+	res, err := s.Select(context.Background(), idx, Request{Capability: "review"})
+	if err != nil {
+		t.Fatalf("Select: %v", err)
+	}
+	if res.Chosen.Key != "default/cheap" {
+		t.Errorf("chosen = %s, want cost tie-break winner default/cheap", res.Chosen.Key)
+	}
+}
+
+func TestCostScore_TokenPriceFallback(t *testing.T) {
+	if got := costScore(Cost{TokenPrice: 0.7}); got != 0.7 {
+		t.Errorf("costScore fallback = %v", got)
+	}
+	if got := costScore(Cost{LatencyClass: "medium"}); got != 0.5 {
+		t.Errorf("costScore medium = %v", got)
+	}
+}


### PR DESCRIPTION
Closes #1581
Part of #1571 (EPIC M8.C — CRD-native Scheduler, canvas O-step 4)

### Why
ADR-039 §3–§4: `SelectAgent` must run the ordered, short-circuiting pipeline over the informer-backed index, query live load/latency from Prometheus **at selection time** behind a short-TTL cache, and degrade to readiness-filtered rotation — never fail — when metrics are unavailable. This is the step that turns the epic's plumbing into the actual dispatch upgrade.

### What you'll get
- Pipeline (capability → constraints [first eliminating filter named in the error] → readiness → expert-strict → metrics-weighted score → cost tie-break), per-stage counts mapping 1:1 to `SelectionRationale`; rotation counter for genuine round-robin ← `internal/domain/scheduler/scorer.go`
- Prometheus `/api/v1/query` MetricsSource with TTL cache (default 5s); every failure ⇒ `ErrMetricsUnavailable` ⇒ degraded mode; `Unavailable` source when `ZYNAX_REGISTRY_PROM_URL` unset ← `internal/infrastructure/promql/`
- gRPC handler with the full contract error taxonomy; response `AgentDef` carries capability `input_schema` (the ADR-028 broker binding) ← `internal/api/scheduler_handler.go`
- `SchedulerService` registered only when the CRD informer is enabled ← `cmd/agent-registry/main.go`; canvas O-step 4 ✅

### Test plan & acceptance
| Acceptance criterion | How verified | Result |
|---|---|---|
| Pipeline order per ADR-039 §4, expert strict no-fallback | scorer unit suite (per-stage elimination cases) | ✅ |
| Prometheus at selection time via TTL cache, configurable | `TestSnapshot_TTLCacheAvoidsHotPathQueries` (2 calls for 5 selections) | ✅ |
| Degradation: OK + degraded rationale, never errors | unit + **live kill test** (below) | ✅ |
| Structured rationale (counts, mode, factors) | unit + grpcurl output | ✅ |
| ≥90% coverage | domain **96.9%**, promql 91.8% | ✅ |
| Step-1 `.feature` scenarios pass against the live handler on kind | grpcurl session (below) covers the same contract paths | ✅ |

### Evidence (runtime, kind zynax-e2e — live handler + fake Prometheus)
- Metrics-weighted pick with live data: `mode: SELECTION_MODE_METRICS_WEIGHTED, summary: … load=0.15 latency_p50=80ms`; counts `matched=2 ready=1` (stale-liveness visible)
- Error taxonomy live: NOT_FOUND (unknown capability) · FAILED_PRECONDITION (`filter: gpu`) · INVALID_ARGUMENT (empty capability)
- **Prometheus killed mid-flight** → next call OK with `SELECTION_MODE_DEGRADED_ROUND_ROBIN`; repeat call also OK
- `input_schema` present in the response capability (ADR-028 binding for #1583)
- Cluster restored afterwards (samples + CRD deleted)

### Risk & rollback
Low — all new surface is behind the default-off informer flag; legacy RPCs untouched. Revert = drop the new files + main wiring.

### Review aids
`scorer.go` `Select()` is the ONE function — compare against ADR-039 §4 stage order. Subtlety: `FilteredError.Stage` feeds contract invariant 4 (first eliminating filter in the message); `promql` caches the **full** label-keyed snapshot so per-selection filtering is free.

### Engineering hygiene
- [x] Canvas O-step 4 ✅ in this diff · Status Aligned
- [x] Fresh origin/main · DCO + Assisted-by · no proto changes (contract landed in #1586)

**SPDD:** Canvas `docs/spdd/1571-crd-native-scheduler/canvas.md` — Status: Aligned · security review PASS

Assisted-by: Claude/claude-fable-5