### PR TITLE
feat(agent-registry): EndpointSlice readiness reconciler + Lease election

### DIFF
--- a/docs/spdd/1571-crd-native-scheduler/canvas.md
+++ b/docs/spdd/1571-crd-native-scheduler/canvas.md
@@ -129,7 +129,7 @@ Consumers / neighbors
    expert-strict); Prometheus at selection time via TTL cache; degradation path; structured
    rationale; step-1 `.feature` passes on kind. → #1581 ✅
 5. **Readiness reconciler** — EndpointSlice → `status.{ready,replicas,conditions}`; Lease leader
-   election (single writer, select path always-serving); stale-liveness scenario green. → #1582
+   election (single writer, select path always-serving); stale-liveness scenario green. → #1582 ✅
 6. **task-broker cutover** — `SelectAgent` replaces `FindByCapability` + round-robin; ADR-028
    binding regression green; rationale on the task record; **joint first-run-on-CRD-path e2e
    (named CI scenario, both engine legs, run twice) — the #1572/ADR-041 gate**. → #1583

--- a/services/agent-registry/cmd/agent-registry/main.go
+++ b/services/agent-registry/cmd/agent-registry/main.go
@@ -52,6 +52,10 @@ type config struct {
 	// canvas O-step 4). Empty => selection runs in the degraded
 	// readiness-filtered mode (never fails on metrics).
 	PromURL string `envconfig:"PROM_URL"`
+	// Namespace holding the leader-election Lease for the single-writer
+	// status reconciler (ADR-039, canvas O-step 5). Empty in-cluster
+	// (auto-detected); required for out-of-cluster/local runs.
+	ElectionNamespace string `envconfig:"ELECTION_NAMESPACE"`
 }
 
 func main() {
@@ -96,7 +100,7 @@ func run(cfg config) error {
 
 	var schedHandler *api.SchedulerHandler
 	if cfg.CRDInformerEnabled {
-		idx, err := startCRDInformer(ctx)
+		idx, err := startCRDInformer(ctx, cfg)
 		if err != nil {
 			return fmt.Errorf("agent-registry: crd informer: %w", err)
 		}
@@ -165,14 +169,14 @@ func newRepository(ctx context.Context, cfg config) (domain.AgentRepository, fun
 	return infrastructure.NewMemoryRepo(), func() {}, nil
 }
 
-// startCRDInformer builds and starts the controller-runtime manager whose
-// informer cache watches Agent CRs and maintains the scheduler capability
-// index (ADR-039, canvas O-step 3). The index becomes the SelectAgent data
-// source in O-step 4; until then it is a warmed, observable projection.
+// startCRDInformer builds and starts the controller-runtime manager: the
+// informer-fed capability index (every replica, O-step 3), the SelectAgent
+// data source (O-step 4), and the Lease-elected readiness reconciler that
+// derives Agent status from EndpointSlices (single writer, O-step 5).
 // The manager runs until ctx is cancelled; a manager error is fatal for the
 // informer only, not for the gRPC surface (logged, not propagated), so the
 // legacy registry path keeps serving during partial failures.
-func startCRDInformer(ctx context.Context) (*scheduler.Index, error) {
+func startCRDInformer(ctx context.Context, cfg config) (*scheduler.Index, error) {
 	// controller-runtime demands a logger before manager construction;
 	// bridge it into the service's structured slog output.
 	ctrl.SetLogger(logr.FromSlogHandler(slog.Default().Handler()))
@@ -181,12 +185,15 @@ func startCRDInformer(ctx context.Context) (*scheduler.Index, error) {
 		return nil, fmt.Errorf("load kubeconfig: %w", err)
 	}
 	idx := scheduler.NewIndex()
-	mgr, err := crd.NewManager(restCfg, idx)
+	mgr, err := crd.NewManager(restCfg, idx, cfg.ElectionNamespace)
 	if err != nil {
 		return nil, fmt.Errorf("build crd manager: %w", err)
 	}
+	if err := crd.SetupReadiness(mgr); err != nil {
+		return nil, fmt.Errorf("setup readiness reconciler: %w", err)
+	}
 	go func() {
-		slog.Info("agent-registry: crd informer started (Agent CRs -> capability index)")
+		slog.Info("agent-registry: crd informer started (Agent CRs -> capability index; readiness reconciler Lease-elected)")
 		if err := mgr.Start(ctx); err != nil {
 			slog.Error("crd informer exited", "err", err)
 		}

--- a/services/agent-registry/go.mod
+++ b/services/agent-registry/go.mod
@@ -8,8 +8,10 @@ require (
 	github.com/zynax-io/zynax/protos/generated/go v0.0.0
 	google.golang.org/grpc v1.81.1
 	google.golang.org/protobuf v1.36.11
+	k8s.io/api v0.35.6
 	k8s.io/apimachinery v0.35.6
 	k8s.io/client-go v0.35.6
+	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2
 	sigs.k8s.io/controller-runtime v0.23.3
 )
 
@@ -57,11 +59,9 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	k8s.io/api v0.35.6 // indirect
 	k8s.io/apiextensions-apiserver v0.35.6 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a // indirect
-	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.2 // indirect

--- a/services/agent-registry/internal/infrastructure/crd/informer.go
+++ b/services/agent-registry/internal/infrastructure/crd/informer.go
@@ -21,8 +21,10 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/rest"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -67,16 +69,29 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	return reconcile.Result{}, nil
 }
 
+// leaderElectionID is the Lease name for the single-writer status reconciler
+// election (ADR-039 Consequences). One Lease per deployment namespace.
+const leaderElectionID = "zynax-agent-registry-scheduler"
+
 // NewManager builds a controller-runtime manager whose informer cache watches
 // Agent CRs and feeds idx. The manager's own metrics/probe servers are
 // disabled — the service already serves Prometheus metrics via zynaxobs.
-// Leader election is deliberately NOT enabled here: the index is a read-only
-// projection every replica must maintain; only the status reconciler
-// (O-step 5) is single-writer.
-func NewManager(restCfg *rest.Config, idx *scheduler.Index) (manager.Manager, error) {
+//
+// Leader election is enabled at the manager level, but the INDEX controller
+// opts out (NeedLeaderElection=false): the index is a read-only projection
+// every replica must maintain, and the select path must serve on non-leaders
+// too. Only the readiness controller (SetupReadiness, default elected) is
+// gated on the Lease — the single status writer (ADR-039 Consequences).
+//
+// electionNamespace is required when running out-of-cluster (local dev);
+// in-cluster it may be empty (auto-detected from the ServiceAccount).
+func NewManager(restCfg *rest.Config, idx *scheduler.Index, electionNamespace string) (manager.Manager, error) {
 	mgr, err := ctrl.NewManager(restCfg, manager.Options{
-		Metrics:                metricsserver.Options{BindAddress: "0"},
-		HealthProbeBindAddress: "0",
+		Metrics:                 metricsserver.Options{BindAddress: "0"},
+		HealthProbeBindAddress:  "0",
+		LeaderElection:          true,
+		LeaderElectionID:        leaderElectionID,
+		LeaderElectionNamespace: electionNamespace,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("crd: create manager: %w", err)
@@ -84,6 +99,7 @@ func NewManager(restCfg *rest.Config, idx *scheduler.Index) (manager.Manager, er
 	watched := &unstructured.Unstructured{}
 	watched.SetGroupVersionKind(AgentGVK)
 	if err := ctrl.NewControllerManagedBy(mgr).For(watched).
+		WithOptions(controller.Options{NeedLeaderElection: ptr.To(false)}).
 		Complete(&Reconciler{Client: mgr.GetClient(), Index: idx}); err != nil {
 		return nil, fmt.Errorf("crd: build controller: %w", err)
 	}

--- a/services/agent-registry/internal/infrastructure/crd/readiness.go
+++ b/services/agent-registry/internal/infrastructure/crd/readiness.go
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package crd
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	discoveryv1 "k8s.io/api/discovery/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// serviceNameLabel is the well-known EndpointSlice label naming the owning
+// Service — the join key between an Agent's spec.endpointRef.serviceName and
+// the dataplane truth about its endpoints.
+const serviceNameLabel = "kubernetes.io/service-name"
+
+// Condition constants for the Agent status.conditions entry this reconciler owns.
+const (
+	conditionReady        = "Ready"
+	reasonServing         = "EndpointsServing"
+	reasonNoEndpoints     = "NoServingEndpoints"
+	messageServingFmt     = "%d serving endpoint(s) behind Service %q"
+	messageNoEndpointsFmt = "no serving endpoints behind Service %q"
+)
+
+// ReadinessReconciler derives each Agent CR's status.{ready,replicas,
+// conditions} from the EndpointSlices of the Service named by endpointRef —
+// the ADR-039 §3 stale-liveness fix: liveness is reconciled from the
+// dataplane, never self-asserted by the agent. It is the single status
+// writer: the manager runs it only on the Lease-elected leader
+// (NeedLeaderElection defaults to true for controllers), while the
+// index/select path serves on every replica.
+type ReadinessReconciler struct {
+	Client client.Client
+}
+
+// Reconcile recomputes one Agent's readiness from its EndpointSlices and
+// writes status only when something actually changed (low-churn guard —
+// steady state produces zero etcd writes, ADR-039 §3).
+func (r *ReadinessReconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	u := &unstructured.Unstructured{}
+	u.SetGroupVersionKind(AgentGVK)
+	if err := r.Client.Get(ctx, req.NamespacedName, u); err != nil {
+		// Deleted CRs need no status; residual errors requeue.
+		if residual := client.IgnoreNotFound(err); residual != nil {
+			return reconcile.Result{}, fmt.Errorf("crd: get agent %s: %w", req.NamespacedName, residual)
+		}
+		return reconcile.Result{}, nil
+	}
+
+	svc, _, _ := unstructured.NestedString(u.Object, "spec", "endpointRef", "serviceName")
+	serving, err := r.countServingEndpoints(ctx, req.Namespace, svc)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	ready := serving > 0
+
+	curReady, _, _ := unstructured.NestedBool(u.Object, "status", "ready")
+	curReplicas, _, _ := unstructured.NestedInt64(u.Object, "status", "replicas")
+	curGen, _, _ := unstructured.NestedInt64(u.Object, "status", "observedGeneration")
+	if curReady == ready && curReplicas == int64(serving) && curGen == u.GetGeneration() {
+		return reconcile.Result{}, nil // steady state: no write
+	}
+
+	if err := r.writeStatus(ctx, u, svc, ready, serving); err != nil {
+		return reconcile.Result{}, err
+	}
+	slog.Info("scheduler readiness: status reconciled",
+		"agent", req.String(), "ready", ready, "serving_endpoints", serving)
+	return reconcile.Result{}, nil
+}
+
+// countServingEndpoints sums ready endpoints across the Service's slices.
+func (r *ReadinessReconciler) countServingEndpoints(ctx context.Context, ns, svc string) (int, error) {
+	if svc == "" {
+		return 0, nil
+	}
+	var slices discoveryv1.EndpointSliceList
+	if err := r.Client.List(ctx, &slices,
+		client.InNamespace(ns), client.MatchingLabels{serviceNameLabel: svc}); err != nil {
+		return 0, fmt.Errorf("crd: list endpointslices for %s/%s: %w", ns, svc, err)
+	}
+	serving := 0
+	for _, slice := range slices.Items {
+		for _, ep := range slice.Endpoints {
+			if ep.Conditions.Ready != nil && *ep.Conditions.Ready {
+				serving++
+			}
+		}
+	}
+	return serving, nil
+}
+
+// writeStatus updates the reconciler-owned status subresource: ready,
+// replicas, observedGeneration, and the single Ready condition. Dynamic
+// metrics are never written here (ADR-039 §3).
+func (r *ReadinessReconciler) writeStatus(ctx context.Context, u *unstructured.Unstructured, svc string, ready bool, serving int) error {
+	condStatus, reason, message := "False", reasonNoEndpoints, fmt.Sprintf(messageNoEndpointsFmt, svc)
+	if ready {
+		condStatus, reason, message = "True", reasonServing, fmt.Sprintf(messageServingFmt, serving, svc)
+	}
+
+	// lastTransitionTime moves only when the Ready condition flips.
+	transition := time.Now().UTC().Format(time.RFC3339)
+	if conds, _, _ := unstructured.NestedSlice(u.Object, "status", "conditions"); len(conds) > 0 {
+		if prev, ok := conds[0].(map[string]any); ok {
+			if prevStatus, _ := prev["status"].(string); prevStatus == condStatus {
+				if prevTime, _ := prev["lastTransitionTime"].(string); prevTime != "" {
+					transition = prevTime
+				}
+			}
+		}
+	}
+
+	status := map[string]any{
+		"ready":              ready,
+		"replicas":           int64(serving),
+		"observedGeneration": u.GetGeneration(),
+		"conditions": []any{map[string]any{
+			"type":               conditionReady,
+			"status":             condStatus,
+			"reason":             reason,
+			"message":            message,
+			"lastTransitionTime": transition,
+		}},
+	}
+	if err := unstructured.SetNestedMap(u.Object, status, "status"); err != nil {
+		return fmt.Errorf("crd: set status: %w", err)
+	}
+	if err := r.Client.Status().Update(ctx, u); err != nil {
+		return fmt.Errorf("crd: update agent status: %w", err)
+	}
+	return nil
+}
+
+// SetupReadiness registers the readiness controller on the manager: it
+// reconciles Agents and additionally wakes on EndpointSlice events, mapped
+// back to the Agents whose endpointRef names the slice's Service. The
+// controller keeps the default NeedLeaderElection=true — only the elected
+// leader writes status (ADR-039 Consequences).
+func SetupReadiness(mgr manager.Manager) error {
+	watched := &unstructured.Unstructured{}
+	watched.SetGroupVersionKind(AgentGVK)
+	r := &ReadinessReconciler{Client: mgr.GetClient()}
+	if err := ctrl.NewControllerManagedBy(mgr).
+		Named("agent-readiness").
+		For(watched).
+		Watches(&discoveryv1.EndpointSlice{}, handler.EnqueueRequestsFromMapFunc(mapSliceToAgents(mgr.GetClient()))).
+		Complete(r); err != nil {
+		return fmt.Errorf("crd: build readiness controller: %w", err)
+	}
+	return nil
+}
+
+// mapSliceToAgents resolves an EndpointSlice event to reconcile requests for
+// every Agent in the slice's namespace whose endpointRef.serviceName matches
+// the slice's owning Service.
+func mapSliceToAgents(c client.Client) handler.MapFunc {
+	return func(ctx context.Context, obj client.Object) []reconcile.Request {
+		svc := obj.GetLabels()[serviceNameLabel]
+		if svc == "" {
+			return nil
+		}
+		agents := &unstructured.UnstructuredList{}
+		agents.SetGroupVersionKind(AgentGVK.GroupVersion().WithKind("AgentList"))
+		if err := c.List(ctx, agents, client.InNamespace(obj.GetNamespace())); err != nil {
+			slog.Error("scheduler readiness: list agents for slice mapping", "err", err)
+			return nil
+		}
+		var reqs []reconcile.Request
+		for _, a := range agents.Items {
+			name, _, _ := unstructured.NestedString(a.Object, "spec", "endpointRef", "serviceName")
+			if name == svc {
+				reqs = append(reqs, reconcile.Request{
+					NamespacedName: client.ObjectKeyFromObject(&a),
+				})
+			}
+		}
+		return reqs
+	}
+}

--- a/services/agent-registry/internal/infrastructure/crd/readiness_test.go
+++ b/services/agent-registry/internal/infrastructure/crd/readiness_test.go
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package crd
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	discoveryv1 "k8s.io/api/discovery/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// slice builds an EndpointSlice for svc with the given endpoint readiness flags.
+func slice(ns, name, svc string, readyFlags ...bool) *discoveryv1.EndpointSlice {
+	eps := make([]discoveryv1.Endpoint, 0, len(readyFlags))
+	for _, rf := range readyFlags {
+		eps = append(eps, discoveryv1.Endpoint{Conditions: discoveryv1.EndpointConditions{Ready: ptr.To(rf)}})
+	}
+	return &discoveryv1.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name, Namespace: ns,
+			Labels: map[string]string{serviceNameLabel: svc},
+		},
+		Endpoints: eps,
+	}
+}
+
+// newReadinessFixture builds a fake client with the Agent CRD scheme, status
+// subresource support, and an update counter for the churn-guard assertions.
+func newReadinessFixture(t *testing.T, updates *atomic.Int32, objs ...client.Object) *ReadinessReconciler {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	scheme.AddKnownTypeWithName(AgentGVK, &unstructured.Unstructured{})
+	scheme.AddKnownTypeWithName(AgentGVK.GroupVersion().WithKind("AgentList"), &unstructured.UnstructuredList{})
+	if err := discoveryv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add discovery scheme: %v", err)
+	}
+	statusObj := &unstructured.Unstructured{}
+	statusObj.SetGroupVersionKind(AgentGVK)
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objs...).
+		WithStatusSubresource(statusObj).
+		WithInterceptorFuncs(interceptor.Funcs{
+			SubResourceUpdate: func(ctx context.Context, cl client.Client, sub string, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+				updates.Add(1)
+				return cl.SubResource(sub).Update(ctx, obj, opts...)
+			},
+		}).
+		Build()
+	return &ReadinessReconciler{Client: c}
+}
+
+func agentReq(ns, name string) reconcile.Request {
+	return reconcile.Request{NamespacedName: types.NamespacedName{Namespace: ns, Name: name}}
+}
+
+func TestReadiness_ServingEndpointsFlipReady(t *testing.T) {
+	var updates atomic.Int32
+	fresh := agentCR("default", "reviewer")
+	unstructured.RemoveNestedField(fresh.Object, "status") // freshly applied CR: no status yet
+	r := newReadinessFixture(t, &updates,
+		fresh,
+		slice("default", "reviewer-abc", "reviewer", true, true, false),
+	)
+
+	if _, err := r.Reconcile(context.Background(), agentReq("default", "reviewer")); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	got := &unstructured.Unstructured{}
+	got.SetGroupVersionKind(AgentGVK)
+	if err := r.Client.Get(context.Background(), types.NamespacedName{Namespace: "default", Name: "reviewer"}, got); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	ready, _, _ := unstructured.NestedBool(got.Object, "status", "ready")
+	replicas, _, _ := unstructured.NestedInt64(got.Object, "status", "replicas")
+	if !ready || replicas != 2 {
+		t.Fatalf("status = ready=%v replicas=%d, want true/2 (two serving endpoints)", ready, replicas)
+	}
+	conds, _, _ := unstructured.NestedSlice(got.Object, "status", "conditions")
+	if len(conds) != 1 {
+		t.Fatalf("conditions = %v", conds)
+	}
+	cond := conds[0].(map[string]any)
+	if cond["type"] != conditionReady || cond["status"] != "True" || cond["reason"] != reasonServing {
+		t.Errorf("condition = %+v", cond)
+	}
+}
+
+// TestReadiness_NoServingEndpoints covers the stale-liveness fix: a crashed
+// agent (no serving endpoints) is authoritatively not ready.
+func TestReadiness_NoServingEndpoints(t *testing.T) {
+	var updates atomic.Int32
+	cases := map[string]client.Object{
+		"slice with only unready endpoints": slice("default", "reviewer-abc", "reviewer", false),
+		"no slice at all":                   slice("default", "other-abc", "other-svc", true),
+	}
+	for name, extra := range cases {
+		t.Run(name, func(t *testing.T) {
+			r := newReadinessFixture(t, &updates, agentCR("default", "reviewer"), extra)
+			if _, err := r.Reconcile(context.Background(), agentReq("default", "reviewer")); err != nil {
+				t.Fatalf("reconcile: %v", err)
+			}
+			got := &unstructured.Unstructured{}
+			got.SetGroupVersionKind(AgentGVK)
+			_ = r.Client.Get(context.Background(), types.NamespacedName{Namespace: "default", Name: "reviewer"}, got)
+			ready, _, _ := unstructured.NestedBool(got.Object, "status", "ready")
+			if ready {
+				t.Fatal("agent without serving endpoints must be not-ready")
+			}
+		})
+	}
+}
+
+// TestReadiness_SteadyStateWritesNothing is the low-churn guard (ADR-039 §3):
+// repeated reconciles of an unchanged world must not touch etcd.
+func TestReadiness_SteadyStateWritesNothing(t *testing.T) {
+	var updates atomic.Int32
+	r := newReadinessFixture(t, &updates,
+		agentCR("default", "reviewer"),
+		slice("default", "reviewer-abc", "reviewer", true),
+	)
+
+	for range 3 {
+		if _, err := r.Reconcile(context.Background(), agentReq("default", "reviewer")); err != nil {
+			t.Fatalf("reconcile: %v", err)
+		}
+	}
+	if n := updates.Load(); n != 1 {
+		t.Fatalf("status updates = %d, want exactly 1 (first write, then steady state)", n)
+	}
+}
+
+func TestReadiness_DeletedAgentIsNoop(t *testing.T) {
+	var updates atomic.Int32
+	r := newReadinessFixture(t, &updates)
+	if _, err := r.Reconcile(context.Background(), agentReq("default", "ghost")); err != nil {
+		t.Fatalf("reconcile of deleted agent: %v", err)
+	}
+	if updates.Load() != 0 {
+		t.Fatal("deleted agent must not trigger a status write")
+	}
+}
+
+// TestMapSliceToAgents resolves slice events to the owning Agent(s) only.
+func TestMapSliceToAgents(t *testing.T) {
+	var updates atomic.Int32
+	r := newReadinessFixture(t, &updates,
+		agentCR("default", "reviewer"),  // endpointRef.serviceName == "reviewer"
+		agentCR("default", "other"),     // endpointRef.serviceName == "other"
+		agentCR("team-x", "reviewer-x"), // different namespace
+	)
+	mapFn := mapSliceToAgents(r.Client)
+
+	reqs := mapFn(context.Background(), slice("default", "reviewer-abc", "reviewer", true))
+	if len(reqs) != 1 || reqs[0].Name != "reviewer" || reqs[0].Namespace != "default" {
+		t.Fatalf("requests = %+v, want exactly default/reviewer", reqs)
+	}
+
+	// A slice without the service-name label maps to nothing.
+	anon := slice("default", "anon", "", true)
+	delete(anon.Labels, serviceNameLabel)
+	if got := mapFn(context.Background(), anon); got != nil {
+		t.Fatalf("unlabeled slice mapped to %+v, want nil", got)
+	}
+}


### PR DESCRIPTION
Closes #1582
Part of #1571 (EPIC M8.C — CRD-native Scheduler, canvas O-step 5)

### Why
ADR-039 problem #2: liveness is self-asserted — a crashed agent leaves a live-looking record and gets round-robined requests. §3 + Consequences: derive `status.{ready,replicas,conditions}` from the backing Service's EndpointSlices, written by a **single Lease-elected reconciler** while the select path serves on every replica.

### What you'll get
- `ReadinessReconciler`: EndpointSlice-derived status; wakes on Agent **and** EndpointSlice events (slices mapped back to owning Agents via `endpointRef.serviceName`) ← `crd/readiness.go`
- **Low-churn guard**: steady state = zero etcd writes (interceptor-asserted: exactly 1 write across 3 reconciles); `lastTransitionTime` moves only on Ready flips
- Manager-level Lease election (`zynax-agent-registry-scheduler`); the **index controller opts out** (`NeedLeaderElection=false`) so SelectAgent serves on non-leaders ← `crd/informer.go`
- `ZYNAX_REGISTRY_ELECTION_NAMESPACE` for out-of-cluster runs; canvas O-step 5 ✅

### Test plan & acceptance
| Acceptance criterion | How verified | Result |
|---|---|---|
| Status from EndpointSlice only (ready/replicas/conditions) | unit fixtures + live kind | ✅ |
| Lease election: one writer, select path on all replicas | **two live instances** (below) | ✅ |
| Stale-liveness: crash → not-ready → excluded from selection | live crash sim (below) | ✅ |
| Steady state low-churn | `TestReadiness_SteadyStateWritesNothing` | ✅ 1 write / 3 reconciles |
| ≥90% coverage, race clean | crd pkg suite, `-race` | ✅ 6 pkgs ok |

### Evidence (runtime, kind zynax-e2e, two instances)
- Fresh CRs reconciled to truthful `READY=false/REPLICAS=0` (no endpoints)
- Serving EndpointSlice applied → `READY=true/REPLICAS=1` within seconds → SelectAgent picks it (`candidatesReady: 1`)
- Slice deleted (crash sim) → `READY=false` → SelectAgent: `FailedPrecondition: … survives filter: ready` — never dispatches into a dead endpoint
- Instance 2: log shows `Attempting to acquire leader lease…` (never leads) **while serving SelectAgent** from its own informer index; Lease holder identity stayed instance 1
- Cluster fully restored afterwards (slice, samples, CRD, Lease deleted)

### Risk & rollback
Low — behind the default-off informer flag. Election adds a Lease dependency only on that path (RBAC already granted in #1589). Revert = drop readiness.go + manager option changes.

### Review aids
`readiness.go` `Reconcile` + `writeStatus` are the core; the subtle bit is the churn guard triple (`ready`, `replicas`, `observedGeneration`) deciding write-vs-skip, and `NeedLeaderElection=false` pinning on the index controller in `informer.go`.

**SPDD:** Canvas `docs/spdd/1571-crd-native-scheduler/canvas.md` — Status: Aligned · security review PASS

Assisted-by: Claude/claude-fable-5