### PR TITLE
feat(infra): Gateway API edge resources + SecurityPolicy in Helm (M8.F step 2)

### DIFF
--- a/helm/zynax-api-gateway/templates/gateway.yaml
+++ b/helm/zynax-api-gateway/templates/gateway.yaml
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Gateway API edge (M8.F, ADR-044). When edge.enabled, an Envoy Gateway fronts
+# the api-gateway Service and enforces bearer auth (see securitypolicy.yaml) and
+# — profile-gated — a global rate-limit. The api-gateway keeps only its Zynax
+# core; its in-process auth/rate-limit are removed in the cutover (#1626).
+#
+# Two HTTPRoutes share the listener:
+#   * the API route (/api/v1/*) — the SecurityPolicy attaches here (auth required);
+#   * the probes/metrics route — deliberately OPEN so kubelet health checks and
+#     the kind host-contract check still pass without a key.
+#
+# The gateway-helm chart (installed as an ordered prereq by cluster-up.sh when
+# EDGE_ENABLED=true, #1623) provides the Gateway API + Envoy Gateway CRDs, so
+# these objects admit only after the controller is Ready.
+{{- if .Values.edge.enabled }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: {{ include "zynax.fullname" . }}-edge
+  labels:
+    {{- include "zynax.labels" . | nindent 4 }}
+spec:
+  controllerName: gateway.envoyproxy.io/gatewayclass-controller
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: {{ include "zynax.fullname" . }}-edge
+  labels:
+    {{- include "zynax.labels" . | nindent 4 }}
+spec:
+  gatewayClassName: {{ include "zynax.fullname" . }}-edge
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: {{ .Values.edge.listenerPort }}
+      allowedRoutes:
+        namespaces:
+          from: Same
+---
+# API route — auth enforced here by the SecurityPolicy (securitypolicy.yaml).
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "zynax.fullname" . }}-api
+  labels:
+    {{- include "zynax.labels" . | nindent 4 }}
+spec:
+  parentRefs:
+    - name: {{ include "zynax.fullname" . }}-edge
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /api/v1
+      backendRefs:
+        - name: {{ include "zynax.fullname" . }}
+          port: {{ .Values.env.httpPort }}
+---
+# Probes/metrics route — OPEN (no SecurityPolicy) so kubelet + the kind
+# host-contract health check reach api-gateway without a bearer token.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "zynax.fullname" . }}-probes
+  labels:
+    {{- include "zynax.labels" . | nindent 4 }}
+spec:
+  parentRefs:
+    - name: {{ include "zynax.fullname" . }}-edge
+  rules:
+    - matches:
+        - path: { type: PathPrefix, value: /healthz }
+        - path: { type: PathPrefix, value: /readyz }
+        - path: { type: PathPrefix, value: /livez }
+        - path: { type: PathPrefix, value: /startupz }
+        - path: { type: PathPrefix, value: /metrics }
+      backendRefs:
+        - name: {{ include "zynax.fullname" . }}
+          port: {{ .Values.env.httpPort }}
+{{- end }}

--- a/helm/zynax-api-gateway/templates/securitypolicy.yaml
+++ b/helm/zynax-api-gateway/templates/securitypolicy.yaml
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Edge bearer auth (M8.F, ADR-044). An Envoy Gateway SecurityPolicy attached to
+# the API HTTPRoute enforces API-key auth. It extracts the credential from the
+# `Authorization` header — Envoy strips the `Bearer ` scheme — and compares it to
+# the values in the referenced Secret, whose data maps client-name -> BARE key
+# (no `Bearer ` prefix). This keeps the CLI header (`Authorization: Bearer <key>`)
+# unchanged (ADR-044 §3), proven live on kind in the M8.F canvas spike.
+#
+# Requires Envoy Gateway v1.5.0+ (apiKeyAuth is absent in v1.4.x). The referenced
+# Secret is created out-of-band (cluster-up.sh, #1627), like the legacy api-key
+# Secret — a chart never ships secret material.
+{{- if .Values.edge.enabled }}
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: {{ include "zynax.fullname" . }}-apikey
+  labels:
+    {{- include "zynax.labels" . | nindent 4 }}
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: {{ include "zynax.fullname" . }}-api
+  apiKeyAuth:
+    credentialRefs:
+      - group: ""
+        kind: Secret
+        name: {{ .Values.edge.apiKeySecretName }}
+    extractFrom:
+      - headers:
+          - Authorization
+{{- end }}

--- a/helm/zynax-api-gateway/values.yaml
+++ b/helm/zynax-api-gateway/values.yaml
@@ -52,6 +52,19 @@ env:
   grpcCallTimeoutS: 30
   livenessThresholdS: 60
 
+# Gateway API edge (M8.F, ADR-044). When enabled, an Envoy Gateway fronts the
+# api-gateway and enforces bearer auth (SecurityPolicy) + a profile-gated global
+# rate-limit — replacing the in-process middleware. Off by default; the Envoy
+# Gateway controller must be installed first (cluster-up.sh EDGE_ENABLED, #1623).
+edge:
+  enabled: false
+  # Gateway HTTP listener port (the Envoy proxy fronts the api-gateway Service).
+  listenerPort: 80
+  # Secret (Opaque, client-name -> BARE key; no "Bearer " prefix) the
+  # SecurityPolicy checks. Created out-of-band (cluster-up.sh), like the legacy
+  # api-key Secret. Envoy extracts the credential from "Authorization: Bearer <key>".
+  apiKeySecretName: zynax-edge-apikey
+
 # Secret references — never store values here
 # ZYNAX_GW_API_KEY is read from this secret's "api-key" key.
 # Set to empty string to skip mounting (dev-insecure mode only).


### PR DESCRIPTION
Story 2 of **M8.F** (#1624 · canvas step 2). Adds the Envoy Gateway edge fronting the api-gateway behind `edge.enabled` (**off by default**) — additive, nothing deleted yet.

## What
- **`templates/gateway.yaml`** — GatewayClass + Gateway + two HTTPRoutes: the **API route** (`/api/v1/*`, auth enforced by the SecurityPolicy) and an **open** probes/metrics route so kubelet + the kind host-contract check pass without a key.
- **`templates/securitypolicy.yaml`** — `apiKeyAuth` on the API route; extracts from `Authorization` (Envoy strips the `Bearer ` scheme) and checks the edge Secret (client-name → **bare key**), so the **unchanged** CLI header authenticates (ADR-044 §3). Requires Envoy Gateway **v1.5.0+**.
- **`values.yaml`** — `edge.{enabled=false, listenerPort, apiKeySecretName}`. The Secret is created out-of-band (`cluster-up.sh`, #1627).

## Verified live (kind: Envoy Gateway v1.5.0 + running api-gateway)
With the bare-key Secret:
- `/api/v1/*` **no key → 401**, **wrong key → 401** (at the edge), **correct `Bearer <key>` → 404** (reached the backend = auth passed);
- probes route `/healthz` **no key → 200** (open).

helm renders the objects **only** when `edge.enabled=true` (0 when false); helm lint clean.

## Scope
Additive edge resources. The rate-limit is #1625; the in-process auth deletion + NetworkPolicy lockdown is the cutover #1626 (which must not merge before this is proven — done).

Closes #1624.

Assisted-by: Claude/claude-fable-5