### PR TITLE
feat(infra): Workflow CRD + controller RBAC (M8.E step 1)

### DIFF
--- a/docs/examples/workflow-crd-sample.yaml
+++ b/docs/examples/workflow-crd-sample.yaml
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Sample Workflow custom resource (ADR-043, M8.E). Apply it on a Kubernetes
+# runtime with the embedded controller enabled:
+#
+#   kubectl apply -f docs/examples/workflow-crd-sample.yaml
+#
+# The controller reconciles it through the existing compile->submit path;
+# `kubectl get workflows.zynax.io` then shows the dispatch status. Run state
+# lives in the engine (Temporal/Argo), not in this object.
+#
+# YAML gotcha: the transition key must be quoted ("on"), because a bare `on`
+# is parsed as a boolean by kubectl's YAML reader.
+apiVersion: zynax.io/v1alpha1
+kind: Workflow
+metadata:
+  name: hello-review
+  namespace: default
+spec:
+  engine: temporal
+  initial_state: review
+  states:
+    review:
+      type: normal
+      actions:
+        - capability: code_review
+          timeout: 30m
+          input:
+            repo: "{{ .trigger.repo }}"
+      "on":
+        - event: capability.completed
+          goto: done
+    done:
+      type: terminal
+      outputs:
+        result: "$.states.review.output.summary"

--- a/helm/zynax-api-gateway/crds/workflows.zynax.io.yaml
+++ b/helm/zynax-api-gateway/crds/workflows.zynax.io.yaml
@@ -1,0 +1,182 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Workflow CRD — a thin, declarative authoring front-end for Zynax workflows
+# (ADR-043, M8.E). It is NOT a workflow store: a controller reconciles a
+# Workflow CR by calling the existing compile->submit path; execution and run
+# state stay in the engine (Temporal/Argo), and `status` is a deliberately thin
+# mirror (compile/dispatch conditions + the dispatched identifiers only) — never
+# a phase timeline, step results, or run history (ADR-040 §3).
+#
+# Group/Version/Kind: zynax.io/v1alpha1, kind: Workflow (namespaced, plural
+# "workflows", short "wf"). Lives under crds/ so Helm installs it before
+# templates; CRD upgrades are applied explicitly (kubectl apply), per Helm's
+# crds/ semantics — mirroring the Agent CRD (ADR-039).
+#
+# The OpenAPI v3 structural schema ports the state-machine shape from
+# spec/schemas/workflow.schema.json (the `kind: Workflow, apiVersion: zynax.io/v1`
+# manifest). The manifest's top-level `kind`/`apiVersion`/`metadata` are supplied
+# by the CR itself; the manifest `spec` maps to `.spec` here. The manifest pins
+# apiVersion `zynax.io/v1`; the CRD serves `v1alpha1` — the reconciler maps
+# `v1alpha1` -> `v1` when it reconstructs the manifest for the compiler (ADR-043 §5).
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: workflows.zynax.io
+spec:
+  group: zynax.io
+  scope: Namespaced
+  names:
+    kind: Workflow
+    listKind: WorkflowList
+    plural: workflows
+    singular: workflow
+    shortNames: [wf]
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - name: Engine
+          type: string
+          jsonPath: .spec.engine
+        - name: Dispatched
+          type: string
+          jsonPath: .status.conditions[?(@.type=="Dispatched")].status
+        - name: Run-ID
+          type: string
+          jsonPath: .status.runID
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
+      schema:
+        openAPIV3Schema:
+          type: object
+          required: [spec]
+          properties:
+            spec:
+              description: >-
+                The workflow state machine (ported from the workflow manifest spec),
+                plus an optional engine hint. Operator-authored.
+              type: object
+              required: [initial_state, states]
+              properties:
+                engine:
+                  description: >-
+                    Optional engine hint passed to the submit path (e.g. "temporal",
+                    "argo", "eval"). Omit to use the platform default. Engine
+                    selection stays behind the engine-adapter interface (ADR-015).
+                  type: string
+                version:
+                  description: Optional SemVer of this workflow definition (mirrors manifest metadata.version).
+                  type: string
+                  pattern: '^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$'
+                initial_state:
+                  description: Name of the state entered on submission; must be a key in states.
+                  type: string
+                  minLength: 1
+                triggers:
+                  description: Optional CloudEvent patterns that start a new instance.
+                  type: array
+                  items:
+                    type: object
+                    required: [event]
+                    properties:
+                      event:
+                        type: string
+                        minLength: 1
+                      filter:
+                        type: object
+                        additionalProperties:
+                          type: string
+                states:
+                  description: Map of state name to state definition (at least one).
+                  type: object
+                  minProperties: 1
+                  additionalProperties:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                        enum: [normal, terminal, human_in_the_loop]
+                      actions:
+                        type: array
+                        items:
+                          type: object
+                          required: [capability]
+                          properties:
+                            capability:
+                              type: string
+                              minLength: 1
+                            timeout:
+                              type: string
+                              pattern: '^([0-9]+(ns|us|ms|s|m|h))+$'
+                            input:
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            output:
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                      # "on" is quoted: bare `on` is a YAML 1.1 boolean.
+                      "on":
+                        type: array
+                        items:
+                          type: object
+                          required: [event, goto]
+                          properties:
+                            event:
+                              type: string
+                              minLength: 1
+                            goto:
+                              type: string
+                              minLength: 1
+                            guard:
+                              type: string
+                              minLength: 1
+                            set:
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                      outputs:
+                        description: Terminal-state workflow outputs (ADR-042). Valid only on terminal states (enforced by the compiler).
+                        type: object
+                        additionalProperties:
+                          type: string
+            status:
+              description: >-
+                Reconciler-owned, deliberately thin. Compile/dispatch mirror only —
+                NEVER run state (no phase timeline, step results, or history). Live
+                progress and results come from the engine (zynax status / zynax result).
+              type: object
+              properties:
+                observedGeneration:
+                  description: The .metadata.generation last reconciled (the re-submit gate, ADR-043 §4).
+                  type: integer
+                  format: int64
+                workflowID:
+                  description: The content-hash ManifestWorkflowID dispatched to the engine (ADR-034).
+                  type: string
+                runID:
+                  description: The engine run id returned by submit. Run state lives in the engine, not here.
+                  type: string
+                engine:
+                  description: The engine the run was dispatched to.
+                  type: string
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    required: [type, status]
+                    properties:
+                      type:
+                        type: string
+                      status:
+                        type: string
+                        enum: ["True", "False", "Unknown"]
+                      reason:
+                        type: string
+                      message:
+                        type: string
+                      lastTransitionTime:
+                        type: string
+                        format: date-time

