### PR TITLE
chore(infra): compose harness README + final reference sweep (2/2)

### DIFF
--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -23,13 +23,11 @@ make install-cli    # builds the zynax CLI → ~/bin/zynax (requires the Go tool
 
 | Command | What it does |
 |---------|-------------|
-| `make run-local` | Build images + start the stack (api-gateway, engine-adapter, workflow-compiler, Temporal, NATS) |
-| `make logs-local` | Tail all stack logs |
-| `make stop-local` | Stop and remove the stack containers |
+| `zynax up` | kind cluster + Helm umbrella — the one local runtime (ADR-041) |
+| `make demo` | Same bring-up + the hero workflow ("Platform ready" banner) |
+| `zynax down` / `make kind-down` | Tear the cluster back down |
 
-Aliases: `make dev-up` / `make dev-logs` / `make dev-down`.
-
-After `make run-local`, point the CLI at the local gateway (it defaults to port `8080`):
+After `zynax up`, point the CLI at the gateway (port-forward; it defaults to port `8080`):
 
 ```bash
 export ZYNAX_API_URL=http://localhost:7080

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -21,7 +21,7 @@ a release binary — see [local-dev.md](local-dev.md). The CLI talks to the api-
 HTTP REST only.
 
 **How do I run a workflow?**
-Bring the stack up (`make run-local`), then `zynax apply <file>`. Try a real example:
+Bring the stack up (`zynax up`, or `make demo`), then `zynax apply <file>`. Try a real example:
 ```bash
 zynax apply spec/workflows/examples/code-review.yaml
 ```

--- a/docs/local-dev-kind.md
+++ b/docs/local-dev-kind.md
@@ -95,7 +95,7 @@ The same workflow runs on Temporal or Argo on the same cluster:
 E2E_ENGINE=argo make demo     # installs the Argo Workflows control plane, same workflow
 ```
 
-## Legacy Docker Compose (deprecated)
+## Legacy Docker Compose (removed)
 
