### PR TITLE
feat(api-gateway): reconcile Workflow CRs via ApplyService + thin status (M8.E step 3)

### DIFF
--- a/services/api-gateway/cmd/api-gateway/main.go
+++ b/services/api-gateway/cmd/api-gateway/main.go
@@ -106,7 +106,7 @@ func run(cfg config) error {
 	// here is fatal to startup, but the manager itself is fault-isolated (its
 	// goroutine logs and exits without taking down the HTTP surface).
 	if cfg.CRDControllerEnabled {
-		if err := crd.StartController(ctx, resolveWatchNamespace(cfg)); err != nil {
+		if err := crd.StartController(ctx, svc, resolveWatchNamespace(cfg)); err != nil {
 			return fmt.Errorf("api-gateway: workflow controller: %w", err)
 		}
 	}

--- a/services/api-gateway/internal/infrastructure/crd/manager.go
+++ b/services/api-gateway/internal/infrastructure/crd/manager.go
@@ -29,7 +29,7 @@ const leaderElectionID = "zynax-api-gateway-workflow-controller"
 // RBAC is a namespaced Role (least privilege, no ClusterRole), so a
 // cluster-scope watch would be forbidden. Required — an empty namespace is a
 // hard error (mirrors the agent-registry scheduler, ADR-039).
-func NewManager(restCfg *rest.Config, namespace string) (manager.Manager, error) {
+func NewManager(restCfg *rest.Config, applier WorkflowApplier, namespace string) (manager.Manager, error) {
 	if namespace == "" {
 		return nil, fmt.Errorf("crd: watch namespace is required (namespaced RBAC forbids cluster-scope watches)")
 	}
@@ -49,7 +49,7 @@ func NewManager(restCfg *rest.Config, namespace string) (manager.Manager, error)
 	watched := &unstructured.Unstructured{}
 	watched.SetGroupVersionKind(WorkflowGVK)
 	if err := ctrl.NewControllerManagedBy(mgr).For(watched).
-		Complete(&WorkflowReconciler{Client: mgr.GetClient()}); err != nil {
+		Complete(&WorkflowReconciler{Client: mgr.GetClient(), Applier: applier}); err != nil {
 		return nil, fmt.Errorf("crd: build controller: %w", err)
 	}
 	return mgr, nil
@@ -59,7 +59,7 @@ func NewManager(restCfg *rest.Config, namespace string) (manager.Manager, error)
 // manager, and runs it in a goroutine until ctx is cancelled. A manager error
 // is fatal to the controller only — it is logged, not propagated — so a
 // controller failure never takes down the api-gateway REST apply path.
-func StartController(ctx context.Context, namespace string) error {
+func StartController(ctx context.Context, applier WorkflowApplier, namespace string) error {
 	// controller-runtime demands a logger before manager construction; bridge
 	// it into the service's structured slog output.
 	ctrl.SetLogger(logr.FromSlogHandler(slog.Default().Handler()))
@@ -67,7 +67,7 @@ func StartController(ctx context.Context, namespace string) error {
 	if err != nil {
 		return fmt.Errorf("crd: load kubeconfig: %w", err)
 	}
-	mgr, err := NewManager(restCfg, namespace)
+	mgr, err := NewManager(restCfg, applier, namespace)
 	if err != nil {
 		return fmt.Errorf("crd: build manager: %w", err)
 	}

--- a/services/api-gateway/internal/infrastructure/crd/reconciler.go
+++ b/services/api-gateway/internal/infrastructure/crd/reconciler.go
@@ -6,36 +6,58 @@
 // existing compile->submit path (domain.ApplyService) — the CRD is an authoring
 // surface only; execution and run state stay in the engine, never in the CR
 // status or etcd (ADR-040 §3).
-//
-// This file is the reconciler skeleton (canvas step 2): it establishes the
-// generation gate that keeps GitOps resync / controller restart / leader change
-// from re-triggering work. The compile->submit call and the thin status write
-// land in step 3 (#1612).
 package crd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
+	"time"
 
+	"gopkg.in/yaml.v3"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/zynax-io/zynax/services/api-gateway/internal/domain"
 )
 
 // WorkflowGVK identifies the Workflow custom resource this controller reconciles.
 var WorkflowGVK = schema.GroupVersionKind{Group: "zynax.io", Version: "v1alpha1", Kind: "Workflow"}
 
-// WorkflowReconciler reconciles a Workflow CR through the existing apply path.
-// In this step it establishes the generation gate; the submit and status write
-// arrive in step 3. It is the single status writer and so runs only on the
-// Lease-elected leader (the manager keeps the default NeedLeaderElection=true).
-type WorkflowReconciler struct {
-	Client client.Client
+// manifestAPIVersion is the apiVersion the compiler expects. The CRD serves
+// v1alpha1; the manifest schema pins zynax.io/v1, so the reconciler maps
+// v1alpha1 -> v1 when it reconstructs the manifest (ADR-043 §5).
+const manifestAPIVersion = "zynax.io/v1"
+
+// Condition types on the Workflow status this reconciler owns.
+const (
+	conditionCompiled   = "Compiled"
+	conditionDispatched = "Dispatched"
+)
+
+// WorkflowApplier is the slice of domain.ApplyService the controller needs:
+// compile the manifest and (unless dry-run) submit it to the engine. Satisfied
+// by *domain.ApplyService — the controller reuses the exact path the REST
+// handler uses, so it re-implements neither compilation nor execution.
+type WorkflowApplier interface {
+	ApplyWorkflow(ctx context.Context, req domain.ApplyRequest) (domain.ApplyResult, error)
 }
 
-// Reconcile implements the controller-runtime Reconciler.
+// WorkflowReconciler reconciles a Workflow CR through the existing apply path
+// and writes a deliberately thin status. It is the single status writer and so
+// runs only on the Lease-elected leader (the manager keeps the default
+// NeedLeaderElection=true).
+type WorkflowReconciler struct {
+	Client  client.Client
+	Applier WorkflowApplier
+}
+
+// Reconcile compiles and submits the Workflow through domain.ApplyService when
+// the spec generation has advanced, then mirrors the outcome into a thin status.
 func (r *WorkflowReconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
 	u := &unstructured.Unstructured{}
 	u.SetGroupVersionKind(WorkflowGVK)
@@ -52,20 +74,167 @@ func (r *WorkflowReconciler) Reconcile(ctx context.Context, req reconcile.Reques
 		return reconcile.Result{}, nil // spec unchanged since last observed generation: no-op
 	}
 
-	// Step 2 skeleton: the generation gate is open (spec changed). The
-	// compile->submit call and the thin status write are wired in step 3.
-	slog.Info("workflow reconcile: spec changed, submit deferred to step 3",
-		"workflow", req.String(), "generation", u.GetGeneration())
-	return reconcile.Result{}, nil
+	manifest, engineHint, err := buildManifest(u)
+	if err != nil {
+		// The CRD OpenAPI schema is the structural gate; a build failure here is
+		// unexpected. Record it and advance the generation so it does not
+		// crash-loop — a corrected spec (new generation) reopens the gate.
+		return r.writeStatus(ctx, u, nil, []conditionSpec{
+			{conditionCompiled, "False", "BuildFailed", err.Error()},
+		})
+	}
+
+	result, err := r.Applier.ApplyWorkflow(ctx, domain.ApplyRequest{
+		ManifestYAML: manifest,
+		Namespace:    u.GetNamespace(),
+		EngineHint:   engineHint,
+	})
+	if err != nil {
+		if errors.Is(err, domain.ErrCompilationFailed) {
+			// Structural error: surface it as a condition, advance the
+			// generation, and do NOT requeue — the user must fix the spec.
+			return r.writeStatus(ctx, u, nil, []conditionSpec{
+				{conditionCompiled, "False", "CompilationFailed", compileErrorMessage(result.Errors)},
+			})
+		}
+		// Transient (engine unavailable, etc.): requeue with backoff and leave
+		// observedGeneration untouched so the next attempt retries.
+		return reconcile.Result{}, fmt.Errorf("crd: apply workflow %s: %w", req.NamespacedName, err)
+	}
+
+	workflowID := domain.ManifestWorkflowID(manifest)
+	slog.Info("workflow reconcile: dispatched",
+		"workflow", req.String(), "workflow_id", workflowID, "run_id", result.RunID, "engine", engineHint)
+	return r.writeStatus(ctx, u,
+		map[string]any{"workflowID": workflowID, "runID": result.RunID, "engine": engineHint},
+		[]conditionSpec{
+			{conditionCompiled, "True", "Compiled", "manifest compiled to the engine-agnostic IR"},
+			{conditionDispatched, "True", "Dispatched", fmt.Sprintf("submitted as run %q", result.RunID)},
+		})
 }
 
 // needsReconcile is the re-submit gate (ADR-043 §4): reconcile only when the
 // spec generation has advanced past the generation the controller last
 // observed. status.observedGeneration is absent/0 on a never-reconciled CR, so
-// a freshly applied CR (generation >= 1) always reconciles exactly once. This
-// is what makes a GitOps resync, a controller restart, or a leader change of an
+// a freshly applied CR (generation >= 1) reconciles exactly once. This is what
+// makes a GitOps resync, a controller restart, or a leader change of an
 // already-dispatched, spec-unchanged workflow a no-op — no duplicate run.
 func needsReconcile(u *unstructured.Unstructured) bool {
 	observed, _, _ := unstructured.NestedInt64(u.Object, "status", "observedGeneration")
 	return u.GetGeneration() != observed
+}
+
+// buildManifest reconstructs the Workflow manifest the compiler expects from the
+// CR: metadata.name/namespace supply the manifest metadata, spec supplies the
+// state machine. The CR-only fields (engine, version) are lifted out — engine
+// becomes the EngineHint, version becomes manifest metadata.version — so what
+// reaches the compiler is byte-identical to a `zynax apply` of the same body.
+func buildManifest(u *unstructured.Unstructured) (manifest []byte, engineHint string, err error) {
+	spec, found, err := unstructured.NestedMap(u.Object, "spec")
+	if err != nil || !found {
+		return nil, "", fmt.Errorf("workflow %s: missing spec", u.GetName())
+	}
+	engineHint, _ = spec["engine"].(string)
+	version, _ := spec["version"].(string)
+
+	manifestSpec := make(map[string]any, len(spec))
+	for k, v := range spec {
+		if k == "engine" || k == "version" {
+			continue // CR-only fields, not part of the manifest spec
+		}
+		manifestSpec[k] = v
+	}
+
+	metadata := map[string]any{"name": u.GetName()}
+	if ns := u.GetNamespace(); ns != "" {
+		metadata["namespace"] = ns
+	}
+	if version != "" {
+		metadata["version"] = version
+	}
+
+	out, err := yaml.Marshal(map[string]any{
+		"apiVersion": manifestAPIVersion,
+		"kind":       "Workflow",
+		"metadata":   metadata,
+		"spec":       manifestSpec,
+	})
+	if err != nil {
+		return nil, "", fmt.Errorf("workflow %s: marshal manifest: %w", u.GetName(), err)
+	}
+	return out, engineHint, nil
+}
+
+// compileErrorMessage renders the first few compile errors into a condition message.
+func compileErrorMessage(errs []domain.CompileError) string {
+	if len(errs) == 0 {
+		return "compilation failed"
+	}
+	parts := make([]string, 0, len(errs))
+	for i, e := range errs {
+		if i == 3 {
+			parts = append(parts, fmt.Sprintf("(+%d more)", len(errs)-3))
+			break
+		}
+		parts = append(parts, fmt.Sprintf("%s: %s", e.Code, e.Message))
+	}
+	return strings.Join(parts, "; ")
+}
+
+// conditionSpec is a desired status condition before lastTransitionTime is resolved.
+type conditionSpec struct{ Type, Status, Reason, Message string }
+
+// writeStatus commits the thin status: observedGeneration (closing the re-submit
+// gate), the given extra mirror fields (workflowID/runID/engine — never run
+// state), and the conditions. It replaces status wholesale, so a success write
+// clears a prior failure's stale fields. lastTransitionTime moves only when a
+// condition's status actually flips.
+func (r *WorkflowReconciler) writeStatus(ctx context.Context, u *unstructured.Unstructured, extra map[string]any, conds []conditionSpec) (reconcile.Result, error) {
+	prev, _, _ := unstructured.NestedSlice(u.Object, "status", "conditions")
+
+	status := map[string]any{"observedGeneration": u.GetGeneration()}
+	for k, v := range extra {
+		status[k] = v
+	}
+	status["conditions"] = mergeConditions(prev, conds)
+
+	if err := unstructured.SetNestedMap(u.Object, status, "status"); err != nil {
+		return reconcile.Result{}, fmt.Errorf("crd: set workflow status: %w", err)
+	}
+	if err := r.Client.Status().Update(ctx, u); err != nil {
+		return reconcile.Result{}, fmt.Errorf("crd: update workflow status: %w", err)
+	}
+	return reconcile.Result{}, nil
+}
+
+// mergeConditions builds the conditions slice, preserving each condition's prior
+// lastTransitionTime when its status is unchanged.
+func mergeConditions(prev []any, specs []conditionSpec) []any {
+	now := time.Now().UTC().Format(time.RFC3339)
+	out := make([]any, 0, len(specs))
+	for _, s := range specs {
+		transition := now
+		for _, p := range prev {
+			pm, ok := p.(map[string]any)
+			if !ok {
+				continue
+			}
+			if t, _ := pm["type"].(string); t != s.Type {
+				continue
+			}
+			if st, _ := pm["status"].(string); st == s.Status {
+				if lt, _ := pm["lastTransitionTime"].(string); lt != "" {
+					transition = lt
+				}
+			}
+		}
+		out = append(out, map[string]any{
+			"type":               s.Type,
+			"status":             s.Status,
+			"reason":             s.Reason,
+			"message":            s.Message,
+			"lastTransitionTime": transition,
+		})
+	}
+	return out
 }

--- a/services/api-gateway/internal/infrastructure/crd/reconciler_test.go
+++ b/services/api-gateway/internal/infrastructure/crd/reconciler_test.go
@@ -4,6 +4,8 @@ package crd
 
 import (
 	"context"
+	"errors"
+	"strings"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -12,7 +14,25 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/zynax-io/zynax/services/api-gateway/internal/domain"
 )
+
+// fakeApplier records ApplyWorkflow calls and returns a canned result/error —
+// standing in for *domain.ApplyService so the reconciler is tested without a
+// compiler or engine.
+type fakeApplier struct {
+	calls   int
+	lastReq domain.ApplyRequest
+	result  domain.ApplyResult
+	err     error
+}
+
+func (f *fakeApplier) ApplyWorkflow(_ context.Context, req domain.ApplyRequest) (domain.ApplyResult, error) {
+	f.calls++
+	f.lastReq = req
+	return f.result, f.err
+}
 
 // workflowCR builds a minimal valid Workflow CR at the given spec generation,
 // optionally carrying status.observedGeneration.
@@ -23,6 +43,7 @@ func workflowCR(ns, name string, generation, observedGen int64) *unstructured.Un
 	u.SetName(name)
 	u.SetGeneration(generation)
 	_ = unstructured.SetNestedMap(u.Object, map[string]any{
+		"engine":        "temporal",
 		"initial_state": "start",
 		"states": map[string]any{
 			"start": map[string]any{"type": "terminal"},
@@ -34,7 +55,7 @@ func workflowCR(ns, name string, generation, observedGen int64) *unstructured.Un
 	return u
 }
 
-func newReconcilerFixture(objs ...client.Object) *WorkflowReconciler {
+func newReconcilerFixture(applier WorkflowApplier, objs ...client.Object) *WorkflowReconciler {
 	scheme := runtime.NewScheme()
 	scheme.AddKnownTypeWithName(WorkflowGVK, &unstructured.Unstructured{})
 	scheme.AddKnownTypeWithName(WorkflowGVK.GroupVersion().WithKind("WorkflowList"), &unstructured.UnstructuredList{})
@@ -45,11 +66,36 @@ func newReconcilerFixture(objs ...client.Object) *WorkflowReconciler {
 		WithObjects(objs...).
 		WithStatusSubresource(statusObj).
 		Build()
-	return &WorkflowReconciler{Client: c}
+	return &WorkflowReconciler{Client: c, Applier: applier}
 }
 
 func wfReq(ns, name string) reconcile.Request {
 	return reconcile.Request{NamespacedName: types.NamespacedName{Namespace: ns, Name: name}}
+}
+
+// readStatus re-fetches the CR and returns its status map.
+func readStatus(t *testing.T, r *WorkflowReconciler, ns, name string) map[string]any {
+	t.Helper()
+	u := &unstructured.Unstructured{}
+	u.SetGroupVersionKind(WorkflowGVK)
+	if err := r.Client.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: name}, u); err != nil {
+		t.Fatalf("re-get %s/%s: %v", ns, name, err)
+	}
+	st, _, _ := unstructured.NestedMap(u.Object, "status")
+	return st
+}
+
+// condition finds a status condition by type.
+func condition(st map[string]any, typ string) map[string]any {
+	conds, _, _ := unstructured.NestedSlice(st, "conditions")
+	for _, c := range conds {
+		if cm, ok := c.(map[string]any); ok {
+			if t, _ := cm["type"].(string); t == typ {
+				return cm
+			}
+		}
+	}
+	return nil
 }
 
 func TestNeedsReconcile_Gate(t *testing.T) {
@@ -75,41 +121,171 @@ func TestNeedsReconcile_Gate(t *testing.T) {
 	}
 }
 
-// A CR whose spec has not changed since the last observed generation must be a
-// no-op — this is the guarantee that GitOps resync / restart / leader change
-// never re-triggers a run.
-func TestReconcile_UnchangedSpecIsNoop(t *testing.T) {
-	cr := workflowCR("default", "reviewer", 4, 4)
-	r := newReconcilerFixture(cr)
-	res, err := r.Reconcile(context.Background(), wfReq("default", "reviewer"))
-	if err != nil {
+// A new CR is compiled+submitted once, and the outcome is mirrored into a thin
+// status that carries NO run state.
+func TestReconcile_NewCR_SubmitsAndWritesThinStatus(t *testing.T) {
+	applier := &fakeApplier{result: domain.ApplyResult{RunID: "run-abc", Status: "new"}}
+	cr := workflowCR("default", "reviewer", 1, 0)
+	r := newReconcilerFixture(applier, cr)
+
+	if _, err := r.Reconcile(context.Background(), wfReq("default", "reviewer")); err != nil {
 		t.Fatalf("reconcile: unexpected error: %v", err)
 	}
-	if res.RequeueAfter != 0 {
-		t.Fatalf("reconcile: expected no requeue for an unchanged CR, got %+v", res)
+	if applier.calls != 1 {
+		t.Fatalf("ApplyWorkflow calls = %d, want 1", applier.calls)
+	}
+	assertManifestAndHint(t, applier.lastReq)
+
+	st := readStatus(t, r, "default", "reviewer")
+	assertDispatchedStatus(t, st)
+	assertNoRunState(t, st)
+}
+
+// assertManifestAndHint checks that the compiler received a v1 Workflow manifest
+// with the engine lifted out to the hint (byte-identical to a `zynax apply`).
+func assertManifestAndHint(t *testing.T, req domain.ApplyRequest) {
+	t.Helper()
+	man := string(req.ManifestYAML)
+	for _, want := range []string{"apiVersion: zynax.io/v1", "kind: Workflow", "initial_state: start"} {
+		if !strings.Contains(man, want) {
+			t.Fatalf("manifest missing %q:\n%s", want, man)
+		}
+	}
+	if strings.Contains(man, "engine:") {
+		t.Fatalf("manifest must not carry the CR-only engine field:\n%s", man)
+	}
+	if req.EngineHint != "temporal" || req.Namespace != "default" {
+		t.Fatalf("apply request = %+v, want engine=temporal namespace=default", req)
 	}
 }
 
-// A freshly applied CR (generation 1, no status) passes the gate and reconciles
-// without error.
-func TestReconcile_NewCRProceeds(t *testing.T) {
+// assertDispatchedStatus checks the thin status fields and conditions of a
+// successfully dispatched Workflow.
+func assertDispatchedStatus(t *testing.T, st map[string]any) {
+	t.Helper()
+	if og, _, _ := unstructured.NestedInt64(st, "observedGeneration"); og != 1 {
+		t.Fatalf("observedGeneration = %d, want 1", og)
+	}
+	if run, _, _ := unstructured.NestedString(st, "runID"); run != "run-abc" {
+		t.Fatalf("runID = %q, want run-abc", run)
+	}
+	if wid, _, _ := unstructured.NestedString(st, "workflowID"); !strings.HasPrefix(wid, "wf-") {
+		t.Fatalf("workflowID = %q, want a wf- prefixed id", wid)
+	}
+	if eng, _, _ := unstructured.NestedString(st, "engine"); eng != "temporal" {
+		t.Fatalf("engine = %q, want temporal", eng)
+	}
+	if c := condition(st, conditionCompiled); c == nil || c["status"] != "True" {
+		t.Fatalf("Compiled condition = %v, want status True", c)
+	}
+	if c := condition(st, conditionDispatched); c == nil || c["status"] != "True" {
+		t.Fatalf("Dispatched condition = %v, want status True", c)
+	}
+}
+
+// assertNoRunState enforces the thin-status contract: only the mirror keys may
+// appear — run state must stay in the engine.
+func assertNoRunState(t *testing.T, st map[string]any) {
+	t.Helper()
+	allowed := map[string]bool{"observedGeneration": true, "workflowID": true, "runID": true, "engine": true, "conditions": true}
+	for k := range st {
+		if !allowed[k] {
+			t.Fatalf("status carries a non-thin key %q (run state must stay in the engine): %v", k, st)
+		}
+	}
+}
+
+// A completed, spec-unchanged CR is not re-submitted on a subsequent reconcile
+// (GitOps resync).
+func TestReconcile_NoResubmitAfterDispatch(t *testing.T) {
+	applier := &fakeApplier{result: domain.ApplyResult{RunID: "run-1"}}
 	cr := workflowCR("default", "reviewer", 1, 0)
-	r := newReconcilerFixture(cr)
+	r := newReconcilerFixture(applier, cr)
+
 	if _, err := r.Reconcile(context.Background(), wfReq("default", "reviewer")); err != nil {
-		t.Fatalf("reconcile: unexpected error: %v", err)
+		t.Fatalf("first reconcile: %v", err)
+	}
+	if _, err := r.Reconcile(context.Background(), wfReq("default", "reviewer")); err != nil {
+		t.Fatalf("second reconcile: %v", err)
+	}
+	if applier.calls != 1 {
+		t.Fatalf("ApplyWorkflow calls = %d after two reconciles, want 1 (gate must hold)", applier.calls)
+	}
+}
+
+// A controller restart re-Lists the CR with its persisted status; an
+// already-dispatched, spec-unchanged CR (observedGeneration == generation) must
+// not be re-submitted.
+func TestReconcile_RestartNoResubmit(t *testing.T) {
+	applier := &fakeApplier{result: domain.ApplyResult{RunID: "run-1"}}
+	dispatched := workflowCR("default", "reviewer", 2, 2) // status already caught up
+	r := newReconcilerFixture(applier, dispatched)
+
+	if _, err := r.Reconcile(context.Background(), wfReq("default", "reviewer")); err != nil {
+		t.Fatalf("reconcile after restart: %v", err)
+	}
+	if applier.calls != 0 {
+		t.Fatalf("ApplyWorkflow calls = %d after restart, want 0", applier.calls)
+	}
+}
+
+// A compilation failure is surfaced as a Compiled=False condition, advances the
+// generation (so it does not crash-loop), and returns no error.
+func TestReconcile_CompileError_ConditionNoCrash(t *testing.T) {
+	applier := &fakeApplier{
+		result: domain.ApplyResult{Errors: []domain.CompileError{{Code: "E_STATE", Message: "unknown state ref"}}},
+		err:    domain.ErrCompilationFailed,
+	}
+	cr := workflowCR("default", "broken", 1, 0)
+	r := newReconcilerFixture(applier, cr)
+
+	if _, err := r.Reconcile(context.Background(), wfReq("default", "broken")); err != nil {
+		t.Fatalf("reconcile of a bad manifest must not error (no crash-loop): %v", err)
+	}
+	st := readStatus(t, r, "default", "broken")
+	if og, _, _ := unstructured.NestedInt64(st, "observedGeneration"); og != 1 {
+		t.Fatalf("observedGeneration = %d, want 1 (gate must close on structural error)", og)
+	}
+	c := condition(st, conditionCompiled)
+	if c == nil || c["status"] != "False" {
+		t.Fatalf("Compiled condition = %v, want status False", c)
+	}
+	if msg, _ := c["message"].(string); !strings.Contains(msg, "unknown state ref") {
+		t.Fatalf("Compiled message = %q, want the compile error", msg)
+	}
+	if _, ok := st["runID"]; ok {
+		t.Fatalf("a failed compile must not write a runID: %v", st)
+	}
+}
+
+// A transient (non-compilation) error requeues and leaves observedGeneration
+// untouched so the next attempt retries.
+func TestReconcile_TransientError_Requeues(t *testing.T) {
+	applier := &fakeApplier{err: errors.New("engine adapter unavailable")}
+	cr := workflowCR("default", "reviewer", 1, 0)
+	r := newReconcilerFixture(applier, cr)
+
+	_, err := r.Reconcile(context.Background(), wfReq("default", "reviewer"))
+	if err == nil {
+		t.Fatal("reconcile: expected a transient error to be returned (for requeue), got nil")
+	}
+	st := readStatus(t, r, "default", "reviewer")
+	if og, found, _ := unstructured.NestedInt64(st, "observedGeneration"); found && og != 0 {
+		t.Fatalf("observedGeneration = %d after a transient error, want unset (gate stays open)", og)
 	}
 }
 
 // A reconcile for a CR that no longer exists is a clean no-op (no run state to
 // unwind — it lives in the engine).
 func TestReconcile_DeletedCRIsNoop(t *testing.T) {
-	r := newReconcilerFixture() // empty client
+	applier := &fakeApplier{}
+	r := newReconcilerFixture(applier) // empty client
 	res, err := r.Reconcile(context.Background(), wfReq("default", "gone"))
 	if err != nil {
 		t.Fatalf("reconcile of missing CR: unexpected error: %v", err)
 	}
-	if res.RequeueAfter != 0 {
-		t.Fatalf("reconcile of missing CR: expected no requeue, got %+v", res)
+	if res.RequeueAfter != 0 || applier.calls != 0 {
+		t.Fatalf("reconcile of missing CR: expected a pure no-op, got res=%+v calls=%d", res, applier.calls)
 	}
 }
 
@@ -117,7 +293,7 @@ func TestReconcile_DeletedCRIsNoop(t *testing.T) {
 // cluster-scope watch, so starting one would fail at runtime with a less clear
 // error.
 func TestNewManager_RejectsEmptyNamespace(t *testing.T) {
-	if _, err := NewManager(nil, ""); err == nil {
+	if _, err := NewManager(nil, &fakeApplier{}, ""); err == nil {
 		t.Fatal("NewManager(\"\"): expected an error for an empty namespace, got nil")
 	}
 }


### PR DESCRIPTION
Story 3 of **M8.E** (#1612 · canvas step 3) — the core of the front-end. The `WorkflowReconciler` now compiles+submits an applied `Workflow` CR through the **existing** `domain.ApplyService` (the same path the REST handler uses) and mirrors the outcome into a **thin** status. Run state stays in the engine (ADR-040 §3).

## What
- **`WorkflowApplier`** interface (satisfied by `*domain.ApplyService`) — re-implements neither compilation nor execution.
- **`buildManifest`** reconstructs the compiler's manifest from the CR: name/namespace → metadata, spec → state machine, CR-only fields lifted out (`engine`→EngineHint, `version`→metadata.version), apiVersion mapped `v1alpha1`→`zynax.io/v1` (ADR-043 §5) — byte-identical to a `zynax apply`.
- **Thin status**: `observedGeneration`, `workflowID` (ManifestWorkflowID, ADR-034), `runID`, `engine`, and Compiled/Dispatched conditions — nothing else.
- **Error handling**: `ErrCompilationFailed` → `Compiled=False` + advance generation (no crash-loop); transient error → requeue, `observedGeneration` untouched.

## Verified (fake ApplyService + fake client, GOWORK=off)
- new CR submits **once** and writes the thin status; the manifest carries `apiVersion: zynax.io/v1`/`kind: Workflow` and **no** engine field (engine → hint);
- **status keys asserted to be a subset of the thin set** (no run state);
- **no re-submit** on GitOps resync; **no re-submit after a simulated restart** (`observedGeneration == generation`);
- compile error → `Compiled=False`, no crash; transient error → requeue.
- Full api-gateway suite green; local `golangci-lint` (repo config, incl. cyclop/contextcheck) clean.

## Scope
The reconcile + status core. CLI bridge is step 4 (#1613); kind e2e is step 5 (#1614).

Closes #1612.

Assisted-by: Claude/claude-fable-5