### PR TITLE
feat(agents): tolerate the CRD-era registry across all six adapters

### DIFF
--- a/agents/adapters/adk/internal/registry/client.go
+++ b/agents/adapters/adk/internal/registry/client.go
@@ -45,6 +45,13 @@ func RegisterAgent(ctx context.Context, stub zynaxv1.AgentRegistryServiceClient,
 			slog.Info("agent registered", "agent_id", def.AgentId)
 			return nil
 		}
+		// CRD-era registry (ADR-039): push registration is retired and the
+		// RPC answers UNIMPLEMENTED — discovery flows through the Agent
+		// custom resource instead. Keep serving; nothing to retry.
+		if status.Code(err) == codes.Unimplemented {
+			slog.Info("push registration retired (ADR-039) — relying on Agent CR discovery", "agent_id", def.AgentId)
+			return nil
+		}
 		if !isTransient(err) {
 			return fmt.Errorf("registry: register failed (non-transient): %w", err)
 		}
@@ -57,6 +64,10 @@ func RegisterAgent(ctx context.Context, stub zynaxv1.AgentRegistryServiceClient,
 // DeregisterAgent calls AgentRegistryService.DeregisterAgent once, no retry.
 func DeregisterAgent(ctx context.Context, stub zynaxv1.AgentRegistryServiceClient, agentID string) error {
 	_, err := stub.DeregisterAgent(ctx, &zynaxv1.DeregisterAgentRequest{AgentId: agentID})
+	if status.Code(err) == codes.Unimplemented {
+		slog.Info("push deregistration retired (ADR-039) — Agent CR lifecycle owns removal", "agent_id", agentID)
+		return nil
+	}
 	if err != nil {
 		return fmt.Errorf("registry: deregister failed: %w", err)
 	}

--- a/agents/adapters/adk/internal/registry/client_unimplemented_test.go
+++ b/agents/adapters/adk/internal/registry/client_unimplemented_test.go
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// UNIMPLEMENTED tolerance (ADR-039): a CRD-era registry retires push
+// registration; the adapter must keep serving, not crash-loop.
+package registry
+
+import (
+	"context"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	zynaxv1 "github.com/zynax-io/zynax/protos/generated/go/zynax/v1"
+)
+
+var errUnimpl = status.Error(codes.Unimplemented, "push registration retired (ADR-039)")
+
+func TestRegisterAgent_UnimplementedTolerated(t *testing.T) {
+	t.Parallel()
+	f := &fakeRegistry{registerErr: errUnimpl}
+	if err := RegisterAgent(context.Background(), f, &zynaxv1.AgentDef{AgentId: "a"}); err != nil {
+		t.Fatalf("UNIMPLEMENTED must be tolerated: %v", err)
+	}
+}
+
+func TestDeregisterAgent_UnimplementedTolerated(t *testing.T) {
+	t.Parallel()
+	f := &fakeRegistry{deregErr: errUnimpl}
+	if err := DeregisterAgent(context.Background(), f, "a"); err != nil {
+		t.Fatalf("UNIMPLEMENTED must be tolerated: %v", err)
+	}
+}

--- a/agents/adapters/ci/internal/registry/client.go
+++ b/agents/adapters/ci/internal/registry/client.go
@@ -44,6 +44,13 @@ func RegisterAgent(ctx context.Context, stub zynaxv1.AgentRegistryServiceClient,
 			slog.Info("agent registered", "agent_id", def.AgentId)
 			return nil
 		}
+		// CRD-era registry (ADR-039): push registration is retired and the
+		// RPC answers UNIMPLEMENTED — discovery flows through the Agent
+		// custom resource instead. Keep serving; nothing to retry.
+		if status.Code(err) == codes.Unimplemented {
+			slog.Info("push registration retired (ADR-039) — relying on Agent CR discovery", "agent_id", def.AgentId)
+			return nil
+		}
 		if !isTransient(err) {
 			return fmt.Errorf("registry: register failed (non-transient): %w", err)
 		}
@@ -56,6 +63,10 @@ func RegisterAgent(ctx context.Context, stub zynaxv1.AgentRegistryServiceClient,
 // DeregisterAgent calls AgentRegistryService.DeregisterAgent once, no retry.
 func DeregisterAgent(ctx context.Context, stub zynaxv1.AgentRegistryServiceClient, agentID string) error {
 	_, err := stub.DeregisterAgent(ctx, &zynaxv1.DeregisterAgentRequest{AgentId: agentID})
+	if status.Code(err) == codes.Unimplemented {
+		slog.Info("push deregistration retired (ADR-039) — Agent CR lifecycle owns removal", "agent_id", agentID)
+		return nil
+	}
 	if err != nil {
 		return fmt.Errorf("registry: deregister failed: %w", err)
 	}

--- a/agents/adapters/ci/internal/registry/client_unimplemented_test.go
+++ b/agents/adapters/ci/internal/registry/client_unimplemented_test.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// UNIMPLEMENTED tolerance (ADR-039): a CRD-era registry retires push
+// registration; the adapter must keep serving, not crash-loop.
+package registry_test
+
+import (
+	"context"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/zynax-io/zynax/agents/adapters/ci/internal/registry"
+	zynaxv1 "github.com/zynax-io/zynax/protos/generated/go/zynax/v1"
+)
+
+var errUnimpl = status.Error(codes.Unimplemented, "push registration retired (ADR-039)")
+
+func TestRegisterAgent_UnimplementedTolerated(t *testing.T) {
+	t.Parallel()
+	stub := &stubRegistryClient{registerErr: errUnimpl}
+	if err := registry.RegisterAgent(context.Background(), stub, &zynaxv1.AgentDef{AgentId: "a"}); err != nil {
+		t.Fatalf("UNIMPLEMENTED must be tolerated: %v", err)
+	}
+	if stub.calls != 1 {
+		t.Errorf("calls = %d, want 1 (no retries against a retired RPC)", stub.calls)
+	}
+}
+
+func TestDeregisterAgent_UnimplementedTolerated(t *testing.T) {
+	t.Parallel()
+	stub := &stubRegistryClient{deregisterErr: errUnimpl}
+	if err := registry.DeregisterAgent(context.Background(), stub, "a"); err != nil {
+		t.Fatalf("UNIMPLEMENTED must be tolerated: %v", err)
+	}
+}

--- a/agents/adapters/git/internal/registry/client.go
+++ b/agents/adapters/git/internal/registry/client.go
@@ -44,6 +44,13 @@ func RegisterAgent(ctx context.Context, stub zynaxv1.AgentRegistryServiceClient,
 			slog.Info("agent registered", "agent_id", def.AgentId)
 			return nil
 		}
+		// CRD-era registry (ADR-039): push registration is retired and the
+		// RPC answers UNIMPLEMENTED — discovery flows through the Agent
+		// custom resource instead. Keep serving; nothing to retry.
+		if status.Code(err) == codes.Unimplemented {
+			slog.Info("push registration retired (ADR-039) — relying on Agent CR discovery", "agent_id", def.AgentId)
+			return nil
+		}
 		if !isTransient(err) {
 			return fmt.Errorf("registry: register failed (non-transient): %w", err)
 		}
@@ -56,6 +63,10 @@ func RegisterAgent(ctx context.Context, stub zynaxv1.AgentRegistryServiceClient,
 // DeregisterAgent calls AgentRegistryService.DeregisterAgent once, no retry.
 func DeregisterAgent(ctx context.Context, stub zynaxv1.AgentRegistryServiceClient, agentID string) error {
 	_, err := stub.DeregisterAgent(ctx, &zynaxv1.DeregisterAgentRequest{AgentId: agentID})
+	if status.Code(err) == codes.Unimplemented {
+		slog.Info("push deregistration retired (ADR-039) — Agent CR lifecycle owns removal", "agent_id", agentID)
+		return nil
+	}
 	if err != nil {
 		return fmt.Errorf("registry: deregister failed: %w", err)
 	}

--- a/agents/adapters/git/internal/registry/client_unimplemented_test.go
+++ b/agents/adapters/git/internal/registry/client_unimplemented_test.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// UNIMPLEMENTED tolerance (ADR-039): a CRD-era registry retires push
+// registration; the adapter must keep serving, not crash-loop.
+package registry_test
+
+import (
+	"context"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/zynax-io/zynax/agents/adapters/git/internal/registry"
+	zynaxv1 "github.com/zynax-io/zynax/protos/generated/go/zynax/v1"
+)
+
+var errUnimpl = status.Error(codes.Unimplemented, "push registration retired (ADR-039)")
+
+func TestRegisterAgent_UnimplementedTolerated(t *testing.T) {
+	t.Parallel()
+	stub := &stubRegistryClient{registerErr: errUnimpl}
+	if err := registry.RegisterAgent(context.Background(), stub, &zynaxv1.AgentDef{AgentId: "a"}); err != nil {
+		t.Fatalf("UNIMPLEMENTED must be tolerated: %v", err)
+	}
+	if stub.calls != 1 {
+		t.Errorf("calls = %d, want 1 (no retries against a retired RPC)", stub.calls)
+	}
+}
+
+func TestDeregisterAgent_UnimplementedTolerated(t *testing.T) {
+	t.Parallel()
+	stub := &stubRegistryClient{deregisterErr: errUnimpl}
+	if err := registry.DeregisterAgent(context.Background(), stub, "a"); err != nil {
+		t.Fatalf("UNIMPLEMENTED must be tolerated: %v", err)
+	}
+}

--- a/agents/adapters/http/internal/registry/client.go
+++ b/agents/adapters/http/internal/registry/client.go
@@ -44,6 +44,13 @@ func RegisterAgent(ctx context.Context, stub zynaxv1.AgentRegistryServiceClient,
 			slog.Info("agent registered", "agent_id", def.AgentId)
 			return nil
 		}
+		// CRD-era registry (ADR-039): push registration is retired and the
+		// RPC answers UNIMPLEMENTED — discovery flows through the Agent
+		// custom resource instead. Keep serving; nothing to retry.
+		if status.Code(err) == codes.Unimplemented {
+			slog.Info("push registration retired (ADR-039) — relying on Agent CR discovery", "agent_id", def.AgentId)
+			return nil
+		}
 		if !isTransient(err) {
 			return fmt.Errorf("registry: register failed (non-transient): %w", err)
 		}
@@ -57,6 +64,10 @@ func RegisterAgent(ctx context.Context, stub zynaxv1.AgentRegistryServiceClient,
 // Propagates caller context cancellation.
 func DeregisterAgent(ctx context.Context, stub zynaxv1.AgentRegistryServiceClient, agentID string) error {
 	_, err := stub.DeregisterAgent(ctx, &zynaxv1.DeregisterAgentRequest{AgentId: agentID})
+	if status.Code(err) == codes.Unimplemented {
+		slog.Info("push deregistration retired (ADR-039) — Agent CR lifecycle owns removal", "agent_id", agentID)
+		return nil
+	}
 	if err != nil {
 		return fmt.Errorf("registry: deregister failed: %w", err)
 	}

--- a/agents/adapters/http/internal/registry/client_unimplemented_test.go
+++ b/agents/adapters/http/internal/registry/client_unimplemented_test.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// UNIMPLEMENTED tolerance (ADR-039): a CRD-era registry retires push
+// registration; the adapter must keep serving, not crash-loop.
+package registry_test
+
+import (
+	"context"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/zynax-io/zynax/agents/adapters/http/internal/registry"
+	zynaxv1 "github.com/zynax-io/zynax/protos/generated/go/zynax/v1"
+)
+
+var errUnimpl = status.Error(codes.Unimplemented, "push registration retired (ADR-039)")
+
+func TestRegisterAgent_UnimplementedTolerated(t *testing.T) {
+	t.Parallel()
+	m := &mockClient{registerResponses: []error{errUnimpl}}
+	if err := registry.RegisterAgent(context.Background(), m, &zynaxv1.AgentDef{AgentId: "a"}); err != nil {
+		t.Fatalf("UNIMPLEMENTED must be tolerated: %v", err)
+	}
+	if m.registerCalls != 1 {
+		t.Errorf("calls = %d, want 1 (no retries against a retired RPC)", m.registerCalls)
+	}
+}
+
+func TestDeregisterAgent_UnimplementedTolerated(t *testing.T) {
+	t.Parallel()
+	m := &mockClient{registerResponses: []error{nil}, deregisterErr: errUnimpl}
+	if err := registry.DeregisterAgent(context.Background(), m, "a"); err != nil {
+		t.Fatalf("UNIMPLEMENTED must be tolerated: %v", err)
+	}
+}

--- a/agents/adapters/langgraph/src/langgraph_adapter/registry/client.py
+++ b/agents/adapters/langgraph/src/langgraph_adapter/registry/client.py
@@ -36,6 +36,12 @@ class RegistrySettings(BaseSettings):
     grpc_port: int = Field(default=50058, alias="ZYNAX_LANGGRAPH_ADAPTER_GRPC_PORT", ge=1)
 
 
+def _is_unimplemented(exc: Exception) -> bool:
+    """Return True when exc is the CRD-era UNIMPLEMENTED answer (ADR-039)."""
+    code_fn = getattr(exc, "code", None)
+    return callable(code_fn) and code_fn() == grpc.StatusCode.UNIMPLEMENTED
+
+
 def _is_transient(exc: Exception) -> bool:
     """Return True when exc carries a retriable gRPC status code."""
     code_fn = getattr(exc, "code", None)
@@ -102,6 +108,15 @@ async def register_agent(agent_def: Any, stub: Any) -> None:
             log.info("agent registered", extra={"agent_id": agent_def.agent_id})
             return
         except Exception as exc:
+            # CRD-era registry (ADR-039): push registration is retired and the
+            # RPC answers UNIMPLEMENTED — discovery flows through the Agent
+            # custom resource instead. Keep serving; nothing to retry.
+            if _is_unimplemented(exc):
+                log.info(
+                    "push registration retired (ADR-039) — relying on Agent CR discovery",
+                    extra={"agent_id": agent_def.agent_id},
+                )
+                return
             if not _is_transient(exc):
                 raise
             last_exc = exc
@@ -120,5 +135,14 @@ async def deregister_agent(agent_id: str, stub: Any) -> None:
         stub: Async ``AgentRegistryServiceStub`` to call ``DeregisterAgent`` on.
     """
     req = agent_registry_pb2.DeregisterAgentRequest(agent_id=agent_id)
-    await stub.DeregisterAgent(req)
+    try:
+        await stub.DeregisterAgent(req)
+    except Exception as exc:
+        if _is_unimplemented(exc):
+            log.info(
+                "push deregistration retired (ADR-039) — Agent CR lifecycle owns removal",
+                extra={"agent_id": agent_id},
+            )
+            return
+        raise
     log.info("agent deregistered", extra={"agent_id": agent_id})

--- a/agents/adapters/langgraph/tests/test_registry.py
+++ b/agents/adapters/langgraph/tests/test_registry.py
@@ -30,6 +30,13 @@ class _TransientError(Exception):
         return grpc.StatusCode.UNAVAILABLE
 
 
+class _UnimplementedError(Exception):
+    """Mimics the CRD-era registry answer (ADR-039): RPC retired."""
+
+    def code(self) -> grpc.StatusCode:
+        return grpc.StatusCode.UNIMPLEMENTED
+
+
 class _PermanentError(Exception):
     """Fake gRPC error with a non-retriable status code."""
 
@@ -129,6 +136,23 @@ class TestRegisterAgent:
         )
         await register_agent(_fake_def(), stub)
         assert stub.RegisterAgent.await_count == 3
+
+    @pytest.mark.asyncio
+    async def test_unimplemented_tolerated(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """CRD-era registry (ADR-039): UNIMPLEMENTED means keep serving, no retry."""
+        monkeypatch.setattr("langgraph_adapter.registry.client.asyncio.sleep", AsyncMock())
+        stub = MagicMock()
+        stub.RegisterAgent = AsyncMock(side_effect=_UnimplementedError())
+        await register_agent(_fake_def(), stub)
+        stub.RegisterAgent.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_deregister_unimplemented_tolerated(self) -> None:
+        """CRD-era registry (ADR-039): deregistration is a tolerated no-op."""
+        stub = MagicMock()
+        stub.DeregisterAgent = AsyncMock(side_effect=_UnimplementedError())
+        await deregister_agent("agent-x", stub)
+        stub.DeregisterAgent.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_raises_on_permanent_error(self, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/agents/adapters/llm/internal/registry/client.go
+++ b/agents/adapters/llm/internal/registry/client.go
@@ -46,6 +46,13 @@ func RegisterAgent(ctx context.Context, stub zynaxv1.AgentRegistryServiceClient,
 			slog.Info("agent registered", "agent_id", def.AgentId)
 			return nil
 		}
+		// CRD-era registry (ADR-039): push registration is retired and the
+		// RPC answers UNIMPLEMENTED — discovery flows through the Agent
+		// custom resource instead. Keep serving; nothing to retry.
+		if status.Code(err) == codes.Unimplemented {
+			slog.Info("push registration retired (ADR-039) — relying on Agent CR discovery", "agent_id", def.AgentId)
+			return nil
+		}
 		if !isTransient(err) {
 			return fmt.Errorf("registry: register failed (non-transient): %w", err)
 		}
@@ -59,6 +66,10 @@ func RegisterAgent(ctx context.Context, stub zynaxv1.AgentRegistryServiceClient,
 // Propagates caller context cancellation.
 func DeregisterAgent(ctx context.Context, stub zynaxv1.AgentRegistryServiceClient, agentID string) error {
 	_, err := stub.DeregisterAgent(ctx, &zynaxv1.DeregisterAgentRequest{AgentId: agentID})
+	if status.Code(err) == codes.Unimplemented {
+		slog.Info("push deregistration retired (ADR-039) — Agent CR lifecycle owns removal", "agent_id", agentID)
+		return nil
+	}
 	if err != nil {
 		return fmt.Errorf("registry: deregister failed: %w", err)
 	}

--- a/agents/adapters/llm/internal/registry/client_unimplemented_test.go
+++ b/agents/adapters/llm/internal/registry/client_unimplemented_test.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// UNIMPLEMENTED tolerance (ADR-039): a CRD-era registry retires push
+// registration; the adapter must keep serving, not crash-loop.
+package registry_test
+
+import (
+	"context"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/zynax-io/zynax/agents/adapters/llm/internal/registry"
+	zynaxv1 "github.com/zynax-io/zynax/protos/generated/go/zynax/v1"
+)
+
+var errUnimpl = status.Error(codes.Unimplemented, "push registration retired (ADR-039)")
+
+func TestRegisterAgent_UnimplementedTolerated(t *testing.T) {
+	t.Parallel()
+	m := &mockClient{registerResponses: []error{errUnimpl}}
+	if err := registry.RegisterAgent(context.Background(), m, &zynaxv1.AgentDef{AgentId: "a"}); err != nil {
+		t.Fatalf("UNIMPLEMENTED must be tolerated: %v", err)
+	}
+	if m.registerCalls != 1 {
+		t.Errorf("calls = %d, want 1 (no retries against a retired RPC)", m.registerCalls)
+	}
+}
+
+func TestDeregisterAgent_UnimplementedTolerated(t *testing.T) {
+	t.Parallel()
+	m := &mockClient{registerResponses: []error{nil}, deregisterErr: errUnimpl}
+	if err := registry.DeregisterAgent(context.Background(), m, "a"); err != nil {
+		t.Fatalf("UNIMPLEMENTED must be tolerated: %v", err)
+	}
+}


### PR DESCRIPTION
Part of #1584 (canvas O-step 7, **part 1 of 3** — rollout-order safety: adapters become tolerant BEFORE the registry RPCs flip to UNIMPLEMENTED in part 2; part 3 drops the registry's Postgres + docs and closes the issue)
Part of #1571 (EPIC M8.C)

### Why
ADR-039 removes push registration from the production path. If the RPCs flip first, every adapter's boot-time registration retry loop crash-loops the very pods whose EndpointSlices feed Agent readiness. This part makes the flip a zero-crash-loop rollout in any order.

### What you'll get
All six adapters (git/ci/http/llm/adk Go registry clients + the langgraph Python client):
- `RegisterAgent` → UNIMPLEMENTED tolerated as *"push registration retired (ADR-039) — relying on Agent CR discovery"*: keep serving, **no retries** against a retired RPC
- `DeregisterAgent` → UNIMPLEMENTED tolerated as a no-op (Agent CR lifecycle owns removal)
- Full code removal is deliberately **M9** (deprecate-then-remove per ADR-039 Consequences)

### Test plan
- Tolerance tests in all five Go registry suites (`client_unimplemented_test.go`, race-clean) — assert exactly 1 call, no retry
- langgraph: 2 new pytest cases; registry suite 18/18 green (tools container)
- Behavior today is UNCHANGED (registry still implements the RPCs — e2e exercises the normal registration path); the tolerance path goes live end-to-end in part 2's e2e run

### Risk & rollback
None today — the new branch is dead code until a registry answers UNIMPLEMENTED. Revert = drop the tolerance blocks.

**SPDD:** Canvas `docs/spdd/1571-crd-native-scheduler/canvas.md` — Status: Aligned (O-step 7 tick rides part 3)

Assisted-by: Claude/claude-fable-5