### PR TITLE
fix(docs): remove merged conflict markers from local-dev.md

### DIFF
--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -128,11 +128,7 @@ zynax down        # tear it back down
 
 Reach the gateway over `kubectl -n zynax port-forward svc/zynax-api-gateway 18080:8080`.
 
-<<<<<<< HEAD
 See [local-dev-kind.md](local-dev-kind.md) for the full kind workflow; the Compose runtime is retired (ADR-041 / #1501).
-=======
-See [local-dev-kind.md](local-dev-kind.md) for the kind workflow; the Compose runtime is retired (ADR-041).
->>>>>>> 257be05 (feat(docs): zynax up as the single documented first-run entry)
 
 ---
 


### PR DESCRIPTION
The #1602 rebase resolution missed a second conflict hunk; the marker block (two variants of the same pointer sentence) reached `main`. Resolved to the fuller variant (`… (ADR-041 / #1501)`). Repo-wide sweep for `<<<<<<</>>>>>>>` is now clean.

Worth a look separately: the required **"No conflict markers"** check passed on #1602 — it evidently does not scan this path/pattern.

Assisted-by: Claude/claude-fable-5