-`make demo-compose` still runs the old Compose Ollama demo, but Compose is
-deprecated under ADR-041 and receives no new feature work. Prefer `make demo`.
+The Compose runtime was removed in M8 (ADR-041 / #1501) — `make demo-compose`
+and `make run-local` no longer exist. `zynax up` / `make demo` are the way.

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -122,14 +122,13 @@ Proto changes require a `.feature` file committed first (ADR-016). Generated stu
 Start all three platform services plus Temporal and NATS with a single command:
 
 ```bash
-make run-local    # build images + start (api-gateway, engine-adapter, workflow-compiler, Temporal, NATS)
-make logs-local   # tail all logs
-make stop-local   # stop and remove containers
+zynax up          # kind cluster + Helm umbrella — the one local runtime (ADR-041)
+zynax down        # tear it back down
 ```
 
-Port map: api-gateway `http://localhost:7080` · Temporal UI `http://localhost:7088` · Temporal gRPC `localhost:7233` · NATS `localhost:7422`.
+Reach the gateway over `kubectl -n zynax port-forward svc/zynax-api-gateway 18080:8080`.
 
-See [infra/docker-compose/README.md](../infra/docker-compose/README.md) for the full port map and startup order.
+See [local-dev-kind.md](local-dev-kind.md) for the full kind workflow; the Compose runtime is retired (ADR-041 / #1501).
 
 ---
 

--- a/docs/spdd/1572-kind-first-run/canvas.md
+++ b/docs/spdd/1572-kind-first-run/canvas.md
@@ -6,7 +6,7 @@
 **Issue:** #1572 · **Milestone:** M8 (v1.0.0)
 **Author:** M8 program plan
 **Date:** 2026-07-03
-**Status:** Aligned
+**Status:** Implemented
 
 ---
 
@@ -40,7 +40,9 @@ zynax up / zynax down (cmd/zynax, ADR-041 amendment)  ← the ONE first-run entr
   └── scripts/e2e/cluster-up.sh → kind + Helm umbrella (Temporal or Argo)
 make demo                                             ← kept: CI/dev alias over the same path
 Compose runtime (RETIRED): docker-compose{,.services,.ollama,.eval-temporal,.observability}.yml
-Compose tools harness (KEPT): docker-compose.tools.yml, docker-compose.test.yml
+Compose harnesses (KEPT): docker-compose.tools.yml, docker-compose.test.yml,
+                        docker-compose.services.yml (test-integration backing — sync note:
+                        reclassified from "runtime" during O-step 2 delivery)
 First-run docs: README quickstart · docs/quickstart.md · docs/faq.md · troubleshooting
 ```
 
@@ -76,12 +78,12 @@ First-run docs: README quickstart · docs/quickstart.md · docs/faq.md · troubl
 
 1. **First-run promotion (feat)** — README + `docs/quickstart.md` lead with `zynax up`; FAQ and
    local-dev docs stop referencing Compose bring-up; `running-with-docker-compose.md` becomes the
-   retirement stub pointing at the migration path. → story issue filed by `/plan`
+   retirement stub pointing at the migration path. → #1600 ✅ (PR #1602)
 2. **Compose runtime purge, part 1 (chore, #1501)** — delete the five runtime compose files +
    `ollama/` + `observability/` + init sql; remove the Make targets/vars; retain the tools
-   harness; `make demo` and `make lint/test` still work (runtime evidence). → #1501
+   harness; `make demo` and `make lint/test` still work (runtime evidence). → #1501 ✅ (PR #1603)
 3. **Compose runtime purge, part 2 (chore, #1501)** — rewrite `infra/docker-compose/README.md`
-   as the tools-harness note; final sweep for dangling references (`grep` gate in the PR). → #1501
+   as the tools-harness note; final sweep for dangling references (`grep` gate in the PR). → #1501 ✅
 4. **(Delivered under #1571)** joint first-run-on-CRD-path e2e — the #1594 named scenario; kept
    as a required check. ✅ → #1583/#1594
 

--- a/infra/docker-compose/README.md
+++ b/infra/docker-compose/README.md
@@ -1,172 +1,26 @@
-# SPDX-License-Identifier: Apache-2.0
-# Zynax — Docker Compose Files
+<!-- SPDX-License-Identifier: Apache-2.0 -->
 
-All Compose files live in this directory:
+# `infra/docker-compose/` — build & test harnesses only
 
-| File | Purpose |
-|------|---------|
-| `docker-compose.yml` | Canonical local dev stack — used by `make run-local` / `make dev-up` |
-| `docker-compose.services.yml` | Profiles-based overlay (testing/dev) — used by `make test-integration` |
-| `docker-compose.tools.yml` | Test-runner container for Python integration tests |
-| `docker-compose.test.yml` | CI overlay — disables persistent volumes for ephemeral test runs |
-| `docker-compose.observability.yml` | Local Uptrace stack — traces/metrics/logs/APM with a login UI |
-| `docker-compose.ollama.yml` | Zero-cost local LLM overlay — bundles `ollama` and repoints `llm-adapter` at it (no API key) |
-| `docker-compose.eval-temporal.yml` | Day-0 overlay — swaps the durable Temporal trio for a single in-memory `temporal server start-dev` (no Postgres/UI container) |
+> **The Compose *runtime* was removed in M8** (ADR-041 / #1501): kind is the one
+> runtime model — bring the platform up with `zynax up` (or `make demo`); see
+> [docs/quickstart.md](../../docs/quickstart.md). Agent discovery lives in the
+> `Agent` custom resource (ADR-039 —
+> [migration guide](../../docs/patterns/agent-crd-migration.md)).
 
-## Local dev stack
+What remains here is **not a runtime**. These files power the Docker-based
+developer/CI toolchain and test backing services:
 
-Canonical stack for end-to-end testing of the three implemented platform services.
+| File | Role | Used by |
+|------|------|---------|
+| `docker-compose.tools.yml` | The pinned tools image harness (buf, linters, pytest, …) | `make bootstrap` / `make lint` / `make test` / `make generate-protos` |
+| `docker-compose.test.yml` | Test-time containers for the tools harness | `make test*` targets |
+| `docker-compose.services.yml` | Backing services (Postgres, …) for `//go:build integration` tests | `make test-integration` (CI `test-integration` job) |
 
-## Quick start
-
-```bash
-make run-local    # build images + start all services
-make logs-local   # tail all logs
-make stop-local   # stop and remove containers
-```
-
-## Port map
-
-| Host port | Service | Purpose |
-|-----------|---------|---------|
-| 7080 | api-gateway | HTTP REST — `export ZYNAX_API_URL=http://localhost:7080` |
-| 7233 | Temporal | gRPC (worker/SDK connections) |
-| 7088 | Temporal Web UI | Workflow inspection — http://localhost:7088 |
-| 7422 | NATS | Client port (optional direct access) |
-
-Internal-only (no host port):
-
-| Container port | Service |
-|---------------|---------|
-| 50054 | workflow-compiler gRPC |
-| 50055 | engine-adapter gRPC |
-
-## Service startup order
-
-```
-postgres (healthy) → temporal (healthy) → engine-adapter (healthy)
-                                        → workflow-compiler (healthy) → api-gateway
-```
-
-## Observability stack (Uptrace)
-
-A separate overlay brings up Uptrace (traces, metrics, logs, APM, service map) with
-a login UI, backed by ClickHouse + Postgres and fronted by an OpenTelemetry Collector.
+Nothing here starts Zynax services. If you are looking for the platform,
+you want the kind path:
 
 ```bash
-cp observability/.env.observability.example observability/.env.observability
-# edit observability/.env.observability — set login + token (no committed defaults)
-make obs-up        # Uptrace UI → http://localhost:7020
-make obs-logs
-make obs-down
-```
-
-Point services at the collector (telemetry is off by default — env-gated):
-
-```bash
-export ZYNAX_OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:7017
-```
-
-| Host port | Service | Purpose |
-|-----------|---------|---------|
-| 7020 | Uptrace UI | Login UI — traces/metrics/logs/APM |
-| 7017 | OTel Collector | OTLP/gRPC ingest (`ZYNAX_OTEL_EXPORTER_OTLP_ENDPOINT`) |
-| 7018 | OTel Collector | OTLP/HTTP ingest |
-
-All observability host ports bind to `127.0.0.1` only — OTLP ingest is never publicly
-exposed (canvas O.7 Safeguards). ClickHouse and Postgres have no host ports.
-
-Logs ship to Uptrace as OTLP log records through the collector `logs` pipeline,
-correlated to traces by `trace_id`/`span_id`. Span, metric, and log naming rules
-live in [docs/observability/naming-conventions.md](../../docs/observability/naming-conventions.md).
-
-## Local Ollama overlay (zero-cost, offline LLM)
-
-The shipped `llm-adapter` points at OpenAI/gpt-4o, which needs a paid key. This overlay
-bundles an `ollama` service inside the compose network (nothing exposed to the host LAN),
-reuses host-pulled models via a read-only bind mount, and repoints `llm-adapter` at it
-with an Ollama provider config — no API key, no cost.
-
-```bash
-docker compose \
-  -f infra/docker-compose/docker-compose.yml \
-  -f infra/docker-compose/docker-compose.ollama.yml \
-  up -d ollama llm-adapter
-```
-
-The overlay defaults the host models directory to a systemd `ollama` install
-(`/usr/share/ollama/.ollama/models`). Override it for a different install path:
-
-```bash
-OLLAMA_HOST_MODELS=/path/to/.ollama/models docker compose \
-  -f infra/docker-compose/docker-compose.yml \
-  -f infra/docker-compose/docker-compose.ollama.yml \
-  up -d ollama llm-adapter
-```
-
-The adapter config (`ollama/llm-adapter.config.yaml`) registers a `codereview`
-capability against the default reference model `qwen2.5-coder:3b` — a small, fast,
-code-focused local model chosen so the first-run demo is zero-cost and
-deterministic. Pull it on the host before bringing the overlay up:
-
-```bash
-ollama pull qwen2.5-coder:3b
-```
-
-**Switching model/provider (one-line override):** edit the `model:` line under
-`provider:` in `ollama/llm-adapter.config.yaml` (e.g. `model: llama3.2:3b`), or
-point `provider.name` / `provider.ollama_base_url` at a different provider. The
-model/provider is config-only and never travels in the workflow input payload
-(ADR-013 / ADR-035), so any workflow stays portable across models. A full
-human-validation guide standard is tracked in #1388.
-
-## Eval-Temporal overlay (single in-memory binary)
-
-By default the stack runs Temporal as **three containers** — `temporalio/auto-setup`,
-a dedicated Postgres, and `temporalio/ui`. For a Day-0 evaluation that is overkill.
-The `docker-compose.eval-temporal.yml` overlay replaces all three with **one**
-self-contained binary, `temporal server start-dev` (embedded in-memory SQLite, no
-external DB), and makes activities **fail fast** (`ZYNAX_ENGINE_MAX_ACTIVITY_ATTEMPTS=1`,
-no durable retry loops). It reuses the proven `TemporalEngine` — no new engine to own
-(this supersedes the rejected in-process `EvalEngine` of ADR-037 / #1359 for the compose
-path).
-
-```bash
-# Bring the whole stack up on the lightweight Temporal:
-docker compose \
-  -f infra/docker-compose/docker-compose.yml \
-  -f infra/docker-compose/docker-compose.eval-temporal.yml \
-  up -d
-
-# Or via the demo (one opt-in flag):
-EVAL_TEMPORAL=1 make demo
-```
-
-The single binary's built-in Web UI is on the same host port as before — http://localhost:7088.
-
-**Graduate to durable production Temporal — one flag, no edits:** simply drop the overlay
-(use the base `docker-compose.yml` alone). That restores `auto-setup` + Postgres + the
-standalone UI and the engine-adapter's default 3 retry attempts. If you need to run the
-durable trio while the overlay is layered on, opt in by profile:
-
-```bash
-docker compose -f infra/docker-compose/docker-compose.yml \
-  -f infra/docker-compose/docker-compose.eval-temporal.yml \
-  --profile durable-temporal up -d
-```
-
-## Not included
-
-The following services are unimplemented stubs awaiting M5 and are intentionally
-omitted from this stack: `agent-registry`, `task-broker`, `memory-service`, `event-bus`.
-
-## Verifying the stack
-
-```bash
-# All healthz probes
-curl http://localhost:7080/healthz
-
-# Apply an example workflow manifest
-export ZYNAX_API_URL=http://localhost:7080
-zynax apply spec/workflows/examples/code-review.yaml
+zynax up        # cluster + charts (add --profile lite, or --engine argo)
+make demo       # same bring-up + the hero workflow
 ```


### PR DESCRIPTION
Closes #1501 (canvas O-steps 2–3 of EPIC #1572 complete; part 1 was PR #1603)

### What
- `infra/docker-compose/README.md` → harnesses-only note (tools + test + **services**, the test-integration backing reclassified from 'runtime' during part-1 delivery — canvas sync note applied)
- Final sweep: `faq` / `local-dev` / `developer-guide` / `local-dev-kind` no longer teach `run-local` / `dev-*` / `demo-compose` (two edits from #1602 had silently no-opped on non-matching text — caught by this step's grep gate)
- Canvas O-steps 1–3 ✅ · **Status: Aligned → Implemented**

Grep gate: `run-local|demo-compose` over docs/ + README returns only the retirement stub/notes + historical review docs.

**SPDD:** Canvas `docs/spdd/1572-kind-first-run/canvas.md` — Implemented in this diff (last open O-step; step 4 was pre-delivered by #1594)

Assisted-by: Claude/claude-fable-5