### PR TITLE
feat(agent-registry): SelectAgent RPC + Prometheus metrics source (2/2)

### DIFF
--- a/docs/spdd/1571-crd-native-scheduler/canvas.md
+++ b/docs/spdd/1571-crd-native-scheduler/canvas.md
@@ -127,7 +127,7 @@ Consumers / neighbors
    surface untouched. → #1580 ✅
 4. **Scoring pipeline + `SelectAgent` live** — promote the spike scorer (ADR-039 §4 order,
    expert-strict); Prometheus at selection time via TTL cache; degradation path; structured
-   rationale; step-1 `.feature` passes on kind. → #1581
+   rationale; step-1 `.feature` passes on kind. → #1581 ✅
 5. **Readiness reconciler** — EndpointSlice → `status.{ready,replicas,conditions}`; Lease leader
    election (single writer, select path always-serving); stale-liveness scenario green. → #1582
 6. **task-broker cutover** — `SelectAgent` replaces `FindByCapability` + round-robin; ADR-028

--- a/services/agent-registry/cmd/agent-registry/main.go
+++ b/services/agent-registry/cmd/agent-registry/main.go
@@ -31,6 +31,7 @@ import (
 	"github.com/zynax-io/zynax/services/agent-registry/internal/infrastructure"
 	"github.com/zynax-io/zynax/services/agent-registry/internal/infrastructure/crd"
 	"github.com/zynax-io/zynax/services/agent-registry/internal/infrastructure/postgres"
+	"github.com/zynax-io/zynax/services/agent-registry/internal/infrastructure/promql"
 )
 
 type config struct {
@@ -47,6 +48,10 @@ type config struct {
 	// path consumes it (O-step 4); requires the Agent CRD + scheduler RBAC
 	// shipped by the chart (O-step 2).
 	CRDInformerEnabled bool `envconfig:"CRD_INFORMER_ENABLED" default:"false"`
+	// Prometheus HTTP API base URL for selection-time metrics (ADR-039 §3,
+	// canvas O-step 4). Empty => selection runs in the degraded
+	// readiness-filtered mode (never fails on metrics).
+	PromURL string `envconfig:"PROM_URL"`
 }
 
 func main() {
@@ -89,13 +94,16 @@ func run(cfg config) error {
 	defer closeRepo()
 	svc := domain.NewAgentRegistryService(repo)
 
+	var schedHandler *api.SchedulerHandler
 	if cfg.CRDInformerEnabled {
-		if err := startCRDInformer(ctx); err != nil {
+		idx, err := startCRDInformer(ctx)
+		if err != nil {
 			return fmt.Errorf("agent-registry: crd informer: %w", err)
 		}
+		schedHandler = api.NewSchedulerHandler(idx, newScorer(cfg))
 	}
 
-	srv := newGRPCServer(creds, svc)
+	srv := newGRPCServer(creds, svc, schedHandler)
 
 	healthSvc := health.NewServer()
 	grpc_health_v1.RegisterHealthServer(srv, healthSvc)
@@ -125,7 +133,7 @@ func run(cfg config) error {
 // newGRPCServer builds the agent-registry gRPC server with OTEL tracing (server
 // stats handler + "<service>.<rpc>" span interceptors, canvas O.3) and the RED
 // metrics interceptor, then registers the service handler and reflection.
-func newGRPCServer(creds credentials.TransportCredentials, svc *domain.AgentRegistryService) *grpc.Server {
+func newGRPCServer(creds credentials.TransportCredentials, svc *domain.AgentRegistryService, sched *api.SchedulerHandler) *grpc.Server {
 	tracingUnary, tracingStream := zynaxobs.TracingServerInterceptors()
 	srv := grpc.NewServer(
 		grpc.Creds(creds),
@@ -135,6 +143,10 @@ func newGRPCServer(creds credentials.TransportCredentials, svc *domain.AgentRegi
 	)
 	reflection.Register(srv)
 	zynaxv1.RegisterAgentRegistryServiceServer(srv, api.NewHandler(svc))
+	if sched != nil {
+		zynaxv1.RegisterSchedulerServiceServer(srv, sched)
+		slog.Info("agent-registry: SchedulerService registered (SelectAgent live)")
+	}
 	return srv
 }
 
@@ -160,18 +172,18 @@ func newRepository(ctx context.Context, cfg config) (domain.AgentRepository, fun
 // The manager runs until ctx is cancelled; a manager error is fatal for the
 // informer only, not for the gRPC surface (logged, not propagated), so the
 // legacy registry path keeps serving during partial failures.
-func startCRDInformer(ctx context.Context) error {
+func startCRDInformer(ctx context.Context) (*scheduler.Index, error) {
 	// controller-runtime demands a logger before manager construction;
 	// bridge it into the service's structured slog output.
 	ctrl.SetLogger(logr.FromSlogHandler(slog.Default().Handler()))
 	restCfg, err := ctrl.GetConfig()
 	if err != nil {
-		return fmt.Errorf("load kubeconfig: %w", err)
+		return nil, fmt.Errorf("load kubeconfig: %w", err)
 	}
 	idx := scheduler.NewIndex()
 	mgr, err := crd.NewManager(restCfg, idx)
 	if err != nil {
-		return fmt.Errorf("build crd manager: %w", err)
+		return nil, fmt.Errorf("build crd manager: %w", err)
 	}
 	go func() {
 		slog.Info("agent-registry: crd informer started (Agent CRs -> capability index)")
@@ -179,7 +191,21 @@ func startCRDInformer(ctx context.Context) error {
 			slog.Error("crd informer exited", "err", err)
 		}
 	}()
-	return nil
+	return idx, nil
+}
+
+// newScorer builds the selection pipeline with its metrics source: the
+// Prometheus client (short-TTL cache) when configured, else the always-
+// degraded source — selection never fails on metrics (ADR-039 §3).
+func newScorer(cfg config) *scheduler.Scorer {
+	var src scheduler.MetricsSource = promql.Unavailable{}
+	if cfg.PromURL != "" {
+		src = promql.New(cfg.PromURL)
+		slog.Info("agent-registry: selection metrics from prometheus", "url", cfg.PromURL) //nolint:gosec // operator-controlled config
+	} else {
+		slog.Info("agent-registry: no prometheus configured — selection runs readiness-filtered (degraded mode)")
+	}
+	return &scheduler.Scorer{Metrics: src}
 }
 
 // setHealth sets both the overall "" key and the per-service named key to the

--- a/services/agent-registry/internal/api/scheduler_handler.go
+++ b/services/agent-registry/internal/api/scheduler_handler.go
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// This file implements the SchedulerService gRPC handler (ADR-039):
+// SelectAgent over the informer-backed capability index + scoring pipeline.
+// Registered only when the CRD informer is enabled — the legacy
+// AgentRegistryService surface is untouched.
+
+package api
+
+import (
+	"context"
+	"errors"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	zynaxv1 "github.com/zynax-io/zynax/protos/generated/go/zynax/v1"
+	"github.com/zynax-io/zynax/services/agent-registry/internal/domain/scheduler"
+)
+
+// SchedulerHandler implements SchedulerServiceServer over the domain scorer.
+type SchedulerHandler struct {
+	zynaxv1.UnimplementedSchedulerServiceServer
+	index  *scheduler.Index
+	scorer *scheduler.Scorer
+}
+
+// NewSchedulerHandler constructs the handler over the informer-fed index.
+func NewSchedulerHandler(idx *scheduler.Index, sc *scheduler.Scorer) *SchedulerHandler {
+	return &SchedulerHandler{index: idx, scorer: sc}
+}
+
+// SelectAgent returns exactly one chosen agent + a structured rationale
+// (contract invariants 1-7 in zynax/v1/scheduler.proto).
+func (h *SchedulerHandler) SelectAgent(ctx context.Context, req *zynaxv1.SelectAgentRequest) (*zynaxv1.SelectAgentResponse, error) {
+	if req.GetCapabilityName() == "" {
+		return nil, status.Error(codes.InvalidArgument, "capability_name must not be empty")
+	}
+
+	res, err := h.scorer.Select(ctx, h.index, scheduler.Request{
+		Capability:   req.GetCapabilityName(),
+		Constraints:  protoConstraints(req.GetConstraints()),
+		RoundRobin:   req.GetPolicy() == zynaxv1.SelectionPolicy_SELECTION_POLICY_ROUND_ROBIN,
+		ExpertTarget: req.GetExpertTarget(),
+	})
+	if err != nil {
+		return nil, schedulerErr(err)
+	}
+
+	return &zynaxv1.SelectAgentResponse{
+		Agent:     candidateToProto(res.Chosen),
+		Rationale: rationaleToProto(res.Rationale),
+	}, nil
+}
+
+// schedulerErr maps domain errors to the contract's gRPC codes.
+func schedulerErr(err error) error {
+	var fe *scheduler.FilteredError
+	switch {
+	case errors.Is(err, scheduler.ErrNoCapability):
+		return status.Error(codes.NotFound, err.Error())
+	case errors.As(err, &fe):
+		return status.Error(codes.FailedPrecondition, err.Error())
+	default:
+		return status.Error(codes.Internal, err.Error())
+	}
+}
+
+func protoConstraints(c *zynaxv1.SelectionConstraints) scheduler.Constraints {
+	if c == nil {
+		return scheduler.Constraints{}
+	}
+	return scheduler.Constraints{
+		RequiredTags:      c.GetTags(),
+		RequiredLanguage:  c.GetLanguage(),
+		RequiredModel:     c.GetModel(),
+		RequireGPU:        c.GetRequireGpu(),
+		RequiredProtocols: c.GetProtocols(),
+	}
+}
+
+// candidateToProto builds the returned AgentDef from the scheduler's view of
+// the Agent CR: agent_id is the CR key ("namespace/name"), the endpoint is
+// directly dialable, and capabilities carry input_schema so the task-broker
+// keeps the ADR-028 context-slice binding from the response.
+func candidateToProto(c scheduler.Candidate) *zynaxv1.AgentDef {
+	caps := make([]*zynaxv1.CapabilityDef, 0, len(c.Capabilities))
+	for _, capability := range c.Capabilities {
+		caps = append(caps, &zynaxv1.CapabilityDef{
+			Name:         capability.ID,
+			Description:  capability.Description,
+			InputSchema:  []byte(capability.InputSchema),
+			OutputSchema: []byte(capability.OutputSchema),
+		})
+	}
+	return &zynaxv1.AgentDef{
+		AgentId:      c.Key,
+		Name:         c.Name,
+		Endpoint:     c.Endpoint,
+		Capabilities: caps,
+		Status:       zynaxv1.AgentStatus_AGENT_STATUS_REGISTERED,
+	}
+}
+
+func rationaleToProto(r scheduler.Rationale) *zynaxv1.SelectionRationale {
+	return &zynaxv1.SelectionRationale{
+		CandidatesMatched:           int32(r.CandidatesMatched),           //nolint:gosec // candidate counts are small
+		CandidatesAfterConstraints:  int32(r.CandidatesAfterConstraints),  //nolint:gosec // candidate counts are small
+		CandidatesReady:             int32(r.CandidatesReady),             //nolint:gosec // candidate counts are small
+		CandidatesAfterExpertFilter: int32(r.CandidatesAfterExpertFilter), //nolint:gosec // candidate counts are small
+		Mode:                        modeToProto(r.Mode),
+		WinningFactors:              r.WinningFactors,
+		Summary:                     r.Summary,
+	}
+}
+
+func modeToProto(m scheduler.Mode) zynaxv1.SelectionMode {
+	switch m {
+	case scheduler.ModeMetricsWeighted:
+		return zynaxv1.SelectionMode_SELECTION_MODE_METRICS_WEIGHTED
+	case scheduler.ModeRoundRobin:
+		return zynaxv1.SelectionMode_SELECTION_MODE_ROUND_ROBIN
+	case scheduler.ModeDegradedRoundRobin:
+		return zynaxv1.SelectionMode_SELECTION_MODE_DEGRADED_ROUND_ROBIN
+	default:
+		return zynaxv1.SelectionMode_SELECTION_MODE_UNSPECIFIED
+	}
+}

--- a/services/agent-registry/internal/infrastructure/promql/client.go
+++ b/services/agent-registry/internal/infrastructure/promql/client.go
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package promql is the Prometheus-backed MetricsSource of the CRD-native
+// scheduler (ADR-039 §3): live load/latency are queried from the existing
+// (M6) Prometheus at selection time through a short-TTL cache — never stored
+// in CRD status. Any transport or decode failure surfaces as
+// scheduler.ErrMetricsUnavailable so the scorer degrades instead of failing.
+package promql
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"sync"
+	"time"
+
+	"github.com/zynax-io/zynax/services/agent-registry/internal/domain/scheduler"
+)
+
+// Default instant queries. Each must return a vector labeled with the agent
+// key label; series whose label matches an indexed agent feed its snapshot.
+// Deployments override them (and the label) via the ZYNAX_REGISTRY_PROM_*
+// env vars when their agent metrics use different names.
+const (
+	DefaultKeyLabel     = "zynax_agent"
+	DefaultLoadQuery    = `avg by (zynax_agent) (zynax_agent_load)`
+	DefaultLatencyQuery = `avg by (zynax_agent) (zynax_agent_latency_p50_ms)`
+	DefaultTTL          = 5 * time.Second
+	requestTimeout      = 2 * time.Second
+)
+
+// Unavailable is the MetricsSource used when no Prometheus endpoint is
+// configured: every snapshot reports the backend unavailable, so selection
+// runs permanently in the (correct) degraded readiness-filtered mode.
+type Unavailable struct{}
+
+// Snapshot implements scheduler.MetricsSource.
+func (Unavailable) Snapshot(context.Context, []string) (map[string]scheduler.Metrics, error) {
+	return nil, scheduler.ErrMetricsUnavailable
+}
+
+// Client queries a Prometheus HTTP API (/api/v1/query) and caches the merged
+// snapshot for TTL — protecting the dispatch hot path from one round-trip per
+// selection (ADR-039 Consequences).
+type Client struct {
+	BaseURL      string
+	KeyLabel     string
+	LoadQuery    string
+	LatencyQuery string
+	TTL          time.Duration
+	HTTPC        *http.Client
+
+	mu      sync.Mutex
+	cached  map[string]scheduler.Metrics
+	fetched time.Time
+	now     func() time.Time // test seam
+}
+
+// New builds a Client with defaults applied for zero-value fields.
+func New(baseURL string) *Client {
+	return &Client{
+		BaseURL:      baseURL,
+		KeyLabel:     DefaultKeyLabel,
+		LoadQuery:    DefaultLoadQuery,
+		LatencyQuery: DefaultLatencyQuery,
+		TTL:          DefaultTTL,
+		HTTPC:        &http.Client{Timeout: requestTimeout},
+		now:          time.Now,
+	}
+}
+
+// Snapshot implements scheduler.MetricsSource. The full label-keyed snapshot
+// is cached; per-call filtering to the requested keys is free.
+func (c *Client) Snapshot(ctx context.Context, keys []string) (map[string]scheduler.Metrics, error) {
+	all, err := c.snapshotAll(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[string]scheduler.Metrics, len(keys))
+	for _, k := range keys {
+		out[k] = all[k] // zero Metrics when the backend has no series for k
+	}
+	return out, nil
+}
+
+func (c *Client) snapshotAll(ctx context.Context) (map[string]scheduler.Metrics, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.cached != nil && c.now().Sub(c.fetched) < c.TTL {
+		return c.cached, nil
+	}
+
+	loads, err := c.instantQuery(ctx, c.LoadQuery)
+	if err != nil {
+		return nil, err
+	}
+	lats, err := c.instantQuery(ctx, c.LatencyQuery)
+	if err != nil {
+		return nil, err
+	}
+
+	merged := make(map[string]scheduler.Metrics, len(loads))
+	for k, v := range loads {
+		m := merged[k]
+		m.Load = v
+		merged[k] = m
+	}
+	for k, v := range lats {
+		m := merged[k]
+		m.LatencyP50Ms = v
+		merged[k] = m
+	}
+	c.cached = merged
+	c.fetched = c.now()
+	return merged, nil
+}
+
+// promResponse mirrors the subset of the Prometheus HTTP API response used.
+type promResponse struct {
+	Status string `json:"status"`
+	Data   struct {
+		Result []struct {
+			Metric map[string]string `json:"metric"`
+			Value  []any             `json:"value"` // [ts, "value"]
+		} `json:"result"`
+	} `json:"data"`
+}
+
+// instantQuery runs one /api/v1/query and returns keyLabel -> value.
+func (c *Client) instantQuery(ctx context.Context, q string) (map[string]float64, error) {
+	u := fmt.Sprintf("%s/api/v1/query?query=%s", c.BaseURL, url.QueryEscape(q))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, fmt.Errorf("%w: build query: %w", scheduler.ErrMetricsUnavailable, err)
+	}
+	resp, err := c.HTTPC.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", scheduler.ErrMetricsUnavailable, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 2048))
+		return nil, fmt.Errorf("%w: status %d", scheduler.ErrMetricsUnavailable, resp.StatusCode)
+	}
+	var pr promResponse
+	if err := json.NewDecoder(resp.Body).Decode(&pr); err != nil {
+		return nil, fmt.Errorf("%w: decode: %w", scheduler.ErrMetricsUnavailable, err)
+	}
+	if pr.Status != "success" {
+		return nil, fmt.Errorf("%w: prometheus status %q", scheduler.ErrMetricsUnavailable, pr.Status)
+	}
+
+	out := make(map[string]float64, len(pr.Data.Result))
+	for _, r := range pr.Data.Result {
+		key := r.Metric[c.KeyLabel]
+		if key == "" || len(r.Value) != 2 {
+			continue
+		}
+		s, ok := r.Value[1].(string)
+		if !ok {
+			continue
+		}
+		var f float64
+		if _, err := fmt.Sscanf(s, "%g", &f); err != nil {
+			continue
+		}
+		out[key] = f
+	}
+	return out, nil
+}

--- a/services/agent-registry/internal/infrastructure/promql/client_test.go
+++ b/services/agent-registry/internal/infrastructure/promql/client_test.go
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package promql
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/zynax-io/zynax/services/agent-registry/internal/domain/scheduler"
+)
+
+func promBody(label string, series map[string]float64) string {
+	out := `{"status":"success","data":{"result":[`
+	first := true
+	for k, v := range series {
+		if !first {
+			out += ","
+		}
+		first = false
+		out += fmt.Sprintf(`{"metric":{"%s":"%s"},"value":[1700000000,"%g"]}`, label, k, v)
+	}
+	return out + `]}}`
+}
+
+func TestSnapshot_MergesLoadAndLatency(t *testing.T) {
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		q := r.URL.Query().Get("query")
+		if q == DefaultLoadQuery {
+			_, _ = w.Write([]byte(promBody(DefaultKeyLabel, map[string]float64{"default/a": 0.4})))
+			return
+		}
+		_, _ = w.Write([]byte(promBody(DefaultKeyLabel, map[string]float64{"default/a": 120})))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL)
+	got, err := c.Snapshot(context.Background(), []string{"default/a", "default/ghost"})
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	if got["default/a"].Load != 0.4 || got["default/a"].LatencyP50Ms != 120 {
+		t.Errorf("merged = %+v", got["default/a"])
+	}
+	// Unknown keys resolve to the zero snapshot, not an error.
+	if got["default/ghost"] != (scheduler.Metrics{}) {
+		t.Errorf("ghost = %+v, want zero", got["default/ghost"])
+	}
+}
+
+func TestSnapshot_TTLCacheAvoidsHotPathQueries(t *testing.T) {
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		_, _ = w.Write([]byte(promBody(DefaultKeyLabel, nil)))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL)
+	now := time.Unix(0, 0)
+	c.now = func() time.Time { return now }
+
+	for range 5 {
+		if _, err := c.Snapshot(context.Background(), []string{"default/a"}); err != nil {
+			t.Fatalf("Snapshot: %v", err)
+		}
+	}
+	if n := calls.Load(); n != 2 { // one load + one latency query, then cache
+		t.Errorf("backend calls = %d, want 2 (TTL cache)", n)
+	}
+
+	// Past the TTL the cache refreshes.
+	now = now.Add(DefaultTTL + time.Second)
+	if _, err := c.Snapshot(context.Background(), []string{"default/a"}); err != nil {
+		t.Fatalf("Snapshot after TTL: %v", err)
+	}
+	if n := calls.Load(); n != 4 {
+		t.Errorf("backend calls = %d, want 4 after TTL expiry", n)
+	}
+}
+
+func TestSnapshot_UnavailableVariants(t *testing.T) {
+	// Transport down.
+	down := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	down.Close()
+	if _, err := New(down.URL).Snapshot(context.Background(), []string{"k"}); !errors.Is(err, scheduler.ErrMetricsUnavailable) {
+		t.Errorf("transport: err = %v, want ErrMetricsUnavailable", err)
+	}
+
+	// Non-200.
+	e500 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer e500.Close()
+	if _, err := New(e500.URL).Snapshot(context.Background(), []string{"k"}); !errors.Is(err, scheduler.ErrMetricsUnavailable) {
+		t.Errorf("status: err = %v, want ErrMetricsUnavailable", err)
+	}
+
+	// Malformed body.
+	bad := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("{not json"))
+	}))
+	defer bad.Close()
+	if _, err := New(bad.URL).Snapshot(context.Background(), []string{"k"}); !errors.Is(err, scheduler.ErrMetricsUnavailable) {
+		t.Errorf("decode: err = %v, want ErrMetricsUnavailable", err)
+	}
+
+	// Prometheus-level error status.
+	perr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"status":"error","data":{"result":[]}}`))
+	}))
+	defer perr.Close()
+	if _, err := New(perr.URL).Snapshot(context.Background(), []string{"k"}); !errors.Is(err, scheduler.ErrMetricsUnavailable) {
+		t.Errorf("prom status: err = %v, want ErrMetricsUnavailable", err)
+	}
+}
+
+func TestUnavailable_AlwaysDegrades(t *testing.T) {
+	if _, err := (Unavailable{}).Snapshot(context.Background(), []string{"k"}); !errors.Is(err, scheduler.ErrMetricsUnavailable) {
+		t.Errorf("err = %v, want ErrMetricsUnavailable", err)
+	}
+}


### PR DESCRIPTION
Closes #1581 (canvas O-step 4, **part 2 of 2** — part 1 was the domain pipeline, #1591)
Part of #1571 (EPIC M8.C)

### What you'll get
- Prometheus `/api/v1/query` MetricsSource with a short-TTL cache — 2 backend calls per TTL window regardless of selection rate (`TestSnapshot_TTLCacheAvoidsHotPathQueries`); every failure ⇒ `ErrMetricsUnavailable` ⇒ degraded mode; `Unavailable` source when `ZYNAX_REGISTRY_PROM_URL` unset ← `internal/infrastructure/promql/` (91.8% cov)
- `SelectAgent` handler with the contract error taxonomy (INVALID_ARGUMENT / NOT_FOUND / FAILED_PRECONDITION); response `AgentDef` carries capability `input_schema` — the ADR-028 broker binding consumed by #1583 ← `internal/api/scheduler_handler.go`
- `SchedulerService` registered only when the CRD informer is enabled ← `cmd/agent-registry/main.go`; canvas O-step 4 ✅

### Evidence (runtime, kind zynax-e2e — live handler + fake Prometheus, via grpcurl)
- `SELECTION_MODE_METRICS_WEIGHTED` with live data (`load=0.15` wins; counts `matched=2 ready=1` show stale-liveness working)
- NOT_FOUND / FAILED_PRECONDITION (`filter: gpu`) / INVALID_ARGUMENT all observed live
- **Prometheus killed mid-flight** → next calls OK with `SELECTION_MODE_DEGRADED_ROUND_ROBIN`
- Cluster restored afterwards

### Test plan
`GOWORK=off go test ./... -race` ✅ 6 packages · promql 91.8% · strict golangci 0 issues · 464 lines (size/L: cohesive wiring seam of the 2-PR chain)

### Risk & rollback
Low — behind the default-off informer flag; legacy RPCs untouched. Revert = drop new files + main wiring.

**SPDD:** Canvas `docs/spdd/1571-crd-native-scheduler/canvas.md` — Status: Aligned · security review PASS

Assisted-by: Claude/claude-fable-5