--- a/helm/zynax-api-gateway/templates/rbac.yaml
+++ b/helm/zynax-api-gateway/templates/rbac.yaml
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Least-privilege RBAC for the embedded Workflow CRD controller (ADR-043, M8.E):
+# the api-gateway watches Workflow CRs and reconciles them through the existing
+# compile->submit path, writes a thin status, and uses a Lease for the
+# single-writer status reconciler election. Nothing else is granted — no write
+# access to Workflow spec, no Secret access, no endpointslices (reconcile is
+# compile->submit, not endpoint-derived).
+#
+# The controller is embedded in the api-gateway pod (ADR-043), so the Role binds
+# to the api-gateway ServiceAccount — which carries no other cluster RBAC, keeping
+# the granted identity minimal and namespaced. Created only when the controller
+# is enabled.
+{{- if and .Values.crdController.enabled .Values.crdController.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "zynax.fullname" . }}-workflow-controller
+  labels:
+    {{- include "zynax.labels" . | nindent 4 }}
+rules:
+  # Informer cache over Workflow CRs (read-only on spec).
+  - apiGroups: ["zynax.io"]
+    resources: ["workflows"]
+    verbs: ["get", "list", "watch"]
+  # Status subresource — written only by the Lease-elected reconciler.
+  - apiGroups: ["zynax.io"]
+    resources: ["workflows/status"]
+    verbs: ["get", "update", "patch"]
+  # Leader election for the single-writer status reconciler.
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  # Leader-election transition Events (observability only).
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "zynax.fullname" . }}-workflow-controller
+  labels:
+    {{- include "zynax.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "zynax.fullname" . }}-workflow-controller
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "zynax.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/helm/zynax-api-gateway/values.yaml
+++ b/helm/zynax-api-gateway/values.yaml
@@ -14,6 +14,21 @@ serviceAccount:
   create: true
   name: ""
 
+# Embedded Workflow CRD controller (ADR-043, M8.E). Off by default: when
+# disabled, api-gateway serves only the REST apply path and starts no
+# controller-runtime manager. When enabled, a namespaced, Lease-elected manager
+# reconciles Workflow CRs (zynax.io/v1alpha1) through the existing compile->submit
+# path. The CRD itself ships in crds/ and installs regardless of this flag.
+crdController:
+  enabled: false
+  rbac:
+    # Create the namespaced Role/RoleBinding for the controller (Workflow CRs +
+    # workflows/status + leases). Bound to the api-gateway ServiceAccount.
+    create: true
+  # Namespace the controller watches. Empty => resolved at runtime from the
+  # downward-API (the pod's own namespace); a cluster-scoped watch is never used.
+  watchNamespace: ""
+
 service:
   type: ClusterIP
   port: 8080


### PR DESCRIPTION
Story 1 of **M8.E** (#1610 · canvas step 1 · gated by ADR-043). The declarative front-end for workflow definitions — mirrors the M8.C Agent CRD.

## What
- **`helm/zynax-api-gateway/crds/workflows.zynax.io.yaml`** — `Workflow` CRD (`zynax.io/v1alpha1`, Namespaced, status subresource). OpenAPI schema ported from `spec/schemas/workflow.schema.json`; `status` is a **thin mirror** (conditions, observedGeneration, workflowID, runID, engine) — never run state (ADR-040 §3). Printer columns: Engine / Dispatched / Run-ID / Age.
- **`templates/rbac.yaml`** — namespaced Role/RoleBinding (workflows get/list/watch, workflows/status update/patch, leases, events). No endpointslices, no Secrets. Created only when `crdController.enabled`.
- **`values.yaml`** — `crdController.{enabled=false, rbac.create, watchNamespace}`. Off by default; the CRD ships in `crds/` regardless.
- **`docs/examples/workflow-crd-sample.yaml`** — a valid sample CR (note the `"on":` quoting for kubectl's YAML reader).

## Verified (kind cluster `zynax-e2e`)
- `helm lint` clean; RBAC renders **only** when `crdController.enabled=true` (0 Roles when disabled).
- CRD registers; a valid CR passes `--dry-run=server`; a malformed CR is **rejected** by the schema (`spec.initial_state: Required`, `spec.states.*.type` enum).

## Scope
CRD + RBAC only. The controller-runtime manager (#1611) and reconcile logic (#1612) follow. Docs-and-helm only; exempt from the PR-size gate.

Closes #1610.

Assisted-by: Claude/claude-fable-5