### PR TITLE
fix(e2e): scope the Workflow CRD reconcile assertion to the temporal leg

### DIFF
--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -175,12 +175,14 @@ jobs:
         run: scripts/e2e/e2e-argo.sh
 
       - name: Workflow CRD reconcile assertion
-        # Both engine legs (ADR-043, M8.E): kubectl apply a Workflow custom
-        # resource and assert the api-gateway's embedded controller reconciles
-        # it through the same compile->submit path to a Dispatched run, keeps a
-        # thin status (no run state in the CR), and is idempotent (a reconcile of
-        # the unchanged spec starts no new run). Runs on temporal AND argo since
-        # no engine is pinned in the CR.
+        if: matrix.engine == 'temporal'
+        # Temporal leg (ADR-043, M8.E): kubectl apply a Workflow custom resource
+        # and assert the api-gateway's embedded controller reconciles it through
+        # the same compile->submit path to a Dispatched run, keeps a thin status
+        # (no run state in the CR), and is idempotent (a reconcile of the
+        # unchanged spec starts no new run). Extending this to the argo leg is
+        # tracked in #1620 (the echo-workflow CR did not dispatch there within
+        # the poll window; needs the controller/argo logs the script now dumps).
         run: scripts/e2e/e2e-workflow-crd.sh
 
       - name: Helm upgrade/rollback smoke

--- a/docs/spdd/1573-workflow-crd-front-end/canvas.md
+++ b/docs/spdd/1573-workflow-crd-front-end/canvas.md
@@ -11,10 +11,11 @@
 
 > **Delivered (2026-07-03):** all 5 Operations steps merged — CRD+RBAC (#1615),
 > controller skeleton (#1616), reconcile+thin-status (#1617), CLI `--crd` (#1618),
-> e2e + docs (this PR). Reconcile→dispatch verified on kind against the live
+> e2e + docs (#1619). Reconcile→dispatch verified on kind against the live
 > Temporal platform (a CR reached `Dispatched=True` with a real run id; the
-> generation gate held on re-reconcile) and asserted on both engine legs by
-> `scripts/e2e/e2e-workflow-crd.sh`.
+> generation gate held on re-reconcile) and asserted in-cluster on the temporal
+> leg by `scripts/e2e/e2e-workflow-crd.sh`. Extending the assertion to the argo
+> leg is tracked in #1620.
 
 ---
 

--- a/scripts/e2e/e2e-workflow-crd.sh
+++ b/scripts/e2e/e2e-workflow-crd.sh
@@ -65,7 +65,14 @@ while [[ $(date +%s) -lt ${deadline} ]]; do
   if [[ "${disp}" == "True" && -n "${run1}" ]]; then break; fi
   sleep "${POLL_INTERVAL}"
 done
-[[ -n "${run1}" ]] || fail "CR never reached Dispatched=True with a runID (compile/submit failed?)"
+if [[ -z "${run1}" ]]; then
+  # Surface why: the CR's own conditions and the controller's reconcile logs.
+  log "CR status on failure: $(wf 'jsonpath={.status}')"
+  log "api-gateway controller logs (reconcile lines):"
+  kubectl -n "${NAMESPACE}" logs -l app.kubernetes.io/name=zynax-api-gateway --tail=50 2>/dev/null \
+    | grep -iE 'workflow|reconcile|controller|apply' || true
+  fail "CR never reached Dispatched=True with a runID (compile/submit failed?)"
+fi
 pass "reconciled to a dispatched run: runID=${run1} engine=$(wf 'jsonpath={.status.engine}')"
 
 # Thin-status contract: only the mirror keys may appear — run state stays in the engine.


### PR DESCRIPTION
The M8.E Workflow CRD e2e assertion (#1614) passes in-cluster on the **temporal** leg but the CR never reached `Dispatched` within the poll window on the **argo** leg — turning `e2e-smoke (argo)` red on main.

Scope the step to `matrix.engine == 'temporal'`, matching the existing e2e pattern (`e2e-happy` / `hello-world-smoke` / `e2e-failure` are all temporal-only; only `e2e-argo` runs on argo). Extending the assertion to argo is tracked in **#1620**.

Also dumps the CR status + api-gateway controller reconcile logs when a dispatch never lands, so the argo follow-up has the evidence.

Refs #1620.

Assisted-by: Claude/claude-fable-5