### PR TITLE
feat(cli): zynax apply --crd applies a Workflow as a custom resource (M8.E step 4)

### DIFF
--- a/cmd/zynax/cmd/apply.go
+++ b/cmd/zynax/cmd/apply.go
@@ -15,6 +15,7 @@ import (
 var (
 	applyDryRun bool
 	applyEngine string
+	applyCRD    bool
 )
 
 var applyCmd = &cobra.Command{
@@ -33,14 +34,20 @@ consumes their capabilities. No new api-gateway endpoint is introduced.`,
 		if err != nil {
 			return err
 		}
-		gw := newGateway()
+		if applyCRD && isScenario {
+			return fmt.Errorf("--crd applies a single Workflow manifest; scenarios use the REST path")
+		}
 		if isScenario {
-			return runApplyScenario(cmd, gw, indexPath)
+			return runApplyScenario(cmd, newGateway(), indexPath)
 		}
 		data, err := os.ReadFile(args[0])
 		if err != nil {
 			return fmt.Errorf("read %s: %w", args[0], err)
 		}
+		if applyCRD {
+			return runApplyCRD(cmd, data)
+		}
+		gw := newGateway()
 		if applyDryRun {
 			return runDryRun(cmd, gw, data)
 		}
@@ -51,6 +58,8 @@ consumes their capabilities. No new api-gateway endpoint is introduced.`,
 func init() {
 	applyCmd.Flags().BoolVar(&applyDryRun, "dry-run", false, "validate manifest without submitting")
 	applyCmd.Flags().StringVar(&applyEngine, "engine", "", "engine hint forwarded to SubmitWorkflow (ADR-015)")
+	applyCmd.Flags().BoolVar(&applyCRD, "crd", false,
+		"apply a Workflow as a custom resource on the current Kubernetes context (GitOps front-end, ADR-043) instead of the REST path")
 	rootCmd.AddCommand(applyCmd)
 }
 
@@ -81,7 +90,7 @@ func runApplyScenario(cmd *cobra.Command, gw *client.Gateway, indexPath string) 
 		if err != nil {
 			return fmt.Errorf("read scenario member %s (%s): %w", m.ID, m.Path, err)
 		}
-		if m.Kind == "Workflow" {
+		if m.Kind == kindWorkflow {
 			data, err = validate.BindContextIntoWorkflow(data, ctxValues)
 			if err != nil {
 				return fmt.Errorf("scenario member %s: %w", m.ID, err)

--- a/cmd/zynax/cmd/apply_crd.go
+++ b/cmd/zynax/cmd/apply_crd.go
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+// crWorkflowAPIVersion is the CRD apiVersion (ADR-043). The Workflow *manifest*
+// pins zynax.io/v1; the CR served by the cluster is v1alpha1, so `--crd` maps
+// v1 -> v1alpha1 when it emits the custom resource.
+const crWorkflowAPIVersion = "zynax.io/v1alpha1"
+
+// kubectlApply pipes a manifest to `kubectl apply -f -` on the current context.
+// Injected so tests run with a fake — no real kubectl or cluster. Per
+// cmd/zynax/AGENTS.md the CLI shells out to the user's kubectl (no client-go).
+var kubectlApply = execKubectlApply
+
+func execKubectlApply(ctx context.Context, manifest []byte, dryRun bool) (string, error) {
+	args := []string{"apply", "-f", "-"}
+	if dryRun {
+		args = append(args, "--dry-run=client")
+	}
+	cmd := exec.CommandContext(ctx, "kubectl", args...) //nolint:gosec // G204: fixed binary, static args; manifest arrives on stdin
+	cmd.Stdin = bytes.NewReader(manifest)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+// runApplyCRD applies a Workflow manifest as a Workflow custom resource on the
+// current Kubernetes context (ADR-043, M8.E) — the declarative GitOps front-end.
+// It reuses the same manifest body: the controller reconciles the CR through the
+// very same compile->submit path the REST apply uses, so the workflow stays
+// engine-portable and run state lives in the engine, not the CR.
+func runApplyCRD(cmd *cobra.Command, data []byte) error {
+	cr, err := workflowManifestToCR(data, applyEngine)
+	if err != nil {
+		return err
+	}
+	out, err := kubectlApply(cmd.Context(), cr, applyDryRun)
+	if out != "" {
+		_, _ = fmt.Fprint(cmd.OutOrStdout(), out)
+	}
+	if err != nil {
+		return fmt.Errorf("kubectl apply: %w", err)
+	}
+	_, _ = fmt.Fprintln(cmd.OutOrStdout(),
+		"applied as a Workflow custom resource — commit it to git for GitOps sync; "+
+			"the controller reconciles it through compile->submit, and run state stays in the engine.")
+	return nil
+}
+
+// workflowManifestToCR converts a `kind: Workflow` manifest into a Workflow
+// custom resource, emitted as JSON. JSON (not YAML) is deliberate: kubectl's
+// YAML reader treats a bare `on:` transition key as a boolean, so a YAML CR
+// would need every `on` quoted; JSON keys are always strings, sidestepping the
+// trap. The manifest apiVersion (zynax.io/v1) maps to the CR's v1alpha1; the
+// engine hint and the manifest version move into the CR spec.
+func workflowManifestToCR(manifest []byte, engineHint string) ([]byte, error) {
+	var doc map[string]any
+	if err := yaml.Unmarshal(manifest, &doc); err != nil {
+		return nil, fmt.Errorf("parse manifest: %w", err)
+	}
+	if kind, _ := doc["kind"].(string); kind != kindWorkflow {
+		return nil, fmt.Errorf("--crd applies only kind: Workflow custom resources (got %q)", kind)
+	}
+
+	crMeta := map[string]any{}
+	var version string
+	if meta, ok := doc["metadata"].(map[string]any); ok {
+		for k, v := range meta {
+			if k == "version" {
+				version, _ = v.(string)
+				continue
+			}
+			crMeta[k] = v
+		}
+	}
+	if _, ok := crMeta["name"]; !ok {
+		return nil, fmt.Errorf("workflow manifest has no metadata.name")
+	}
+
+	crSpec := map[string]any{}
+	if spec, ok := doc["spec"].(map[string]any); ok {
+		for k, v := range spec {
+			crSpec[k] = v
+		}
+	}
+	if engineHint != "" {
+		crSpec["engine"] = engineHint
+	}
+	if version != "" {
+		crSpec["version"] = version
+	}
+
+	out, err := json.MarshalIndent(map[string]any{
+		"apiVersion": crWorkflowAPIVersion,
+		"kind":       kindWorkflow,
+		"metadata":   crMeta,
+		"spec":       crSpec,
+	}, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshal workflow CR: %w", err)
+	}
+	return out, nil
+}

--- a/cmd/zynax/cmd/apply_crd_test.go
+++ b/cmd/zynax/cmd/apply_crd_test.go
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// crdTestEngine is the engine hint used by the CRD-apply tests (a single literal
+// keeps goconst quiet across the CLI test package).
+const crdTestEngine = "argo"
+
+const workflowManifest = `apiVersion: zynax.io/v1
+kind: Workflow
+metadata:
+  name: review
+  version: 1.2.0
+spec:
+  initial_state: start
+  states:
+    start:
+      type: normal
+      on:
+        - event: done
+          goto: end
+    end:
+      type: terminal
+`
+
+func TestWorkflowManifestToCR_MapsAndInjects(t *testing.T) {
+	cr, err := workflowManifestToCR([]byte(workflowManifest), "temporal")
+	if err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(cr, &m); err != nil {
+		t.Fatalf("CR is not valid JSON: %v", err)
+	}
+
+	// apiVersion maps v1 -> v1alpha1 (ADR-043 §5).
+	if m["apiVersion"] != "zynax.io/v1alpha1" {
+		t.Fatalf("apiVersion = %v, want zynax.io/v1alpha1", m["apiVersion"])
+	}
+	if m["kind"] != "Workflow" {
+		t.Fatalf("kind = %v, want Workflow", m["kind"])
+	}
+
+	meta, _ := m["metadata"].(map[string]any)
+	if meta["name"] != "review" {
+		t.Fatalf("metadata.name = %v, want review", meta["name"])
+	}
+	if _, ok := meta["version"]; ok {
+		t.Fatalf("metadata.version must move to spec.version, still present: %v", meta)
+	}
+
+	spec, _ := m["spec"].(map[string]any)
+	if spec["engine"] != "temporal" {
+		t.Fatalf("spec.engine = %v, want temporal (from --engine)", spec["engine"])
+	}
+	if spec["version"] != "1.2.0" {
+		t.Fatalf("spec.version = %v, want 1.2.0", spec["version"])
+	}
+
+	// The `on` transition key survives as a string (the whole reason JSON is
+	// emitted — a YAML CR would need it quoted to dodge the boolean trap).
+	states, _ := spec["states"].(map[string]any)
+	start, _ := states["start"].(map[string]any)
+	if _, ok := start["on"]; !ok {
+		t.Fatalf("states.start.on lost in conversion: %v", start)
+	}
+}
+
+func TestWorkflowManifestToCR_NoEngineHint(t *testing.T) {
+	cr, err := workflowManifestToCR([]byte(workflowManifest), "")
+	if err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+	var m map[string]any
+	_ = json.Unmarshal(cr, &m)
+	spec, _ := m["spec"].(map[string]any)
+	if _, ok := spec["engine"]; ok {
+		t.Fatalf("no --engine given: spec.engine must be omitted, got %v", spec["engine"])
+	}
+}
+
+func TestWorkflowManifestToCR_RejectsNonWorkflow(t *testing.T) {
+	if _, err := workflowManifestToCR([]byte("kind: AgentDef\nmetadata:\n  name: x\n"), ""); err == nil {
+		t.Fatal("expected an error for a non-Workflow manifest")
+	}
+}
+
+func TestWorkflowManifestToCR_RequiresName(t *testing.T) {
+	if _, err := workflowManifestToCR([]byte("kind: Workflow\nspec:\n  initial_state: s\n"), ""); err == nil {
+		t.Fatal("expected an error for a manifest with no metadata.name")
+	}
+}
+
+func TestRunApplyCRD_InvokesKubectlWithCR(t *testing.T) {
+	var gotManifest []byte
+	var gotDryRun bool
+	orig := kubectlApply
+	kubectlApply = func(_ context.Context, m []byte, dryRun bool) (string, error) {
+		gotManifest, gotDryRun = m, dryRun
+		return "workflow.zynax.io/review created", nil
+	}
+	t.Cleanup(func() { kubectlApply = orig })
+
+	oe, od, oc := applyEngine, applyDryRun, applyCRD
+	applyEngine, applyDryRun, applyCRD = crdTestEngine, false, true
+	t.Cleanup(func() { applyEngine, applyDryRun, applyCRD = oe, od, oc })
+
+	var out bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&out)
+	cmd.SetContext(context.Background())
+
+	if err := runApplyCRD(cmd, []byte(workflowManifest)); err != nil {
+		t.Fatalf("runApplyCRD: %v", err)
+	}
+	if gotDryRun {
+		t.Fatal("dryRun should be false")
+	}
+	var cr map[string]any
+	if err := json.Unmarshal(gotManifest, &cr); err != nil {
+		t.Fatalf("kubectl received non-JSON: %v", err)
+	}
+	if cr["apiVersion"] != "zynax.io/v1alpha1" {
+		t.Fatalf("kubectl CR apiVersion = %v", cr["apiVersion"])
+	}
+	if spec, _ := cr["spec"].(map[string]any); spec["engine"] != crdTestEngine {
+		t.Fatalf("kubectl CR spec.engine = %v, want %s", spec["engine"], crdTestEngine)
+	}
+	if !strings.Contains(out.String(), "created") {
+		t.Fatalf("kubectl output not forwarded to the user: %q", out.String())
+	}
+}

--- a/cmd/zynax/cmd/kinds.go
+++ b/cmd/zynax/cmd/kinds.go
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+// Manifest-kind literals shared across the CLI (DetectKind allowlist mirror).
+const (
+	kindWorkflow = "Workflow"
+	kindAgentDef = "AgentDef"
+)

--- a/cmd/zynax/cmd/noun_aliases_test.go
+++ b/cmd/zynax/cmd/noun_aliases_test.go
@@ -19,12 +19,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// Manifest-kind literals shared across the CLI tests (satisfies goconst).
-const (
-	kindWorkflow = "Workflow"
-	kindAgentDef = "AgentDef"
-)
-
 // runEPtr returns the comparable pointer of a command's RunE for identity asserts.
 func runEPtr(c *cobra.Command) uintptr {
 	if c == nil || c.RunE == nil {


### PR DESCRIPTION
Story 4 of **M8.E** (#1613 · canvas step 4). `zynax apply --crd` bridges the familiar apply UX to the GitOps front-end: it converts a `kind: Workflow` manifest into a `Workflow` custom resource and `kubectl apply`s it on the current context. The REST path is unchanged otherwise.

## What
- **`--crd` flag** on `apply` — routes a single Workflow manifest to the CR path (scenarios stay on REST; `--crd`+scenario is rejected).
- **`workflowManifestToCR`** — maps apiVersion `zynax.io/v1`→`v1alpha1` (ADR-043 §5), lifts `--engine`→`spec.engine` and `metadata.version`→`spec.version`. **Emits JSON, not YAML**: kubectl's YAML reader treats a bare `on:` transition key as a boolean, so a YAML CR would need every `on` quoted — JSON keys are always strings. Piped to `kubectl apply -f -` (the CLI shells to kubectl per cmd/zynax/AGENTS.md — no client-go dep) via an injectable runner.
- **`kinds.go`** — promotes `kindWorkflow`/`kindAgentDef` to production constants.

Reuses the same manifest body, so the controller reconciles the CR through the **very same compile→submit path** the REST apply uses — engine-portable, run state in the engine.

## Verified
- Unit (fake kubectl runner, GOWORK=off): apiVersion mapping, engine/version injection, the `on` key surviving as a string, non-Workflow + missing-name rejection, the CR reaching kubectl.
- **Runtime on kind**: `zynax apply --crd --engine temporal hello-world.yaml` created the CR — `kubectl get workflows.zynax.io` showed `apiVersion v1alpha1`, `engine temporal`, and the `on` transition preserved in the state. Local golangci-lint (repo config, incl. goconst/cyclop) clean.

## Scope
The CLI bridge. End-to-end reconcile-to-dispatch is proven in the kind e2e (step 5, #1614).

Closes #1613.

Assisted-by: Claude/claude-fable-5