### PR TITLE
feat(docs): zynax up as the single documented first-run entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,18 +35,18 @@ makes local Kubernetes the one runtime model — see [why](#why-kind) below.)
 ### 1. Boot the cluster — one command
 
 ```bash
-make demo
+zynax up
 ```
 
-`make demo` creates a [kind](https://kind.sigs.k8s.io/) cluster, loads the images, installs the
-**production Helm charts**, waits for every Deployment to roll out, then runs the hero workflow with
-the in-cluster **`echo`** capability — **no Ollama, no model, no API key needed for first success**.
-When it finishes it prints a **Platform ready** banner with the gateway URL
-(`http://localhost:8080`). Lean laptop? `PROFILE=lite make demo`.
+`zynax up` creates a [kind](https://kind.sigs.k8s.io/) cluster, loads the images, installs the
+**production Helm charts**, and waits for every Deployment to roll out — **no Ollama, no model, no
+API key needed for first success**. Add `--profile lite` for a lean laptop, or `--engine argo` to
+run the same workflows on the Argo engine (the wedge, live). `zynax down` tears it back down.
 
-> Prefer the CLI? `zynax up` (add `--profile lite`, or `--engine argo` for the wedge) brings the same
-> stack up `make`-free from any directory — it wraps the same script as `make kind-up` — and `zynax down`
-> tears it back down. See [local dev on kind](docs/local-dev-kind.md).
+> Prefer `make`? `make demo` drives the same bring-up from the repo root and additionally runs the
+> hero workflow, ending in a **Platform ready** banner (`PROFILE=lite make demo` for the lean
+> stack; `ENGINE=argo make demo` for the Argo leg). Both entries wrap the same script — one
+> runtime, two spellings. See [local dev on kind](docs/local-dev-kind.md).
 
 ### 2. Reach the gateway and run your first workflow
 
@@ -388,7 +388,7 @@ the code-review model demo, scaling onto k3s / managed Kubernetes, and observabi
 > **Docker Compose is deprecated** as the local runtime ([ADR-041](docs/adr/ADR-041-kind-native-unified-runtime.md)):
 > it cannot run the Argo engine and structurally diverges from production. Use the kind path above.
 > The legacy Compose runbook is kept for reference only at
-> [docs/running-with-docker-compose.md](docs/running-with-docker-compose.md).
+> [docs/running-with-docker-compose.md](docs/running-with-docker-compose.md) (retired — kind is the one runtime).
 
 ### Develop locally
 
@@ -454,7 +454,7 @@ task-broker + agent-registry were delivered in M5.C (#479, #480).
 **M4** delivered the YAML system and CLI: api-gateway HTTP REST layer
 (`POST /api/v1/apply`, `GET /api/v1/workflows/{id}`, `DELETE /api/v1/workflows/{id}`),
 the `zynax` CLI (`apply`, `get`,
-`delete`, `status`, `logs`), local Docker Compose runner (`make run-local`),
+`delete`, `status`, `logs`), the kind bring-up (`zynax up` / `zynax down`),
 pre-built CLI binaries published to GitHub Releases for five platforms, and GitOps integration.
 Canvas: `docs/spdd/314-yaml-system-cli/canvas.md`.
 

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -128,7 +128,11 @@ zynax down        # tear it back down
 
 Reach the gateway over `kubectl -n zynax port-forward svc/zynax-api-gateway 18080:8080`.
 
+<<<<<<< HEAD
 See [local-dev-kind.md](local-dev-kind.md) for the full kind workflow; the Compose runtime is retired (ADR-041 / #1501).
+=======
+See [local-dev-kind.md](local-dev-kind.md) for the kind workflow; the Compose runtime is retired (ADR-041).
+>>>>>>> 257be05 (feat(docs): zynax up as the single documented first-run entry)
 
 ---
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -10,7 +10,7 @@ beyond kind, and observability.
 
 > **Docker Compose is deprecated** as the local runtime ([ADR-041](adr/ADR-041-kind-native-unified-runtime.md)):
 > it cannot run the Argo engine and structurally diverges from production. The legacy Compose runbook
-> is kept for reference only at [running-with-docker-compose.md](running-with-docker-compose.md).
+> is retired; [running-with-docker-compose.md](running-with-docker-compose.md) is a migration stub.
 
 ---
 
@@ -90,7 +90,7 @@ To run a workflow where a real model reviews a git diff, you need a model availa
 llm-adapter. Pull it once on the host so the in-cluster adapter can reach it:
 
 ```bash
-ollama pull qwen2.5-coder:3b           # default model; see infra/docker-compose/ollama/llm-adapter.config.yaml
+ollama pull qwen2.5-coder:3b           # default model for the llm-adapter
 ```
 
 Then apply [`code-review-ollama.yaml`](../spec/workflows/examples/code-review-ollama.yaml) — it runs

--- a/docs/running-with-docker-compose.md
+++ b/docs/running-with-docker-compose.md
@@ -1,180 +1,20 @@
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-# Running Zynax with raw `docker compose` — DEPRECATED
+# Running Zynax with raw `docker compose` — RETIRED
 
-> ## ⚠️ DEPRECATED — Docker Compose is no longer the sanctioned local runtime
+> ## The Compose runtime was removed in M8 (ADR-041 / #1501)
 >
-> [**ADR-041**](adr/ADR-041-kind-native-unified-runtime.md) retires Docker Compose as the primary
-> local path. It cannot run the **Argo engine** (Argo is Kubernetes-native), so the
-> engine-portability wedge cannot be demonstrated on Compose, and it structurally diverges from
-> production. No new feature work targets Compose; it will be **removed** once the kind path reaches
-> parity.
+> [**ADR-041**](adr/ADR-041-kind-native-unified-runtime.md) made local Kubernetes (kind) the one
+> runtime model, and [**ADR-039**](adr/ADR-039-crd-native-scheduler.md) moved agent discovery to
+> the `Agent` custom resource — a path Compose cannot serve. The runtime compose files and their
+> `make run-local` / `make demo-compose` targets no longer exist.
 >
-> **Use the kind path instead:** the five-minute golden path in the root
-> [README "See it run"](../README.md#see-it-run--the-five-minute-golden-path), and the full
-> [Quick Start on kind](quickstart.md). This page is retained for reference only.
-
-The historical runbook below documents everything `make demo-compose` did, as plain `docker compose` +
-`zynax` commands — no `make` required.
-
----
-
-## Simplest run
-
-Three steps to a real code review. (Prereqs: Docker, the `zynax` CLI, and
-`ollama pull qwen2.5-coder:3b` — see [Prerequisites](#prerequisites).)
-
-```bash
-# 1) boot the two demo services (their dependencies start automatically)
-docker compose \
-  -f infra/docker-compose/docker-compose.yml \
-  -f infra/docker-compose/docker-compose.ollama.yml \
-  up -d --build --wait api-gateway llm-adapter
-
-# 2) apply a workflow — copy the run_id it prints
-export ZYNAX_API_URL=http://localhost:7080
-zynax apply spec/workflows/examples/code-review-ollama.yaml
-#   → run_id: wf-abcd1234...
-
-# 3) print the model's review
-zynax result wf-abcd1234...
-```
-
-What each step does: (1) builds current images and starts only the api-gateway + llm-adapter and the
-services they depend on; (2) compiles and submits the workflow over the gateway's REST API;
-(3) tails the run until it finishes and prints the capability output.
-
-Tear it down when finished:
-
-```bash
-docker compose \
-  -f infra/docker-compose/docker-compose.yml \
-  -f infra/docker-compose/docker-compose.ollama.yml \
-  down -v --remove-orphans
-```
-
-> The whole `docker compose -f … -f …` prefix repeats a lot. Save it once:
-> `DC="docker compose -f infra/docker-compose/docker-compose.yml -f infra/docker-compose/docker-compose.ollama.yml"`
-> then use `$DC up …` / `$DC down …`.
-
----
-
-## Prerequisites
-
-- **Docker** Engine + the Compose plugin (`docker compose version`).
-- **The `zynax` CLI** — build it from the repo (Go 1.26.3):
-  ```bash
-  cd cmd/zynax && GOWORK=off go build -trimpath -o ~/bin/zynax .   # ensure ~/bin is on your PATH
-  ```
-  or download a release binary (see the root `README.md` § *zynax CLI*).
-- **A local model** on the host (the ollama container reuses host models read-only):
-  ```bash
-  ollama pull qwen2.5-coder:3b
-  ```
-  To use a model you already have, set `model:` in
-  `infra/docker-compose/ollama/llm-adapter.config.yaml` and pull that one instead.
-
----
-
-## More workflows
-
-Same boot as above — just change the `zynax apply` target (and reuse `$DC` from the tip above):
-
-```bash
-# Two-step data-flow: review, then categorize (type) + rank (severity) the issues
-zynax apply spec/workflows/examples/code-review-rank-ollama.yaml
-
-# Watch every step live (run right after apply, not after it finishes)
-zynax logs <run_id> --follow
-
-# Review a real GitHub PR's diff — read-only, never writes to the PR (needs `gh`)
-tools/pr-review-workflow.sh 1446 > /tmp/review.yaml
-zynax apply /tmp/review.yaml
-
-# Declarative scenario (injects spec/scenarios/code-review/diff.patch as context)
-zynax apply spec/scenarios/code-review
-```
-
-`zynax result` prints the final capability output; `zynax logs --follow` streams **every** state and
-each step's output as it completes (per step, not per token). `zynax status workflow <run_id>` reports
-progress.
-
----
-
-## The full platform (optional)
-
-To run all seven services plus the five adapters (not just the demo two), use the base file alone:
-
-```bash
-export GITHUB_TOKEN=<token>   # the git- and ci-adapters exit(1) without it
-docker compose -f infra/docker-compose/docker-compose.yml up -d --build
-docker compose -f infra/docker-compose/docker-compose.yml logs -f      # tail
-docker compose -f infra/docker-compose/docker-compose.yml down -v --remove-orphans
-```
-
-| Host port | Service |
-|-----------|---------|
-| 7080 | api-gateway (HTTP REST — `ZYNAX_API_URL`) |
-| 7088 | Temporal Web UI |
-| 7233 | Temporal gRPC |
-| 7422 | NATS |
-
-**Lighter Temporal** — swap the durable Temporal trio (auto-setup + Postgres + UI) for a single
-in-memory `temporal server start-dev` by layering the eval overlay onto any of the above:
-
-```bash
-docker compose \
-  -f infra/docker-compose/docker-compose.yml \
-  -f infra/docker-compose/docker-compose.eval-temporal.yml \
-  up -d --build --wait api-gateway llm-adapter
-```
-
----
-
-## Observability (optional)
-
-Bring up the Uptrace stack (traces, metrics, logs, APM, login UI):
-
-```bash
-cp infra/docker-compose/observability/.env.observability.example \
-   infra/docker-compose/observability/.env.observability
-# edit the five change-me values: UPTRACE_ADMIN_EMAIL / UPTRACE_ADMIN_PASSWORD /
-# UPTRACE_PROJECT_TOKEN / PG_PASSWORD / UPTRACE_DSN
-
-docker compose \
-  --env-file infra/docker-compose/observability/.env.observability \
-  -f infra/docker-compose/docker-compose.observability.yml up -d
-# Uptrace UI → http://localhost:7020 ; OTLP/gRPC → localhost:7017
-```
-
-Wiring the platform services to emit to it (OTEL endpoint, sampling, etc.) is covered in
-[observability/](observability/) — see `opentelemetry.md` and `uptrace.md`.
-
----
-
-## Reference
-
-**Compose files** (all under `infra/docker-compose/`):
-
-| File | Purpose |
-|------|---------|
-| `docker-compose.yml` | Base stack — all services, adapters, Temporal, NATS |
-| `docker-compose.ollama.yml` | Zero-cost local-LLM overlay (no API key) |
-| `docker-compose.eval-temporal.yml` | Single in-memory `temporal server start-dev` (no Postgres/UI) |
-| `docker-compose.observability.yml` | Local Uptrace stack |
-
-**Key environment variables:**
-
-| Variable | Used for |
-|----------|----------|
-| `ZYNAX_API_URL` | the `zynax` CLI → gateway (`http://localhost:7080`) |
-| `GITHUB_TOKEN` | git-adapter + ci-adapter (full platform only) |
-| `OPENAI_API_KEY` | only if you drop the ollama overlay and use the baked OpenAI default |
-
-**Teardown** always uses `down -v --remove-orphans` (the `-v` clears the persistent Postgres-backed
-registry so the next run starts clean).
-
-> **Intermittent boot race:** `up --wait` can occasionally report a container `exited (0)` /
-> `dependency failed to start` during startup. It's transient — just run the command again.
-
-See also: [quickstart.md](quickstart.md) · [infra/docker-compose/README.md](../infra/docker-compose/README.md).
+> This stub keeps old links alive. What to use instead:
+>
+> - **First run:** [`docs/quickstart.md`](quickstart.md) — `zynax up` (or `make demo`).
+> - **Local development:** [`docs/local-dev-kind.md`](local-dev-kind.md).
+> - **Agent registration migration:** [`docs/patterns/agent-crd-migration.md`](patterns/agent-crd-migration.md).
+>
+> The Docker **build-tools harness** (`infra/docker-compose/docker-compose.tools.yml`,
+> `docker-compose.test.yml`) is unrelated to the retired runtime and still powers
+> `make bootstrap / lint / test`.


### PR DESCRIPTION
Closes #1600 (canvas O-step 1 of EPIC #1572 — ADR-041 closeout)

### What
- README quickstart + `docs/quickstart.md` lead with **`zynax up`** (`make demo` noted as the same-script alias with the hero-workflow extra)
- `docs/faq.md` / `docs/local-dev.md` stop teaching the retired Compose bring-up
- `docs/running-with-docker-compose.md` → retirement stub (keeps inbound links alive; points at quickstart, local-dev-kind, and the Agent CR migration guide; notes the retained tools harness)
- Grep gate: `run-local|demo-compose` over docs/ + README returns only the stub + historical review docs

Docs-only; the file/target deletions land next under #1501 (steps 2–3).

**SPDD:** Canvas `docs/spdd/1572-kind-first-run/canvas.md` — Status: Aligned (PR #1601)

Assisted-by: Claude/claude-fable-5